### PR TITLE
runtime: converge mongo and graphiti smoke config

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,15 @@
+---
+tracker:
+  kind: local
+  sqlite_path: $SYMPHONY_TRACKER_DB
+workspace:
+  root: $SYMPHONY_WORKSPACE_ROOT
+runtime:
+  cli_name: $MAESTRO_CLI_NAME
+  collab_backend: sqlite
+  collab_mongo_uri: mongodb://localhost:27017
+  collab_mongo_db: mystocks_coord
+---
+
+You are working on {{ issue.identifier }} ({{ issue.title }}).
+Follow AGENTS.md, stay inside the assigned scope, and record concrete verification evidence before handoff.

--- a/governance/mainline/task-cards/pr-23.yaml
+++ b/governance/mainline/task-cards/pr-23.yaml
@@ -1,0 +1,104 @@
+version: "v0.2"
+
+task:
+  id: "pr-23"
+  title: "converge mongo runtime configuration and graphiti smoke CLI support"
+  owner: "main"
+  created_at: "2026-04-01"
+
+mainline:
+  id: "L1-runtime-convergence"
+  objective: "land the shared Mongo runtime config and Graphiti smoke helper convergence on main with focused runtime verification"
+  milestone_id: "L2-runtime-convergence"
+  slice_id: "L3-mongo-graphiti-runtime"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "runtime-collab-convergence-is-infrastructure-not-product-domain-work"
+
+scope:
+  allowed_paths:
+    - "WORKFLOW.md"
+    - "governance/mainline/task-cards/pr-23.yaml"
+    - "scripts/runtime/export_collab_snapshots.py"
+    - "scripts/runtime/graphiti_smoke_common.py"
+    - "scripts/runtime/maestro_collab.py"
+    - "scripts/runtime/migrate_collab_to_mongo.py"
+    - "scripts/runtime/smoke_graphiti_cli.py"
+    - "scripts/runtime/smoke_graphiti_preflight.py"
+    - "scripts/runtime/smoke_mongo_multicli.py"
+    - "src/utils/cli_error_output.py"
+    - "src/utils/mongo_runtime_config.py"
+    - "tests/unit/core/test_runtime_config_governance.py"
+    - "tests/unit/maestro_collab/test_profile_defaults.py"
+    - "tests/unit/runtime/test_cli_error_output.py"
+    - "tests/unit/runtime/test_graphiti_smoke_common.py"
+    - "tests/unit/runtime/test_collab_migration_scripts.py"
+    - "tests/unit/runtime/test_maestro_coordination_cli.py"
+    - "tests/unit/runtime/test_smoke_graphiti_cli.py"
+    - "tests/unit/runtime/test_smoke_graphiti_preflight.py"
+    - "tests/unit/runtime/test_smoke_mongo_multicli.py"
+    - "tests/unit/services/symphony/test_run_symphony_cli.py"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No unrelated frontend or workflow cleanup outside the declared runtime convergence files"
+  - "No business-domain feature behavior change outside Mongo/Graphiti CLI runtime support"
+
+acceptance:
+  checks:
+    - id: "runtime-targeted-tests"
+      command: "pytest tests/unit/core/test_runtime_config_governance.py tests/unit/maestro_collab/test_profile_defaults.py tests/unit/runtime/test_cli_error_output.py tests/unit/runtime/test_graphiti_smoke_common.py tests/unit/runtime/test_collab_migration_scripts.py tests/unit/runtime/test_maestro_coordination_cli.py tests/unit/runtime/test_smoke_graphiti_cli.py tests/unit/runtime/test_smoke_graphiti_preflight.py tests/unit/runtime/test_smoke_mongo_multicli.py tests/unit/services/symphony/test_run_symphony_cli.py tests/unit/services/symphony/test_maestro_collab_cli.py tests/unit/services/maestro/test_task_report_graphiti_projection.py -q --no-cov"
+      required: true
+    - id: "runtime-ruff"
+      command: "ruff check scripts/runtime/export_collab_snapshots.py scripts/runtime/graphiti_smoke_common.py scripts/runtime/maestro_collab.py scripts/runtime/migrate_collab_to_mongo.py scripts/runtime/smoke_graphiti_cli.py scripts/runtime/smoke_graphiti_preflight.py scripts/runtime/smoke_mongo_multicli.py src/utils/cli_error_output.py src/utils/mongo_runtime_config.py tests/unit/core/test_runtime_config_governance.py tests/unit/maestro_collab/test_profile_defaults.py tests/unit/runtime/test_cli_error_output.py tests/unit/runtime/test_graphiti_smoke_common.py tests/unit/runtime/test_collab_migration_scripts.py tests/unit/runtime/test_maestro_coordination_cli.py tests/unit/runtime/test_smoke_graphiti_cli.py tests/unit/runtime/test_smoke_graphiti_preflight.py tests/unit/runtime/test_smoke_mongo_multicli.py tests/unit/services/symphony/test_run_symphony_cli.py"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-23.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Shared Mongo runtime helpers now sit under multiple runtime CLIs, so a bad fallback rule would fan out across smoke and migration entrypoints"
+    - "The root WORKFLOW.md asset is now part of the runtime CLI contract and should not silently drift from the tested expectations"
+  rollback_plan: "git revert <merge-commit-sha> if the shared Mongo/Graphiti runtime helpers regress CLI behavior or governance gates after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "remove duplicated Mongo/Graphiti runtime configuration and CLI error handling from the Maestro support scripts"
+    modified_scope: "runtime scripts, two shared utility modules, the root workflow definition, and focused runtime regression tests"
+    dependency_changes: "none"
+    legacy_logic_impact: "existing CLI behaviors are preserved while env parsing, docker fallback, and error JSON handling become shared"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the branch if runtime smoke, migration, or coordination CLI regress after merge"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-01T00:00:00Z"
+    approval_note: "runtime convergence cleanup does not introduce a new product capability"
+    secondary_approved: false

--- a/scripts/runtime/export_collab_snapshots.py
+++ b/scripts/runtime/export_collab_snapshots.py
@@ -6,31 +6,48 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from pymongo import MongoClient
+from pymongo.errors import OperationFailure
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from src.services.maestro.collab.backends.mongo.store import MongoCollaborationStore
+from src.utils.cli_error_output import print_cli_error
+from src.utils.mongo_runtime_config import (
+    build_mongo_auth_runtime_error,
+    build_runtime_mongo_client,
+    get_runtime_mongo_db_default,
+    get_runtime_mongo_uri_default,
+    is_mongo_auth_error,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Export Mongo collaboration work items as markdown snapshots.")
-    parser.add_argument("--mongo-uri", default="mongodb://localhost:27017")
-    parser.add_argument("--mongo-db", default="mystocks_coord")
+    parser.add_argument("--mongo-uri", default=get_runtime_mongo_uri_default("mongodb://localhost:27017"))
+    parser.add_argument("--mongo-db", default=get_runtime_mongo_db_default("mystocks_coord"))
     parser.add_argument("--output-dir", default="reports/governance/mongo-collab-snapshots")
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    database = MongoClient(args.mongo_uri)[args.mongo_db]
-    output_dir = Path(args.output_dir)
-    written_paths = export_work_item_snapshots(database=database, output_dir=output_dir)
-    for path in written_paths:
-        print(path)
-    return 0
+    try:
+        database = build_runtime_mongo_client(args.mongo_uri)[args.mongo_db]
+        output_dir = Path(args.output_dir)
+        written_paths = export_work_item_snapshots(database=database, output_dir=output_dir)
+        for path in written_paths:
+            print(path)
+        return 0
+    except OperationFailure as exc:
+        if is_mongo_auth_error(exc):
+            print_cli_error(build_mongo_auth_runtime_error("Mongo export"))
+            return 1
+        raise
+    except RuntimeError as exc:
+        print_cli_error(exc)
+        return 1
 
 
 def export_work_item_snapshots(*, database: Any, output_dir: Path) -> list[Path]:
@@ -212,7 +229,5 @@ def _extract_graphiti_projection(events: list[dict[str, Any]]) -> dict[str, str]
         "ingest_status": str(payload.get("ingest_status", "(none)")),
         "search_summary": str(payload.get("search_summary", "(none)")),
     }
-
-
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/runtime/graphiti_smoke_common.py
+++ b/scripts/runtime/graphiti_smoke_common.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import io
+import os
+import shlex
+import subprocess
+from contextlib import redirect_stdout
+from typing import Callable
+
+from src.utils.cli_error_output import build_external_command_runtime_error, parse_json_command_output
+
+
+def run_coordctl_json(argv: list[str], *, coordctl_main: Callable[[list[str]], int]) -> dict[str, object]:
+    command_prefix = os.getenv("GRAPHITI_SMOKE_COMMAND")
+    if command_prefix:
+        command = [*shlex.split(command_prefix), *argv]
+        try:
+            completed = subprocess.run(
+                command,
+                text=True,
+                capture_output=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise build_external_command_runtime_error(argv, exc) from exc
+        payload = completed.stdout.strip()
+        return parse_json_command_output(payload, argv=argv, source="external smoke command")
+
+    buffer = io.StringIO()
+    with redirect_stdout(buffer):
+        exit_code = coordctl_main(argv)
+    if exit_code != 0:
+        raise RuntimeError(f"coordctl failed for argv={argv!r}")
+    payload = buffer.getvalue().strip()
+    return parse_json_command_output(payload, argv=argv, source="coordctl")

--- a/scripts/runtime/maestro_collab.py
+++ b/scripts/runtime/maestro_collab.py
@@ -8,8 +8,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from uuid import uuid4
 
-from dotenv import load_dotenv
 from pymongo import MongoClient
+from pymongo.errors import OperationFailure
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
@@ -27,7 +27,14 @@ from src.services.maestro.collab.backends.mongo import MongoCollaborationStore
 from src.services.maestro.collab.services import CoordinationService, GraphitiPreflightService
 from src.services.maestro.collab.store.models import WorkItemRecord, WorkRequestRecord, WorkUpdateRecord
 from src.services.maestro.profiles.mystocks import COLLAB_CONTROL_PLANE_DEFAULTS
-from src.utils.mongo_runtime_config import get_mongo_connection_kwargs
+from src.utils.cli_error_output import build_cli_error_payload
+from src.utils.mongo_runtime_config import (
+    build_mongo_auth_runtime_error,
+    build_project_runtime_mongo_client,
+    get_runtime_mongo_db_default,
+    get_runtime_mongo_uri_default,
+    is_mongo_auth_error,
+)
 from scripts.runtime.export_collab_snapshots import render_task_markdown, render_task_report_markdown
 
 GRAPHITI_CLI_EXAMPLES = """Examples:
@@ -293,12 +300,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--sqlite-path", default=".symphony/tracker.db", help="Path to the local tracker sqlite DB.")
     parser.add_argument(
         "--mongo-uri",
-        default=None,
-        help="MongoDB URI for coordination state. If omitted, use env/config-driven Mongo connection settings.",
+        default=get_runtime_mongo_uri_default(COLLAB_CONTROL_PLANE_DEFAULTS["mongo_uri"]),
+        help="MongoDB URI for coordination state.",
     )
     parser.add_argument(
         "--mongo-db",
-        default=COLLAB_CONTROL_PLANE_DEFAULTS["mongo_db"],
+        default=get_runtime_mongo_db_default(COLLAB_CONTROL_PLANE_DEFAULTS["mongo_db"]),
         help="MongoDB database name for coordination state.",
     )
 
@@ -497,7 +504,13 @@ def main(argv: list[str] | None = None) -> int:
                 return 0
         finally:
             registry.close()
-    except (AuthorizationError, KeyError, ValueError) as exc:
+    except OperationFailure as exc:
+        output = getattr(args, "output", "json")
+        if is_mongo_auth_error(exc):
+            _emit_error(build_mongo_auth_runtime_error("Mongo control plane"), output=output)
+            return 1
+        raise
+    except (AuthorizationError, KeyError, ValueError, RuntimeError) as exc:
         output = getattr(args, "output", "json")
         _emit_error(exc, output=output)
         return 1
@@ -528,11 +541,7 @@ def _build_graphiti_facade(args: argparse.Namespace) -> _GraphitiFacade:
 
 
 def _build_mongo_client(mongo_uri: str | None) -> MongoClient:
-    if mongo_uri:
-        return MongoClient(mongo_uri)
-
-    load_dotenv(PROJECT_ROOT / ".env", override=False)
-    return MongoClient(**get_mongo_connection_kwargs(server_selection_timeout_ms=3000))
+    return build_project_runtime_mongo_client(PROJECT_ROOT, mongo_uri, server_selection_timeout_ms=3000)
 
 
 def _handle_coordination_command(args: argparse.Namespace, service: _MongoCoordinationFacade) -> tuple[dict | list[dict] | str, str]:
@@ -730,11 +739,7 @@ def _emit(payload: dict | list[dict] | str, *, output: str) -> None:
 
 
 def _emit_error(error: Exception, *, output: str) -> None:
-    payload = {
-        "error_code": error.__class__.__name__,
-        "message": str(error),
-        "audit_id": f"err-{uuid4().hex[:12]}",
-    }
+    payload = build_cli_error_payload(error, audit_id=f"err-{uuid4().hex[:12]}")
     _emit(payload, output=output)
 
 

--- a/scripts/runtime/migrate_collab_to_mongo.py
+++ b/scripts/runtime/migrate_collab_to_mongo.py
@@ -9,7 +9,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from pymongo import MongoClient
+from pymongo.errors import OperationFailure
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
@@ -18,13 +18,21 @@ if str(PROJECT_ROOT) not in sys.path:
 from src.services.maestro.collab.runtime_registry import MongoCollaborationRegistry
 from src.services.maestro.collab.backends.mongo.store import MongoCollaborationStore
 from src.services.maestro.collab.store.models import WorkItemRecord, WorkUpdateRecord
+from src.utils.cli_error_output import print_cli_error
+from src.utils.mongo_runtime_config import (
+    build_mongo_auth_runtime_error,
+    build_runtime_mongo_client,
+    get_runtime_mongo_db_default,
+    get_runtime_mongo_uri_default,
+    is_mongo_auth_error,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Migrate SQLite collab runtime state into MongoDB.")
     parser.add_argument("--sqlite-path", default=".symphony/tracker.db")
-    parser.add_argument("--mongo-uri", default="mongodb://localhost:27017")
-    parser.add_argument("--mongo-db", default="mystocks_coord")
+    parser.add_argument("--mongo-uri", default=get_runtime_mongo_uri_default("mongodb://localhost:27017"))
+    parser.add_argument("--mongo-db", default=get_runtime_mongo_db_default("mystocks_coord"))
     parser.add_argument("--task-path", default=None)
     parser.add_argument("--report-path", default=None)
     return parser
@@ -32,17 +40,26 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    mongo_database = MongoClient(args.mongo_uri)[args.mongo_db]
-    counts = migrate_runtime_registry(sqlite_path=Path(args.sqlite_path), mongo_database=mongo_database)
-    if args.task_path or args.report_path:
-        task_counts = migrate_markdown_contract(
-            task_path=Path(args.task_path) if args.task_path else Path("TASK.md"),
-            report_path=Path(args.report_path) if args.report_path else Path("TASK-REPORT.md"),
-            mongo_database=mongo_database,
-        )
-        counts.update(task_counts)
-    print(json.dumps(counts, ensure_ascii=False, indent=2, sort_keys=True))
-    return 0
+    try:
+        mongo_database = build_runtime_mongo_client(args.mongo_uri)[args.mongo_db]
+        counts = migrate_runtime_registry(sqlite_path=Path(args.sqlite_path), mongo_database=mongo_database)
+        if args.task_path or args.report_path:
+            task_counts = migrate_markdown_contract(
+                task_path=Path(args.task_path) if args.task_path else Path("TASK.md"),
+                report_path=Path(args.report_path) if args.report_path else Path("TASK-REPORT.md"),
+                mongo_database=mongo_database,
+            )
+            counts.update(task_counts)
+        print(json.dumps(counts, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+    except OperationFailure as exc:
+        if is_mongo_auth_error(exc):
+            print_cli_error(build_mongo_auth_runtime_error("Mongo migration"))
+            return 1
+        raise
+    except RuntimeError as exc:
+        print_cli_error(exc)
+        return 1
 
 
 def migrate_runtime_registry(*, sqlite_path: Path, mongo_database: Any) -> dict[str, int]:
@@ -150,7 +167,5 @@ def _table_exists(connection: sqlite3.Connection, table_name: str) -> bool:
         (table_name,),
     ).fetchone()
     return row is not None
-
-
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/runtime/smoke_graphiti_cli.py
+++ b/scripts/runtime/smoke_graphiti_cli.py
@@ -1,13 +1,8 @@
 from __future__ import annotations
 
 import argparse
-import io
 import json
-import os
-import shlex
-import subprocess
 import sys
-from contextlib import redirect_stdout
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -15,6 +10,10 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from scripts.runtime import coordctl
+from scripts.runtime.graphiti_smoke_common import run_coordctl_json
+from src.utils.cli_error_output import (
+    print_cli_error,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -30,16 +29,20 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    summary = run_smoke(
-        actor_cli=args.actor_cli,
-        group_id=args.group_id,
-        name=args.name,
-        body=args.body,
-        query=args.query,
-        max_wait_seconds=args.max_wait_seconds,
-    )
-    print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
-    return 0
+    try:
+        summary = run_smoke(
+            actor_cli=args.actor_cli,
+            group_id=args.group_id,
+            name=args.name,
+            body=args.body,
+            query=args.query,
+            max_wait_seconds=args.max_wait_seconds,
+        )
+        print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+    except RuntimeError as exc:
+        print_cli_error(exc)
+        return 1
 
 
 def run_smoke(
@@ -101,29 +104,7 @@ def run_smoke(
 
 
 def _run_coordctl_json(argv: list[str]) -> dict[str, object]:
-    command_prefix = os.getenv("GRAPHITI_SMOKE_COMMAND")
-    if command_prefix:
-        command = [*shlex.split(command_prefix), *argv]
-        completed = subprocess.run(
-            command,
-            text=True,
-            capture_output=True,
-            check=True,
-        )
-        payload = completed.stdout.strip()
-        if not payload:
-            raise RuntimeError(f"external smoke command returned no output for argv={argv!r}")
-        return json.loads(payload)
-
-    buffer = io.StringIO()
-    with redirect_stdout(buffer):
-        exit_code = coordctl.main(argv)
-    if exit_code != 0:
-        raise RuntimeError(f"coordctl failed for argv={argv!r}")
-    payload = buffer.getvalue().strip()
-    if not payload:
-        raise RuntimeError(f"coordctl returned no output for argv={argv!r}")
-    return json.loads(payload)
+    return run_coordctl_json(argv, coordctl_main=coordctl.main)
 
 
 if __name__ == "__main__":

--- a/scripts/runtime/smoke_graphiti_preflight.py
+++ b/scripts/runtime/smoke_graphiti_preflight.py
@@ -1,30 +1,35 @@
 from __future__ import annotations
 
 import argparse
-import io
 import json
-import os
-import shlex
-import subprocess
 import sys
-from contextlib import redirect_stdout
 from datetime import UTC, datetime
 from pathlib import Path
 from uuid import uuid4
 
 from dotenv import load_dotenv
 from pymongo import MongoClient
+from pymongo.errors import OperationFailure
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from scripts.runtime import coordctl
+from scripts.runtime.graphiti_smoke_common import run_coordctl_json
 from src.services.maestro.collab.authz import ActorIdentity
 from src.services.maestro.collab.backends.mongo.store import MongoCollaborationStore
 from src.services.maestro.collab.services import CoordinationService
 from src.services.maestro.collab.store.models import WorkItemRecord
-from src.utils.mongo_runtime_config import build_mongo_connection_uri, get_mongo_connection_kwargs
+from src.utils.cli_error_output import (
+    print_cli_error,
+)
+from src.utils.mongo_runtime_config import (
+    build_mongo_auth_runtime_error,
+    build_project_runtime_mongo_client,
+    get_effective_runtime_mongo_uri,
+    is_mongo_auth_error,
+)
 
 SMOKE_WORK_ITEM_ID = "GRAPHITI-PREFLIGHT-SMOKE"
 
@@ -40,14 +45,23 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    summary = run_smoke(
-        mongo_uri=args.mongo_uri,
-        mongo_db=args.mongo_db,
-        actor_cli=args.actor_cli,
-        max_wait_seconds=args.max_wait_seconds,
-    )
-    print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
-    return 0
+    try:
+        summary = run_smoke(
+            mongo_uri=args.mongo_uri,
+            mongo_db=args.mongo_db,
+            actor_cli=args.actor_cli,
+            max_wait_seconds=args.max_wait_seconds,
+        )
+        print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+    except OperationFailure as exc:
+        if is_mongo_auth_error(exc):
+            print_cli_error(build_mongo_auth_runtime_error("Graphiti preflight smoke"))
+            return 1
+        raise
+    except RuntimeError as exc:
+        print_cli_error(exc)
+        return 1
 
 
 def run_smoke(
@@ -122,44 +136,15 @@ def run_smoke(
 
 
 def _build_mongo_client(mongo_uri: str | None) -> MongoClient:
-    if mongo_uri:
-        return MongoClient(mongo_uri)
-    load_dotenv(PROJECT_ROOT / ".env", override=False)
-    return MongoClient(**get_mongo_connection_kwargs(server_selection_timeout_ms=3000))
+    return build_project_runtime_mongo_client(PROJECT_ROOT, mongo_uri, server_selection_timeout_ms=3000)
 
 
 def _resolve_effective_mongo_uri(mongo_uri: str | None) -> str:
-    if mongo_uri:
-        return mongo_uri
     load_dotenv(PROJECT_ROOT / ".env", override=False)
-    return build_mongo_connection_uri()
+    return get_effective_runtime_mongo_uri(mongo_uri)
 
 
 def _run_coordctl_json(argv: list[str]) -> dict[str, object]:
-    command_prefix = os.getenv("GRAPHITI_SMOKE_COMMAND")
-    if command_prefix:
-        command = [*shlex.split(command_prefix), *argv]
-        completed = subprocess.run(
-            command,
-            text=True,
-            capture_output=True,
-            check=True,
-        )
-        payload = completed.stdout.strip()
-        if not payload:
-            raise RuntimeError(f"external smoke command returned no output for argv={argv!r}")
-        return json.loads(payload)
-
-    buffer = io.StringIO()
-    with redirect_stdout(buffer):
-        exit_code = coordctl.main(argv)
-    if exit_code != 0:
-        raise RuntimeError(f"coordctl failed for argv={argv!r}")
-    payload = buffer.getvalue().strip()
-    if not payload:
-        raise RuntimeError(f"coordctl returned no output for argv={argv!r}")
-    return json.loads(payload)
-
-
+    return run_coordctl_json(argv, coordctl_main=coordctl.main)
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/runtime/smoke_mongo_multicli.py
+++ b/scripts/runtime/smoke_mongo_multicli.py
@@ -8,8 +8,8 @@ from pathlib import Path
 from uuid import uuid4
 
 from fastapi.testclient import TestClient
-from dotenv import load_dotenv
 from pymongo import MongoClient
+from pymongo.errors import OperationFailure
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(PROJECT_ROOT) not in sys.path:
@@ -24,7 +24,12 @@ from src.services.symphony.mongo_tracker import MongoWorkItemTrackerClient
 from src.services.symphony.models import WorkflowDefinition
 from src.services.symphony.orchestrator import SymphonyOrchestrator
 from src.services.symphony.status_api import create_status_app
-from src.utils.mongo_runtime_config import get_mongo_connection_kwargs
+from src.utils.cli_error_output import print_cli_error
+from src.utils.mongo_runtime_config import (
+    build_mongo_auth_runtime_error,
+    build_project_runtime_mongo_client,
+    is_mongo_auth_error,
+)
 
 
 class _SmokeRunnerFactory:
@@ -41,9 +46,13 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    summary = run_smoke(mongo_uri=args.mongo_uri, mongo_db=args.mongo_db)
-    print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
-    return 0
+    try:
+        summary = run_smoke(mongo_uri=args.mongo_uri, mongo_db=args.mongo_db)
+        print(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+    except RuntimeError as exc:
+        _emit_error(exc)
+        return 1
 
 
 def run_smoke(*, mongo_uri: str | None, mongo_db: str | None = None) -> dict[str, object]:
@@ -53,8 +62,7 @@ def run_smoke(*, mongo_uri: str | None, mongo_db: str | None = None) -> dict[str
 
     try:
         database = client[db_name]
-        should_drop_database = True
-        service = CoordinationService(database_store := __import__(
+        service = CoordinationService(__import__(
             "src.services.maestro.collab.backends.mongo.store",
             fromlist=["MongoCollaborationStore"],
         ).MongoCollaborationStore(database))
@@ -79,6 +87,7 @@ def run_smoke(*, mongo_uri: str | None, mongo_db: str | None = None) -> dict[str
             ),
             work_item,
         )
+        should_drop_database = True
 
         workflow_definition = WorkflowDefinition(
             config={
@@ -129,6 +138,10 @@ def run_smoke(*, mongo_uri: str | None, mongo_db: str | None = None) -> dict[str
             "control_plane_status": control_plane[0]["status"] if control_plane else None,
             "status_api_control_plane_count": state_payload["control_plane"]["count"],
         }
+    except OperationFailure as exc:
+        if is_mongo_auth_error(exc):
+            raise RuntimeError(_build_auth_error_message(mongo_uri=mongo_uri, db_name=db_name, error=exc)) from exc
+        raise
     finally:
         try:
             if should_drop_database:
@@ -138,10 +151,27 @@ def run_smoke(*, mongo_uri: str | None, mongo_db: str | None = None) -> dict[str
 
 
 def _build_mongo_client(mongo_uri: str | None) -> MongoClient:
+    return build_project_runtime_mongo_client(PROJECT_ROOT, mongo_uri, server_selection_timeout_ms=3000)
+
+
+def _build_auth_error_message(*, mongo_uri: str | None, db_name: str, error: OperationFailure) -> str:
     if mongo_uri:
-        return MongoClient(mongo_uri)
-    load_dotenv(PROJECT_ROOT / ".env", override=False)
-    return MongoClient(**get_mongo_connection_kwargs(server_selection_timeout_ms=3000))
+        credential_hint = f"the provided --mongo-uri for database '{db_name}'"
+    else:
+        credential_hint = (
+            "a writable Mongo URI via --mongo-uri or one of "
+            "MAESTRO_COLLAB_MONGO_URI/COLLAB_MONGO_URI/MONGODB_URI/MONGO_URI"
+        )
+
+    return (
+        f"{build_mongo_auth_runtime_error('Mongo smoke')}. "
+        f"Provide {credential_hint}. "
+        f"Original error: {error}"
+    )
+
+
+def _emit_error(error: Exception) -> None:
+    print_cli_error(error)
 
 
 if __name__ == "__main__":

--- a/src/utils/cli_error_output.py
+++ b/src/utils/cli_error_output.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+
+
+def build_cli_error_payload(error: Exception, *, audit_id: str | None = None) -> dict[str, str]:
+    payload = {
+        "error_code": error.__class__.__name__,
+        "message": str(error),
+    }
+    if audit_id:
+        payload["audit_id"] = audit_id
+    return payload
+
+
+def render_cli_error_json(error: Exception, *, audit_id: str | None = None) -> str:
+    return json.dumps(build_cli_error_payload(error, audit_id=audit_id), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def print_cli_error(error: Exception, *, audit_id: str | None = None) -> None:
+    print(render_cli_error_json(error, audit_id=audit_id))
+
+
+def build_external_command_runtime_error(argv: list[str], error: Exception, *, prefix: str = "external smoke command failed") -> RuntimeError:
+    detail = getattr(error, "stderr", None) or str(error)
+    return RuntimeError(f"{prefix} for argv={argv!r}: {detail}")
+
+
+def parse_json_command_output(payload: str, *, argv: list[str], source: str) -> dict[str, object]:
+    if not payload:
+        raise RuntimeError(f"{source} returned no output for argv={argv!r}")
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{source} returned invalid JSON for argv={argv!r}") from exc

--- a/src/utils/cli_error_output.py
+++ b/src/utils/cli_error_output.py
@@ -21,7 +21,9 @@ def print_cli_error(error: Exception, *, audit_id: str | None = None) -> None:
     print(render_cli_error_json(error, audit_id=audit_id))
 
 
-def build_external_command_runtime_error(argv: list[str], error: Exception, *, prefix: str = "external smoke command failed") -> RuntimeError:
+def build_external_command_runtime_error(
+    argv: list[str], error: Exception, *, prefix: str = "external smoke command failed"
+) -> RuntimeError:
     detail = getattr(error, "stderr", None) or str(error)
     return RuntimeError(f"{prefix} for argv={argv!r}: {detail}")
 

--- a/src/utils/mongo_runtime_config.py
+++ b/src/utils/mongo_runtime_config.py
@@ -11,14 +11,14 @@ from pymongo import MongoClient
 from pymongo.errors import OperationFailure
 
 
-DEFAULT_MONGODB_HOST = 'localhost'
+DEFAULT_MONGODB_HOST = "localhost"
 DEFAULT_MONGODB_PORT = 27017
-DEFAULT_MONGODB_DATABASE = 'mystocks'
-DEFAULT_MONGODB_AUTH_SOURCE = 'admin'
+DEFAULT_MONGODB_DATABASE = "mystocks"
+DEFAULT_MONGODB_AUTH_SOURCE = "admin"
 
 
 def _normalize_secret(value: str | None) -> str | None:
-    if value is None or value == '':
+    if value is None or value == "":
         return None
     return value
 
@@ -26,44 +26,44 @@ def _normalize_secret(value: str | None) -> str | None:
 def _split_legacy_host_port(raw_value: str | None) -> Tuple[str | None, int | None]:
     if not raw_value:
         return None, None
-    if ':' not in raw_value:
+    if ":" not in raw_value:
         return raw_value, None
-    host, port = raw_value.rsplit(':', 1)
+    host, port = raw_value.rsplit(":", 1)
     return host.strip() or None, int(port)
 
 
 def get_mongo_host(default: str = DEFAULT_MONGODB_HOST) -> str:
-    if os.getenv('MONGODB_HOST'):
-        return os.getenv('MONGODB_HOST', default)
-    host, _ = _split_legacy_host_port(os.getenv('MONGODB_IP'))
+    if os.getenv("MONGODB_HOST"):
+        return os.getenv("MONGODB_HOST", default)
+    host, _ = _split_legacy_host_port(os.getenv("MONGODB_IP"))
     return host or default
 
 
 def get_mongo_port(default: int = DEFAULT_MONGODB_PORT) -> int:
-    if os.getenv('MONGODB_PORT'):
-        return int(os.getenv('MONGODB_PORT', str(default)))
-    _, port = _split_legacy_host_port(os.getenv('MONGODB_IP'))
+    if os.getenv("MONGODB_PORT"):
+        return int(os.getenv("MONGODB_PORT", str(default)))
+    _, port = _split_legacy_host_port(os.getenv("MONGODB_IP"))
     return port or default
 
 
 def get_mongo_username() -> str | None:
-    return os.getenv('MONGODB_ROOT_USERNAME') or None
+    return os.getenv("MONGODB_ROOT_USERNAME") or None
 
 
 def get_mongo_password() -> str | None:
-    return _normalize_secret(os.getenv('MONGODB_ROOT_PASSWORD'))
+    return _normalize_secret(os.getenv("MONGODB_ROOT_PASSWORD"))
 
 
 def get_mongo_database(default: str = DEFAULT_MONGODB_DATABASE) -> str:
-    return os.getenv('MONGODB_DATABASE', default)
+    return os.getenv("MONGODB_DATABASE", default)
 
 
 def get_mongo_auth_source(default: str = DEFAULT_MONGODB_AUTH_SOURCE) -> str:
-    return os.getenv('MONGODB_AUTH_SOURCE', default)
+    return os.getenv("MONGODB_AUTH_SOURCE", default)
 
 
 def get_mongo_connection_uri() -> str | None:
-    for key in ('MAESTRO_COLLAB_MONGO_URI', 'COLLAB_MONGO_URI', 'MONGODB_URI', 'MONGO_URI'):
+    for key in ("MAESTRO_COLLAB_MONGO_URI", "COLLAB_MONGO_URI", "MONGODB_URI", "MONGO_URI"):
         value = os.getenv(key)
         if value:
             return value
@@ -75,16 +75,16 @@ def get_runtime_mongo_uri_default(default: str) -> str:
 
 
 def get_runtime_mongo_db_default(default: str) -> str:
-    return os.getenv('MAESTRO_COLLAB_MONGO_DB', default)
+    return os.getenv("MAESTRO_COLLAB_MONGO_DB", default)
 
 
-def get_effective_runtime_mongo_uri(mongo_uri: str | None, *, default_database: str = 'admin') -> str:
+def get_effective_runtime_mongo_uri(mongo_uri: str | None, *, default_database: str = "admin") -> str:
     if mongo_uri:
         return inject_local_docker_auth_into_uri(mongo_uri)
     return inject_local_docker_auth_into_uri(build_mongo_connection_uri(default_database=default_database))
 
 
-def build_mongo_connection_uri(*, default_database: str = 'admin') -> str:
+def build_mongo_connection_uri(*, default_database: str = "admin") -> str:
     explicit_uri = get_mongo_connection_uri()
     if explicit_uri:
         return explicit_uri
@@ -95,20 +95,20 @@ def build_mongo_connection_uri(*, default_database: str = 'admin') -> str:
     password = get_mongo_password()
     auth_source = get_mongo_auth_source()
 
-    auth_prefix = ''
+    auth_prefix = ""
     if username:
         auth_prefix = quote_plus(username)
         if password:
-            auth_prefix = f'{auth_prefix}:{quote_plus(password)}'
-        auth_prefix = f'{auth_prefix}@'
+            auth_prefix = f"{auth_prefix}:{quote_plus(password)}"
+        auth_prefix = f"{auth_prefix}@"
 
-    return f'mongodb://{auth_prefix}{host}:{port}/{default_database}?authSource={quote_plus(auth_source)}'
+    return f"mongodb://{auth_prefix}{host}:{port}/{default_database}?authSource={quote_plus(auth_source)}"
 
 
-def read_local_docker_mongo_env(container_name: str = 'mystocks-mongodb') -> dict[str, str]:
+def read_local_docker_mongo_env(container_name: str = "mystocks-mongodb") -> dict[str, str]:
     try:
         result = subprocess.run(
-            ['docker', 'inspect', container_name, '--format', '{{json .Config.Env}}'],
+            ["docker", "inspect", container_name, "--format", "{{json .Config.Env}}"],
             capture_output=True,
             text=True,
             check=False,
@@ -129,61 +129,61 @@ def read_local_docker_mongo_env(container_name: str = 'mystocks-mongodb') -> dic
 
     env_map: dict[str, str] = {}
     for entry in env_entries:
-        if not isinstance(entry, str) or '=' not in entry:
+        if not isinstance(entry, str) or "=" not in entry:
             continue
-        key, value = entry.split('=', 1)
+        key, value = entry.split("=", 1)
         env_map[key] = value
     return env_map
 
 
-def inject_local_docker_auth_into_uri(mongo_uri: str, *, container_name: str = 'mystocks-mongodb') -> str:
+def inject_local_docker_auth_into_uri(mongo_uri: str, *, container_name: str = "mystocks-mongodb") -> str:
     parsed = urlparse(mongo_uri)
     if parsed.username or parsed.password:
         return mongo_uri
-    if parsed.hostname not in {'localhost', '127.0.0.1', '::1'}:
+    if parsed.hostname not in {"localhost", "127.0.0.1", "::1"}:
         return mongo_uri
 
     env_map = read_local_docker_mongo_env(container_name=container_name)
-    username = env_map.get('MONGO_INITDB_ROOT_USERNAME')
-    password = env_map.get('MONGO_INITDB_ROOT_PASSWORD')
+    username = env_map.get("MONGO_INITDB_ROOT_USERNAME")
+    password = env_map.get("MONGO_INITDB_ROOT_PASSWORD")
     if not username or not password:
         return mongo_uri
 
-    hostname = parsed.hostname or 'localhost'
-    if ':' in hostname and not hostname.startswith('['):
-        hostname = f'[{hostname}]'
-    port = f':{parsed.port}' if parsed.port else ''
-    netloc = f'{quote_plus(username)}:{quote_plus(password)}@{hostname}{port}'
+    hostname = parsed.hostname or "localhost"
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    port = f":{parsed.port}" if parsed.port else ""
+    netloc = f"{quote_plus(username)}:{quote_plus(password)}@{hostname}{port}"
     return parsed._replace(netloc=netloc).geturl()
 
 
 def merge_local_docker_auth_into_connection_kwargs(
     kwargs: Dict[str, Any],
     *,
-    container_name: str = 'mystocks-mongodb',
+    container_name: str = "mystocks-mongodb",
 ) -> Dict[str, Any]:
-    host = str(kwargs.get('host') or '')
-    username = kwargs.get('username')
-    password = kwargs.get('password')
+    host = str(kwargs.get("host") or "")
+    username = kwargs.get("username")
+    password = kwargs.get("password")
 
     if username or password:
         return kwargs
-    if host.startswith('mongodb://'):
+    if host.startswith("mongodb://"):
         return kwargs
-    if host not in {'localhost', '127.0.0.1', '::1'}:
+    if host not in {"localhost", "127.0.0.1", "::1"}:
         return kwargs
 
     env_map = read_local_docker_mongo_env(container_name=container_name)
-    docker_username = env_map.get('MONGO_INITDB_ROOT_USERNAME')
-    docker_password = env_map.get('MONGO_INITDB_ROOT_PASSWORD')
+    docker_username = env_map.get("MONGO_INITDB_ROOT_USERNAME")
+    docker_password = env_map.get("MONGO_INITDB_ROOT_PASSWORD")
     if not docker_username or not docker_password:
         return kwargs
 
     return {
         **kwargs,
-        'username': docker_username,
-        'password': docker_password,
-        'authSource': str(kwargs.get('authSource') or 'admin'),
+        "username": docker_username,
+        "password": docker_password,
+        "authSource": str(kwargs.get("authSource") or "admin"),
     }
 
 
@@ -191,18 +191,20 @@ def is_mongo_auth_error(error: Exception) -> bool:
     if not isinstance(error, OperationFailure):
         return False
 
-    code_name = str((error.details or {}).get('codeName', '')).lower()
+    code_name = str((error.details or {}).get("codeName", "")).lower()
     message = str(error).lower()
-    return error.code in {13, 18} or code_name in {'unauthorized', 'authenticationfailed'} or any(
-        fragment in message for fragment in ('requires authentication', 'authentication failed')
+    return (
+        error.code in {13, 18}
+        or code_name in {"unauthorized", "authenticationfailed"}
+        or any(fragment in message for fragment in ("requires authentication", "authentication failed"))
     )
 
 
 def build_mongo_auth_runtime_error(subject: str) -> RuntimeError:
     return RuntimeError(
-        f'{subject} requires writable credentials. '
-        'Provide --mongo-uri, set MAESTRO_COLLAB_MONGO_URI/COLLAB_MONGO_URI/MONGODB_URI/MONGO_URI, '
-        'or ensure the local mystocks-mongodb Docker container is reachable.'
+        f"{subject} requires writable credentials. "
+        "Provide --mongo-uri, set MAESTRO_COLLAB_MONGO_URI/COLLAB_MONGO_URI/MONGODB_URI/MONGO_URI, "
+        "or ensure the local mystocks-mongodb Docker container is reachable."
     )
 
 
@@ -227,7 +229,7 @@ def build_project_runtime_mongo_client(
     server_selection_timeout_ms: int = 3000,
 ) -> MongoClient:
     if mongo_uri is None:
-        load_dotenv(project_root / '.env', override=False)
+        load_dotenv(project_root / ".env", override=False)
     return build_runtime_mongo_client(mongo_uri, server_selection_timeout_ms=server_selection_timeout_ms)
 
 
@@ -235,16 +237,16 @@ def get_mongo_connection_kwargs(*, server_selection_timeout_ms: int | None = Non
     mongo_uri = get_mongo_connection_uri()
     if mongo_uri:
         kwargs: Dict[str, Any] = {
-            'host': mongo_uri,
+            "host": mongo_uri,
         }
     else:
         kwargs = {
-            'host': get_mongo_host(),
-            'port': get_mongo_port(),
-            'username': get_mongo_username(),
-            'password': get_mongo_password(),
-            'authSource': get_mongo_auth_source(),
+            "host": get_mongo_host(),
+            "port": get_mongo_port(),
+            "username": get_mongo_username(),
+            "password": get_mongo_password(),
+            "authSource": get_mongo_auth_source(),
         }
     if server_selection_timeout_ms is not None:
-        kwargs['serverSelectionTimeoutMS'] = server_selection_timeout_ms
+        kwargs["serverSelectionTimeoutMS"] = server_selection_timeout_ms
     return kwargs

--- a/src/utils/mongo_runtime_config.py
+++ b/src/utils/mongo_runtime_config.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import json
 import os
+import subprocess
 from typing import Any, Dict, Tuple
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus, urlparse
+
+from dotenv import load_dotenv
+from pymongo import MongoClient
+from pymongo.errors import OperationFailure
 
 
 DEFAULT_MONGODB_HOST = 'localhost'
@@ -64,6 +70,20 @@ def get_mongo_connection_uri() -> str | None:
     return None
 
 
+def get_runtime_mongo_uri_default(default: str) -> str:
+    return get_mongo_connection_uri() or default
+
+
+def get_runtime_mongo_db_default(default: str) -> str:
+    return os.getenv('MAESTRO_COLLAB_MONGO_DB', default)
+
+
+def get_effective_runtime_mongo_uri(mongo_uri: str | None, *, default_database: str = 'admin') -> str:
+    if mongo_uri:
+        return inject_local_docker_auth_into_uri(mongo_uri)
+    return inject_local_docker_auth_into_uri(build_mongo_connection_uri(default_database=default_database))
+
+
 def build_mongo_connection_uri(*, default_database: str = 'admin') -> str:
     explicit_uri = get_mongo_connection_uri()
     if explicit_uri:
@@ -83,6 +103,132 @@ def build_mongo_connection_uri(*, default_database: str = 'admin') -> str:
         auth_prefix = f'{auth_prefix}@'
 
     return f'mongodb://{auth_prefix}{host}:{port}/{default_database}?authSource={quote_plus(auth_source)}'
+
+
+def read_local_docker_mongo_env(container_name: str = 'mystocks-mongodb') -> dict[str, str]:
+    try:
+        result = subprocess.run(
+            ['docker', 'inspect', container_name, '--format', '{{json .Config.Env}}'],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return {}
+
+    if result.returncode != 0 or not result.stdout.strip():
+        return {}
+
+    try:
+        env_entries = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {}
+
+    if not isinstance(env_entries, list):
+        return {}
+
+    env_map: dict[str, str] = {}
+    for entry in env_entries:
+        if not isinstance(entry, str) or '=' not in entry:
+            continue
+        key, value = entry.split('=', 1)
+        env_map[key] = value
+    return env_map
+
+
+def inject_local_docker_auth_into_uri(mongo_uri: str, *, container_name: str = 'mystocks-mongodb') -> str:
+    parsed = urlparse(mongo_uri)
+    if parsed.username or parsed.password:
+        return mongo_uri
+    if parsed.hostname not in {'localhost', '127.0.0.1', '::1'}:
+        return mongo_uri
+
+    env_map = read_local_docker_mongo_env(container_name=container_name)
+    username = env_map.get('MONGO_INITDB_ROOT_USERNAME')
+    password = env_map.get('MONGO_INITDB_ROOT_PASSWORD')
+    if not username or not password:
+        return mongo_uri
+
+    hostname = parsed.hostname or 'localhost'
+    if ':' in hostname and not hostname.startswith('['):
+        hostname = f'[{hostname}]'
+    port = f':{parsed.port}' if parsed.port else ''
+    netloc = f'{quote_plus(username)}:{quote_plus(password)}@{hostname}{port}'
+    return parsed._replace(netloc=netloc).geturl()
+
+
+def merge_local_docker_auth_into_connection_kwargs(
+    kwargs: Dict[str, Any],
+    *,
+    container_name: str = 'mystocks-mongodb',
+) -> Dict[str, Any]:
+    host = str(kwargs.get('host') or '')
+    username = kwargs.get('username')
+    password = kwargs.get('password')
+
+    if username or password:
+        return kwargs
+    if host.startswith('mongodb://'):
+        return kwargs
+    if host not in {'localhost', '127.0.0.1', '::1'}:
+        return kwargs
+
+    env_map = read_local_docker_mongo_env(container_name=container_name)
+    docker_username = env_map.get('MONGO_INITDB_ROOT_USERNAME')
+    docker_password = env_map.get('MONGO_INITDB_ROOT_PASSWORD')
+    if not docker_username or not docker_password:
+        return kwargs
+
+    return {
+        **kwargs,
+        'username': docker_username,
+        'password': docker_password,
+        'authSource': str(kwargs.get('authSource') or 'admin'),
+    }
+
+
+def is_mongo_auth_error(error: Exception) -> bool:
+    if not isinstance(error, OperationFailure):
+        return False
+
+    code_name = str((error.details or {}).get('codeName', '')).lower()
+    message = str(error).lower()
+    return error.code in {13, 18} or code_name in {'unauthorized', 'authenticationfailed'} or any(
+        fragment in message for fragment in ('requires authentication', 'authentication failed')
+    )
+
+
+def build_mongo_auth_runtime_error(subject: str) -> RuntimeError:
+    return RuntimeError(
+        f'{subject} requires writable credentials. '
+        'Provide --mongo-uri, set MAESTRO_COLLAB_MONGO_URI/COLLAB_MONGO_URI/MONGODB_URI/MONGO_URI, '
+        'or ensure the local mystocks-mongodb Docker container is reachable.'
+    )
+
+
+def build_runtime_mongo_client(
+    mongo_uri: str | None,
+    *,
+    server_selection_timeout_ms: int = 3000,
+) -> MongoClient:
+    if mongo_uri:
+        return MongoClient(inject_local_docker_auth_into_uri(mongo_uri))
+
+    kwargs = merge_local_docker_auth_into_connection_kwargs(
+        get_mongo_connection_kwargs(server_selection_timeout_ms=server_selection_timeout_ms)
+    )
+    return MongoClient(**kwargs)
+
+
+def build_project_runtime_mongo_client(
+    project_root,
+    mongo_uri: str | None,
+    *,
+    server_selection_timeout_ms: int = 3000,
+) -> MongoClient:
+    if mongo_uri is None:
+        load_dotenv(project_root / '.env', override=False)
+    return build_runtime_mongo_client(mongo_uri, server_selection_timeout_ms=server_selection_timeout_ms)
 
 
 def get_mongo_connection_kwargs(*, server_selection_timeout_ms: int | None = None) -> Dict[str, Any]:

--- a/tests/unit/core/test_runtime_config_governance.py
+++ b/tests/unit/core/test_runtime_config_governance.py
@@ -140,6 +140,182 @@ def test_build_mongo_connection_uri_constructs_uri_from_standard_env_names(monke
     assert build_mongo_connection_uri() == 'mongodb://root-user:root-pass@mongo-host:27019/admin?authSource=admin'
 
 
+def test_inject_local_docker_auth_into_uri_adds_credentials_for_localhost_uri(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.utils import mongo_runtime_config
+
+    monkeypatch.setattr(
+        mongo_runtime_config,
+        'read_local_docker_mongo_env',
+        lambda container_name='mystocks-mongodb': {
+            'MONGO_INITDB_ROOT_USERNAME': 'mongo',
+            'MONGO_INITDB_ROOT_PASSWORD': 'secret',
+        },
+    )
+
+    resolved = mongo_runtime_config.inject_local_docker_auth_into_uri('mongodb://localhost:27017/admin?authSource=admin')
+
+    assert resolved == 'mongodb://mongo:secret@localhost:27017/admin?authSource=admin'
+
+
+def test_merge_local_docker_auth_into_connection_kwargs_adds_credentials_for_localhost_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from src.utils import mongo_runtime_config
+
+    monkeypatch.setattr(
+        mongo_runtime_config,
+        'read_local_docker_mongo_env',
+        lambda container_name='mystocks-mongodb': {
+            'MONGO_INITDB_ROOT_USERNAME': 'mongo',
+            'MONGO_INITDB_ROOT_PASSWORD': 'secret',
+        },
+    )
+
+    resolved = mongo_runtime_config.merge_local_docker_auth_into_connection_kwargs(
+        {
+            'host': '127.0.0.1',
+            'port': 27017,
+            'username': None,
+            'password': None,
+            'authSource': 'admin',
+            'serverSelectionTimeoutMS': 3000,
+        }
+    )
+
+    assert resolved == {
+        'host': '127.0.0.1',
+        'port': 27017,
+        'username': 'mongo',
+        'password': 'secret',
+        'authSource': 'admin',
+        'serverSelectionTimeoutMS': 3000,
+    }
+
+
+def test_build_runtime_mongo_client_prefers_explicit_uri_with_local_injection(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.utils import mongo_runtime_config
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        mongo_runtime_config,
+        'inject_local_docker_auth_into_uri',
+        lambda uri, **_: 'mongodb://mongo:secret@localhost:27017/admin?authSource=admin',
+    )
+    monkeypatch.setattr(
+        mongo_runtime_config,
+        'MongoClient',
+        lambda uri: captured.update({'mongo_uri': uri}) or object(),
+    )
+
+    mongo_runtime_config.build_runtime_mongo_client('mongodb://localhost:27017/admin?authSource=admin')
+
+    assert captured['mongo_uri'] == 'mongodb://mongo:secret@localhost:27017/admin?authSource=admin'
+
+
+def test_build_runtime_mongo_client_uses_env_kwargs_when_uri_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.utils import mongo_runtime_config
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        mongo_runtime_config,
+        'get_mongo_connection_kwargs',
+        lambda **kwargs: {
+            'host': '127.0.0.1',
+            'port': 27017,
+            'username': None,
+            'password': None,
+            'authSource': 'admin',
+            'serverSelectionTimeoutMS': kwargs['server_selection_timeout_ms'],
+        },
+    )
+    monkeypatch.setattr(
+        mongo_runtime_config,
+        'merge_local_docker_auth_into_connection_kwargs',
+        lambda kwargs, **_: {**kwargs, 'username': 'mongo', 'password': 'secret'},
+    )
+    monkeypatch.setattr(
+        mongo_runtime_config,
+        'MongoClient',
+        lambda **kwargs: captured.update({'client_kwargs': kwargs}) or object(),
+    )
+
+    mongo_runtime_config.build_runtime_mongo_client(None)
+
+    assert captured['client_kwargs'] == {
+        'host': '127.0.0.1',
+        'port': 27017,
+        'username': 'mongo',
+        'password': 'secret',
+        'authSource': 'admin',
+        'serverSelectionTimeoutMS': 3000,
+    }
+
+
+def test_get_runtime_mongo_uri_default_prefers_env_uri(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('MAESTRO_COLLAB_MONGO_URI', 'mongodb://coord-user:coord-pass@mongo-host:27017/admin?authSource=admin')
+
+    from src.utils.mongo_runtime_config import get_runtime_mongo_uri_default
+
+    assert get_runtime_mongo_uri_default('mongodb://localhost:27017') == (
+        'mongodb://coord-user:coord-pass@mongo-host:27017/admin?authSource=admin'
+    )
+
+
+def test_get_runtime_mongo_db_default_prefers_env_db(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv('MAESTRO_COLLAB_MONGO_DB', 'coord_runtime')
+
+    from src.utils.mongo_runtime_config import get_runtime_mongo_db_default
+
+    assert get_runtime_mongo_db_default('mystocks_coord') == 'coord_runtime'
+
+
+def test_get_effective_runtime_mongo_uri_injects_local_docker_auth_when_uri_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    from src.utils import mongo_runtime_config
+
+    monkeypatch.setattr(
+        mongo_runtime_config,
+        'build_mongo_connection_uri',
+        lambda default_database='admin': 'mongodb://127.0.0.1:27017/admin?authSource=admin',
+    )
+    monkeypatch.setattr(
+        mongo_runtime_config,
+        'inject_local_docker_auth_into_uri',
+        lambda uri, **_: 'mongodb://mongo:secret@127.0.0.1:27017/admin?authSource=admin',
+    )
+
+    assert mongo_runtime_config.get_effective_runtime_mongo_uri(None) == (
+        'mongodb://mongo:secret@127.0.0.1:27017/admin?authSource=admin'
+    )
+
+
+def test_build_project_runtime_mongo_client_loads_dotenv_before_building(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from src.utils import mongo_runtime_config
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        mongo_runtime_config,
+        'load_dotenv',
+        lambda path, override=False: captured.update({'dotenv_path': str(path), 'override': override}),
+    )
+    monkeypatch.setattr(
+        mongo_runtime_config,
+        'build_runtime_mongo_client',
+        lambda mongo_uri, server_selection_timeout_ms=3000: captured.update(
+            {'mongo_uri': mongo_uri, 'timeout': server_selection_timeout_ms}
+        )
+        or object(),
+    )
+
+    mongo_runtime_config.build_project_runtime_mongo_client(tmp_path, None, server_selection_timeout_ms=1234)
+
+    assert captured == {
+        'dotenv_path': str(tmp_path / '.env'),
+        'override': False,
+        'mongo_uri': None,
+        'timeout': 1234,
+    }
+
+
 def test_database_connection_manager_uses_role_aware_redis_kwargs() -> None:
     with patch('dotenv.load_dotenv', return_value=True):
         module = importlib.import_module('src.storage.database.connection_manager')
@@ -194,7 +370,8 @@ def test_redis_manager_uses_role_aware_redis_kwargs() -> None:
 
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     module = importlib.util.module_from_spec(spec)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
 
     fake_settings = type(
         'FakeSettings',
@@ -262,7 +439,8 @@ def test_app_container_uses_role_aware_redis_kwargs() -> None:
 
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     module = importlib.util.module_from_spec(spec)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
 
     fake_redis_client = MagicMock()
     fake_redis_module = MagicMock()
@@ -336,7 +514,8 @@ def test_initialize_realtime_mtm_uses_role_aware_redis_kwargs() -> None:
 
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     module = importlib.util.module_from_spec(spec)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
 
     fake_event_bus = MagicMock()
     fake_redis_event_bus_cls = MagicMock(return_value=fake_event_bus)
@@ -381,7 +560,8 @@ def test_redis_event_bus_defaults_to_monitoring_role_kwargs() -> None:
 
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     module = importlib.util.module_from_spec(spec)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
 
     fake_redis_client = MagicMock()
     fake_redis_module = MagicMock(Redis=MagicMock(return_value=fake_redis_client))
@@ -418,7 +598,8 @@ def test_redis_event_bus_preserves_explicit_db_argument() -> None:
 
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     module = importlib.util.module_from_spec(spec)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
 
     fake_redis_client = MagicMock()
     fake_redis_module = MagicMock(Redis=MagicMock(return_value=fake_redis_client))

--- a/tests/unit/maestro_collab/test_profile_defaults.py
+++ b/tests/unit/maestro_collab/test_profile_defaults.py
@@ -18,3 +18,13 @@ def test_maestro_collab_parser_uses_profile_defaults_for_mongo_settings() -> Non
 
     assert args.mongo_uri == mystocks.COLLAB_CONTROL_PLANE_DEFAULTS["mongo_uri"]
     assert args.mongo_db == mystocks.COLLAB_CONTROL_PLANE_DEFAULTS["mongo_db"]
+
+
+def test_maestro_collab_parser_prefers_env_mongo_defaults(monkeypatch) -> None:
+    monkeypatch.setenv("MAESTRO_COLLAB_MONGO_URI", "mongodb://coord-user:coord-pass@mongo-host:27017/admin?authSource=admin")
+    monkeypatch.setenv("MAESTRO_COLLAB_MONGO_DB", "coord_runtime")
+
+    args = build_parser().parse_args(["work", "list"])
+
+    assert args.mongo_uri == "mongodb://coord-user:coord-pass@mongo-host:27017/admin?authSource=admin"
+    assert args.mongo_db == "coord_runtime"

--- a/tests/unit/runtime/test_cli_error_output.py
+++ b/tests/unit/runtime/test_cli_error_output.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import pytest
+
+from src.utils.cli_error_output import (
+    build_cli_error_payload,
+    build_external_command_runtime_error,
+    parse_json_command_output,
+    print_cli_error,
+    render_cli_error_json,
+)
+
+
+def test_build_cli_error_payload_includes_error_code_and_message() -> None:
+    payload = build_cli_error_payload(RuntimeError("example failure"))
+
+    assert payload == {
+        "error_code": "RuntimeError",
+        "message": "example failure",
+    }
+
+
+def test_build_cli_error_payload_can_include_audit_id() -> None:
+    payload = build_cli_error_payload(ValueError("bad input"), audit_id="err-123")
+
+    assert payload == {
+        "audit_id": "err-123",
+        "error_code": "ValueError",
+        "message": "bad input",
+    }
+
+
+def test_render_cli_error_json_serializes_payload() -> None:
+    rendered = render_cli_error_json(RuntimeError("boom"), audit_id="err-9")
+
+    assert json.loads(rendered) == {
+        "audit_id": "err-9",
+        "error_code": "RuntimeError",
+        "message": "boom",
+    }
+
+
+def test_build_external_command_runtime_error_uses_stderr_when_available() -> None:
+    error = subprocess.CalledProcessError(1, ["fake", "cmd"], output="out", stderr="boom")
+
+    runtime_error = build_external_command_runtime_error(["graphiti", "search"], error)
+
+    assert "external smoke command failed" in str(runtime_error)
+    assert "graphiti" in str(runtime_error)
+    assert "boom" in str(runtime_error)
+
+
+def test_parse_json_command_output_returns_payload_on_valid_json() -> None:
+    payload = parse_json_command_output('{"ok": true}', argv=["graphiti", "search"], source="coordctl")
+
+    assert payload == {"ok": True}
+
+
+def test_parse_json_command_output_raises_on_empty_output() -> None:
+    with pytest.raises(RuntimeError, match="coordctl returned no output"):
+        parse_json_command_output("", argv=["graphiti", "search"], source="coordctl")
+
+
+def test_parse_json_command_output_raises_on_invalid_json() -> None:
+    with pytest.raises(RuntimeError, match="external smoke command returned invalid JSON"):
+        parse_json_command_output("not-json", argv=["graphiti", "search"], source="external smoke command")
+
+
+def test_print_cli_error_emits_rendered_json(capsys) -> None:
+    print_cli_error(RuntimeError("boom"), audit_id="err-7")
+
+    assert json.loads(capsys.readouterr().out) == {
+        "audit_id": "err-7",
+        "error_code": "RuntimeError",
+        "message": "boom",
+    }

--- a/tests/unit/runtime/test_collab_migration_scripts.py
+++ b/tests/unit/runtime/test_collab_migration_scripts.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
+
+from pymongo.errors import OperationFailure
 
 from src.services.maestro.collab.backends.mongo.store import MongoCollaborationStore
 from src.services.maestro.collab.models import AssignmentState
@@ -14,6 +17,7 @@ from scripts.runtime.export_collab_snapshots import (
     render_task_markdown,
     render_task_report_markdown,
 )
+from scripts.runtime import export_collab_snapshots
 from scripts.runtime import migrate_collab_to_mongo
 from scripts.runtime.migrate_collab_to_mongo import migrate_markdown_contract, migrate_runtime_registry
 
@@ -140,7 +144,7 @@ def test_migrate_cli_can_optionally_import_markdown_contract(monkeypatch, tmp_pa
     report_path.write_text("- Latest Progress: imported", encoding="utf-8")
     fake_database = _FakeMongoDatabase()
 
-    monkeypatch.setattr("scripts.runtime.migrate_collab_to_mongo.MongoClient", lambda _uri: _FakeMongoClient(fake_database))
+    monkeypatch.setattr("scripts.runtime.migrate_collab_to_mongo.build_runtime_mongo_client", lambda *_args, **_kwargs: _FakeMongoClient(fake_database))
 
     exit_code = migrate_collab_to_mongo.main(
         [
@@ -160,6 +164,108 @@ def test_migrate_cli_can_optionally_import_markdown_contract(monkeypatch, tmp_pa
     assert exit_code == 0
     payload = capsys.readouterr().out
     assert "work_items" in payload
+
+
+def test_migrate_cli_can_inject_local_docker_credentials_for_default_local_uri(monkeypatch, tmp_path: Path, capsys) -> None:
+    fake_database = _FakeMongoDatabase()
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "scripts.runtime.migrate_collab_to_mongo.build_runtime_mongo_client",
+        lambda mongo_uri, **_kwargs: captured.update({"mongo_uri": mongo_uri}) or _FakeMongoClient(fake_database),
+    )
+
+    exit_code = migrate_collab_to_mongo.main(
+        [
+            "--sqlite-path",
+            str(tmp_path / "tracker.db"),
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["mongo_uri"] == "mongodb://localhost:27017"
+    assert "assignments" in capsys.readouterr().out
+
+
+def test_export_collab_snapshots_cli_can_inject_local_docker_credentials_for_default_local_uri(
+    monkeypatch, tmp_path: Path, capsys
+) -> None:
+    fake_database = _FakeMongoDatabase()
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "scripts.runtime.export_collab_snapshots.build_runtime_mongo_client",
+        lambda mongo_uri, **_kwargs: captured.update({"mongo_uri": mongo_uri}) or _FakeMongoClient(fake_database),
+    )
+
+    exit_code = export_collab_snapshots.main(
+        [
+            "--output-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["mongo_uri"] == "mongodb://localhost:27017"
+    assert capsys.readouterr().out == ""
+
+
+def test_export_collab_snapshots_parser_prefers_env_mongo_uri(monkeypatch) -> None:
+    monkeypatch.setenv("MAESTRO_COLLAB_MONGO_URI", "mongodb://coord-user:coord-pass@mongo-host:27017/admin?authSource=admin")
+
+    args = export_collab_snapshots.build_parser().parse_args([])
+
+    assert args.mongo_uri == "mongodb://coord-user:coord-pass@mongo-host:27017/admin?authSource=admin"
+
+
+def test_migrate_cli_parser_prefers_env_mongo_uri(monkeypatch) -> None:
+    monkeypatch.setenv("MAESTRO_COLLAB_MONGO_URI", "mongodb://coord-user:coord-pass@mongo-host:27017/admin?authSource=admin")
+    monkeypatch.setenv("MAESTRO_COLLAB_MONGO_DB", "coord_runtime")
+
+    args = migrate_collab_to_mongo.build_parser().parse_args([])
+
+    assert args.mongo_uri == "mongodb://coord-user:coord-pass@mongo-host:27017/admin?authSource=admin"
+    assert args.mongo_db == "coord_runtime"
+
+
+def test_migrate_cli_emits_structured_json_error_when_mongo_auth_fails(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        "scripts.runtime.migrate_collab_to_mongo.build_runtime_mongo_client",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            OperationFailure(
+                "Authentication failed.",
+                18,
+                {"ok": 0.0, "errmsg": "Authentication failed.", "code": 18, "codeName": "AuthenticationFailed"},
+            )
+        ),
+    )
+
+    exit_code = migrate_collab_to_mongo.main([])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error_code"] == "RuntimeError"
+    assert "Mongo migration requires writable credentials" in payload["message"]
+
+
+def test_export_collab_snapshots_cli_emits_structured_json_error_when_mongo_auth_fails(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        "scripts.runtime.export_collab_snapshots.build_runtime_mongo_client",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            OperationFailure(
+                "createIndexes requires authentication",
+                13,
+                {"ok": 0.0, "errmsg": "createIndexes requires authentication", "code": 13, "codeName": "Unauthorized"},
+            )
+        ),
+    )
+
+    exit_code = export_collab_snapshots.main([])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error_code"] == "RuntimeError"
+    assert "Mongo export requires writable credentials" in payload["message"]
 
 
 def test_render_task_artifacts_from_mongo_records() -> None:

--- a/tests/unit/runtime/test_graphiti_smoke_common.py
+++ b/tests/unit/runtime/test_graphiti_smoke_common.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from scripts.runtime import graphiti_smoke_common
+
+
+def test_run_coordctl_json_uses_external_command_prefix(monkeypatch) -> None:
+    monkeypatch.setenv("GRAPHITI_SMOKE_COMMAND", "/tmp/fake-cmd")
+    monkeypatch.setattr(
+        graphiti_smoke_common.subprocess,
+        "run",
+        lambda *_args, **_kwargs: type(
+            "CompletedProcess",
+            (),
+            {"stdout": '{"ok": true}', "stderr": "", "returncode": 0},
+        )(),
+    )
+
+    payload = graphiti_smoke_common.run_coordctl_json(["graphiti", "search"], coordctl_main=lambda _argv: 0)
+
+    assert payload == {"ok": True}
+
+
+def test_run_coordctl_json_wraps_external_failure(monkeypatch) -> None:
+    monkeypatch.setenv("GRAPHITI_SMOKE_COMMAND", "/tmp/fake-cmd")
+
+    def _raise(*_args, **_kwargs):
+        raise subprocess.CalledProcessError(1, ["fake", "cmd"], output="out", stderr="boom")
+
+    monkeypatch.setattr(graphiti_smoke_common.subprocess, "run", _raise)
+
+    with pytest.raises(RuntimeError, match="external smoke command failed"):
+        graphiti_smoke_common.run_coordctl_json(["graphiti", "search"], coordctl_main=lambda _argv: 0)
+
+
+def test_run_coordctl_json_uses_coordctl_main_when_no_external_prefix(monkeypatch) -> None:
+    monkeypatch.delenv("GRAPHITI_SMOKE_COMMAND", raising=False)
+
+    def _coordctl_main(_argv: list[str]) -> int:
+        print(json.dumps({"ok": True}))
+        return 0
+
+    payload = graphiti_smoke_common.run_coordctl_json(["graphiti", "search"], coordctl_main=_coordctl_main)
+
+    assert payload == {"ok": True}

--- a/tests/unit/runtime/test_maestro_coordination_cli.py
+++ b/tests/unit/runtime/test_maestro_coordination_cli.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 
-import pytest
+from pymongo.errors import OperationFailure
 
 from scripts.runtime import maestro_collab
 
@@ -228,20 +228,14 @@ def test_build_coordination_service_uses_env_driven_mongo_client_when_uri_omitte
             captured["mongo_db"] = name
             return object()
 
-    monkeypatch.setattr(maestro_collab, "load_dotenv", lambda path, override=False: captured.update({"dotenv_path": str(path)}))
     monkeypatch.setattr(
         maestro_collab,
-        "get_mongo_connection_kwargs",
-        lambda **kwargs: {
-            "host": "mongo.local",
-            "port": 27017,
-            "username": "coord",
-            "password": "secret",
-            "authSource": "admin",
-            "serverSelectionTimeoutMS": kwargs["server_selection_timeout_ms"],
-        },
+        "build_project_runtime_mongo_client",
+        lambda project_root, mongo_uri, server_selection_timeout_ms=3000: captured.update(
+            {"project_root": str(project_root), "mongo_uri": mongo_uri, "server_selection_timeout_ms": server_selection_timeout_ms}
+        )
+        or _FakeClient(),
     )
-    monkeypatch.setattr(maestro_collab, "MongoClient", lambda **kwargs: captured.update({"client_kwargs": kwargs}) or _FakeClient())
     monkeypatch.setattr(maestro_collab, "MongoCollaborationStore", lambda database: captured.update({"database": database}) or object())
     monkeypatch.setattr(maestro_collab, "CoordinationService", lambda store: captured.update({"store": store}) or object())
 
@@ -249,15 +243,66 @@ def test_build_coordination_service_uses_env_driven_mongo_client_when_uri_omitte
 
     assert isinstance(facade, maestro_collab._MongoCoordinationFacade)
     assert captured["mongo_db"] == "mystocks_coord"
-    assert captured["client_kwargs"] == {
-        "host": "mongo.local",
-        "port": 27017,
-        "username": "coord",
-        "password": "secret",
-        "authSource": "admin",
-        "serverSelectionTimeoutMS": 3000,
-    }
-    assert str(maestro_collab.PROJECT_ROOT / ".env") == captured["dotenv_path"]
+    assert captured["mongo_uri"] is None
+    assert captured["server_selection_timeout_ms"] == 3000
+    assert str(maestro_collab.PROJECT_ROOT) == captured["project_root"]
+
+
+def test_build_coordination_service_can_fallback_to_local_docker_container_credentials(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeClient:
+        def __getitem__(self, name: str):
+            captured["mongo_db"] = name
+            return object()
+
+    monkeypatch.setattr(
+        maestro_collab,
+        "build_project_runtime_mongo_client",
+        lambda project_root, mongo_uri, server_selection_timeout_ms=3000: captured.update(
+            {"project_root": str(project_root), "mongo_uri": mongo_uri, "server_selection_timeout_ms": server_selection_timeout_ms}
+        )
+        or _FakeClient(),
+    )
+    monkeypatch.setattr(maestro_collab, "MongoCollaborationStore", lambda database: captured.update({"database": database}) or object())
+    monkeypatch.setattr(maestro_collab, "CoordinationService", lambda store: captured.update({"store": store}) or object())
+
+    facade = maestro_collab._build_coordination_service(argparse.Namespace(mongo_uri=None, mongo_db="mystocks_coord"))
+
+    assert isinstance(facade, maestro_collab._MongoCoordinationFacade)
+    assert captured["mongo_db"] == "mystocks_coord"
+    assert str(maestro_collab.PROJECT_ROOT) == captured["project_root"]
+    assert captured["mongo_uri"] is None
+    assert captured["server_selection_timeout_ms"] == 3000
+
+
+def test_build_coordination_service_can_inject_local_docker_credentials_for_default_local_uri(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeClient:
+        def __getitem__(self, name: str):
+            captured["mongo_db"] = name
+            return object()
+
+    monkeypatch.setattr(
+        maestro_collab,
+        "build_project_runtime_mongo_client",
+        lambda project_root, mongo_uri, server_selection_timeout_ms=3000: captured.update(
+            {"project_root": str(project_root), "mongo_uri": mongo_uri, "server_selection_timeout_ms": server_selection_timeout_ms}
+        )
+        or _FakeClient(),
+    )
+    monkeypatch.setattr(maestro_collab, "MongoCollaborationStore", lambda database: captured.update({"database": database}) or object())
+    monkeypatch.setattr(maestro_collab, "CoordinationService", lambda store: captured.update({"store": store}) or object())
+
+    facade = maestro_collab._build_coordination_service(
+        argparse.Namespace(mongo_uri="mongodb://localhost:27017", mongo_db="mystocks_coord")
+    )
+
+    assert isinstance(facade, maestro_collab._MongoCoordinationFacade)
+    assert captured["mongo_db"] == "mystocks_coord"
+    assert str(maestro_collab.PROJECT_ROOT) == captured["project_root"]
+    assert captured["mongo_uri"] == "mongodb://localhost:27017"
 
 
 def test_build_coordination_service_prefers_explicit_mongo_uri(monkeypatch) -> None:
@@ -268,13 +313,14 @@ def test_build_coordination_service_prefers_explicit_mongo_uri(monkeypatch) -> N
             captured["mongo_db"] = name
             return object()
 
-    monkeypatch.setattr(maestro_collab, "load_dotenv", lambda *_args, **_kwargs: pytest.fail("load_dotenv should not run"))
     monkeypatch.setattr(
         maestro_collab,
-        "get_mongo_connection_kwargs",
-        lambda **_kwargs: pytest.fail("env-driven mongo kwargs should not be used when uri is explicit"),
+        "build_project_runtime_mongo_client",
+        lambda project_root, mongo_uri, server_selection_timeout_ms=3000: captured.update(
+            {"project_root": str(project_root), "mongo_uri": mongo_uri, "server_selection_timeout_ms": server_selection_timeout_ms}
+        )
+        or _FakeClient(),
     )
-    monkeypatch.setattr(maestro_collab, "MongoClient", lambda uri: captured.update({"mongo_uri": uri}) or _FakeClient())
     monkeypatch.setattr(maestro_collab, "MongoCollaborationStore", lambda database: captured.update({"database": database}) or object())
     monkeypatch.setattr(maestro_collab, "CoordinationService", lambda store: captured.update({"store": store}) or object())
 
@@ -283,8 +329,51 @@ def test_build_coordination_service_prefers_explicit_mongo_uri(monkeypatch) -> N
     )
 
     assert isinstance(facade, maestro_collab._MongoCoordinationFacade)
+    assert str(maestro_collab.PROJECT_ROOT) == captured["project_root"]
     assert captured["mongo_uri"] == "mongodb://user:pass@mongo.example:27017/admin?authSource=admin"
     assert captured["mongo_db"] == "mystocks_coord"
+
+
+def test_main_emits_structured_error_when_mongo_auth_fails(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        maestro_collab,
+        "_build_coordination_service",
+        lambda _args: (_ for _ in ()).throw(
+            OperationFailure(
+                "createIndexes requires authentication",
+                13,
+                {"ok": 0.0, "errmsg": "createIndexes requires authentication", "code": 13, "codeName": "Unauthorized"},
+            )
+        ),
+    )
+
+    exit_code = maestro_collab.main(["work", "list", "--output", "json"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error_code"] == "RuntimeError"
+    assert "Mongo control plane requires writable credentials" in payload["message"]
+
+
+def test_main_emits_structured_error_when_mongo_authentication_failed(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        maestro_collab,
+        "_build_coordination_service",
+        lambda _args: (_ for _ in ()).throw(
+            OperationFailure(
+                "Authentication failed.",
+                18,
+                {"ok": 0.0, "errmsg": "Authentication failed.", "code": 18, "codeName": "AuthenticationFailed"},
+            )
+        ),
+    )
+
+    exit_code = maestro_collab.main(["work", "list", "--output", "json"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error_code"] == "RuntimeError"
+    assert "Mongo control plane requires writable credentials" in payload["message"]
 
 
 class _FakeCoordinationService:

--- a/tests/unit/runtime/test_smoke_graphiti_cli.py
+++ b/tests/unit/runtime/test_smoke_graphiti_cli.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-import io
 import json
 import os
 import subprocess
+import pytest
 
 from scripts.runtime import smoke_graphiti_cli
+from scripts.runtime import graphiti_smoke_common
 
 
 def test_run_smoke_executes_remember_then_search_via_shared_cli(monkeypatch) -> None:
@@ -75,6 +76,33 @@ def test_main_emits_json_summary(monkeypatch, capsys) -> None:
     assert payload["remember_server_status"] == "ok"
 
 
+def test_main_emits_structured_json_error_when_run_smoke_fails(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        smoke_graphiti_cli,
+        "run_smoke",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("Graphiti smoke CLI failed")),
+    )
+
+    assert smoke_graphiti_cli.main(
+        [
+            "--actor-cli",
+            "cli-smoke",
+            "--group-id",
+            "mystocks_spec_smoke",
+            "--name",
+            "Smoke Memory",
+            "--body",
+            "Graphiti smoke body",
+            "--query",
+            "Smoke Memory",
+        ]
+    ) == 1
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error_code"] == "RuntimeError"
+    assert payload["message"] == "Graphiti smoke CLI failed"
+
+
 def test_smoke_graphiti_cli_script_runs_standalone_with_external_command(tmp_path) -> None:
     fake_command = tmp_path / "fake_coordctl.sh"
     fake_command.write_text(
@@ -123,3 +151,31 @@ def test_smoke_graphiti_cli_script_runs_standalone_with_external_command(tmp_pat
     payload = json.loads(completed.stdout)
     assert payload["episode_uuid"] == "ep-standalone"
     assert payload["search_outcome"] == "hit"
+
+
+def test_run_coordctl_json_wraps_external_command_failure_as_runtime_error(monkeypatch) -> None:
+    monkeypatch.setenv("GRAPHITI_SMOKE_COMMAND", "/tmp/fake-cmd")
+
+    def _raise(*_args, **_kwargs):
+        raise subprocess.CalledProcessError(1, ["fake", "cmd"], output="out", stderr="boom")
+
+    monkeypatch.setattr(graphiti_smoke_common.subprocess, "run", _raise)
+
+    with pytest.raises(RuntimeError, match="external smoke command failed"):
+        smoke_graphiti_cli._run_coordctl_json(["graphiti", "search"])
+
+
+def test_run_coordctl_json_wraps_invalid_external_json_as_runtime_error(monkeypatch) -> None:
+    monkeypatch.setenv("GRAPHITI_SMOKE_COMMAND", "/tmp/fake-cmd")
+    monkeypatch.setattr(
+        graphiti_smoke_common.subprocess,
+        "run",
+        lambda *_args, **_kwargs: type(
+            "CompletedProcess",
+            (),
+            {"stdout": "not-json", "stderr": "", "returncode": 0},
+        )(),
+    )
+
+    with pytest.raises(RuntimeError, match="external smoke command returned invalid JSON"):
+        smoke_graphiti_cli._run_coordctl_json(["graphiti", "search"])

--- a/tests/unit/runtime/test_smoke_graphiti_preflight.py
+++ b/tests/unit/runtime/test_smoke_graphiti_preflight.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
+from urllib.parse import parse_qs, urlparse
 
 import pytest
+import subprocess
 
 from scripts.runtime import smoke_graphiti_preflight
+from scripts.runtime import graphiti_smoke_common
 
 
 def test_run_smoke_creates_temp_work_item_and_runs_shared_preflight(monkeypatch) -> None:
@@ -12,6 +15,7 @@ def test_run_smoke_creates_temp_work_item_and_runs_shared_preflight(monkeypatch)
     calls: list[list[str]] = []
 
     monkeypatch.setattr(smoke_graphiti_preflight, "_build_mongo_client", lambda _mongo_uri: fake_client)
+    monkeypatch.setattr(smoke_graphiti_preflight, "get_effective_runtime_mongo_uri", lambda _mongo_uri: "mongodb://localhost:27017")
 
     def _fake_run(argv: list[str]) -> dict[str, object]:
         calls.append(argv)
@@ -66,6 +70,21 @@ def test_main_emits_json_summary(monkeypatch, capsys) -> None:
     assert payload["work_item_id"] == "GRAPHITI-PREFLIGHT-SMOKE"
 
 
+def test_main_emits_structured_json_error_when_run_smoke_fails(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        smoke_graphiti_preflight,
+        "run_smoke",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("Graphiti preflight smoke requires writable credentials")),
+    )
+
+    exit_code = smoke_graphiti_preflight.main(["--actor-cli", "cli-preflight"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error_code"] == "RuntimeError"
+    assert "Graphiti preflight smoke requires writable credentials" in payload["message"]
+
+
 def test_run_smoke_passes_resolved_mongo_uri_when_env_driven(monkeypatch) -> None:
     fake_client = _FakeMongoClient()
     calls: list[list[str]] = []
@@ -99,6 +118,24 @@ def test_run_smoke_passes_resolved_mongo_uri_when_env_driven(monkeypatch) -> Non
         "--mongo-db",
         "graphiti_preflight_smoke_db",
     ]
+
+
+def test_resolve_effective_mongo_uri_can_fallback_to_local_docker_container_credentials(monkeypatch) -> None:
+    monkeypatch.setattr(smoke_graphiti_preflight, "load_dotenv", lambda path, override=False: None)
+    monkeypatch.setattr(
+        smoke_graphiti_preflight,
+        "get_effective_runtime_mongo_uri",
+        lambda _mongo_uri: "mongodb://mongo:secret@127.0.0.1:27017/admin?authSource=admin",
+    )
+
+    resolved = smoke_graphiti_preflight._resolve_effective_mongo_uri(None)
+    parsed = urlparse(resolved)
+
+    assert parsed.username == "mongo"
+    assert parsed.password == "secret"
+    assert parsed.hostname == "127.0.0.1"
+    assert parsed.port == 27017
+    assert parse_qs(parsed.query)["authSource"] == ["admin"]
 
 
 def test_run_smoke_uses_unique_default_db_name(monkeypatch) -> None:
@@ -149,6 +186,34 @@ def test_run_smoke_skips_drop_database_when_mongo_setup_fails(monkeypatch) -> No
 
     assert fake_client.closed is True
     assert fake_client.drop_attempts == 0
+
+
+def test_run_coordctl_json_wraps_external_command_failure_as_runtime_error(monkeypatch) -> None:
+    monkeypatch.setenv("GRAPHITI_SMOKE_COMMAND", "/tmp/fake-cmd")
+
+    def _raise(*_args, **_kwargs):
+        raise subprocess.CalledProcessError(1, ["fake", "cmd"], output="out", stderr="boom")
+
+    monkeypatch.setattr(graphiti_smoke_common.subprocess, "run", _raise)
+
+    with pytest.raises(RuntimeError, match="external smoke command failed"):
+        smoke_graphiti_preflight._run_coordctl_json(["graphiti", "preflight"])
+
+
+def test_run_coordctl_json_wraps_invalid_external_json_as_runtime_error(monkeypatch) -> None:
+    monkeypatch.setenv("GRAPHITI_SMOKE_COMMAND", "/tmp/fake-cmd")
+    monkeypatch.setattr(
+        graphiti_smoke_common.subprocess,
+        "run",
+        lambda *_args, **_kwargs: type(
+            "CompletedProcess",
+            (),
+            {"stdout": "not-json", "stderr": "", "returncode": 0},
+        )(),
+    )
+
+    with pytest.raises(RuntimeError, match="external smoke command returned invalid JSON"):
+        smoke_graphiti_preflight._run_coordctl_json(["graphiti", "preflight"])
 
 
 class _FakeMongoClient:

--- a/tests/unit/runtime/test_smoke_mongo_multicli.py
+++ b/tests/unit/runtime/test_smoke_mongo_multicli.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
-import os
+import json
 
 import pytest
+from pymongo.errors import OperationFailure
 
+from scripts.runtime import smoke_mongo_multicli
 from scripts.runtime.smoke_mongo_multicli import run_smoke
 
 
 def test_run_smoke_returns_summary_with_control_plane_and_status_views(monkeypatch) -> None:
     fake_client = _FakeMongoClient()
-    monkeypatch.setattr("scripts.runtime.smoke_mongo_multicli.MongoClient", lambda *_args, **_kwargs: fake_client)
+    monkeypatch.setattr("scripts.runtime.smoke_mongo_multicli.build_project_runtime_mongo_client", lambda *_args, **_kwargs: fake_client)
 
     summary = run_smoke(mongo_uri="mongodb://localhost:27017", mongo_db="smoke_test_db")
 
@@ -23,30 +25,80 @@ def test_run_smoke_returns_summary_with_control_plane_and_status_views(monkeypat
 
 def test_run_smoke_can_use_env_driven_mongo_connection(monkeypatch) -> None:
     fake_client = _FakeMongoClient()
-    calls: list[str] = []
-    monkeypatch.setattr("scripts.runtime.smoke_mongo_multicli.MongoClient", lambda **_kwargs: fake_client)
-    monkeypatch.setattr("scripts.runtime.smoke_mongo_multicli.load_dotenv", lambda path, override=False: calls.append(str(path)))
+    captured: dict[str, object] = {}
     monkeypatch.setattr(
-        "scripts.runtime.smoke_mongo_multicli.get_mongo_connection_kwargs",
-        lambda **_kwargs: {"host": "localhost", "port": 27017, "username": "mongo", "password": "secret"},
+        "scripts.runtime.smoke_mongo_multicli.build_project_runtime_mongo_client",
+        lambda project_root, mongo_uri, server_selection_timeout_ms=3000: captured.update(
+            {"project_root": str(project_root), "mongo_uri": mongo_uri, "server_selection_timeout_ms": server_selection_timeout_ms}
+        )
+        or fake_client,
     )
 
     summary = run_smoke(mongo_uri=None, mongo_db="smoke_env_db")
 
     assert summary["db_name"] == "smoke_env_db"
     assert fake_client.dropped == ["smoke_env_db"]
-    assert calls
+    assert captured == {
+        "project_root": str(smoke_mongo_multicli.PROJECT_ROOT),
+        "mongo_uri": None,
+        "server_selection_timeout_ms": 3000,
+    }
+
+
+def test_build_mongo_client_can_fallback_to_local_docker_container_credentials(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        smoke_mongo_multicli,
+        "build_project_runtime_mongo_client",
+        lambda project_root, mongo_uri, server_selection_timeout_ms=3000: captured.update(
+            {"project_root": str(project_root), "mongo_uri": mongo_uri, "server_selection_timeout_ms": server_selection_timeout_ms}
+        )
+        or _FakeMongoClient(),
+    )
+
+    smoke_mongo_multicli._build_mongo_client(None)
+
+    assert str(smoke_mongo_multicli.PROJECT_ROOT) == captured["project_root"]
+    assert captured["mongo_uri"] is None
+    assert captured["server_selection_timeout_ms"] == 3000
 
 
 def test_run_smoke_skips_drop_database_when_mongo_setup_fails(monkeypatch) -> None:
     fake_client = _FailingMongoClient()
-    monkeypatch.setattr("scripts.runtime.smoke_mongo_multicli.MongoClient", lambda *_args, **_kwargs: fake_client)
+    monkeypatch.setattr("scripts.runtime.smoke_mongo_multicli.build_project_runtime_mongo_client", lambda *_args, **_kwargs: fake_client)
 
     with pytest.raises(RuntimeError, match="mongo unavailable"):
         run_smoke(mongo_uri="mongodb://localhost:27017", mongo_db="smoke_fail_db")
 
     assert fake_client.drop_attempts == 0
     assert fake_client.closed is True
+
+
+def test_run_smoke_skips_drop_database_when_write_access_fails_after_db_resolution(monkeypatch) -> None:
+    fake_client = _UnauthorizedMongoClient()
+    monkeypatch.setattr("scripts.runtime.smoke_mongo_multicli.build_project_runtime_mongo_client", lambda *_args, **_kwargs: fake_client)
+
+    with pytest.raises(RuntimeError, match="Mongo smoke requires writable credentials"):
+        run_smoke(mongo_uri="mongodb://localhost:27017", mongo_db="smoke_unauthorized_db")
+
+    assert fake_client.drop_attempts == 0
+    assert fake_client.closed is True
+
+
+def test_main_emits_structured_json_error_when_run_smoke_fails(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        smoke_mongo_multicli,
+        "run_smoke",
+        lambda **_: (_ for _ in ()).throw(RuntimeError("Mongo smoke requires writable credentials")),
+    )
+
+    exit_code = smoke_mongo_multicli.main(["--mongo-uri", "mongodb://bad:bad@localhost:27017/admin?authSource=admin"])
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error_code"] == "RuntimeError"
+    assert "Mongo smoke requires writable credentials" in payload["message"]
 
 
 class _FakeMongoClient:
@@ -83,6 +135,36 @@ class _FailingMongoClient:
 
     def close(self) -> None:
         self.closed = True
+
+
+class _UnauthorizedMongoClient:
+    def __init__(self) -> None:
+        self.drop_attempts = 0
+        self.closed = False
+
+    def __getitem__(self, _name: str):
+        return _UnauthorizedDatabase()
+
+    def drop_database(self, _name: str) -> None:
+        self.drop_attempts += 1
+        raise AssertionError("drop_database should not run when setup never completed")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _UnauthorizedDatabase:
+    def __getitem__(self, _name: str):
+        return _UnauthorizedCollection()
+
+
+class _UnauthorizedCollection:
+    def create_indexes(self, _indexes) -> None:
+        raise OperationFailure(
+            "createIndexes requires authentication",
+            13,
+            {"ok": 0.0, "errmsg": "createIndexes requires authentication", "code": 13, "codeName": "Unauthorized"},
+        )
 
 
 class _FakeDatabase:

--- a/tests/unit/services/symphony/test_run_symphony_cli.py
+++ b/tests/unit/services/symphony/test_run_symphony_cli.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import importlib
+from pathlib import Path
+
+from src.services.symphony.workflow_loader import load_workflow_definition
 
 
 def test_run_symphony_module_imports_without_circular_dependency() -> None:
@@ -25,3 +28,13 @@ def test_run_symphony_cli_accepts_explicit_path_and_port() -> None:
 
     assert args.workflow_path == "custom/WORKFLOW.md"
     assert args.port == 9030
+
+
+def test_default_root_workflow_file_exists_and_is_loadable() -> None:
+    project_root = Path(__file__).resolve().parents[4]
+    workflow_path = project_root / "WORKFLOW.md"
+
+    definition = load_workflow_definition(workflow_path)
+
+    assert definition.config["tracker"]["kind"] == "local"
+    assert definition.config["runtime"]["collab_backend"] == "sqlite"


### PR DESCRIPTION
## Summary
- converge Mongo runtime configuration resolution into shared helpers used by the Maestro / Graphiti runtime CLIs
- add shared CLI JSON error helpers and Graphiti smoke command helpers to remove duplicated failure handling paths
- move the runtime smoke / migration / coordination / profile tests onto the new shared behavior and add the root `WORKFLOW.md` asset expected by the symphony CLI tests

## Test Plan
- pytest tests/unit/core/test_runtime_config_governance.py tests/unit/maestro_collab/test_profile_defaults.py tests/unit/runtime/test_cli_error_output.py tests/unit/runtime/test_graphiti_smoke_common.py tests/unit/runtime/test_collab_migration_scripts.py tests/unit/runtime/test_maestro_coordination_cli.py tests/unit/runtime/test_smoke_graphiti_cli.py tests/unit/runtime/test_smoke_graphiti_preflight.py tests/unit/runtime/test_smoke_mongo_multicli.py tests/unit/services/symphony/test_run_symphony_cli.py tests/unit/services/symphony/test_maestro_collab_cli.py tests/unit/services/maestro/test_task_report_graphiti_projection.py -q --no-cov
- ruff check scripts/runtime/export_collab_snapshots.py scripts/runtime/graphiti_smoke_common.py scripts/runtime/maestro_collab.py scripts/runtime/migrate_collab_to_mongo.py scripts/runtime/smoke_graphiti_cli.py scripts/runtime/smoke_graphiti_preflight.py scripts/runtime/smoke_mongo_multicli.py src/utils/cli_error_output.py src/utils/mongo_runtime_config.py tests/unit/core/test_runtime_config_governance.py tests/unit/maestro_collab/test_profile_defaults.py tests/unit/runtime/test_cli_error_output.py tests/unit/runtime/test_graphiti_smoke_common.py tests/unit/runtime/test_collab_migration_scripts.py tests/unit/runtime/test_maestro_coordination_cli.py tests/unit/runtime/test_smoke_graphiti_cli.py tests/unit/runtime/test_smoke_graphiti_preflight.py tests/unit/runtime/test_smoke_mongo_multicli.py tests/unit/services/symphony/test_run_symphony_cli.py
