### PR TITLE
docs: refresh artdeco start and indexes

### DIFF
--- a/docs/guides/INDEX.md
+++ b/docs/guides/INDEX.md
@@ -1,8 +1,8 @@
 # Guides
 
-**最后更新**: 2026-03-25 02:04:55
+**最后更新**: 2026-04-01 13:57:41
 
-**文档数量**: 215
+**文档数量**: 249
 
 
 ---
@@ -41,7 +41,7 @@
   - *AMP配置*
 
 - [ARTDECO_COMPONENT_GUIDE](web/ARTDECO_COMPONENT_GUIDE.md)
-  - *ArtDeco Component Development Guide (V3.1 Governance Baseline)*
+  - *ArtDeco Component Development Guide*
 
 - [ARTDECO_FINTECH_UNIFIED_SPEC](web/ARTDECO_FINTECH_UNIFIED_SPEC.md)
   - *ArtDeco Fintech Unified Spec*
@@ -53,7 +53,7 @@
   - *ArtDeco Grid系统快速参考指南*
 
 - [ARTDECO_MASTER_INDEX](web/ARTDECO_MASTER_INDEX.md)
-  - *ArtDeco v3/v3.1 Governance Baseline - Master Index*
+  - *ArtDeco Master Index*
 
 - [ARTDECO_MENU_API_MAPPING](web/ARTDECO_MENU_API_MAPPING.md)
   - *ArtDeco菜单系统 - API映射表*

--- a/docs/guides/web/ARTDECO_START_HERE.md
+++ b/docs/guides/web/ARTDECO_START_HERE.md
@@ -1,41 +1,43 @@
 # ArtDeco Start Here
 
-本文件是 MyStocks 前端 ArtDeco / ArtDeco Fintech 的单页入口文档。
+本文件是 MyStocks 前端 ArtDeco / ArtDeco Fintech 体系的单页入口文档。
 
-如果你是第一次接手这个体系，先看这份，再决定要不要继续读更细的治理文档。
+如果你是第一次接手这个体系，先看这份，再决定是否进入更细的治理文档。
 
 ## 0. 本文档的职责
 
 `ARTDECO_START_HERE.md` 只负责 3 件事：
 
-1. 用最短路径解释“当前 ArtDeco 到底是什么”
-2. 告诉你“先看哪几份文档、先跑哪些命令”
-3. 按任务把你路由到正确文档
+1. 用最短路径解释“当前 ArtDeco 到底是什么”。
+2. 告诉你“先看哪几份文档、先跑哪些命令”。
+3. 把你路由到正确的治理文档和源码目录。
 
-它不是完整目录，也不追求收录所有文档。
+它不是完整目录。
 
 如果你需要：
 
-- **完整目录** -> 看 `ARTDECO_MASTER_INDEX.md`
-- **详细组件目录** -> 看 `ARTDECO_COMPONENTS_CATALOG.md`
-- **详细页面治理结论** -> 看 `ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT.md`
-- **详细样式真值和兼容层边界** -> 看 `ARTDECO_SCSS_GOVERNANCE_BASELINE.md`
+- **完整目录** -> 看 `docs/guides/web/ARTDECO_MASTER_INDEX.md`
+- **统一规格** -> 看 `docs/guides/web/ARTDECO_FINTECH_UNIFIED_SPEC.md`
+- **详细组件目录** -> 看 `web/frontend/ARTDECO_COMPONENTS_CATALOG.md`
+- **页面治理结论** -> 看 `docs/guides/web/ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT.md`
+- **详细样式真值和兼容边界** -> 看 `docs/guides/web/ARTDECO_SCSS_GOVERNANCE_BASELINE.md`
 
-## 1. 先记住这 7 句话
+## 1. 先记住这 8 句话
 
-1. 当前项目的活跃风格不是“原始 ArtDeco 复刻”，而是 `ArtDeco Fintech v1`。
+1. 当前项目的活跃风格是 `ArtDeco Fintech`，不是原始 ArtDeco 的机械复刻。
 2. 新代码只认 `artdeco-*` 主链，不认历史 `theme-*` / `fintech-*` 为真值。
-3. 视觉属性禁止硬编码，优先走 `artdeco-tokens.scss`。
-4. 页面不能只做黑金配色，必须有 `hero / meta / stats / tabs / content` 这类舞台层。
+3. 字体真值是 `Cinzel + Barlow + JetBrains Mono`。
+4. 间距真值是 `13` 个编号级别：`1, 2, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24, 32`。
 5. A 股语义强制执行“红涨绿跌”。
-6. 涉及 Layout 或路由变更，必须跑 `bash scripts/run_e2e_pm2.sh`。
-7. 任何菜单结构、UI/UX 风格、核心架构变更，都先遵守 `architecture/STANDARDS.md` 的 `Proposal-First Rule`。
+6. 页面不能只做黑金配色，必须有明确的舞台层和内容节奏。
+7. 涉及 Layout、路由或菜单结构时，必须跑 `bash scripts/run_e2e_pm2.sh`。
+8. 菜单结构、UI/UX 风格、核心架构变更，先遵守 `architecture/STANDARDS.md` 的 `Proposal-First Rule`。
 
 ## 2. 当前设计身份
 
 当前项目应被理解为：
 
-`Original ArtDeco` + `A 股金融语义` + `高密度量化终端` = `ArtDeco Fintech v1`
+`Original ArtDeco` + `A 股金融语义` + `高密度量化工作台` = `ArtDeco Fintech`
 
 核心气质：
 
@@ -43,16 +45,24 @@
 - 几何优先于圆润
 - 标题 uppercase + tracking
 - glow 优先于普通阴影
-- JetBrains Mono 承载数值和数据
+- `JetBrains Mono` 承载数值、状态与元信息
 - A 股红涨绿跌
-
-原始参考文件：
-
-- `/opt/mydoc/design/ArtDeco/ArtDeco.md`
 
 ## 3. 认哪套真值
 
-### 3.1 主真值层
+### 3.1 文档真值链
+
+当前活跃文档链路：
+
+1. `ARTDECO_START_HERE.md`
+2. `ARTDECO_MASTER_INDEX.md`
+3. `ARTDECO_FINTECH_UNIFIED_SPEC.md`
+4. `ARTDECO_SCSS_GOVERNANCE_BASELINE.md`
+5. `ARTDECO_COMPONENT_GUIDE.md`
+6. `web/frontend/ARTDECO_COMPONENTS_CATALOG.md`
+7. `docs/api/ArtDeco_System_Architecture_Summary.md`
+
+### 3.2 样式真值层
 
 新开发默认只认这 5 个文件：
 
@@ -73,11 +83,11 @@
 - `artdeco-financial.scss`
   金融语义色、风险/指标/监控语义
 - `artdeco-quant-extended.scss`
-  高密度交易终端扩展、dense spacing、数据字体
+  高密度交易工作台扩展、dense spacing、数据字体
 
-### 3.2 兼容层
+### 3.3 兼容层
 
-这些文件仍在运行，但不再是新真值：
+这些文件仍可能在运行链路里出现，但不再是新真值：
 
 - `web/frontend/src/styles/fintech-design-system.scss`
 - `web/frontend/src/styles/visual-optimization.scss`
@@ -99,14 +109,16 @@
 
 ### 4.1 视觉架构
 
-建议按这 3 层理解：
+建议按这 4 层理解：
 
 1. **样式基础设施层**
    `artdeco-tokens / grid / global / financial / quant-extended`
 2. **布局壳层**
    例如 `ArtDecoLayoutEnhanced.vue`
-3. **页面舞台层**
-   例如 `ArtDecoMarketData.vue`、`ArtDecoTradingCenter.vue`
+3. **可复用资产层**
+   `src/components/artdeco/**`
+4. **页面工作台层**
+   `views/artdeco-pages/**`
 
 ### 4.2 页面骨架
 
@@ -117,21 +129,31 @@
 3. `stats strip`
 4. `tabs shell`
 5. `content shell`
-6. 内部再放 domain 组件
+6. 内部再挂 domain 组件或 workbench block
 
 不要反过来先堆业务组件，再希望页面“看起来像 ArtDeco”。
 
-### 4.3 组件架构
+### 4.3 运行时承载模式
 
-总体采用 `Container-Tab` 混合架构：
+当前仓库不是单一 `Container-Tab` 模型，而是三种模式并存：
 
-- 父容器：`web/frontend/src/views/artdeco-pages/`
-- 领域组件：`web/frontend/src/views/artdeco-pages/components/`
-- 基础资产：`web/frontend/src/components/artdeco/`
+- **模板化工作台**
+  例如 `ArtDecoPageTemplate.vue`、`ArtDecoRiskManagement.vue`
+- **直接 Tab 容器**
+  例如 `ArtDecoMarketData.vue`
+- **功能树驱动总控容器**
+  例如 `ArtDecoTradingCenter.vue`
 
-组件目录总览见：
+### 4.4 组件边界
 
-- `web/frontend/ARTDECO_COMPONENTS_CATALOG.md`
+当前要区分 3 类对象：
+
+- `src/components/artdeco/**`
+  可持续沉淀的 reusable assets
+- `views/artdeco-pages/components/`
+  页面系统内部共享片段
+- `views/artdeco-pages/*-tabs/`
+  域内工作台块
 
 ## 5. 当前开发必须遵守的规则
 
@@ -145,8 +167,9 @@
 
 ### 5.2 页面规则
 
-- 新页面优先使用 `ArtDecoHeader` 或已有页面骨架模式
-- 页面至少要明确：标题区、元信息区、tabs 层、内容层
+- 新页面优先复用现有工作台壳层
+- 页面至少要明确：标题区、元信息区、内容层
+- 需要 tabs 时，优先延续 `tabs shell -> content shell` 的结构
 - TRACE_ID / request meta 位要有落点，不要完全丢掉可观测性
 
 ### 5.3 工程规则
@@ -154,6 +177,7 @@
 - 先读 `architecture/STANDARDS.md`
 - 涉及菜单结构、UI/UX 风格、核心架构时，先走审批门禁
 - 不要把旧兼容链升级为新真值
+- 当前项目是桌面端工作台，不做移动端 / 平板适配
 
 ## 6. 你要改什么，就去哪里改
 
@@ -163,9 +187,12 @@
 | Grid 模式、断点、语义布局类 | `artdeco-grid.scss` |
 | 全局 reset、背景、排版、滚动条 | `artdeco-global.scss` |
 | 指标/风险/监控/金融语义 | `artdeco-financial.scss` |
-| 高密度交易终端扩展 | `artdeco-quant-extended.scss` |
+| 高密度交易工作台扩展 | `artdeco-quant-extended.scss` |
 | Element Plus 对齐 | `element-plus-override.scss` |
-| 页面舞台层 | 对应 `views/artdeco-pages/*.vue` |
+| 可复用资产 | `src/components/artdeco/**` |
+| 页面系统共享片段 | `views/artdeco-pages/components/` |
+| 域内工作台块 | `views/artdeco-pages/*-tabs/` |
+| 页面舞台层 | `views/artdeco-pages/*.vue` |
 | 布局壳层 | `layouts/*.vue` |
 
 ## 7. 新页面 / 新组件的开发顺序
@@ -175,193 +202,25 @@
 建议顺序：
 
 1. 确定它属于哪个业务域
-2. 先复用已有页面骨架
-3. 再接入 `ArtDecoHeader`
+2. 判断它更适合模板化工作台、直接 Tab 容器，还是总控容器
+3. 先复用已有页面骨架
 4. 再放 stats / tabs / content
-5. 最后才做领域组件细节
+5. 最后才做领域细节
 
 ### 7.2 新组件
 
 建议顺序：
 
-1. 优先放在 `src/components/artdeco/`
-2. 先判断属于 `base / core / business / charts / trading / advanced`
-3. 样式优先用 token，不要自带第二套视觉语言
+1. 先判断它是不是 reusable asset
+2. 如果是 reusable，再判断属于 `base / core / business / charts / trading / advanced / specialized`
+3. 如果不是 reusable，再判断应放 `views/artdeco-pages/components/` 还是 `views/artdeco-pages/*-tabs/`
+4. 样式优先用 token，不要自带第二套视觉语言
 
 ## 8. 验证怎么做
 
 ### 8.1 基础门禁
 
-单文件样式检查：
-
-```bash
-cd web/frontend
-node scripts/check-artdeco-tokens.js --target-file src/path/to/file.vue
-```
-
 当前变更范围检查：
-
-```bash
-cd web/frontend
-npm run lint:artdeco:changed
-```
-
-### 8.2 Layout / 路由变更
-
-涉及 Layout、路由、菜单结构时，必须跑：
-
-```bash
-bash scripts/run_e2e_pm2.sh
-```
-
-当前这条链已经验证通过：
-
-- 项目：`chromium`
-- 套件：`tests/navigation-consistency.spec.ts`
-- 结果：`14 passed`
-
-## 9. 当前已完成到什么程度
-
-### 9.1 已完成
-
-- P0：字体真值、glow 语义、主导入链路统一
-- P1：兼容层边界显式化、活跃旧字体清理
-- P2 第一轮页面治理：
-  - `ArtDecoMarketData.vue`
-  - `ArtDecoSystemSettings.vue`
-  - `ArtDecoTradingCenter.vue`
-  - `ArtDecoTechnicalAnalysis.vue`
-  - `ArtDecoSettings.vue`
-  - `ArtDecoDataAnalysis.vue`
-  - `ArtDecoLayoutEnhanced.vue`
-  - `ArtDecoMarketOverview.vue`
-
-### 9.2 进行中
-
-- P3 第二轮页面治理：
-  - `ArtDecoStockManagement.vue`
-  - `ArtDecoMarketQuotes.vue`
-  - `ArtDecoTradingManagement.vue`
-
-### 9.3 仍待继续
-
-- 剩余未专项治理页面的一致性审查
-- 页面壳层进一步模板化
-- 历史兼容层长期归档/下线顺序
-
-## 10. 文档地图
-
-### 10.1 先读
-
-- [ARTDECO_SCSS_GOVERNANCE_BASELINE](./ARTDECO_SCSS_GOVERNANCE_BASELINE.md)
-- [ARTDECO_FINTECH_UNIFIED_SPEC](./ARTDECO_FINTECH_UNIFIED_SPEC.md)
-- [ARTDECO_FINTECH_IMPLEMENTATION_AUDIT](./ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md)
-- [ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT](./ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT.md)
-
-### 10.2 继续读
-
-- [ARTDECO_MASTER_INDEX](./ARTDECO_MASTER_INDEX.md)
-- [ARTDECO_COMPONENT_GUIDE](./ARTDECO_COMPONENT_GUIDE.md)
-- [ARTDECO_GRID_QUICK_REFERENCE](./ARTDECO_GRID_QUICK_REFERENCE.md)
-- [ARTDECO_PAGE_TEMPLATE_GUIDE](./ARTDECO_PAGE_TEMPLATE_GUIDE.md)
-- [ARTDECO_UI_UX_FUNCTIONALITY_GUIDE](./ARTDECO_UI_UX_FUNCTIONALITY_GUIDE.md)
-
-### 10.3 架构与组件
-
-- [ArtDeco System Architecture Summary](/opt/claude/mystocks_spec/docs/api/ArtDeco_System_Architecture_Summary.md)
-- [ARTDECO_COMPONENTS_CATALOG](/opt/claude/mystocks_spec/web/frontend/ARTDECO_COMPONENTS_CATALOG.md)
-- [ARTDECO_V3_COMPLETE_SUMMARY](/opt/claude/mystocks_spec/docs/reports/ARTDECO_V3_COMPLETE_SUMMARY.md)
-
-### 10.4 历史高价值文档
-
-这些文档不是当前唯一事实源，但仍值得保留：
-
-- `docs/api/ArtDeco_System_Architecture_Summary.md`
-- `web/frontend/ARTDECO_COMPONENTS_CATALOG.md`
-- `docs/reports/ARTDECO_V3_COMPLETE_SUMMARY.md`
-
-使用方式：
-
-- 看它们是为了理解历史架构、组件存量和 V3.0 升级过程
-- 真正决定“现在怎么写”的，仍然是本目录下 `web/` 入口体系
-
-## 11. 常见任务入口
-
-如果你不是要“通读体系”，而是要“马上开始一个任务”，直接按下面找：
-
-### 11.1 我要改页面骨架 / 页面布局
-
-先看：
-
-- `docs/guides/web/ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT.md`
-- `docs/guides/web/ARTDECO_PAGE_TEMPLATE_GUIDE.md`
-- `docs/guides/web/ARTDECO_SCSS_GOVERNANCE_BASELINE.md`
-
-再看源码：
-
-- 目标页面对应的 `views/artdeco-pages/*.vue`
-- `web/frontend/src/layouts/ArtDecoLayoutEnhanced.vue`
-
-### 11.2 我要新增组件 / 判断组件该放哪里
-
-先看：
-
-- `docs/guides/web/ARTDECO_COMPONENT_GUIDE.md`
-- `web/frontend/ARTDECO_COMPONENTS_CATALOG.md`
-
-再做判断：
-
-- 原子 UI -> `base`
-- 页面骨架 / 导航 / 反馈 -> `core`
-- 通用业务交互 -> `business`
-- 图表 -> `charts`
-- 交易域 -> `trading`
-- 高阶分析 -> `advanced`
-- 强专题 -> `specialized`
-- 单页面专属 -> 页面域，不要提升
-
-### 11.3 我要修样式 / token / 布局令牌
-
-先看：
-
-- `docs/guides/web/ARTDECO_SCSS_GOVERNANCE_BASELINE.md`
-- `docs/guides/web/ARTDECO_FINTECH_UNIFIED_SPEC.md`
-
-再改源码：
-
-- `artdeco-tokens.scss`
-- `artdeco-grid.scss`
-- `artdeco-global.scss`
-- `artdeco-financial.scss`
-- `artdeco-quant-extended.scss`
-
-### 11.4 我要修兼容层 / 历史层
-
-先看：
-
-- `docs/guides/web/ARTDECO_SCSS_GOVERNANCE_BASELINE.md`
-- `docs/guides/web/ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md`
-
-原则：
-
-- 兼容层可以修，但只做最小必要修复
-- 不要把兼容层重新升级为真值
-
-### 11.5 我要判断当前进展到哪一步
-
-先看：
-
-- `docs/guides/web/ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md`
-- `docs/guides/web/ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT.md`
-
-它们分别回答：
-
-- 基础设施层和治理层做到哪里了
-- 页面级构图治理做到哪里了
-
-### 11.6 我要做验证 / 自测
-
-先跑：
 
 ```bash
 cd web/frontend
@@ -375,44 +234,34 @@ cd web/frontend
 node scripts/check-artdeco-tokens.js --target-file src/path/to/file.vue
 ```
 
-如果改了 Layout / 路由 / 菜单：
+### 8.2 Layout / 路由变更
+
+涉及 Layout、路由、菜单结构时，必须跑：
 
 ```bash
 bash scripts/run_e2e_pm2.sh
 ```
 
-### 11.7 我要理解历史背景 / 为什么会有今天这套体系
+报告时必须写实际执行结果，不要复用固定通过文案。
 
-先看：
+## 9. 当前文档地图
 
-- `docs/api/ArtDeco_System_Architecture_Summary.md`
-- `web/frontend/ARTDECO_COMPONENTS_CATALOG.md`
-- `docs/reports/ARTDECO_V3_COMPLETE_SUMMARY.md`
+### 9.1 先读
 
-注意：
+- [ARTDECO_MASTER_INDEX](./ARTDECO_MASTER_INDEX.md)
+- [ARTDECO_FINTECH_UNIFIED_SPEC](./ARTDECO_FINTECH_UNIFIED_SPEC.md)
+- [ARTDECO_SCSS_GOVERNANCE_BASELINE](./ARTDECO_SCSS_GOVERNANCE_BASELINE.md)
+- [ARTDECO_COMPONENT_GUIDE](./ARTDECO_COMPONENT_GUIDE.md)
 
-- 这些是高价值历史和结构文档
-- 不是当前唯一事实源
+### 9.2 再读
 
-## 12. 推荐阅读顺序
+- [ARTDECO_FINTECH_IMPLEMENTATION_AUDIT](./ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md)
+- [ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT](./ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT.md)
+- [ARTDECO_PAGE_TEMPLATE_GUIDE](./ARTDECO_PAGE_TEMPLATE_GUIDE.md)
+- [ArtDeco System Architecture Summary](/opt/claude/mystocks_spec/docs/api/ArtDeco_System_Architecture_Summary.md)
+- [ARTDECO_COMPONENTS_CATALOG](/opt/claude/mystocks_spec/web/frontend/ARTDECO_COMPONENTS_CATALOG.md)
+- [ARTDECO_V3_COMPLETE_SUMMARY](/opt/claude/mystocks_spec/docs/reports/ARTDECO_V3_COMPLETE_SUMMARY.md)
 
-如果你是后续 AI 或开发者，建议按这个顺序接手：
+## 10. 一句话结论
 
-1. 本文档
-2. `architecture/STANDARDS.md`
-3. `ARTDECO_SCSS_GOVERNANCE_BASELINE.md`
-4. `artdeco-tokens.scss`
-5. `ARTDECO_FINTECH_UNIFIED_SPEC.md`
-6. `ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md`
-7. `ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT.md`
-8. 需要改的具体页面/组件源码
-
-## 13. 一句话结论
-
-现在的 MyStocks ArtDeco 已经不是“黑金主题集合”，而是一套已成形的 `ArtDeco Fintech v1` 前端体系。
-
-后续开发的关键，不再是重新发明风格，而是：
-
-- 继续坚持主 token 链
-- 继续复用统一页面骨架
-- 不让历史兼容层重新变成事实源
+现在的 MyStocks ArtDeco 已经不是“黑金主题集合”，而是一套由统一规格、设计令牌、组件分层和页面工作台共同维持的 `ArtDeco Fintech` 前端体系。

--- a/docs/guides/web/INDEX.md
+++ b/docs/guides/web/INDEX.md
@@ -1,6 +1,6 @@
 # MyStocks 文档索引
 
-**生成时间**: 2026-03-26 11:20:03
+**生成时间**: 2026-04-01 13:57:41
 
 
 ---
@@ -13,9 +13,9 @@
 ## 📊 统计信息
 
 
-- **总文档数**: 57
+- **总文档数**: 59
 - **总目录数**: 0
-- **最后更新**: 2026-03-26
+- **最后更新**: 2026-04-01
 
 ---
 
@@ -25,6 +25,7 @@
 - 📄 [README](./INDEX.md)
 - 📄 [2026-01-23-html5-migration-experience-optimization](2026-01-23-html5-migration-experience-optimization.md)
 - 📄 [ARTDECO_COMPONENT_GUIDE](ARTDECO_COMPONENT_GUIDE.md)
+- 📄 [ARTDECO_FINTECH_UNIFIED_SPEC](ARTDECO_FINTECH_UNIFIED_SPEC.md)
 - 📄 [ARTDECO_FINTECH_IMPLEMENTATION_AUDIT](ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md)
 - 📄 [ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT](ARTDECO_FINTECH_PAGE_COMPOSITION_AUDIT.md)
 - 📄 [ARTDECO_GRID_QUICK_REFERENCE](ARTDECO_GRID_QUICK_REFERENCE.md)

--- a/governance/mainline/task-cards/pr-25.yaml
+++ b/governance/mainline/task-cards/pr-25.yaml
@@ -1,0 +1,86 @@
+version: "v0.2"
+
+task:
+  id: "pr-25"
+  title: "refresh artdeco start-here and docs indexes"
+  owner: "main"
+  created_at: "2026-04-01"
+
+mainline:
+  id: "L1-artdeco-doc-followup"
+  objective: "land the remaining ArtDeco start-here and docs index refresh on main with valid guide references"
+  milestone_id: "L2-artdeco-docs"
+  slice_id: "L3-start-here-followup"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "documentation-entrypoint-refresh-does-not-change-product-domain-behavior"
+
+scope:
+  allowed_paths:
+    - "docs/guides/INDEX.md"
+    - "docs/guides/web/ARTDECO_START_HERE.md"
+    - "docs/guides/web/INDEX.md"
+    - "governance/mainline/task-cards/pr-25.yaml"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No frontend runtime or style implementation changes"
+  - "No broad docs taxonomy rewrite beyond the three guide entrypoint files"
+
+acceptance:
+  checks:
+    - id: "docs-diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "docs-path-presence"
+      command: "test -f docs/guides/web/ARTDECO_MASTER_INDEX.md && test -f docs/guides/web/ARTDECO_FINTECH_UNIFIED_SPEC.md && test -f docs/guides/web/ARTDECO_COMPONENT_GUIDE.md"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-25.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the refreshed start-here document points at stale paths, new readers will still fall onto invalid guide routes"
+    - "If the generated guide indexes drift from the actual file set, docs discovery regresses again"
+  rollback_plan: "git revert <merge-commit-sha> if the guide entrypoint refresh introduces broken references after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close the remaining ArtDeco documentation entrypoint gaps after the guide index refresh batch"
+    modified_scope: "the top-level guides index, the ArtDeco start-here entrypoint, the web guide index, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "no runtime behavior changes; only documentation navigation and wording are refreshed"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the follow-up if guide links or index metadata regress after merge"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-01T00:00:00Z"
+    approval_note: "ArtDeco docs follow-up is documentation-only cleanup"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- refresh the main docs indexes so the ArtDeco guide titles, counts, and generated timestamps match the current guide set
- rewrite `ARTDECO_START_HERE.md` to point at the unified spec, current truth chain, and current runtime/page boundaries
- keep the follow-up scope limited to guide navigation and entrypoint wording, without changing frontend runtime code

## Test Plan
- git diff --check
- verified the referenced ArtDeco guide targets exist from the docs worktree
