### PR TITLE
docs: refresh artdeco guide index

### DIFF
--- a/docs/guides/ARTDECO_COMPONENT_GUIDE.md
+++ b/docs/guides/ARTDECO_COMPONENT_GUIDE.md
@@ -1,0 +1,12 @@
+# ArtDeco Component Guide
+
+该路径保留为历史兼容入口。
+
+当前规范正文位于：
+
+- [docs/guides/web/ARTDECO_COMPONENT_GUIDE.md](/opt/claude/mystocks_spec/docs/guides/web/ARTDECO_COMPONENT_GUIDE.md)
+
+保留原因：
+
+- 历史报告与审核记录曾引用缺少 `web/` 子目录的路径
+- 为避免旧链接失效，此处只做转发，不再维护独立正文

--- a/docs/guides/ARTDECO_MASTER_INDEX.md
+++ b/docs/guides/ARTDECO_MASTER_INDEX.md
@@ -1,0 +1,12 @@
+# ArtDeco Master Index
+
+该路径保留为历史兼容入口。
+
+当前规范正文位于：
+
+- [docs/guides/web/ARTDECO_MASTER_INDEX.md](/opt/claude/mystocks_spec/docs/guides/web/ARTDECO_MASTER_INDEX.md)
+
+保留原因：
+
+- 历史报告与审核记录曾引用缺少 `web/` 子目录的路径
+- 为避免旧链接失效，此处只做转发，不再维护独立正文

--- a/docs/guides/multi-cli-tasks/CLI_WORKFLOW_GUIDE.md
+++ b/docs/guides/multi-cli-tasks/CLI_WORKFLOW_GUIDE.md
@@ -124,7 +124,7 @@ gh pr create --base dev --head [分支名] \
    - `docs/guides/multi-cli-tasks/MONGO_MULTICLI_OPERATION_CHECKLIST.md`
    - `docs/guides/ai-tools/GRAPHITI_MCP_WORKFLOW.md`
 3. 在 Mongo control plane 中记录开工：
-   - `work claim`
+   - `work mark --status in_progress`
 4. 创建或更新 `TASK-REPORT.md`
 5. 识别依赖与风险，并记录到报告
 
@@ -200,7 +200,7 @@ git push -u origin [分支名]
 - 代码已推送到远程分支
 - PR 已创建（base=dev）
 - `TASK-*-REPORT.md` 已生成（如阶段性任务）
-- Mongo control plane 已执行 `work submit`
+- Mongo control plane 已执行 `update add --status ready_for_review` 与 `work transition --to ready_for_review`
 
 ---
 

--- a/docs/guides/web/ARTDECO_COMPONENT_GUIDE.md
+++ b/docs/guides/web/ARTDECO_COMPONENT_GUIDE.md
@@ -1,221 +1,156 @@
-# ArtDeco Component Development Guide (V3.1 Governance Baseline)
+# ArtDeco Component Development Guide
 
-本文档定义了 MyStocks 项目中 ArtDeco 风格组件的工程标准与交付规范，并作为 V3.1 Governance Baseline 的开发准入文档。
+本文档定义 ArtDeco 组件与页面块的放置规则、命名边界和开发准入标准。
 
-> 2026-03-25 状态说明
+## 1. 先记住 4 条铁律
+
+1. `src/components/artdeco/**` 只放可持续沉淀的可复用资产。
+2. `views/artdeco-pages/components/` 只放 ArtDeco 页面系统内部共享片段。
+3. `views/artdeco-pages/*-tabs/` 只放域内工作台块，不默认跨域复用。
+4. 页面专属逻辑不要上提到 `base / core`，临时页面块不要伪装成全局组件。
+
+## 2. 目录治理矩阵
+
+| 目录 | 定位 | 可以做什么 | 不该做什么 |
+|------|------|------------|------------|
+| `src/components/artdeco/base/` | 原子 UI | Button、Card、Input、Alert | 承载页面编排逻辑 |
+| `src/components/artdeco/core/` | 壳层与框架能力 | Header、Breadcrumb、Skeleton、Icon、Toast | 承载某个业务域的专属流程 |
+| `src/components/artdeco/business/` | 通用业务交互 | FilterBar、DateRange、Rule、Status | 绑定单一页面状态树 |
+| `src/components/artdeco/charts/` | 通用图表 | Chart、KLine、Matrix、Depth | 写死单域业务语义 |
+| `src/components/artdeco/trading/` | 交易域可复用组件 | OrderBook、Ticker、TradeForm | 绑定某一页的局部容器状态 |
+| `src/components/artdeco/advanced/` | 高阶分析组件 | CapitalFlow、ChipDistribution、Sentiment | 变成临时页面拼装代码 |
+| `src/components/artdeco/specialized/` | 强专题组件 | LongHuBang、BlockTrading | 冒充全局通用组件 |
+| `views/artdeco-pages/components/` | 页面系统内部共享片段 | 在多个 ArtDeco 页面工作台之间复用 | 当作通用 UI 组件库 |
+| `views/artdeco-pages/*-tabs/` | 域内工作台块 | 独立路由块、Tab block、内嵌块 | 随意跨域 import |
+
+## 3. `*-tabs` 与 `components/` 的铁律
+
+### 3.1 `*-tabs/`
+
+适用条件：
+
+- 属于某个业务域或某个页面工作流
+- 绑定当前页面的 tabs、筛选、路由或局部状态
+- 更像工作台块，而不是组件库资产
+
+规则：
+
+- 默认不跨域 import
+- 可以保留页面级上下文
+- 如果未来要跨域长期复用，应提升到更高层
+
+### 3.2 `views/artdeco-pages/components/`
+
+适用条件：
+
+- 在多个 ArtDeco 页面/工作台之间复用
+- 仍然带页面系统语境，但不是全站原子 UI
+- 适合沉淀页面内部共享片段
+
+规则：
+
+- 允许被多个 ArtDeco 页面复用
+- 不要承载顶层路由/页面初始化逻辑
+- 不要与 `src/components/artdeco/` 重复建设
+
+> 兼容说明
 >
-> - 本文档仍然有效，但它只回答“组件怎么组织、怎么开发”。
-> - 如果你是第一次接手，请先读：
->   - `docs/guides/web/ARTDECO_START_HERE.md`
->   - `docs/guides/web/ARTDECO_MASTER_INDEX.md`
-> - 如果你要判断样式真值、兼容层边界、页面骨架，请结合：
->   - `docs/guides/web/ARTDECO_SCSS_GOVERNANCE_BASELINE.md`
->   - `docs/guides/web/ARTDECO_FINTECH_UNIFIED_SPEC.md`
->   - `docs/guides/web/ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT.md`
+> 历史审核材料常写成 `components/[Domain]`。当前仓库现实更接近“平铺的 `views/artdeco-pages/components/` 共享层 + `*-tabs/` 域块层”。如果未来重新切分成 `components/[domain]/`，仍应沿用同一铁律：只放可复用的页面共享片段，不放页面专属逻辑。
 
-## 1. 组件组织铁律 (Architectural Iron Law)
+## 4. 决策树
 
-为防止分拆过程中的目录膨胀与逻辑耦合，必须严格遵守以下确权定义：
+### 4.1 新能力先问 3 个问题
 
-### 1.1 `components/[Domain]/` —— 稳定、可复用、跨页面
-*   **存放内容**: 领域内通用业务组件；可被多个页面、多个 Tabs 复用；纯展示或纯逻辑封装，不绑定特定页面。
-*   **核心规则**:
-    *   **必须可复用**: 严禁存放仅某个特定 Tab 专属的代码。
-    *   **无页面逻辑**: 禁止写页面级初始化或复杂的全局状态修改逻辑。
-    *   **稳定可测试**: 必须具备良好的单元测试基础。
+1. 它是不是纯视觉 / 通用交互？
+2. 它是不是会在多个页面或多个域中稳定复用？
+3. 它是不是强依赖当前页面的 tab、路由、筛选或局部状态？
 
-### 1.2 `[Domain]-tabs/` —— 页面级、页签块、不可复用
-*   **存放内容**: 属于某个业务页面的子面板/子路由；业务逻辑重、一次性、页面专属。
-*   **核心规则**:
-    *   **专属分拆**: 仅用于拆分超大 Vue 文件，不做通用组件。
-    *   **禁止外导**: 严禁被该页面以外的任何页面 `import`。
-    *   **逻辑闭环**: 允许包含该 Tab 专属的复杂业务逻辑。
+### 4.2 放置建议
 
-> **⚠️ 铁律**: `tabs/` 目录只放 “页面块”，`components/` 只放 “可复用组件”。
+| 情况 | 应放目录 |
+|------|----------|
+| 原子 UI | `base/` |
+| 壳层、导航、状态、框架能力 | `core/` |
+| 通用业务交互 | `business/` |
+| 通用图表能力 | `charts/` |
+| 交易域稳定复用 | `trading/` |
+| 高阶分析稳定复用 | `advanced/` |
+| 强专题、难泛化 | `specialized/` |
+| 多个 ArtDeco 页面内部共享 | `views/artdeco-pages/components/` |
+| 单域工作台块 / 单页 tabs 块 | `views/artdeco-pages/*-tabs/` |
 
-## 2. 物理目录映射 (Physical Mapping)
+## 5. 样式与实现规则
 
-| 目录路径 | 属性 | 适用场景示例 |
-|:---|:---|:---|
-| `src/components/artdeco/base/` | 原子 UI | Button, Card, Input |
-| `src/components/artdeco/core/` | 框架级能力 | Header, Breadcrumb, Icon, FunctionTree |
-| `src/components/artdeco/business/` | 通用业务交互 | FilterBar, DateRange, AlertRule, DataSourceTable |
-| `src/components/artdeco/charts/` | 通用图表 | ArtDecoChart, KLineChartContainer, PerformanceTable |
-| `src/components/artdeco/trading/` | 交易领域组件 | Ticker, OrderBook, PositionCard, TradeForm |
-| `src/components/artdeco/advanced/` | 高阶分析组件 | CapitalFlow, MarketPanorama, SentimentAnalysis |
-| `src/components/artdeco/specialized/` | 高定制专题组件 | BlockTrading, LongHuBang |
-| `src/views/artdeco-pages/components/[domain]/` | 通用业务 | `ArtDecoRealtimeMonitor`, `ArtDecoRiskGauge` |
-| `src/views/artdeco-pages/[domain]-tabs/` | 页面块 | `MarketFundFlowTab`, `StrategyConfigTab` |
+### 5.1 样式导入
 
-## 3. 组件选型决策树 (Decision Tree)
-
-这部分回答一个高频问题：
-
-> “我要做一个新能力，到底是新建基础组件、领域组件，还是直接写在页面里？”
-
-### 3.1 第一步：先判断是不是页面块
-
-如果同时满足以下条件，优先放到 `views/artdeco-pages/[domain]-tabs/` 或当前页面域：
-
-- 只服务于一个页面或一个 Tab
-- 强绑定当前页面状态、路由或局部业务流程
-- 其他页面几乎不会复用
-
-不要急着抽成全局组件。
-
-### 3.2 第二步：如果要复用，再判断复用层级
-
-按这个顺序选：
-
-1. **`base/`**
-   适合原子 UI。
-   例：按钮、卡片、输入框、折叠面板、对话框。
-2. **`core/`**
-   适合页面骨架、导航、反馈、框架级能力。
-   例：Header、Breadcrumb、Icon、Skeleton、LoadingOverlay。
-3. **`business/`**
-   适合通用业务交互。
-   例：筛选条、告警规则、日期范围、数据源表格。
-4. **`charts/`**
-   适合跨页面通用图表。
-   例：ArtDecoChart、K 线容器、PerformanceTable。
-5. **`trading/`**
-   适合交易领域专用组件。
-   例：OrderBook、TradeForm、PositionCard。
-6. **`advanced/`**
-   适合复杂分析结果展示。
-   例：CapitalFlow、ChipDistribution、SentimentAnalysis。
-7. **`specialized/`**
-   适合高定制专题资产。
-   例：LongHuBang、BlockTrading。
-
-### 3.3 快速判断口诀
-
-- **跨页面 + 原子交互** -> `base`
-- **跨页面 + 页面骨架/导航/反馈** -> `core`
-- **跨页面 + 通用业务面板** -> `business`
-- **跨页面 + 图表能力** -> `charts`
-- **只在交易域稳定复用** -> `trading`
-- **只在复杂分析域稳定复用** -> `advanced`
-- **强专题、高定制、不宜泛化** -> `specialized`
-- **只给某个页面/Tab 用** -> 页面域，不要提升
-
-## 4. 组件开发前检查
-
-新建组件前，先完成这 4 个判断：
-
-1. 当前仓库里是不是已经有现成组件可复用。
-2. 这个能力是不是只属于当前页面。
-3. 如果未来复用，复用边界是原子 UI、框架能力、业务交互，还是领域组件。
-4. 它是否会把页面级逻辑错误地提升到全局组件层。
-
-建议同时对照：
-
-- `web/frontend/ARTDECO_COMPONENTS_CATALOG.md`
-- `docs/guides/web/ARTDECO_START_HERE.md`
-- `docs/guides/web/ARTDECO_SCSS_GOVERNANCE_BASELINE.md`
-
-## 5. 工程编码标准 (Engineering Standards)
-
-### 2.1 样式导入规范 (强制)
-必须使用 SCSS 且必须通过令牌系统定义样式。禁止使用内联样式或硬编码颜色。
-详细规则以 [ARTDECO_SCSS_GOVERNANCE_BASELINE.md](./ARTDECO_SCSS_GOVERNANCE_BASELINE.md) 为准。
-
-```vue
-<style scoped lang="scss">
-@use '@/styles/artdeco-tokens.scss' as *;
-
-.your-component {
-  background: var(--artdeco-bg-card);
-  padding: var(--artdeco-spacing-4);
-  color: var(--artdeco-gold-primary);
-}
-</style>
-```
-
-说明：
-
-*   新代码优先使用 `@use`。
-*   兼容别名如 `--artdeco-accent-gold` 可以继续读取，但不应在新代码中继续扩散。
-
-### 2.2 金融语义颜色
-在显示盈亏数据时，必须调用语义别名：
-*   **盈利/上涨**: 使用 `var(--artdeco-profit)` 或 `var(--artdeco-rise)`
-*   **亏损/下跌**: 使用 `var(--artdeco-loss)` 或 `var(--artdeco-down)`
-
-### 2.3 响应式网格
-优先复用语义化 Grid 类或现有 Grid mixin，确保在各断点下的一致性：
+新代码优先：
 
 ```scss
+@use '@/styles/artdeco-tokens.scss' as *;
 @use '@/styles/artdeco-grid.scss' as *;
-
-.stats-grid {
-  display: grid;
-  @include artdeco-grid-4-cols;
-  gap: var(--artdeco-spacing-4);
-}
 ```
 
-优先级：
+规则：
 
-*   先复用 `.summary-section`、`.charts-section` 等语义化 Grid 类
-*   再使用 `artdeco-grid-2-cols`、`artdeco-grid-3-cols`、`artdeco-grid-4-cols` 等 mixin
-*   禁止使用不存在的伪接口，例如 `@include artdeco-grid(4)`
+- 禁止新增硬编码颜色、间距、圆角、阴影、过渡
+- 新代码优先 `@use`，不要继续扩散 `@import`
+- 涉及金融语义时，用 `artdeco-financial.scss` 提供的语义
 
-## 6. 页面骨架组件优先级
+### 5.2 字体与间距
 
-如果你在做新页面，默认优先从这组组件开始组合，而不是从零拼：
+当前真值：
 
-### P0 首选
+- 标题：`Cinzel`
+- 正文：`Barlow`
+- 数值与元信息：`JetBrains Mono`
+- 间距：13 个编号级别 + 语义别名 + 紧凑变量
 
-- `ArtDecoHeader`
-- `ArtDecoBreadcrumb`
-- `ArtDecoIcon`
-- `ArtDecoCard`
-- `ArtDecoButton`
-- `ArtDecoStatCard`
+### 5.3 A 股颜色
 
-### P1 常用
+- 上涨 / 盈利：红
+- 下跌 / 亏损：绿
 
-- `ArtDecoSkeleton`
-- `ArtDecoLoadingOverlay`
-- `ArtDecoStatusIndicator`
-- `ArtDecoToast`
-- `ArtDecoCollapsible`
+不要自行发明第二套市场语义。
 
-### P2 视场景接入
+## 6. 桌面端约束
 
-- `business/*`
-- `charts/*`
-- `trading/*`
-- `advanced/*`
-- `specialized/*`
+- 当前项目是桌面端工作台
+- 可以做桌面端 Grid 列数折叠
+- 不做移动端 / 平板适配
+- 不要把“响应式治理”写成移动端适配任务
 
-原则：
+## 7. 命名建议
 
-- 先搭舞台层，再挂领域组件。
-- 先复用已有骨架能力，再决定是否扩展。
+当前仓库命名并不完全统一，因此本指南不强推机械改名；但新文件建议满足以下原则：
 
-## 7. 可验证性核对表 (Definition of Done)
+- 能看出业务域或职责
+- 与所在目录语义一致
+- 避免同层出现两个职责接近但命名风格完全不同的文件
 
-在提交任何 ArtDeco 相关变更前，必须自测以下项目：
-- [ ] **物理一致性**: 新组件是否放在了正确的分类目录下？
-- [ ] **令牌完整性**: 是否所有颜色和间距都使用了 `--artdeco-*` 变量？
-- [ ] **A 股符合度**: 涨跌幅颜色是否符合“红涨绿跌”规范？
-- [ ] **分拆有效性**: 大型 Vue 文件是否已按 Tab 有效分拆，且父组件正确下发配置？
-- [ ] **编译验证**: `npx vue-tsc --noEmit` 是否零错误？
+比“统一成单一公式”更重要的是：目录边界正确、职责边界正确。
 
-涉及 Layout、路由或菜单结构时，还必须补：
+## 8. 提交前检查
 
-- [ ] **PM2 冒烟**: `bash scripts/run_e2e_pm2.sh`
+至少确认：
 
-当前已验证通过的 E2E 口径：
+- 新文件放在了正确目录
+- 没有把页面专属逻辑提到 `base/core`
+- 没有把域内工作台块错误抽成全局组件
+- 没有新增硬编码视觉值
+- 新样式优先使用 `@use`
+- A 股语义没有写反
 
-- 浏览器项目：`chromium`
-- 套件：`tests/navigation-consistency.spec.ts`
-- 结果：`14 passed`
+若改动涉及前端构建 / 类型检查 / E2E / 服务启动，还应按项目统一门禁报告：
 
----
-**维护者**: Frontend Architecture Team
-**治理口径**: V3.1 Governance Baseline
-**最后审核**: 2026-03-25 (补充组件选型决策树与页面骨架优先级)
+- 结构性语法错误
+- 类型错误是否高于基线
+- PM2 服务状态
+- 实际 E2E 执行结果
+
+## 9. 与其他文档的关系
+
+- 先上手：`ARTDECO_START_HERE.md`
+- 看总目录：`ARTDECO_MASTER_INDEX.md`
+- 看运行时架构：`docs/api/ArtDeco_System_Architecture_Summary.md`
+- 看组件清单：`web/frontend/ARTDECO_COMPONENTS_CATALOG.md`
+- 看样式真值：`ARTDECO_SCSS_GOVERNANCE_BASELINE.md`

--- a/docs/guides/web/ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md
+++ b/docs/guides/web/ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md
@@ -332,6 +332,82 @@
    - `ArtDecoRiskManagement.vue`
    - `BacktestHeader.vue` / `BacktestKpiGrid.vue` / `BacktestWorkbenchTabs.vue` 子组件链已切换到 `@use` 并补足 tabs rail header
    - `ArtDecoRiskMonitor.vue` 已将历史失效样式替换为标准化占位壳层
+   - `src/views/market` 活跃链已完成一轮真实值债清理：
+     `Auction.vue`、`MarketDataView.vue`、`CapitalFlow.scss`、`Concepts.scss`、`Etf.scss`、`Realtime.scss`、`Tdx.scss`、`Technical.scss`
+     已通过目录级 `check-artdeco-tokens.js --target-dir src/views/market`
+   - `src/views/market` 已重新纳入 `lint:artdeco:changed`
+   - `MarketDataView` 直连组件链首批已纳入门禁：
+     `FundFlowPanel.vue`、`ETFDataTable.vue`、`ChipRaceTable.vue`、`LongHuBangTable.vue`
+     已完成单文件 token 收口并加入 `lint:artdeco:changed`
+   - `MarketData.vue` 兼容 panel 链首批已完成同类收口：
+     `ChipRacePanel.vue`、`ETFDataPanel.vue`、`LongHuBangPanel.vue`
+     已完成单文件 token 收口并加入 `lint:artdeco:changed`
+   - `components/market` 补充小型交互组件首批已纳入门禁：
+     `IndicatorSelector.vue`、`ProKLineChart.vue`、`WencaiPanelSimple.vue`
+     已完成单文件 token 收口并加入 `lint:artdeco:changed`
+   - `Wencai` 活跃面板链已完成第二轮收口：
+     `WencaiPanel.vue`、`styles/WencaiPanel.scss`、`WencaiPanelV2.vue`、`styles/WencaiPanelV2.scss`
+     已完成 token 收口并加入 `lint:artdeco:changed`
+   - 相邻技术/图表入口已完成旧样式入口语法收口：
+     `components/technical/IndicatorPanel.vue`、`components/Charts/AdvancedHeatmap.vue`、`components/Charts/RelationChart.vue`
+     已切换到 `@use`，并加入 `lint:artdeco:changed`
+   - `components/Charts/ProKLineChart.vue` 与 `components/chart/HealthRadarChart.vue`
+     已将旧 CSS 入口从 `@import` 收口为 `scss + @use`，并加入 `lint:artdeco:changed`
+   - `components/market/SmartRecommendation.vue`、`components/Market/SmartRecommendation.vue`、
+     `views/system/DatabaseMonitor.vue`、`views/monitoring/MonitoringDashboard.vue`
+     已完成旧样式入口收口并加入 `lint:artdeco:changed`
+   - `views/system/Architecture.vue`、`views/monitoring/AlertRulesManagement.vue`、
+     `views/monitoring/RiskDashboard.vue`、`views/announcement/AnnouncementMonitor.vue`
+     已完成旧样式入口收口并加入 `lint:artdeco:changed`
+   - `views/system/PerformanceMonitor.vue` 与 `views/monitoring/WatchlistManagement.vue`
+     已完成旧样式入口收口并加入 `lint:artdeco:changed`
+   - 根页面入口链新增收口：
+     `SmartDataSourceTest.vue`、`DataVisualizationShowcase.vue`、`TechnicalAnalysis.vue`、
+     `BacktestAnalysis.vue`、`TradingDashboard.vue`、`StrategyManagement.vue`、`IndicatorLibrary.vue`
+     已完成旧样式入口收口并加入 `lint:artdeco:changed`
+   - 根页面补充收口：
+     `Analysis.vue`、`BacktestWizard.vue`、`Dashboard.vue`、`Market.vue`、`Settings.vue`、`IndustryConceptAnalysis.vue`
+     已完成旧样式入口收口并加入 `lint:artdeco:changed`
+   - strategy/demo/components 补充入口收口：
+     `BatchScan.vue`、`SingleRun.vue`、`StatsAnalysis.vue`、`ResultsQuery.vue`、`StrategyList.vue`、`BacktestGPU.vue`、
+     `demo/Phase4Dashboard.vue`、`demo/Wencai.vue`、`demo/pyprofiling/components/Prediction.vue`、
+     `views/components/StopLossMonitoringTab.vue`、`views/components/RiskOverviewTab.vue`、
+     `trade-management/components/TradeHistoryTab.vue`、`components/monitoring/MonitoringAlertPanel.vue`、
+     `components/monitoring/MonitoringDataTable.vue`、`components/sse/DashboardMetrics.vue`
+     已完成旧样式入口收口并加入 `lint:artdeco:changed`
+   - 根页面入口继续收口：
+     `TaskManagement.vue`、`monitor.vue`、`Phase4Dashboard.vue`、`Wencai.vue`、`RealTimeMonitor.vue`、
+     `StockDetail.vue`、`TdxMarket.vue`、`PortfolioManagement.vue`、`StockAnalysisDemo.vue`、
+     `EnhancedDashboard.vue`、`PyprofilingDemo.vue`、`errors/ServiceUnavailable.vue`
+     已完成旧样式入口收口并加入 `lint:artdeco:changed`
+   - 边缘活跃组件入口收口：
+     `components/data/DataCard.vue`、`components/realtime/RealtimePositionPanel.vue`、
+     `components/menu_root/TreeMenu.vue`、`components/charts/AdvancedHeatmap.vue`、
+     `components/charts/RelationChart.vue`
+     已完成旧样式入口收口并加入 `lint:artdeco:changed`
+   - command-palette / stocks / `TradeManagement.vue` 仍保留真实 token 债，
+     当前不再是单纯入口语法问题；后续需按“真实值债治理”单独推进
+   - `Activity.vue`、`Screener.vue`、`TradeManagement.vue`
+     已完成首轮真实 token 债收口并加入 `lint:artdeco:changed`
+   - `Industry.vue`
+     已完成首轮真实 token 债收口并加入 `lint:artdeco:changed`
+   - `shared/command-palette/styles/CommandPalette.scss`
+     已完成首轮真实 token 债收口并加入 `lint:artdeco:changed`
+   - `views/technical/TechnicalAnalysis.scss`
+     已补齐最小 web3 兼容 token/mixin 层，并加入 `lint:artdeco:changed`
+   - `src/views/stocks`
+     已从若干 target-file 升级为目录级 `lint:artdeco:changed` 门禁
+   - `components/shared/charts/ChartContainer.vue`、`views/SkeletonUsage.vue`
+     已完成收口并通过门禁
+   - `src/views/components`、`src/views/technical`、
+     `src/components/shared/charts`、`src/components/shared/command-palette`
+     已升级为目录级门禁
+   - `components/shared/ui/DetailDialog.vue`、
+     `views/styles/*.scss`（`Analysis.scss`、`BacktestWizard.scss`、`Dashboard.scss`、`IndustryConceptAnalysis.scss`、`Market.scss`、`Settings.scss`、`TradingDecisionCenter.scss`）、
+     `views/stock-analysis/*.vue`
+     已完成旧样式入口语法收口，当前相关范围 `@import = 0`
+   - `src/views/stocks`
+     已完成目录级 token 收口，旧 `@import` 为 `0`，并已升级为 `lint:artdeco:changed` 的目录级门禁
 
    待继续：
 
@@ -357,7 +433,8 @@
 2. **P1 已完成主要目标**：活跃 ArtDeco/Fintech 链路中的旧字体引用已收敛，真值层/兼容层/历史层边界已显式定义。
 3. **P2 已完成第一轮**：关键页面、布局壳层与活跃占位页已完成 ArtDeco Fintech 工作站化收敛。
 4. **P3 已开始推进**：`ArtDecoStockManagement.vue`、`ArtDecoMarketQuotes.vue`、`ArtDecoTradingManagement.vue`、`ArtDecoStrategyManagement.vue`、`ArtDecoStrategyOptimization.vue`、`ArtDecoBacktestAnalysis.vue`、`StrategyParametersTab.vue`、`StrategySignalsTab.vue`、`ArtDecoSignalsView.vue`、`ArtDecoTradingHistory.vue`、`ArtDecoTradingPositions.vue`、`ArtDecoMonitoringDashboard.vue`、`ArtDecoDataManagement.vue`、`SystemHealthTab.vue`、`ArtDecoRiskAlerts.vue`、`ArtDecoAnnouncementMonitor.vue`、`RiskOverviewTab.vue`、`StopLossMonitorTab.vue`、`MarketRealtimeTab.vue`、`MarketKLineTab.vue`、`MarketConceptTab.vue`、`MarketETFTab.vue`、`TechnicalScannerTab.vue`、`PortfolioOverviewTab.vue`、`DragonTigerAnalysis.vue`、`FundFlowAnalysis.vue`、`ArtDecoIndustryAnalysis.vue` 与 `ArtDecoRiskManagement.vue` 已完成第二轮页面级补强。
-5. **剩余工作**：历史兼容层的长期归档策略、剩余页面一致性审查、页面骨架模板化。
+5. **P3 新进展**：`src/views/market` 已从“导入链已清、真实值债未过门禁”推进到“目录级 token 自检通过，并被重新纳入 changed-scope 门禁”。
+6. **剩余工作**：历史兼容层的长期归档策略、剩余页面一致性审查、页面骨架模板化。
 
 ---
 

--- a/docs/guides/web/ARTDECO_FINTECH_UNIFIED_SPEC.md
+++ b/docs/guides/web/ARTDECO_FINTECH_UNIFIED_SPEC.md
@@ -1,0 +1,170 @@
+# ArtDeco Fintech Unified Spec
+
+本文件是当前 MyStocks ArtDeco Fintech 体系的统一规格文档。
+
+它回答的不是“历史上怎么做过”，而是：
+
+1. 当前活跃的 ArtDeco 设计身份是什么。
+2. 组件、页面块、容器分别应该放在哪里。
+3. 运行时实际上有哪些承载模式。
+4. 新增页面或组件时必须遵守哪些工程边界。
+
+## 1. 设计身份
+
+当前项目的活跃风格应理解为：
+
+`Original ArtDeco` + `A 股金融语义` + `高密度量化工作台` = `ArtDeco Fintech`
+
+关键特征：
+
+- 黑金高对比，不走普通后台灰蓝语法
+- 标题使用 `Cinzel`
+- 正文使用 `Barlow`
+- 数值、代码、状态元信息优先使用 `JetBrains Mono`
+- A 股语义强制执行“红涨绿跌”
+- 页面必须有舞台层，而不只是把业务卡片堆在一起
+
+## 2. 当前真值链
+
+### 2.1 样式真值
+
+新代码默认只认以下主链文件：
+
+- `web/frontend/src/styles/artdeco-tokens.scss`
+- `web/frontend/src/styles/artdeco-grid.scss`
+- `web/frontend/src/styles/artdeco-global.scss`
+- `web/frontend/src/styles/artdeco-financial.scss`
+- `web/frontend/src/styles/artdeco-quant-extended.scss`
+
+其中：
+
+- `artdeco-tokens.scss` 当前明确包含 `Cinzel + Barlow + JetBrains Mono`
+- 间距体系以源码为准，当前为 **13 个编号级别**
+  - `1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24, 32`
+  - 另有 `sm/md/lg/xl` 语义别名
+  - 另有 `compact-*` 紧凑间距变量
+
+### 2.2 文档真值
+
+活跃治理链路为：
+
+1. `ARTDECO_START_HERE.md`
+2. `ARTDECO_FINTECH_UNIFIED_SPEC.md`
+3. `ARTDECO_SCSS_GOVERNANCE_BASELINE.md`
+4. `ARTDECO_COMPONENT_GUIDE.md`
+5. `web/frontend/ARTDECO_COMPONENTS_CATALOG.md`
+6. `docs/api/ArtDeco_System_Architecture_Summary.md`
+
+## 3. 组件与页面的目录边界
+
+### 3.1 Reusable UI / Base 资产
+
+目录：`web/frontend/src/components/artdeco/`
+
+当前分成 7 层：
+
+- `base/`：原子 UI
+- `core/`：壳层、导航、状态、框架级能力
+- `business/`：通用业务交互
+- `charts/`：通用图表能力
+- `trading/`：交易域可复用组件
+- `advanced/`：高阶分析组件
+- `specialized/`：强专题资产
+
+### 3.2 Page-Level Shared Fragments
+
+目录：`web/frontend/src/views/artdeco-pages/components/`
+
+这是页面工作台内部的共享片段层，职责是：
+
+- 在多个 ArtDeco 页面/页签块间复用
+- 仍然带有页面工作台语境
+- 不应伪装成全站原子 UI
+
+它与 `src/components/artdeco/` 的区别是：
+
+- `src/components/artdeco/` 面向稳定资产沉淀
+- `views/artdeco-pages/components/` 面向 ArtDeco 页面系统内部复用
+
+### 3.3 Domain Tab Blocks
+
+目录：`web/frontend/src/views/artdeco-pages/*-tabs/`
+
+这类文件是域内工作台块，不是全局组件库。规则：
+
+- 允许绑定当前页面状态、路由和局部业务流
+- 允许为独立路由态和内嵌态做壳层适配
+- 默认不跨域 import
+- 如果某个块开始被多个域长期复用，应提升到更高层级
+
+## 4. 当前运行时承载模式
+
+当前仓库不是单一容器模式，而是三种模式并存：
+
+| 模式 | 代表文件 | 特征 |
+|------|----------|------|
+| 模板化工作台 | `views/artdeco-pages/_templates/ArtDecoPageTemplate.vue`、`ArtDecoRiskManagement.vue` | 通过 `pageConfig + stats + tabs + content` 插槽统一承载 |
+| 直接 Tab 容器 | `ArtDecoMarketData.vue` | 容器内直接声明 tab rail 和 tab content |
+| 功能树驱动容器 | `ArtDecoTradingCenter.vue` | 左侧功能树 + 右侧动态组件，适合总控类页面 |
+
+补充说明：
+
+- `router/index.ts` 以 `ArtDecoLayoutEnhanced.vue` 为主壳层。
+- `pageConfig.ts` 是自动生成的路由元数据源，但它 **不是** 当前所有 ArtDeco tabs 的唯一事实源。
+- 许多工作台页面已经可作为独立路由直接挂载，例如：
+  - `strategy-tabs/ArtDecoStrategyManagement.vue`
+  - `strategy-tabs/ArtDecoBacktestAnalysis.vue`
+  - `trading-tabs/ArtDecoSignalsView.vue`
+  - `risk-tabs/RiskOverviewTab.vue`
+  - `system-tabs/ArtDecoMonitoringDashboard.vue`
+
+## 5. 工程铁律
+
+### 5.1 视觉实现
+
+- 禁止新增硬编码颜色、间距、圆角、阴影、过渡
+- 新代码优先使用 `@use`
+- 禁止把兼容层重新当成真值层
+- A 股涨跌语义只用 `--artdeco-rise` / `--artdeco-down` 或对应语义别名
+
+### 5.2 目录治理
+
+- `src/components/artdeco/**` 只放可持续沉淀的可复用资产
+- `views/artdeco-pages/components/` 只放页面系统内共享片段
+- `*-tabs/` 只放域内工作台块
+- 页面专属逻辑不要上提到 base/core
+
+### 5.3 页面承载
+
+- 新页面优先复用现有工作台壳层
+- 页面至少要有明确的 header、meta、content 节奏
+- 需要 tabs 时，优先延续当前 `tabs shell -> content shell` 结构
+
+### 5.4 桌面端约束
+
+- 项目当前是桌面端工作台，不做移动端/平板适配
+- 允许桌面端内部的 Grid 断点与列数折叠
+- 不允许以“响应式治理”为名新增移动端语法分支
+
+## 6. 验证基线
+
+涉及 ArtDeco 代码改动时，至少确认：
+
+- `npx vue-tsc --noEmit`
+- ArtDeco token 合规检查
+- 涉及 Layout / 路由 / 菜单时运行 `bash scripts/run_e2e_pm2.sh`
+
+报告时必须写实际结果，不允许再写固定文案：
+
+- 实际执行命令
+- 浏览器项目
+- 通过 / 失败 / 跳过数量
+- PM2 服务地址与状态
+
+## 7. 与其他文档的关系
+
+- 入门看 `ARTDECO_START_HERE.md`
+- 目录看 `ARTDECO_MASTER_INDEX.md`
+- 组件清单看 `web/frontend/ARTDECO_COMPONENTS_CATALOG.md`
+- 运行时摘要看 `docs/api/ArtDeco_System_Architecture_Summary.md`
+- 历史基准看 `docs/reports/ARTDECO_V3_COMPLETE_SUMMARY.md`

--- a/docs/guides/web/ARTDECO_MASTER_INDEX.md
+++ b/docs/guides/web/ARTDECO_MASTER_INDEX.md
@@ -1,108 +1,104 @@
-# ArtDeco v3/v3.1 Governance Baseline - Master Index
+# ArtDeco Master Index
 
-This document is the authoritative entry point for ArtDeco v3/v3.1 governance in the MyStocks project.
+本文件是 MyStocks 项目 ArtDeco 文档体系的唯一总目录，负责回答三件事：
 
-## 0. 本文档的职责
+1. 当前哪些文档是活跃治理文档。
+2. 每份文档的职责边界是什么。
+3. 遇到具体任务时应该先读哪一份。
 
-`ARTDECO_MASTER_INDEX.md` 负责的是“完整目录和定位”，不是新手上手摘要。
+> 2026-04-01 文档治理刷新
+>
+> - 修正旧链路中的失效路径与缺失入口。
+> - 补齐 `ARTDECO_FINTECH_UNIFIED_SPEC.md`。
+> - 为历史上缺少 `web/` 子目录的两条常用路径提供兼容入口。
 
-它主要回答：
+## 1. 文档分层
 
-1. 当前有哪些 ArtDeco 核心文档
-2. 每份文档属于什么类别
-3. 你该按什么标签去找文档
+### 1.1 活跃治理文档
 
-如果你是第一次接手，不要先从这里开始通读，先看：
+| 标签 | 文档 | 职责 |
+|------|------|------|
+| `[必读]` | [ARTDECO_START_HERE](./ARTDECO_START_HERE.md) | 单页上手入口，给第一次接手的人最短阅读路径 |
+| `[必读][架构]` | [ARTDECO_FINTECH_UNIFIED_SPEC](./ARTDECO_FINTECH_UNIFIED_SPEC.md) | 当前 ArtDeco Fintech 的统一规格：设计身份、目录边界、运行时承载模式 |
+| `[必读][样式真值]` | [ARTDECO_SCSS_GOVERNANCE_BASELINE](./ARTDECO_SCSS_GOVERNANCE_BASELINE.md) | 令牌、Grid、兼容层、样式导入规范的事实源 |
+| `[必读][组件]` | [ARTDECO_COMPONENT_GUIDE](./ARTDECO_COMPONENT_GUIDE.md) | 组件目录治理、`*-tabs` 铁律、放置决策树 |
+| `[组件][目录]` | [ARTDECO_COMPONENTS_CATALOG](../../../web/frontend/ARTDECO_COMPONENTS_CATALOG.md) | 当前组件全景目录，覆盖 reusable assets 与 page-level workbench blocks |
+| `[页面][模板]` | [ARTDECO_PAGE_TEMPLATE_GUIDE](./ARTDECO_PAGE_TEMPLATE_GUIDE.md) | 模板化工作台页面的承载方式 |
+| `[页面][验证]` | [ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT](./ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT.md) | 页面骨架、一致性与工作台化收敛的审计记录 |
+| `[验证]` | [ARTDECO_FINTECH_IMPLEMENTATION_AUDIT](./ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md) | 活跃实现与统一规格的对账文档 |
 
-- `ARTDECO_START_HERE.md`
+### 1.2 运行时与历史基准文档
 
-然后再回到这里按标签和场景查完整目录。
+| 标签 | 文档 | 职责 |
+|------|------|------|
+| `[架构][运行时摘要]` | [ArtDeco_System_Architecture_Summary](../../api/ArtDeco_System_Architecture_Summary.md) | 从 Vue 路由、容器模式、组件边界角度总结当前运行时 |
+| `[历史基准]` | [ARTDECO_V3_COMPLETE_SUMMARY](../../reports/ARTDECO_V3_COMPLETE_SUMMARY.md) | V3 升级过程与后续治理刷新之间的历史基准 |
 
-## 1. 标签说明 (Reading Tags)
+### 1.3 兼容入口
 
-为减少后续接手成本，本文档给每份核心文档加上阅读标签：
+以下两个入口保留是为了兼容历史报告、审核记录和外部引用；真实内容仍在 `docs/guides/web/`：
 
-- `[必读]`: 第一次接手必须先读
-- `[样式真值]`: 样式、token、布局规则的事实源
-- `[组件]`: 组件目录、组件开发、组件选型
-- `[页面]`: 页面骨架、页面构图、页面治理
-- `[架构]`: 架构口径、布局壳层、Container-Tab 体系
-- `[验证]`: 测试、门禁、验证路径
-- `[历史基准]`: 历史上仍有参考价值，但不是当前唯一事实源
+| 兼容路径 | 指向 |
+|----------|------|
+| [docs/guides/ARTDECO_MASTER_INDEX.md](/opt/claude/mystocks_spec/docs/guides/ARTDECO_MASTER_INDEX.md) | `docs/guides/web/ARTDECO_MASTER_INDEX.md` |
+| [docs/guides/ARTDECO_COMPONENT_GUIDE.md](/opt/claude/mystocks_spec/docs/guides/ARTDECO_COMPONENT_GUIDE.md) | `docs/guides/web/ARTDECO_COMPONENT_GUIDE.md` |
 
-## 1.1 优先阅读顺序
+## 2. 推荐阅读顺序
 
-如果你是第一次接手，建议先按下面顺序读：
+如果你是第一次接手 ArtDeco：
 
-1. `[必读]` [ArtDeco Start Here](./ARTDECO_START_HERE.md)
-2. `[样式真值]` [ArtDeco SCSS Governance Baseline](./ARTDECO_SCSS_GOVERNANCE_BASELINE.md)
-3. `[架构]` [ArtDeco Fintech Unified Spec](./ARTDECO_FINTECH_UNIFIED_SPEC.md)
-4. `[页面]` [ArtDeco Fintech Page Composition Audit](./ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT.md)
-5. `[组件]` [ArtDeco Component Development Guide](./ARTDECO_COMPONENT_GUIDE.md)
-6. `[组件]` [ArtDeco Components Catalog](../../../web/frontend/ARTDECO_COMPONENTS_CATALOG.md)
+1. [ARTDECO_START_HERE](./ARTDECO_START_HERE.md)
+2. [ARTDECO_FINTECH_UNIFIED_SPEC](./ARTDECO_FINTECH_UNIFIED_SPEC.md)
+3. [ARTDECO_SCSS_GOVERNANCE_BASELINE](./ARTDECO_SCSS_GOVERNANCE_BASELINE.md)
+4. [ARTDECO_COMPONENT_GUIDE](./ARTDECO_COMPONENT_GUIDE.md)
+5. [ArtDeco_System_Architecture_Summary](../../api/ArtDeco_System_Architecture_Summary.md)
+6. [ARTDECO_COMPONENTS_CATALOG](../../../web/frontend/ARTDECO_COMPONENTS_CATALOG.md)
 
-## 1.2 按任务查找
+## 3. 按任务找文档
 
-如果你不是通读，而是要马上执行任务，直接按这里找：
+| 任务 | 优先文档 |
+|------|----------|
+| 判断当前 ArtDeco 到底是什么 | `ARTDECO_START_HERE.md` |
+| 判断“现在该按什么规则实现” | `ARTDECO_FINTECH_UNIFIED_SPEC.md` |
+| 改 token / 字体 / 间距 / glow / Grid | `ARTDECO_SCSS_GOVERNANCE_BASELINE.md` |
+| 判断组件放哪里 | `ARTDECO_COMPONENT_GUIDE.md` |
+| 查现有组件与页面块存量 | `web/frontend/ARTDECO_COMPONENTS_CATALOG.md` |
+| 理解页面模板与工作台壳层 | `ARTDECO_PAGE_TEMPLATE_GUIDE.md` |
+| 理解当前运行时架构 | `ArtDeco_System_Architecture_Summary.md` |
+| 查历史基线与升级背景 | `ARTDECO_V3_COMPLETE_SUMMARY.md` |
+| 查实现/页面是否已治理到位 | `ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md` / `ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT.md` |
 
-- 改 token / spacing / color / glow / 字体
-  看 `[样式真值]` 文档
-- 改页面骨架 / tabs shell / hero / layout
-  看 `[页面]` 和 `[架构]` 文档
-- 新增组件 / 判断组件放哪里
-  看 `[组件]` 文档
-- 跑验证 / 查门禁
-  看 `[验证]` 文档
-- 查历史背景 / 版本基准
-  看 `[历史基准]` 文档
+## 4. 当前目录口径
 
-## 2. 核心设计规范 (Core Specifications)
+当前 ArtDeco 文档体系按三层理解：
 
-*   **[必读][架构][样式真值] Start Here**: [ArtDeco Start Here](./ARTDECO_START_HERE.md)
-    *   One-page entry document for later AI / developers: source of truth, architecture, rules, workflow, verification, and doc map.
-*   **[样式真值] Design Tokens**: `web/frontend/src/styles/artdeco-tokens.scss`
-    *   Primary source of truth for colors (#D4AF37), spacing, and typography (Cinzel/Barlow/JetBrains Mono).
-*   **[必读][样式真值] SCSS Governance Baseline**: [ArtDeco SCSS Governance Baseline](./ARTDECO_SCSS_GOVERNANCE_BASELINE.md)
-    *   Active source of truth for SCSS layering, token usage, grid usage, compatibility boundaries, and new-code rules.
-*   **[必读][架构] ArtDeco Fintech Unified Spec**: [ArtDeco Fintech Unified Spec](./ARTDECO_FINTECH_UNIFIED_SPEC.md)
-    *   Defines how the project inherits the original ArtDeco style and where the current fintech-oriented evolution is intentional.
-*   **[架构][验证] Implementation Audit**: [ArtDeco Fintech Implementation Audit](./ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md)
-    *   Tracks what has already been implemented in the active ArtDeco/Fintech runtime chain and what remains in compatibility layers.
-*   **[页面][验证] Page Composition Audit**: [ArtDeco Fintech Page Composition Audit](./ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT.md)
-    *   Tracks page-level ArtDeco inheritance quality, first-wave remediation results, and the next consistency priorities.
-*   **[架构][历史基准] System Architecture**: [ArtDeco System Architecture Summary](../../api/ArtDeco_System_Architecture_Summary.md)
-    *   Overview of the active Container-Tab hybrid architecture and base asset boundaries.
-*   **[架构][历史基准] V3.1 Design Spec**: [ArtDeco Trading Center Optimized V3.1](../../api/ARTDECO_TRADING_CENTER_OPTIMIZED_V3.1.md)
-    *   The latest specification for the Trading Center and V3 upgrades.
-*   **[组件][历史基准] Component Catalog**: [ArtDeco Components Catalog](../../../web/frontend/ARTDECO_COMPONENTS_CATALOG.md)
-    *   Governance baseline for 80+ components and Base/Domain boundaries.
+1. **治理层**
+   `START_HERE`、`UNIFIED_SPEC`、`SCSS_GOVERNANCE_BASELINE`、`COMPONENT_GUIDE`
+2. **运行时与目录层**
+   `COMPONENTS_CATALOG`、`System_Architecture_Summary`、`PAGE_TEMPLATE_GUIDE`
+3. **验证与历史层**
+   `FINTECH_IMPLEMENTATION_AUDIT`、`FINTECH_PAGE_COMPOSITION_AUDIT`、`V3_COMPLETE_SUMMARY`
 
-## 3. 实施与指南 (Implementation & Guides)
+## 5. 不再作为当前唯一事实源的文档
 
-*   **[历史基准] V3.0 Complete Summary**: [ArtDeco V3.0 Complete Summary](../../reports/ARTDECO_V3_COMPLETE_SUMMARY.md)
-    *   Comprehensive summary of the V3.0 design system upgrade.
-*   **[历史基准] 历史/归档**: [ArtDeco v2.0 Final Completion Report](../../reports/ARTDECO_V2_FINAL_COMPLETION_REPORT.md)
-    *   Historical archive reference only, not active governance baseline.
-*   **[必读][组件] Component Guide**: [ArtDeco Component Development Guide](./ARTDECO_COMPONENT_GUIDE.md)
-    *   Coding standards and patterns for creating new ArtDeco components.
-*   **[样式真值] Grid System**: [ArtDeco Grid Quick Reference](./ARTDECO_GRID_QUICK_REFERENCE.md)
-    *   Usage guide for the responsive grid layout system (`artdeco-grid.scss`).
-*   **[页面][架构] API Mapping**: [ArtDeco Menu API Mapping](./ARTDECO_MENU_API_MAPPING.md)
-    *   Defines the relationship between menu items and backend API endpoints.
+以下文档仍可保留为历史参考，但不应作为新实现的直接规范：
 
-## 4. 页面开发与测试 (Page Development & Testing)
+- `ART_DECO_COMPONENT_SHOWCASE*.md`
+- `mystocks-artdeco-available-components.md`
+- 各类早期 ArtDeco 设计展示、阶段报告、迁移笔记
 
-*   **[页面] UI/UX Functionality**: [ArtDeco UI/UX Functionality Guide](./ARTDECO_UI_UX_FUNCTIONALITY_GUIDE.md)
-    *   Detailed breakdown of UI features and page-specific implementations.
-*   **[验证] Integration Test Plan**: [Web Frontend ArtDeco Integration Test Plan](../../reports/WEB_FRONTEND_ARTDECO_INTEGRATION_TEST_PLAN.md)
-    *   Verification strategy for components and visual consistency.
+判断原则：
 
-## 5. 视觉参考 (Visual References)
+- 能决定“现在怎么写”的，只能是活跃治理文档和源码。
+- 历史文档用来理解背景，不用来覆盖当前真值。
 
-*   **[历史基准] Component Showcase**: [ArtDeco Component Showcase V2.md](./ART_DECO_COMPONENT_SHOWCASE_V2.md)
-    *   Visual guide to component variants and rendering.
-*   **[历史基准] Visual Optimization**: [ArtDeco Visual Optimization Completion Report](../../reports/ARTDECO_VISUAL_OPTIMIZATION_COMPLETION_REPORT.md)
-    *   Recent updates to button heights, card ratios, and spacing.
+## 6. 维护规则
 
----
-**Maintenance**: All new ArtDeco documentation must be indexed here. Active guidance must stay aligned to the ArtDeco v3/v3.1 Governance Baseline. Obsolete documents are moved to `archive/docs/artdeco/`.
+- 新增 ArtDeco 文档时，必须先判断它属于治理层、运行时层还是历史层，再回填到本索引。
+- 如果文档职责变了，先改本索引，再改文档正文。
+- 如果文档路径变了，必须保留兼容入口或同步修正所有上游引用。
+- 当 `web/frontend/src/styles/artdeco-tokens.scss`、`web/frontend/src/views/artdeco-pages/**`、`web/frontend/src/components/artdeco/**` 的结构发生变化时，至少同步更新：
+  - 本索引
+  - `ARTDECO_FINTECH_UNIFIED_SPEC.md`
+  - `ARTDECO_COMPONENTS_CATALOG.md`
+  - `ArtDeco_System_Architecture_Summary.md`

--- a/governance/mainline/task-cards/pr-24.yaml
+++ b/governance/mainline/task-cards/pr-24.yaml
@@ -1,0 +1,90 @@
+version: "v0.2"
+
+task:
+  id: "pr-24"
+  title: "refresh artdeco guide index and restore compatibility entrypoints"
+  owner: "main"
+  created_at: "2026-04-01"
+
+mainline:
+  id: "L1-artdeco-doc-governance"
+  objective: "land the current ArtDeco guide map, unified spec, and compatibility entrypoints on main without broken documentation links"
+  milestone_id: "L2-artdeco-docs"
+  slice_id: "L3-guide-index-refresh"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "documentation-governance-refresh-does-not-change-product-domain-behavior"
+
+scope:
+  allowed_paths:
+    - "docs/guides/ARTDECO_COMPONENT_GUIDE.md"
+    - "docs/guides/ARTDECO_MASTER_INDEX.md"
+    - "docs/guides/multi-cli-tasks/CLI_WORKFLOW_GUIDE.md"
+    - "docs/guides/web/ARTDECO_COMPONENT_GUIDE.md"
+    - "docs/guides/web/ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md"
+    - "docs/guides/web/ARTDECO_FINTECH_UNIFIED_SPEC.md"
+    - "docs/guides/web/ARTDECO_MASTER_INDEX.md"
+    - "governance/mainline/task-cards/pr-24.yaml"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No frontend runtime or style implementation changes"
+  - "No expansion into unrelated governance or workflow assets"
+
+acceptance:
+  checks:
+    - id: "docs-diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "docs-path-presence"
+      command: "test -f docs/guides/ARTDECO_MASTER_INDEX.md && test -f docs/guides/ARTDECO_COMPONENT_GUIDE.md && test -f docs/guides/web/ARTDECO_FINTECH_UNIFIED_SPEC.md"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-24.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If compatibility entrypoints drift from the canonical web guide paths, older links and reports will continue to break"
+    - "If the master index points at missing documents, ArtDeco guide discovery regresses even though no runtime code changes"
+  rollback_plan: "git revert <merge-commit-sha> if the refreshed ArtDeco guide map introduces broken links or governance regressions"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "rebuild the ArtDeco documentation entrypoint around the active guide set and restore compatibility links"
+    modified_scope: "one worker CLI workflow guide plus the ArtDeco component guide, implementation audit, unified spec, master index, and two compatibility entrypoints"
+    dependency_changes: "none"
+    legacy_logic_impact: "no runtime behavior changes; only documentation discovery, wording, and compatibility path coverage are updated"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the docs refresh if broken links or invalid guide pointers are detected after merge"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-01T00:00:00Z"
+    approval_note: "documentation governance refresh does not require a separate OpenSpec proposal"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- refresh the worker CLI workflow guide to match the current Mongo control-plane command surface
- tighten the ArtDeco guide system around a single master index, a unified fintech spec, and compatibility entrypoints for historical links
- extend the ArtDeco implementation audit with the latest page and token-governance closure notes

## Test Plan
- git diff --check
- verified referenced guide targets exist in the docs worktree
