### PR TITLE
docs: close maestro local acceptance loop

### DIFF
--- a/docs/guides/ai-tools/GRAPHITI_MCP_WORKFLOW.md
+++ b/docs/guides/ai-tools/GRAPHITI_MCP_WORKFLOW.md
@@ -41,7 +41,7 @@
 
 - work item creation
 - assignment / dispatch
-- claim / plan / submit
+- mark / update / request / transition
 - ready_for_review / verified / merged
 - worker progress percentage and review lifecycle
 
@@ -169,10 +169,61 @@ worker CLI 适合在这些时机调用 Graphiti MCP：
 worker 不应把以下内容只写入 Graphiti 而不写 Mongo：
 
 - 开工回执状态
-- plan item 完成状态
+- 进度更新与审批状态
 - ready_for_review 申请
 
 这些仍必须走 Mongo control plane。
+
+补充：
+
+- 相关 Graphiti smoke / shared CLI 在失败时会返回结构化 JSON，至少包含 `error_code` 与 `message`
+
+## Local Smoke Commands
+
+当前仓库里与 Graphiti 相关、已在本机环境验证过的命令：
+
+```bash
+python scripts/runtime/smoke_graphiti_cli.py \
+  --actor-cli cli-smoke \
+  --group-id mystocks_spec_smoke \
+  --name "Smoke Memory" \
+  --body "Graphiti smoke body" \
+  --query "Smoke Memory"
+
+python scripts/runtime/smoke_graphiti_preflight.py --actor-cli cli-preflight
+```
+
+预期：
+
+- `smoke_graphiti_cli.py` 成功时返回 remember/search 的结构化 JSON 摘要
+- `smoke_graphiti_preflight.py --actor-cli cli-preflight` 成功时返回 `server_status=ok`
+- 若外部命令失败、无输出或返回非法 JSON，脚本会返回带 `error_code` 与 `message` 的结构化 JSON
+
+### One-Command Repo-Local Acceptance
+
+若需要把 Graphiti preflight 放回完整的 repo-local 协作验收链，而不是单独跑 smoke，统一使用：
+
+```bash
+python scripts/runtime/run_local_maestro_acceptance.sh
+```
+
+这条一键验收会顺序执行：
+
+- `python scripts/runtime/coordctl.py work list --output json`
+- `python scripts/runtime/smoke_mongo_multicli.py`
+- `python scripts/runtime/smoke_graphiti_preflight.py --actor-cli cli-preflight`
+- `python scripts/runtime/export_collab_snapshots.py --output-dir /tmp/mongo-collab-snapshots-codex`
+
+其中 Graphiti 相关的核心验收物是：
+
+- `/tmp/maestro_graphiti_preflight.json`
+- `/tmp/mongo-collab-snapshots-codex`
+
+推荐使用场景：
+
+- 交付前确认 Mongo control plane 与 Graphiti preflight 仍然协同一致
+- cleanup / convergence 收尾时提供可复跑证据
+- 排查 “单个 Graphiti smoke 能过，但整条本地协作链未验证” 的情况
 
 ## Graphiti API Status
 

--- a/docs/guides/multi-cli-tasks/MONGO_MULTICLI_COORDINATION_GUIDE.md
+++ b/docs/guides/multi-cli-tasks/MONGO_MULTICLI_COORDINATION_GUIDE.md
@@ -5,7 +5,7 @@
 本指南说明如何在 MyStocks 当前仓库内使用 `Maestro` 的 MongoDB 多 CLI 协作控制面。
 
 操作层的命名规范、主/从 CLI 命令分工、以及当前有效开工顺序，统一以
-`docs/guides/MONGO_MULTICLI_OPERATION_CHECKLIST.md` 为准。
+`docs/guides/multi-cli-tasks/MONGO_MULTICLI_OPERATION_CHECKLIST.md` 为准。
 本文件保留为控制面能力说明；不要再以 `MT-*` 作为新的正式任务命名。
 
 当前定位：
@@ -113,46 +113,54 @@ python scripts/runtime/coordctl.py work create \
 ```bash
 python scripts/runtime/coordctl.py work list --output json
 python scripts/runtime/coordctl.py work show 2026-03-14-api-route-governance-mystocks-spec1 --output json
-python scripts/runtime/coordctl.py work show 2026-03-14-api-route-governance-mystocks-spec1 --include-plan --output json
-python scripts/runtime/coordctl.py work board --active-only --output json
 python scripts/runtime/coordctl.py work transition 2026-03-14-api-route-governance-mystocks-spec1 --to merged --output json
 ```
 
 ```bash
-python scripts/runtime/coordctl.py work claim 2026-03-14-api-route-governance-mystocks-spec1 \
+python scripts/runtime/coordctl.py work mark 2026-03-14-api-route-governance-mystocks-spec1 \
   --actor-cli mystocks_spec1 \
-  --summary "Accepted task and started execution"
-```
-
-```bash
-python scripts/runtime/coordctl.py plan add 2026-03-14-api-route-governance-mystocks-spec1 \
-  --actor-cli mystocks_spec1 \
-  --title "Inspect current router state" \
-  --order 10
-```
-
-```bash
-python scripts/runtime/coordctl.py plan mark 2026-03-14-api-route-governance-mystocks-spec1 plan-abc123 \
-  --actor-cli mystocks_spec1 \
-  --status done \
-  --evidence "Verified scoped prefixes and duplicate registrations"
+  --status in_progress \
+  --summary "Accepted task and started execution" \
+  --output json
 ```
 
 ```bash
 python scripts/runtime/coordctl.py update add 2026-03-14-api-route-governance-mystocks-spec1 \
   --actor-cli mystocks_spec1 \
-  --summary "Implemented CLI command surface" \
-  --status in_progress
+  --summary "Verified scoped prefixes and duplicate registrations" \
+  --status in_progress \
+  --output json
 ```
 
 ```bash
-python scripts/runtime/coordctl.py work submit 2026-03-14-api-route-governance-mystocks-spec1 \
+python scripts/runtime/coordctl.py request create 2026-03-14-api-route-governance-mystocks-spec1 \
+  --actor-cli mystocks_spec1 \
+  --request-id req-scope-1 \
+  --request-type definition_change \
+  --summary "Need broader allowed path coverage" \
+  --output json
+```
+
+```bash
+python scripts/runtime/coordctl.py work preflight 2026-03-14-api-route-governance-mystocks-spec1 \
+  --actor-cli mystocks_spec1 \
+  --task-path TASK.md \
+  --output json
+```
+
+```bash
+python scripts/runtime/coordctl.py update add 2026-03-14-api-route-governance-mystocks-spec1 \
   --actor-cli mystocks_spec1 \
   --summary "Code, verification, and TASK-REPORT are ready for review" \
-  --commit abc123def \
-  --branch mystocks_spec1 \
-  --remote origin \
-  --verify "pytest tests/unit/runtime -q"
+  --status ready_for_review \
+  --output json
+```
+
+```bash
+python scripts/runtime/coordctl.py work transition 2026-03-14-api-route-governance-mystocks-spec1 \
+  --to ready_for_review \
+  --actor-cli mystocks_spec1 \
+  --output json
 ```
 
 ## Real Smoke Verification
@@ -181,8 +189,10 @@ python scripts/runtime/smoke_mongo_multicli.py \
 - 显式 `--mongo-uri` 最高优先
 - 未显式传入时，先按 URI 环境变量顺序解析
 - 只有 URI 环境变量都不存在时，才回落到 host/port + username/password + authSource
+- 若上述路径仍未提供账号密码，且本机存在 `mystocks-mongodb` 容器，脚本会尝试从容器初始化环境中读取 root 凭据作为 local-only fallback
+- 同样的 local-only fallback 也适用于共享 CLI 入口 `coordctl.py` / `maestro_collab.py` 的 Mongo control-plane 命令
 
-当前仓库实测可直接无参运行：
+只有在当前会话已经提供可写 Mongo 凭据时，才建议无参运行：
 
 ```bash
 python scripts/runtime/smoke_mongo_multicli.py
@@ -190,7 +200,8 @@ python scripts/runtime/smoke_mongo_multicli.py
 
 前提：
 
-- 项目根目录 `.env` 已提供可写 Mongo 凭据
+- 项目根目录 `.env` 或当前 shell 环境已提供可写 Mongo 凭据
+- 或本机 Docker 中存在可访问的 `mystocks-mongodb` 容器，并保留了初始化 root 凭据
 - 本机会话允许访问该 Mongo 实例
 
 输出示例：
@@ -211,6 +222,53 @@ python scripts/runtime/smoke_mongo_multicli.py
 - 执行 control-plane -> runtime -> status API 的 smoke 链路
 - 执行结束后自动删除临时数据库
 - 本地 Mongo 若开启鉴权，必须传入可写认证 URI
+- 若凭据无效或无写权限，相关 CLI / smoke / 导出 / 迁移脚本会返回结构化 JSON 错误，至少包含 `error_code` 与 `message`
+
+## Validated Local Commands
+
+在当前本机 WSL + Docker 环境下，以下命令已实际验证：
+
+```bash
+python scripts/runtime/coordctl.py work list --output json
+python scripts/runtime/smoke_mongo_multicli.py
+python scripts/runtime/smoke_graphiti_preflight.py --actor-cli cli-preflight
+python scripts/runtime/export_collab_snapshots.py --output-dir /tmp/mongo-collab-snapshots-codex
+```
+
+预期：
+
+- `coordctl.py work list --output json` 返回 Mongo control plane 中的 work item 列表
+- `smoke_mongo_multicli.py` 返回 `work_item_id=SMOKE-1` 与 `control_plane_status=ready_for_review`
+- `smoke_graphiti_preflight.py --actor-cli cli-preflight` 返回 `server_status=ok` 与 `search_outcome=hit`
+- `export_collab_snapshots.py --output-dir /tmp/mongo-collab-snapshots-codex` 在目标目录生成快照文件
+
+### One-Command Local Acceptance
+
+如果需要把 Mongo control plane、Graphiti preflight、以及快照导出串成一条本机验收链路，统一使用：
+
+```bash
+python scripts/runtime/run_local_maestro_acceptance.sh
+```
+
+该脚本会顺序执行并落盘：
+
+- `python scripts/runtime/coordctl.py work list --output json`
+- `python scripts/runtime/smoke_mongo_multicli.py`
+- `python scripts/runtime/smoke_graphiti_preflight.py --actor-cli cli-preflight`
+- `python scripts/runtime/export_collab_snapshots.py --output-dir /tmp/mongo-collab-snapshots-codex`
+
+默认输出位置：
+
+- `/tmp/maestro_work_list.json`
+- `/tmp/maestro_mongo_smoke.json`
+- `/tmp/maestro_graphiti_preflight.json`
+- `/tmp/mongo-collab-snapshots-codex`
+
+适用场景：
+
+- cleanup wave 收尾时做本机一键回归
+- 向主 CLI / reviewer 证明当前 Mongo + Graphiti 收敛线可复跑
+- 需要快速确认共享 CLI 入口与导出快照没有漂移
 
 ## Migration Scripts
 
@@ -257,6 +315,7 @@ python scripts/runtime/export_collab_snapshots.py \
 - 从 Mongo control plane 导出 Markdown 快照
 - 供主 CLI 审阅、归档、回放
 - 供 worker worktree 生成只读 `TASK.md` / `TASK-REPORT.md`
+- 在当前本机 WSL + Docker 环境下，若未显式传 `--mongo-uri`，该脚本同样会复用 `mystocks-mongodb` 容器的 local-only 凭据 fallback
 
 ### 2B. Export Worktree Task Artifacts
 
@@ -280,10 +339,10 @@ python scripts/runtime/coordctl.py work export-task-report <WORK_ITEM_ID> \
 
 - worker 不能直接改 `work_item` 定义
 - worker 只能读取/写入自己 owner 的任务范围
-- `work claim` / `plan add` / `plan mark` / `work submit` 已作为正式命令面提供
+- `work mark` / `update add` / `request create|review` / `work transition` 已作为正式命令面提供
 - `work_update` / `work_request` 会自动触发审计事件
-- `worker_status_views` 会在任务、claim、plan、update、request、submit 变化后自动刷新
-- `worker_status_views` 当前已汇总 claim、plan progress、delivery metadata
+- `worker_status_views` 会在任务、update、request 变化后自动刷新
+- `worker_status_views` 当前已汇总最新状态、最近更新、pending request 标记
 - 旧的 `assign/state/suggest` CLI 仍兼容
 - `tracker.kind: mongo` 已可直接驱动 runtime candidate dispatch
 

--- a/docs/guides/multi-cli-tasks/MONGO_MULTICLI_OPERATION_CHECKLIST.md
+++ b/docs/guides/multi-cli-tasks/MONGO_MULTICLI_OPERATION_CHECKLIST.md
@@ -47,10 +47,10 @@ python scripts/runtime/coordctl.py work export-task-report <WORK_ITEM_ID> --outp
 ### 复核时
 
 1. 查 Mongo：
-   - `claim`
-   - `plan`
-   - `submit`
-   - `ready_for_review`
+   - `work show`
+   - `work export-task-report`
+   - `request review`
+   - `work transition`
 2. 查 Graphiti：
    - handoff 摘要
    - 历史事实
@@ -65,7 +65,7 @@ python scripts/runtime/coordctl.py work export-task-report <WORK_ITEM_ID> --outp
    - `docs/guides/ai-tools/GRAPHITI_MCP_WORKFLOW.md`
    - 涉及的 `openspec` / `docs` / ownership 文件
 3. 先在 Mongo control plane 中开工留痕：
-   - `work claim`
+   - `work mark --status in_progress`
 4. 如需要历史上下文，再查 Graphiti：
    - 优先运行 `graphiti preflight`
    - 或手工执行 `get_status` / `search_nodes` / `search_memory_facts`
@@ -73,9 +73,10 @@ python scripts/runtime/coordctl.py work export-task-report <WORK_ITEM_ID> --outp
 ### 执行中
 
 1. 只修改任务范围内文件
-2. 任务分解走 Mongo：
-   - `plan add`
-   - `plan mark`
+2. 批次进展走 Mongo：
+   - `work mark`
+   - `update add`
+   - 如需审批或扩边界，使用 `request create`
 3. 每完成一个批次：
    - 在 `TASK-REPORT.md` 记录证据
    - 必要时向 Graphiti 写入 handoff / fact summary
@@ -85,9 +86,11 @@ python scripts/runtime/coordctl.py work export-task-report <WORK_ITEM_ID> --outp
 
 1. 做最小必要验证
 2. 更新 `TASK-REPORT.md`
-3. 在 Mongo control plane 中提交：
-   - `work submit`
+3. 在 Mongo control plane 中提审：
+   - `update add --status ready_for_review`
+   - `work transition --to ready_for_review`
 4. 不要只把状态写到 Graphiti 而跳过 Mongo
+5. 若 Mongo 凭据无效或无写权限，相关共享 CLI 会返回结构化 JSON 错误，至少包含 `error_code` 与 `message`
 
 ## Boundary Summary
 
@@ -97,7 +100,7 @@ python scripts/runtime/coordctl.py work export-task-report <WORK_ITEM_ID> --outp
 
 - work item lifecycle
 - owner / worker
-- claim / plan / submit
+- mark / update / request / transition
 - ready_for_review / verified / merged
 
 ### Graphiti
@@ -137,10 +140,22 @@ repo-local canonical 命令：
 ### Worker CLI
 
 ```text
-开工留痕 -> Mongo claim
+开工留痕 -> Mongo work mark --status in_progress
 Graphiti 预检 -> coordctl graphiti preflight
-做任务分解 -> Mongo plan
+记录批次进展 -> Mongo work mark / update add
 导出快照 -> coordctl work export-task / export-task-report
 写长期记忆 -> coordctl graphiti remember
-提审 -> Mongo submit
+提审 -> update add --status ready_for_review + work transition --to ready_for_review
 ```
+
+### One-Command Local Acceptance
+
+```bash
+python scripts/runtime/run_local_maestro_acceptance.sh
+```
+
+用途：
+
+- 串联 `coordctl work list`、Mongo smoke、Graphiti preflight、快照导出
+- 在本机快速复跑当前 Mongo / Graphiti 收敛线
+- 生成 `/tmp/maestro_work_list.json`、`/tmp/maestro_mongo_smoke.json`、`/tmp/maestro_graphiti_preflight.json` 与 `/tmp/mongo-collab-snapshots-codex`

--- a/governance/mainline/task-cards/pr-22.yaml
+++ b/governance/mainline/task-cards/pr-22.yaml
@@ -1,0 +1,90 @@
+version: "v0.2"
+
+task:
+  id: "pr-22"
+  title: "close the maestro local acceptance loop and align PR governance metadata"
+  owner: "main"
+  created_at: "2026-04-01"
+
+mainline:
+  id: "L1-maestro-local-acceptance"
+  objective: "land the one-command Maestro / Mongo / Graphiti acceptance entrypoint on main with matching documentation and governance metadata"
+  milestone_id: "L2-maestro-governance-closeout"
+  slice_id: "L3-local-acceptance-entrypoint"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "meta-governance-doc-and-runtime-acceptance-closeout"
+
+scope:
+  allowed_paths:
+    - "docs/guides/ai-tools/GRAPHITI_MCP_WORKFLOW.md"
+    - "docs/guides/multi-cli-tasks/MONGO_MULTICLI_COORDINATION_GUIDE.md"
+    - "docs/guides/multi-cli-tasks/MONGO_MULTICLI_OPERATION_CHECKLIST.md"
+    - "scripts/runtime/run_local_maestro_acceptance.sh"
+    - "tests/unit/docs/test_maestro_doc_sync.py"
+    - "tests/unit/runtime/test_local_maestro_acceptance_script.py"
+    - "governance/mainline/task-cards/pr-22.yaml"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No product feature work beyond the local acceptance entrypoint and its discoverability guardrails"
+  - "No scope expansion outside the declared docs, script, tests, and governance task card"
+
+acceptance:
+  checks:
+    - id: "doc-sync-and-script-tests"
+      command: "pytest tests/unit/docs/test_maestro_doc_sync.py tests/unit/runtime/test_local_maestro_acceptance_script.py -q --no-cov"
+      required: true
+    - id: "doc-sync-lint"
+      command: "ruff check tests/unit/docs/test_maestro_doc_sync.py"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-22.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the task card paths drift from the actual PR diff, the mainline governance gate will remain red"
+    - "If the one-command acceptance script and docs fall out of sync again, reviewers will see a discoverability regression instead of a runtime regression"
+  rollback_plan: "git revert <merge-commit-sha> if the acceptance entrypoint or governance card causes unexpected mainline gate regressions"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close the Maestro / Mongo / Graphiti acceptance line with one canonical local entrypoint and matching governance metadata"
+    modified_scope: "three documentation guides, one runtime acceptance script, two focused regression tests, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "existing collaboration CLI behavior stays unchanged; only discoverability, validation, and governance reporting are tightened"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the PR if governance scope enforcement or acceptance-script discoverability regresses after merge"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-01T00:00:00Z"
+    approval_note: "doc-and-runtime acceptance cleanup does not require a separate OpenSpec proposal"
+    secondary_approved: false

--- a/scripts/runtime/run_local_maestro_acceptance.sh
+++ b/scripts/runtime/run_local_maestro_acceptance.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+SNAPSHOT_DIR="/tmp/mongo-collab-snapshots-codex"
+
+cd "${PROJECT_ROOT}"
+
+echo "[1/4] coordctl work list"
+python scripts/runtime/coordctl.py work list --output json >/tmp/maestro_work_list.json
+echo "  wrote /tmp/maestro_work_list.json"
+
+echo "[2/4] mongo smoke"
+python scripts/runtime/smoke_mongo_multicli.py >/tmp/maestro_mongo_smoke.json
+echo "  wrote /tmp/maestro_mongo_smoke.json"
+
+echo "[3/4] graphiti preflight smoke"
+python scripts/runtime/smoke_graphiti_preflight.py --actor-cli cli-preflight >/tmp/maestro_graphiti_preflight.json
+echo "  wrote /tmp/maestro_graphiti_preflight.json"
+
+echo "[4/4] export collab snapshots"
+rm -rf /tmp/mongo-collab-snapshots-codex
+python scripts/runtime/export_collab_snapshots.py --output-dir /tmp/mongo-collab-snapshots-codex >/tmp/maestro_snapshot_export.txt
+echo "  wrote ${SNAPSHOT_DIR}"
+
+echo "Local Maestro acceptance completed."

--- a/tests/unit/docs/test_maestro_doc_sync.py
+++ b/tests/unit/docs/test_maestro_doc_sync.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_mongo_coordination_guide_uses_current_checklist_path_and_cli_surface() -> None:
+    guide = (PROJECT_ROOT / "docs" / "guides" / "multi-cli-tasks" / "MONGO_MULTICLI_COORDINATION_GUIDE.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "docs/guides/multi-cli-tasks/MONGO_MULTICLI_OPERATION_CHECKLIST.md" in guide
+    assert "docs/guides/MONGO_MULTICLI_OPERATION_CHECKLIST.md" not in guide
+    assert "python scripts/runtime/coordctl.py plan add" not in guide
+    assert "python scripts/runtime/coordctl.py plan mark" not in guide
+    assert "python scripts/runtime/coordctl.py work mark" in guide
+    assert "python scripts/runtime/coordctl.py update add" in guide
+    assert "python scripts/runtime/coordctl.py work transition" in guide
+    assert "mystocks-mongodb" in guide
+    assert "coordctl.py` / `maestro_collab.py`" in guide
+    assert "export_collab_snapshots.py" in guide
+    assert "`error_code`" in guide
+    assert "`message`" in guide
+    assert "python scripts/runtime/coordctl.py work list --output json" in guide
+    assert "python scripts/runtime/smoke_mongo_multicli.py" in guide
+    assert "python scripts/runtime/smoke_graphiti_preflight.py --actor-cli cli-preflight" in guide
+    assert "/tmp/mongo-collab-snapshots-codex" in guide
+    assert "python scripts/runtime/run_local_maestro_acceptance.sh" in guide
+
+
+def test_mongo_operation_checklist_matches_current_control_plane_commands() -> None:
+    checklist = (
+        PROJECT_ROOT / "docs" / "guides" / "multi-cli-tasks" / "MONGO_MULTICLI_OPERATION_CHECKLIST.md"
+    ).read_text(encoding="utf-8")
+
+    assert "`work claim`" not in checklist
+    assert "`plan add`" not in checklist
+    assert "`plan mark`" not in checklist
+    assert "`work submit`" not in checklist
+    assert "`work mark`" in checklist
+    assert "`update add`" in checklist
+    assert "`work transition`" in checklist
+    assert "`error_code`" in checklist
+    assert "`message`" in checklist
+    assert "python scripts/runtime/run_local_maestro_acceptance.sh" in checklist
+
+
+def test_graphiti_workflow_guide_mentions_structured_json_error_output() -> None:
+    guide = (PROJECT_ROOT / "docs" / "guides" / "ai-tools" / "GRAPHITI_MCP_WORKFLOW.md").read_text(encoding="utf-8")
+
+    assert "`error_code`" in guide
+    assert "`message`" in guide
+    assert "python scripts/runtime/smoke_graphiti_cli.py" in guide
+    assert "python scripts/runtime/smoke_graphiti_preflight.py --actor-cli cli-preflight" in guide
+    assert "python scripts/runtime/run_local_maestro_acceptance.sh" in guide

--- a/tests/unit/runtime/test_local_maestro_acceptance_script.py
+++ b/tests/unit/runtime/test_local_maestro_acceptance_script.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_local_maestro_acceptance_script_exists_and_references_validated_commands() -> None:
+    script_path = PROJECT_ROOT / "scripts" / "runtime" / "run_local_maestro_acceptance.sh"
+
+    assert script_path.is_file()
+
+    content = script_path.read_text(encoding="utf-8")
+    assert "python scripts/runtime/coordctl.py work list --output json" in content
+    assert "python scripts/runtime/smoke_mongo_multicli.py" in content
+    assert "python scripts/runtime/smoke_graphiti_preflight.py --actor-cli cli-preflight" in content
+    assert "python scripts/runtime/export_collab_snapshots.py --output-dir /tmp/mongo-collab-snapshots-codex" in content
+
+
+def test_local_maestro_acceptance_script_has_valid_bash_syntax() -> None:
+    script_path = PROJECT_ROOT / "scripts" / "runtime" / "run_local_maestro_acceptance.sh"
+
+    subprocess.run(["bash", "-n", str(script_path)], check=True)


### PR DESCRIPTION
## Summary
- add `run_local_maestro_acceptance.sh` as the one-command local acceptance path for the Maestro / Mongo / Graphiti convergence line
- document the acceptance entrypoint in the Mongo coordination guide, Mongo operation checklist, and Graphiti workflow guide
- lock script discoverability and shell validity with focused doc-sync and runtime tests

## Test Plan
- pytest tests/unit/docs/test_maestro_doc_sync.py tests/unit/runtime/test_local_maestro_acceptance_script.py -q --no-cov
- ruff check tests/unit/docs/test_maestro_doc_sync.py
