### PR TITLE
api: harden legacy market compatibility typing

### DIFF
--- a/governance/mainline/task-cards/pr-26.yaml
+++ b/governance/mainline/task-cards/pr-26.yaml
@@ -1,0 +1,88 @@
+version: "v0.2"
+
+task:
+  id: "pr-26"
+  title: "harden legacy market api compatibility typing"
+  owner: "main"
+  created_at: "2026-04-01"
+
+mainline:
+  id: "L1-frontend-api-compat"
+  objective: "land typed cleanup for the legacy frontend market compatibility layer without changing current mock behavior"
+  milestone_id: "L2-frontend-api-compat"
+  slice_id: "L3-legacy-market-typing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "frontend-api-compatibility-layer-is-not-currently-covered-by-function-tree-catalog"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-26.yaml"
+    - "web/frontend/src/api/marketWithFallback.ts"
+    - "web/frontend/src/api/mockApiClient.ts"
+    - "web/frontend/src/api/__tests__/market-integration.test.ts"
+    - "web/frontend/src/api/__tests__/strategy.test.ts"
+    - "web/frontend/src/api/klineApi.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No broad frontend API type migration outside the legacy market compatibility path"
+  - "No product behavior change beyond preserving compatibility with the current typed service contracts"
+
+acceptance:
+  checks:
+    - id: "frontend-api-vitest"
+      command: "cd web/frontend && npx vitest run src/api/__tests__/market-integration.test.ts src/api/__tests__/strategy.test.ts src/api/klineApi.spec.ts"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-26.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "The typed cleanup touches a legacy compatibility layer still consumed by older frontend code paths"
+    - "Mock API helper changes could affect downstream test fixtures if behavior changes instead of just typing"
+  rollback_plan: "git revert <merge-commit-sha> if legacy market compatibility or mock API frontend tests regress after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "remove ts-nocheck and align the legacy market compatibility layer with current typed frontend APIs"
+    modified_scope: "legacy market compatibility layer, mock API client typing, and focused frontend API regression tests"
+    dependency_changes: "none"
+    legacy_logic_impact: "existing compatibility behavior is preserved while parameter mapping and mock request typing become explicit"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if frontend API compatibility tests or downstream mock consumers regress"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-01T00:00:00Z"
+    approval_note: "legacy frontend api typing cleanup does not require a separate OpenSpec proposal"
+    secondary_approved: false

--- a/web/frontend/src/api/__tests__/market-integration.test.ts
+++ b/web/frontend/src/api/__tests__/market-integration.test.ts
@@ -6,6 +6,8 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 
 const {
   getMarketOverviewMock,
@@ -74,5 +76,58 @@ describe('Market API legacy compatibility layer', () => {
     expect(marketApiService.getMarketOverview).toBeDefined()
     expect(marketApiService.getFundFlow).toBeDefined()
     expect(marketApiService.getKLineData).toBeDefined()
+  })
+
+  it('does not rely on ts-nocheck in the legacy compatibility layer', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/api/marketWithFallback.ts'), 'utf8')
+    const forbiddenDirective = '@ts-' + 'nocheck'
+
+    expect(source).not.toContain(forbiddenDirective)
+  })
+
+  it('delegates fund flow requests using the modern parameter names', async () => {
+    const fundFlow = [{ date: '2026-03-31', netInflow: 12.5 }]
+    getFundFlowMock.mockResolvedValueOnce(fundFlow)
+
+    await expect(
+      marketApiService.getFundFlow({
+        startDate: '2026-03-01',
+        endDate: '2026-03-31',
+        market: 'sz'
+      })
+    ).resolves.toEqual(fundFlow)
+
+    expect(getFundFlowMock).toHaveBeenCalledWith({
+      startDate: '2026-03-01',
+      endDate: '2026-03-31',
+      market: 'sz'
+    })
+  })
+
+  it('falls back unsupported legacy kline intervals to 1d with modern field names', async () => {
+    const kline = {
+      categoryData: ['2026-03-31'],
+      values: [[1, 2, 0.5, 2.5]],
+      volumes: [1000]
+    }
+    getKLineDataMock.mockResolvedValueOnce(kline)
+
+    await expect(
+      marketApiService.getKLineData({
+        symbol: '000001.SZ',
+        interval: '4h',
+        startDate: '2026-03-01',
+        endDate: '2026-03-31',
+        limit: 50
+      })
+    ).resolves.toEqual(kline)
+
+    expect(getKLineDataMock).toHaveBeenCalledWith({
+      symbol: '000001.SZ',
+      interval: '1d',
+      startDate: '2026-03-01',
+      endDate: '2026-03-31',
+      limit: 50
+    })
   })
 })

--- a/web/frontend/src/api/__tests__/strategy.test.ts
+++ b/web/frontend/src/api/__tests__/strategy.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { StrategyAdapter } from '@/api/adapters/strategyAdapter';
 import { mockStrategyList, mockStrategyDetail, mockBacktestTask } from '@/mock/strategyMock';
 import type { UnifiedResponse } from '@/api/apiClient';
+import type { Strategy } from '@/api/types/extensions/strategy';
 
 // Mock console methods
 global.console = {
@@ -231,16 +232,19 @@ describe('StrategyAdapter', () => {
     });
 
     it('should reject strategy with invalid type', () => {
-      const invalidStrategy = {
+      const invalidStrategy: Strategy = {
         id: '1',
         name: 'Test',
         description: 'Test',
-        type: 'invalid_type' as any,
+        type: 'custom',
         status: 'active' as const,
-        createdAt: new Date(),
-        updatedAt: new Date(),
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
         parameters: {},
       };
+      Object.defineProperty(invalidStrategy, 'type', {
+        value: 'invalid_type',
+      });
 
       const result = StrategyAdapter.validateStrategy(invalidStrategy);
       expect(result).toBe(false);

--- a/web/frontend/src/api/klineApi.spec.ts
+++ b/web/frontend/src/api/klineApi.spec.ts
@@ -11,13 +11,14 @@ describe('klineApi', () => {
   describe('getKline', () => {
     it('should return K-line data structure', async () => {
       // Mock the API response
-      vi.spyOn(klineApi as any, 'getKline').mockResolvedValue({
+      const getKlineSpy = vi.spyOn(klineApi, 'getKline').mockResolvedValue({
         symbol: '000001.SH',
         candles: []
       })
 
       // The test would verify the structure when real API is available
       expect(klineApi).toBeDefined()
+      getKlineSpy.mockRestore()
     })
   })
 

--- a/web/frontend/src/api/marketWithFallback.ts
+++ b/web/frontend/src/api/marketWithFallback.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * Market Data API with Fallback - Refactored
  *
@@ -17,7 +16,7 @@
  */
 
 import MarketApiServiceClass from './market.ts';
-import type { MarketOverviewVM, FundFlowChartPoint, KLineChartData } from './types/market.ts';
+import type { MarketOverviewVM, FundFlowChartPoint, KLineChartData } from '@/utils/adapters.ts';
 
 // Re-export types for backward compatibility
 export type {
@@ -71,11 +70,9 @@ class MarketApiServiceWithFallback {
   ): Promise<FundFlowChartPoint[]> {
     console.warn('[DEPRECATED] getFundFlow() - use useMarket() composable instead');
 
-    return this.marketService.getFundFlow({
-      symbol: params?.market || 'sh000001', // Default to Shanghai index
-      start_date: params?.startDate,
-      end_date: params?.endDate,
-    });
+    void this.useRealData;
+
+    return this.marketService.getFundFlow(params);
   }
 
   /**
@@ -100,20 +97,22 @@ class MarketApiServiceWithFallback {
 
     // Map legacy intervals to new API intervals
     // New API only supports: "1m" | "5m" | "15m" | "30m" | "1h" | "1d"
-    const supportedIntervals = ['1m', '5m', '15m', '30m', '1h', '1d'] as const;
-    const interval = supportedIntervals.includes(params.interval as unknown)
-      ? params.interval
-      : '1d'; // Default to 1d for unsupported intervals
+    type SupportedInterval = '1m' | '5m' | '15m' | '30m' | '1h' | '1d';
+    const supportedIntervals = new Set<SupportedInterval>(['1m', '5m', '15m', '30m', '1h', '1d']);
+    const interval: SupportedInterval = supportedIntervals.has(params.interval as SupportedInterval)
+      ? (params.interval as SupportedInterval)
+      : '1d';
 
-    if (!supportedIntervals.includes(params.interval as unknown)) {
+    if (interval !== params.interval) {
       console.warn(`[MarketApiServiceWithFallback] Interval '${params.interval}' not supported by new API, using '1d' instead`);
     }
 
     return this.marketService.getKLineData({
       symbol: params.symbol,
-      interval: interval as typeof supportedIntervals[number],
-      start_date: params.startDate,
-      end_date: params.endDate,
+      interval,
+      startDate: params.startDate,
+      endDate: params.endDate,
+      limit: params.limit,
     });
   }
 

--- a/web/frontend/src/api/mockApiClient.ts
+++ b/web/frontend/src/api/mockApiClient.ts
@@ -1,9 +1,23 @@
-// @ts-nocheck
 // web/frontend/src/api/mockApiClient.ts
 
 import type { UnifiedResponse } from './types/common.ts';
 import mockDashboard from '../mock/mockDashboard.js';
 import { loadMockKlineData } from './mockKlineData.ts';
+import type { IntervalType } from '../types/kline.ts';
+
+type RequestParams = Record<string, unknown>;
+
+interface MockRequestConfig {
+  params?: RequestParams;
+}
+
+function getRequestParams(config?: MockRequestConfig): RequestParams {
+  return config?.params ?? {};
+}
+
+function isIntervalType(value: unknown): value is IntervalType {
+  return value === '1m' || value === '5m' || value === '15m' || value === '1h' || value === '1d' || value === '1w' || value === '1M';
+}
 
 // A simple delay function to simulate network latency
 const simulateNetworkDelay = (min = 100, max = 500) =>
@@ -20,6 +34,8 @@ const createMockResponse = <T>(data: T): UnifiedResponse<T> => ({
   errors: null,
 });
 
+const toMockResult = <T>(value: unknown): T => value as T;
+
 const normalizeMockPath = (url = '') => url.replace(/^\/api(?=\/)/, '');
 
 const matchesMockRoute = (url: string, route: string): boolean => {
@@ -34,10 +50,11 @@ const matchesMockRoute = (url: string, route: string): boolean => {
 };
 
 export const mockApiClient = {
-  async get<T = UnifiedResponse>(url: string, config?: unknown): Promise<T> {
+  async get<T = UnifiedResponse<unknown>>(url: string, config?: MockRequestConfig): Promise<T> {
     await simulateNetworkDelay();
+    console.log(`[Mock API] GET ${url}`, config);
 
-    const params = config?.params || {};
+    const params = getRequestParams(config);
 
     // --- Dashboard & Market Routes ---
 
@@ -68,7 +85,7 @@ export const mockApiClient = {
       return {
         ...response,
         process_time: '0.00'
-      } as unknown;
+      } as T;
     }
 
     // 2. Market Overview (ETF List / Indices)
@@ -80,7 +97,7 @@ export const mockApiClient = {
         { symbol: '399006.SZ', name: '创业板指', latest_price: 2156.89, change_percent: -0.45, volume: 500000 },
         { symbol: '510300.SH', name: '沪深300', latest_price: 3800.00, change_percent: 0.50, volume: 800000 },
       ];
-      return createMockResponse(indices) as unknown;
+      return toMockResult<T>(createMockResponse(indices));
     }
 
     // 3. Fund Flow
@@ -91,7 +108,7 @@ export const mockApiClient = {
         northTotal: { amount: 58.8, monthly: 1256 },
         mainForce: { amount: 126.5, percentage: 68 }
       };
-      return createMockResponse(flowData) as unknown;
+      return toMockResult<T>(createMockResponse(flowData));
     }
 
     if (url.includes('/api/market/fund-flow')) {
@@ -102,7 +119,7 @@ export const mockApiClient = {
         northTotal: { amount: 58.8, monthly: 1256 },
         mainForce: { amount: 126.5, percentage: 68 }
       };
-      return createMockResponse(flowData) as unknown;
+      return toMockResult<T>(createMockResponse(flowData));
     }
 
     // 4. Industry Flow
@@ -111,13 +128,13 @@ export const mockApiClient = {
         ...sector,
         amount: Number((150 - index * 12.5).toFixed(1))
       }));
-      return createMockResponse(sectors) as unknown;
+      return toMockResult<T>(createMockResponse(sectors));
     }
 
     if (url.includes('/api/market/industry/flow')) {
       // Use mockDashboard logic
       const sectors = mockDashboard.getLeadingSectors();
-      return createMockResponse(sectors) as unknown;
+      return toMockResult<T>(createMockResponse(sectors));
     }
 
     // 5. Stock Flow Ranking
@@ -129,7 +146,7 @@ export const mockApiClient = {
         { code: '600036', name: '招商银行', amount: 6.7, change: 1.2 },
         { code: '000002', name: '万科A', amount: -3.1, change: -0.9 }
       ];
-      return createMockResponse(stocks) as unknown;
+      return toMockResult<T>(createMockResponse(stocks));
     }
 
     if (url.includes('/api/monitoring/stock/flow/ranking')) {
@@ -140,7 +157,7 @@ export const mockApiClient = {
         { code: '600036', name: '招商银行', amount: 6.7, change: 1.2 },
         { code: '000002', name: '万科A', amount: -3.1, change: -0.9 }
       ];
-      return createMockResponse(stocks) as unknown;
+      return toMockResult<T>(createMockResponse(stocks));
     }
 
     // 6. Long Hu Bang (Dragon Tiger List)
@@ -149,7 +166,7 @@ export const mockApiClient = {
         { code: '000001', name: '平安银行', reason: '日涨幅偏离值达7%', amount: 12000, change_percent: 10.01 },
         { code: '600000', name: '浦发银行', reason: '连续三个交易日内，涨幅偏离值累计达20%', amount: 8500, change_percent: 9.98 }
       ];
-      return createMockResponse(lhb) as unknown;
+      return toMockResult<T>(createMockResponse(lhb));
     }
 
     // 7. Block Trading
@@ -158,15 +175,15 @@ export const mockApiClient = {
         { code: '600519', name: '贵州茅台', price: 1800.00, amount: 5000, buyer: '机构专用', seller: '中信证券北京总部' },
         { code: '300750', name: '宁德时代', price: 240.00, amount: 3000, buyer: '深股通专用', seller: '机构专用' }
       ];
-      return createMockResponse(block) as unknown;
+      return toMockResult<T>(createMockResponse(block));
     }
 
     // 8. K-Line Data
     if (url.includes('/api/market/kline')) {
-        const symbol = params.symbol || '000001.SH';
-        const period = params.period || '1d';
+        const symbol = typeof params.symbol === 'string' ? params.symbol : '000001.SH';
+        const period = isIntervalType(params.period) ? params.period : '1d';
         const kline = await loadMockKlineData(symbol, period);
-        return createMockResponse(kline.candles) as unknown;
+        return toMockResult<T>(createMockResponse(kline.candles));
     }
 
     // 9. Real-time Quote
@@ -180,7 +197,7 @@ export const mockApiClient = {
             volume: Math.floor(Math.random() * 1000000),
             turnover: Math.floor(Math.random() * 100000000)
         };
-        return createMockResponse(quote) as unknown;
+        return toMockResult<T>(createMockResponse(quote));
     }
 
     // 10. Intraday Trend
@@ -199,26 +216,26 @@ export const mockApiClient = {
         // push order: oldest first. So it is chronological. 
         // However, let's just return what generateMockCandles returns.
         
-        return createMockResponse({
+        return toMockResult<T>(createMockResponse({
             symbol,
             lastClose: kline.candles[0].open * 0.98, // approximate
             data: kline.candles.map(c => c.close) // Simpler trend array
-        }) as unknown;
+        }));
     }
 
     // 11. Technical Indicators
     if (url.includes('/api/strategy/v2/indicators')) {
-      return createMockResponse([
+      return toMockResult<T>(createMockResponse([
         { name: 'RSI', value: '65.2', signal: '超买', signalType: 'fall' },
         { name: 'MACD', value: '+0.45', signal: '金叉', signalType: 'rise' },
         { name: 'KDJ', value: '78.5', signal: '中性', signalType: 'neutral' },
         { name: 'BOLL', value: '上轨', signal: '强势', signalType: 'rise' }
-      ]) as unknown;
+      ]));
     }
 
     // 12. Portfolio Summary & Positions
     if (url.includes('/api/portfolio/v2/summary')) {
-      return createMockResponse({
+      return toMockResult<T>(createMockResponse({
         total_assets: 1256789,
         daily_pnl: 8450,
         daily_pnl_percent: 0.68,
@@ -228,12 +245,12 @@ export const mockApiClient = {
           { symbol: '600519', name: '贵州茅台', quantity: 100, cost: 1800, price: 1850, pnl: 5000, pnl_percent: 2.78 },
           { symbol: '300750', name: '宁德时代', quantity: 200, cost: 230, price: 245, pnl: 3000, pnl_percent: 6.52 }
         ]
-      }) as unknown;
+      }));
     }
 
     // 13. Watchlist Data
     if (url.includes('/api/portfolio/v2/watchlist')) {
-      return createMockResponse([
+      return toMockResult<T>(createMockResponse([
         { 
           id: 'default', 
           name: '默认自选', 
@@ -250,47 +267,47 @@ export const mockApiClient = {
             { symbol: '002230', name: '科大讯飞', price: '45.6', change: -1.2 }
           ] 
         }
-      ]) as unknown;
+      ]));
     }
 
     // 14. Data Quality Monitoring
     if (url.includes('/api/monitoring/v2/data-quality')) {
-      return createMockResponse({
+      return toMockResult<T>(createMockResponse({
         metrics: { integrity: 99.8, accuracy: 99.5, timeliness: 98.2, consistency: 99.1 },
         sources: [
           { name: '交易所实时行情', type: '实时', status: 'healthy', statusText: '正常', quality: 100 },
           { name: '财务报表数据库', type: '离线', status: 'healthy', statusText: '正常', quality: 99.5 },
           { name: '问财三方数据', type: 'API', status: 'warning', statusText: '稍慢', quality: 85.2 }
         ]
-      }) as unknown;
+      }));
     }
 
     // Default fallback
     console.warn(`[Mock API] No handler for GET ${url}, returning generic mock.`);
-    return { ...createMockResponse({}), data: { url, method: 'GET', ...config?.params } } as T;
+      return { ...createMockResponse({}), data: { url, method: 'GET', ...params } } as T;
   },
 
-  async post<T = UnifiedResponse>(url: string, data?: unknown, config?: unknown): Promise<T> {
+  async post<T = UnifiedResponse<unknown>>(url: string, data?: unknown, config?: MockRequestConfig): Promise<T> {
     await simulateNetworkDelay();
     console.warn(`[Mock API] POST request to ${url} with data:`, data, 'and config:', config);
-    return { ...createMockResponse({}), data: { url, method: 'POST', requestData: data, ...config?.params } } as T;
+    return { ...createMockResponse({}), data: { url, method: 'POST', requestData: data, ...getRequestParams(config) } } as T;
   },
 
-  async put<T = UnifiedResponse>(url: string, data?: unknown, config?: unknown): Promise<T> {
+  async put<T = UnifiedResponse<unknown>>(url: string, data?: unknown, config?: MockRequestConfig): Promise<T> {
     await simulateNetworkDelay();
     console.warn(`[Mock API] PUT request to ${url} with data:`, data, 'and config:', config);
-    return { ...createMockResponse({}), data: { url, method: 'PUT', requestData: data, ...config?.params } } as T;
+    return { ...createMockResponse({}), data: { url, method: 'PUT', requestData: data, ...getRequestParams(config) } } as T;
   },
 
-  async patch<T = UnifiedResponse>(url: string, data?: unknown, config?: unknown): Promise<T> {
+  async patch<T = UnifiedResponse<unknown>>(url: string, data?: unknown, config?: MockRequestConfig): Promise<T> {
     await simulateNetworkDelay();
     console.warn(`[Mock API] PATCH request to ${url} with data:`, data, 'and config:', config);
-    return { ...createMockResponse({}), data: { url, method: 'PATCH', requestData: data, ...config?.params } } as T;
+    return { ...createMockResponse({}), data: { url, method: 'PATCH', requestData: data, ...getRequestParams(config) } } as T;
   },
 
-  async delete<T = UnifiedResponse>(url: string, config?: unknown): Promise<T> {
+  async delete<T = UnifiedResponse<unknown>>(url: string, config?: MockRequestConfig): Promise<T> {
     await simulateNetworkDelay();
     console.warn(`[Mock API] DELETE request to ${url} with config:`, config);
-    return { ...createMockResponse({}), data: { url, method: 'DELETE', ...config?.params } } as T;
+    return { ...createMockResponse({}), data: { url, method: 'DELETE', ...getRequestParams(config) } } as T;
   },
 };


### PR DESCRIPTION
## Summary
- remove `@ts-nocheck` from the legacy market compatibility layer and align it with the current typed adapter contracts
- tighten the mock API client request helpers and interval handling without changing its external mock behavior
- add focused API regression coverage for the legacy market compatibility path and related typed test cases

## Test Plan
- cd web/frontend && npx vitest run src/api/__tests__/market-integration.test.ts src/api/__tests__/strategy.test.ts src/api/klineApi.spec.ts
