### PR TITLE
fix(ci): repair api compliance workflow metadata

### DIFF
--- a/.github/workflows/api-compliance-testing.yml
+++ b/.github/workflows/api-compliance-testing.yml
@@ -51,12 +51,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -184,6 +184,8 @@ jobs:
         fi
 
     - name: Generate Comprehensive Test Report
+      env:
+        MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}
       run: |
         cd web/backend
         python << 'EOF'
@@ -264,7 +266,7 @@ jobs:
         print("\n" + "="*80)
         print("API COMPLIANCE TEST SUITE SUMMARY")
         print("="*80)
-        print(f"Python Version: ${{{{ matrix.python-version }}}}")
+        print(f"Python Version: {os.getenv('MATRIX_PYTHON_VERSION', 'unknown')}")
         print(f"Total Tests: {total_tests}")
         print(f"Passed: {total_passed}")
         print(f"Failed: {total_failed}")
@@ -301,7 +303,7 @@ jobs:
 
     - name: Comment PR with Results
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const fs = require('fs');

--- a/governance/mainline/task-cards/pr-20.yaml
+++ b/governance/mainline/task-cards/pr-20.yaml
@@ -1,0 +1,81 @@
+version: "v0.2"
+
+task:
+  id: "pr-20"
+  title: "repair api compliance workflow metadata for runner compatibility"
+  owner: "main"
+  created_at: "2026-03-31"
+
+mainline:
+  id: "L1-api-compliance-workflow-repair"
+  objective: "restore runner-compatible metadata for the api compliance workflow without overlapping the separate ci governance slices"
+  milestone_id: "L2-ci-governance"
+  slice_id: "L3-api-compliance-metadata"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "api-compliance-workflow-metadata-fix"
+
+scope:
+  allowed_paths:
+    - ".github/workflows/api-compliance-testing.yml"
+    - "governance/mainline/task-cards/pr-20.yaml"
+    - "tests/unit/scripts/test_ci_workflow_runtime_setup.py"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No broader security-testing or task-card remediation from the other active CLI lines"
+  - "No product feature changes outside API compliance workflow metadata and its regression test"
+
+acceptance:
+  checks:
+    - id: "workflow-lint"
+      command: "actionlint .github/workflows/api-compliance-testing.yml"
+      required: true
+    - id: "runtime-test"
+      command: "pytest tests/unit/scripts/test_ci_workflow_runtime_setup.py -q -o addopts='' -k api_compliance_workflow_uses_supported_actions_and_safe_python_matrix_expansion"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Workflow metadata fixes can hide parser issues if matrix interpolation is not converted to a runner-safe form"
+    - "Regression coverage must stay limited to the API compliance workflow so this slice does not sprawl into unrelated CI files"
+  rollback_plan: "git revert <merge-commit-sha> if API compliance workflow behavior regresses after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "fix deprecated action versions and invalid workflow interpolation in api-compliance-testing"
+    modified_scope: "api-compliance-testing workflow plus one workflow runtime regression test and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "existing API compliance behavior stays the same while workflow metadata becomes runner-compatible"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this slice if the API compliance workflow regresses after merge"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-03-31T00:00:00Z"
+    approval_note: "approved as isolated api compliance workflow repair"
+    secondary_approved: false

--- a/tests/unit/scripts/test_ci_workflow_runtime_setup.py
+++ b/tests/unit/scripts/test_ci_workflow_runtime_setup.py
@@ -88,6 +88,17 @@ def test_api_contract_validation_pr_comment_is_non_blocking() -> None:
     assert "continue-on-error: true" in comment_section
 
 
+def test_api_compliance_workflow_uses_supported_actions_and_safe_python_matrix_expansion() -> None:
+    workflow = _read_workflow("api-compliance-testing.yml")
+
+    assert "uses: actions/setup-python@v5" in workflow
+    assert "uses: actions/cache@v4" in workflow
+    assert "uses: actions/github-script@v7" in workflow
+    assert 'MATRIX_PYTHON_VERSION: ${{ matrix.python-version }}' in workflow
+    assert "print(f\"Python Version: {os.getenv('MATRIX_PYTHON_VERSION', 'unknown')}\")" in workflow
+    assert "${{{{ matrix.python-version }}}}" not in workflow
+
+
 def test_api_contract_and_api_file_workflows_install_backend_runtime_dependencies() -> None:
     contract_workflow = _read_workflow("api-contract-validation.yml")
     api_file_workflow = _read_workflow("api-file-tests.yml")


### PR DESCRIPTION
## Summary
- upgrade deprecated GitHub Action versions in api-compliance-testing
- replace the invalid matrix interpolation inside the Python heredoc with an env-backed value
- add a workflow runtime test that locks the supported action versions and safe matrix expansion

## Verification
- actionlint .github/workflows/api-compliance-testing.yml
- pytest tests/unit/scripts/test_ci_workflow_runtime_setup.py -q -o addopts='' -k api_compliance_workflow_uses_supported_actions_and_safe_python_matrix_expansion

## Scope Note
- this slice is isolated to api-compliance-testing only and does not touch the task-card or frontend gate repair line
