### PR TITLE
docs: preserve historical cleanup reports

### DIFF
--- a/docs/reports/INDEX.md
+++ b/docs/reports/INDEX.md
@@ -64,6 +64,9 @@
 - [2026-03-23-frontend-gates-ship-kit](tasks/2026-03-23-frontend-gates-ship-kit.md)
   - *Frontend Gates Ship Kit*
 
+- [2026-03-27-local-dirty-worktree-batch-plan](tasks/2026-03-27-local-dirty-worktree-batch-plan.md)
+  - *历史工作计划：本地脏工作区分批方案*
+
 - [AGENTS_CLEANUP_COMPLETION_SUMMARY](completion_reports/AGENTS_CLEANUP_COMPLETION_SUMMARY.md)
   - *Claude Code Agents Cleanup - Final Completion Summary*
 
@@ -373,6 +376,12 @@
 - [CODE_REVIEW_REPORT](CODE_REVIEW_REPORT.md)
   - *MyStocks 项目代码审查报告*
 
+- [code-cleanup-proposal-2026-03-29](code-cleanup-proposal-2026-03-29.md)
+  - *历史提案：前端代码清理候选项（未执行）*
+
+- [codebase-cleanup-2026-03-29](codebase-cleanup-2026-03-29.md)
+  - *历史报告：仓库精简尝试回溯记录*
+
 - [COMPLETE_TEST_REPORT_2026-01-27](COMPLETE_TEST_REPORT_2026-01-27.md)
   - *MyStocks 前端完整测试报告*
 
@@ -624,6 +633,9 @@
 
 - [DEPLOYMENT_GUIDE](legacy-cn/06-项目管理与报告/历史指南/DEPLOYMENT_GUIDE.md)
   - *问财功能部署快速指南*
+
+- [deleted-content-inventory-2026-03-29](deleted-content-inventory-2026-03-29.md)
+  - *历史清单：候选删除内容回溯记录（不可作为当前删除依据）*
 
 - [DEVELOPMENT_SUMMARY_2025](DEVELOPMENT_SUMMARY_2025.md)
   - *MyStocks 后端开发总结（2025年11月）*

--- a/docs/reports/code-cleanup-proposal-2026-03-29.md
+++ b/docs/reports/code-cleanup-proposal-2026-03-29.md
@@ -1,0 +1,171 @@
+# 代码清理提案 — 2026-03-29 历史提案
+
+> 日期: 2026-03-29
+> 状态: 历史材料，仅供回溯，不代表当前主线状态。
+> 说明: 该提案未在当前主线按原样执行，文中候选清理项需要重新评估后方可实施。
+> 范围: `web/frontend/src/`
+> 前置条件: 已完成响应式 media query 清理（87 文件，1624 行）
+
+---
+
+## 1. 移除调试日志 `console.log/debug/info`（94 处，20 文件）
+
+### 理由
+
+项目规范要求"保持最小变更"，生产代码中的 `console.log` 是开发调试残留，会：
+- 污染浏览器控制台，影响用户排查问题
+- 在某些环境下造成性能开销（大量日志序列化）
+- 泄露内部实现细节
+
+**保留规则**: `console.error` 和 `console.warn` 不移除（它们用于运行时错误报告，是有意义的）。
+
+### 文件清单
+
+| 文件 | 数量 | 说明 |
+|------|------|----------|
+| `src/stores/marketData.ts` | 10 | IndexedDB 缓存/网络请求日志 |
+| `src/layouts/BaseLayout.vue` | 5 | 命令面板、API 调用日志 |
+| `src/stores/examples/pageConfigStoreExample.ts` | 7 | 示例代码日志 |
+| `src/views/examples/WebSocketConfigExample.vue` | 7 | WebSocket 示例日志 |
+| `src/views/examples/PageConfigExample.vue` | 7 | 页面配置示例日志 |
+| `src/views/examples/composables/useTradingDashboard.migrated.ts` | 6 | 迁移示例日志 |
+| `src/views/artdeco-pages/ArtDecoMarketQuotes.vue` | 2 | API/WebSocket 调试 |
+| `src/views/artdeco-pages/composables/useArtDecoTradingManagement.ts` | 6 | 交易管理操作日志 |
+| `src/views/artdeco-pages/ArtDecoTradingCenter.vue` | 3 | 交易中心日志 |
+| `src/views/artdeco-pages/ArtDecoTechnicalAnalysis.vue` | 2 | 技术分析日志 |
+| `src/views/artdeco-pages/ArtDecoRiskManagement.vue` | 4 | 风险管理日志 |
+| `src/views/artdeco-pages/ArtDecoDataAnalysis.vue` | 2 | 数据分析日志 |
+| `src/views/artdeco-pages/ArtDecoStockManagement.vue` | 1 | 股票管理日志 |
+| `src/views/monitoring/MonitoringDashboard.vue` | 5 | 监控排序/刷新日志 |
+| `src/views/trading-decision/*.vue` | 7 | 交易决策操作日志 |
+| `src/stores/baseStore.ts` | 2 | 基础 store 日志 |
+| `src/stores/ui.ts` | 3 | UI 状态日志 |
+| `src/stores/trading.ts` | 2 | 交易切换日志 |
+| `src/views/Stocks.vue` | 1 | 选择变更日志 |
+| `src/views/StrategyManagement.vue` | 3 | 策略操作占位日志 |
+| 其他（ArtDecoTest, MinimalTest, PyprofilingDemo 等） | ~13 | 测试/Demo 页面日志 |
+
+### 处理方式
+
+- **删除**: 纯调试日志（`console.log('xxx')`、`console.log('Started...')`）
+- **替换为空操作**: 带有占位逻辑的（如 `const handleView = (s) => console.log('View:', s)` → `const handleView = (_s: Strategy) => { /* TODO */ }`)
+- **保留不处理**: `examples/` 目录下的示例文件（教学用途），以及注释中的 `console.log`（文档示例）
+
+### 预计影响
+
+- 修改约 15 个文件
+- 删除约 80 行
+- 无功能影响（console.log 不影响逻辑）
+- 构建产物体积微减
+
+---
+
+## 2. 静态内联样式 `style="..."` 迁移（69 处，20+ 文件）
+
+### 理由
+
+项目 CSS/SCSS 开发规范明确要求：
+> **禁止内联样式**：Vue 组件 `<style>` 块仅允许 `@import` 引用外部 SCSS 文件，不得直接编写 CSS
+
+### 分类
+
+| 类型 | 数量 | 示例 | 处理方式 |
+|------|------|------|----------|
+| **布局辅助** | ~30 | `style="width: 100%"`, `style="margin-top: 20px"` | 提取为 CSS class |
+| **间距/边距** | ~15 | `style="margin-top: 15px"`, `style="padding: 15px"` | 用 ArtDeco token class 替代 |
+| **字号/颜色** | ~10 | `style="font-size: var(--artdeco-text-4xl)"` | 已用 token，直接移入 class |
+| **硬编码值** | ~10 | `style="border-color: var(--artdeco-gold-primary)"` | 提取为 class |
+| **表格/组件宽度** | ~4 | `style="width: 100%"` (el-table) | 提取为 class |
+
+### 重点文件
+
+| 文件 | 内联样式数 | 说明 |
+|------|-----------|------|
+| `views/demo/pyprofiling/components/Profiling.vue` | ~8 | 全部为 margin-top/width |
+| `views/demo/pyprofiling/components/Tech.vue` | ~5 | margin-top/padding |
+| `views/demo/pyprofiling/components/Features.vue` | ~4 | margin-top/width |
+| `views/demo/OpenStockDemo.vue` | ~4 | margin/width |
+| `views/stocks/Watchlist.vue` | 1 | width: 100% |
+| `views/TradingDashboard.vue` | 1 | width: 100% |
+| `views/TaskManagement.vue` | 1 | borderColor |
+| `views/data/Concepts.vue` | 1 | width: 100% |
+
+### 处理方式
+
+对每个 `style="..."` 属性：
+1. 在组件的 `<style>` 块或对应 `.scss` 文件中创建命名 class
+2. 使用 ArtDeco token 值替代硬编码像素值
+3. 替换 template 中的 `style="..."` 为 `class="..."`
+
+### 注意事项
+
+- `el-table style="width: 100%"` 是 Element Plus 常见用法，需保留或用 `:class` + CSS 替代
+- 单值 `style="width: 100%"` 可用 Tailwind 等效 class 或自定义 class 替代
+- 每个文件单独处理，避免批量替换引入错误
+
+---
+
+## 3. 动态内联样式 `:style="..."` 评估（36 处，20+ 文件）
+
+### 理由
+
+动态 `:style` 绑定用于运行时计算的样式值（如进度条宽度、条件颜色），部分合理，部分可优化。
+
+### 分类
+
+| 类型 | 数量 | 合理性 | 处理建议 |
+|------|------|--------|----------|
+| **进度条/仪表盘宽度** | ~15 | ✅ 合理 | 保留（需要动态百分比） |
+| **条件颜色** | ~8 | ⚠️ 可优化 | 改用 `:class` + CSS 条件类 |
+| **图表容器尺寸** | ~5 | ✅ 合理 | 保留（ECharts 需要动态尺寸） |
+| **ArtDeco token 内联** | ~3 | ❌ 不合理 | 移入 CSS class（token 是静态的） |
+| **其他** | ~5 | 逐个评估 | — |
+
+### 具体可优化项
+
+```vue
+<!-- ❌ 当前: 静态 ArtDeco token 用了 :style -->
+<div :style="{ padding: 'var(--artdeco-spacing-6)' }">
+
+<!-- ✅ 应改为: -->
+<div class="content-section-padded">
+<!-- CSS: .content-section-padded { padding: var(--artdeco-spacing-6); } -->
+```
+
+涉及文件：
+- `views/stock-analysis/StockBacktestTab.vue`
+- `views/stock-analysis/StockRealtimeTab.vue`
+- `views/stock-analysis/StockStatusTab.vue`
+
+### 不建议处理的项
+
+- 图表组件的 `:style="{ width, height }"` — ECharts/动态图表需要运行时尺寸
+- 进度条 `:style="{ width: xxx + '%' }"` — 数据驱动的动态宽度
+- 条件复杂的颜色计算 — 重构成本高于收益
+
+---
+
+## 4. 执行优先级建议
+
+| 优先级 | 任务 | 风险 | 工作量 |
+|--------|------|------|--------|
+| **P0** | 移除 console.log | 极低 | 小（批量替换） |
+| **P1** | 修复静态 ArtDeco token 的 `:style` | 低 | 小（3 文件） |
+| **P2** | 迁移静态内联 `style="..."` | 低 | 中（20+ 文件） |
+| **P3** | 评估动态 `:style` 条件颜色 | 中 | 中（需逐个分析） |
+
+---
+
+## 5. 不建议清理的项
+
+| 项目 | 原因 |
+|------|------|
+| `@media (prefers-color-scheme)` | 无障碍支持，非响应式 |
+| `@media print` | 打印样式，合理 |
+| `console.error` / `console.warn` | 运行时错误报告，有意义 |
+| `examples/` 目录下的 console.log | 教学用途 |
+| 图表组件的 `:style` 动态尺寸 | ECharts API 需要 |
+
+---
+
+**请审核后告知执行哪些部分。**

--- a/docs/reports/codebase-cleanup-2026-03-29.md
+++ b/docs/reports/codebase-cleanup-2026-03-29.md
@@ -1,0 +1,170 @@
+# 代码库精简报告 — 2026-03-29
+
+> 执行人: Claude AI 辅助
+> 审核人: 项目 owner
+> 状态: 历史材料，仅供回溯，不代表当前主线状态。
+> 说明: 文中记录的是一次未整体合入主线的清理尝试，不能视为当前仓库基线。
+
+---
+
+## 1. 背景与目标
+
+项目 Git 跟踪约 **164 万行代码**（10,341 文件），经分析发现大量非源码内容（自动生成报告、历史归档、未使用的 Demo 页面）占比超过 60%。目标是清理这些内容，降低仓库体积和维护负担。
+
+## 2. 执行范围
+
+用户选择了三个精简方向（不含源码重构）：
+
+1. 清理自动生成的 JSON 报告
+2. 归档旧文档和 archive/ 目录
+3. 清理 Demo/Test/归档的 Vue 文件
+
+## 3. 精简结果
+
+| 指标 | 精简前 | 精简后 | 变化 |
+|------|--------|--------|------|
+| Git 跟踪文件数 | 10,341 | ~8,500 | -49% |
+| Git 跟踪行数 | ~164 万 | ~59 万 | -64% |
+| 删除文件数 | - | 1,829 | - |
+
+## 4. Phase 1: 清理自动生成的 JSON 报告
+
+**减少约 ~40 万行**
+
+以下文件均为脚本自动生成，可随时重新运行恢复：
+
+| 文件/目录 | 行数 | 说明 |
+|-----------|------|------|
+| `src/monitoring/code_inventory/inventory.json` | 54,540 | 代码清单扫描结果 |
+| `config/code_quality_report.json` | 47,059 | 代码质量报告 |
+| `config/pylint_report.json` | 40,341 | Pylint 静态分析报告 |
+| `config/safety_report.json` | 13,290 | Safety 安全扫描 |
+| `docs/reports/code_quality/*.json` | 69,053 | 质量报告副本 |
+| `docs/reports/security/*.json` | 25,375 | 安全报告副本 |
+| `docs/reports/api_split/` (142 文件) | 6,487 | API 拆分文档 |
+| `reports/` 目录 (1163 文件) | 84,306 | 各类报告汇总 |
+| `docs/references/function-classification-manual/metadata/` | 46,070 | 函数分类元数据 |
+
+**操作**:
+- 在 `.gitignore` 中新增上述路径
+- `git rm --cached` 取消跟踪（文件仍保留在磁盘）
+
+**重新生成方式**:
+```bash
+python -m src.monitoring.code_inventory.cli --no-validation --scan-dirs src scripts web/backend/app
+pylint src/ --output-format=json > config/pylint_report.json
+safety check --json > config/safety_report.json
+```
+
+## 5. Phase 2: 归档 archive/ 目录
+
+**减少约 ~9.4 万行，12,380 个文件，240MB**
+
+| 子目录 | 内容 |
+|--------|------|
+| `archive/legacy-docs/` | 旧版前端文档备份 |
+| `archive/legacy-root-archived/` | 根目录清理时的归档 |
+| `archive/legacy-dot-archive/` | .archive 目录的历史迁移 |
+| `archive/docs/artdeco/` | ArtDeco 旧文档 |
+
+**操作**:
+- 压缩备份: `/tmp/archive-backup-20260329.tar.gz`（240MB -> 36MB）
+- `.gitignore` 新增 `archive/`
+- `git rm -r --cached archive/`
+
+## 6. Phase 3: 清理 Demo/Test/归档 Vue 文件
+
+**减少约 ~1.7 万行，48 个文件**
+
+### 已移除的文件
+
+| 文件/目录 | 行数 | 文件数 |
+|-----------|------|--------|
+| `web/frontend/src/views/converted.archive/` | 5,339 | 9 |
+| `web/frontend/src/views/demo/` (部分) | ~2,000 | 12 |
+| `web/frontend/src/views/freqtrade-demo/` | 652 | 6 |
+| `web/frontend/src/views/tdxpy-demo/` | 723 | 6 |
+| `web/frontend/src/views/examples/` | 847 | 3 |
+
+根目录移除的 Demo/Test 文件:
+- `ArtDecoTest.vue`, `Test.vue`, `TestPage.vue`, `MinimalTest.vue`
+- `KLineDemo.vue`, `MarketDataDemo.vue`, `FreqtradeDemo.vue`
+- `OpenStockDemo.vue`, `TdxpyDemo.vue`, `StockAnalysisDemo.vue`
+- `PyprofilingDemo.vue`, `PageTitleDemo.vue`, `SmartDataSourceTest.vue`
+- `BacktestWizard.vue`, `BacktestAnalysis.vue`
+- `Phase4Dashboard.vue`, `EnhancedDashboard.vue`
+
+关联移除的样式和 composable:
+- `views/styles/BacktestWizard.scss`, `FreqtradeDemo.css`, `Phase4Dashboard.scss`
+- `views/styles/PyprofilingDemo.css`, `SmartDataSourceTest.css`, `StockAnalysisDemo.scss`
+- `views/styles/TdxpyDemo.css`, `BacktestAnalysis.css`
+- `views/composables/useBacktestWizard.ts`, `usePyprofilingDemo.ts`, `usePhase4Dashboard.ts`
+
+### 保留的文件（有活跃测试引用）
+
+以下 pyprofiling 演示文件因被 6 个单元测试引用而保留:
+- `web/frontend/src/views/demo/pyprofiling/` (10 个文件)
+- `web/frontend/src/views/demo/Phase4Dashboard.vue`
+- `web/frontend/src/views/demo/Wencai.vue`
+
+## 7. Phase 4: 清理其他项
+
+| 项目 | 文件数 | 说明 |
+|------|--------|------|
+| `.map` source map 文件 | 241 | 已在 .gitignore，从 git 移除 |
+| `.omc/state/` 会话状态 | ~150 | OMC 运行时状态文件 |
+
+## 8. .gitignore 变更
+
+新增以下规则:
+
+```gitignore
+# Auto-generated report files (regenerate with scripts)
+src/monitoring/code_inventory/inventory.json
+config/code_quality_report.json
+config/pylint_report.json
+config/safety_report.json
+docs/reports/code_quality/*.json
+docs/reports/security/*.json
+docs/reports/api_split/
+docs/references/function-classification-manual/metadata/
+reports/docs-inventory.json
+reports/code_inventory_report_*.md
+
+# Source maps (build artifacts)
+*.map
+
+# Archive directory (backed up externally)
+archive/
+```
+
+## 9. 同步更新的文件
+
+| 文件 | 变更说明 |
+|------|----------|
+| `.gitignore` | 新增上述规则 |
+| `.github/workflows/frontend-testing.yml` | 移除 ArtDecoTest.vue 和 PerformanceMonitor.css 的 CI 触发路径 |
+| `web/frontend/tests/unit/workflows/ci-workflow-gates.spec.ts` | 移除已删除文件的断言 |
+
+## 10. 验证结果
+
+| 检查项 | 结果 |
+|--------|------|
+| 前端构建 (`npm run build`) | 通过 (25.56s) |
+| 稳定单元测试 (33 文件 / 354 用例) | 全部通过 |
+| `git ls-files` 文件数 | ~8,500 |
+| 工作区文件完整性 | 未删除任何磁盘文件 |
+
+## 11. 回滚方案
+
+- 所有变更仅在 git 暂存区，可通过 `git reset HEAD` 撤销
+- `archive/` 备份位于 `/tmp/archive-backup-20260329.tar.gz`
+- 被移除的文件仍在磁盘上（`git rm --cached` 不删除工作区文件）
+- 完整回滚命令: `git checkout HEAD -- .` 恢复所有跟踪文件
+
+## 12. 后续建议
+
+1. 提交后运行一次完整的报告生成脚本，验证报告可正常重新生成
+2. 定期执行 `git gc` 清理松散对象
+3. 考虑将 `reports/` 目录完全迁移到 CI artifact 存储
+4. 剩余源码层面精简（合并重复 API 文件、提取共享 composables）可在后续迭代中推进

--- a/docs/reports/deleted-content-inventory-2026-03-29.md
+++ b/docs/reports/deleted-content-inventory-2026-03-29.md
@@ -1,0 +1,156 @@
+# 已删除内容清单 — 2026-03-29 历史清单
+
+> 日期: 2026-03-29
+> 状态: 历史材料，仅供回溯，不代表当前主线状态。
+> 说明: 该清单记录的是当时工作区中的候选删除项，不能作为当前删除依据。
+> 命令查看: `git diff -- web/frontend/src/`
+
+---
+
+## A. 响应式 Media Query 块删除（87 文件，纯删除 0 新增）
+
+**删除内容**: 每个文件中的 `@media (width <= 48rem) { ... }` 整段块
+**理由**: 项目仅支持桌面端（最小 1280x720），48rem = 768px 的断点不会触发
+
+### 按删除行数排序
+
+| 删除行 | 文件路径 |
+|--------|----------|
+| 52 | `views/strategy/styles/StatsAnalysis.scss` |
+| 48 | `views/errors/styles/ServiceUnavailable.scss` |
+| 48 | `views/errors/Forbidden.vue` |
+| 43 | `views/strategy/styles/StrategyList.scss` |
+| 42 | `views/errors/NetworkError.vue` |
+| 40 | `views/strategy/styles/BacktestGPU.scss` |
+| 39 | `views/strategy/styles/SingleRun.scss` |
+| 36 | `views/strategy/styles/BatchScan.scss` |
+| 27 | `components/monitoring/styles/MonitoringDataTable.css` |
+| 27 | `components/chart/styles/HealthRadarChart.css` |
+| 27 | `components/artdeco/core/ArtDecoBreadcrumb.vue` |
+| 26 | `views/system/styles/Architecture.scss` |
+| 25 | `components/Charts/TreeChart.vue` |
+| 24 | `views/demo/pyprofiling/components/styles/Prediction.scss` |
+| 24 | `components/sse/styles/DashboardMetrics.scss` |
+| 23 | `views/system/styles/PerformanceMonitor.css` |
+| 23 | `components/monitoring/styles/MonitoringAlertPanel.css` |
+| 22 | `views/system/styles/DatabaseMonitor.scss` |
+| 22 | `views/monitoring/styles/MonitoringDashboard.scss` |
+| 22 | `views/market/Realtime.vue` |
+| 22 | `components/market/styles/SmartRecommendation.css` |
+| 21 | `views/market/LHB.vue` |
+| 21 | `views/demo/pyprofiling/components/Overview.vue` |
+| 21 | `views/data/FundFlow.vue` |
+| 21 | `views/announcement/styles/AnnouncementMonitor.scss` |
+| 20 | `views/artdeco-pages/risk-tabs/RiskOverviewTab.vue` |
+| 19 | `components/artdeco/base/ArtDecoDialog.vue` |
+| 19 | `components/Charts/SankeyChart.vue` |
+| 18 | `views/artdeco-pages/technical-tabs/TechnicalScannerTab.vue` |
+| 18 | `views/artdeco-pages/stock-management-tabs/WatchlistManager.vue` |
+| 18 | `views/artdeco-pages/market-tabs/MarketETFTab.vue` |
+| 18 | `components/artdeco/base/ArtDecoSkipLink.vue` |
+| 17 | `components/technical/KLineChart.vue` |
+| 16 | `views/artdeco-pages/system-tabs/ArtDecoMonitoringDashboard.vue` |
+| 16 | `views/artdeco-pages/system-tabs/ArtDecoDataManagement.vue` |
+| 16 | `views/artdeco-pages/strategy-tabs/styles/StrategySignalsTab.scss` |
+| 16 | `views/artdeco-pages/market-data-tabs/ETFAnalysis.vue` |
+| 16 | `views/artdeco-pages/components/AnalysisIndicators.vue` |
+| 15 | `views/strategy/styles/ResultsQuery.scss` |
+| 15 | `views/demo/pyprofiling/components/API.vue` |
+| 15 | `views/artdeco-pages/strategy-tabs/styles/StrategyParametersTab.scss` |
+| 15 | `views/artdeco-pages/components/AnalysisScreener.vue` |
+| 15 | `views/artdeco-pages/analysis-tabs/KLineAnalysis.vue` |
+| 14 | `views/trade-management/components/PositionsTab.vue` |
+| 13 | `views/artdeco-pages/components/MarketConcepts.vue` |
+| 12 | `views/artdeco-pages/strategy-tabs/styles/ArtDecoStrategyOptimization.scss` |
+| 12 | `views/artdeco-pages/strategy-tabs/styles/ArtDecoStrategyManagement.scss` |
+| 12 | `views/artdeco-pages/strategy-tabs/components/styles/BacktestWorkbenchTabs.scss` |
+| 12 | `views/artdeco-pages/risk-tabs/ArtDecoRiskAlerts.vue` |
+| 12 | `views/artdeco-pages/risk-tabs/ArtDecoAnnouncementMonitor.vue` |
+| 12 | `views/artdeco-pages/market-data-tabs/DataQualityPanel.vue` |
+| 12 | `views/artdeco-pages/components/ArtDecoTradingHistoryControls.vue` |
+| 12 | `views/artdeco-pages/_templates/ExampleRiskManagement.vue` |
+| 12 | `views/artdeco-pages/ArtDecoRiskManagement.vue` |
+| 12 | `components/artdeco/charts/styles/DepthChart.scss` |
+| 11 | `views/market/Technical.vue` |
+| 11 | `views/demo/pyprofiling/components/Data.vue` |
+| 11 | `views/data/Industry.vue` |
+| 11 | `views/data/Concepts.vue` |
+| 11 | `views/artdeco-pages/trading-tabs/ArtDecoTradingPositions.vue` |
+| 11 | `views/artdeco-pages/trading-tabs/ArtDecoTradingHistory.vue` |
+| 11 | `views/artdeco-pages/trading-tabs/ArtDecoSignalsView.vue` |
+| 11 | `views/artdeco-pages/system-tabs/SystemHealthTab.vue` |
+| 11 | `views/artdeco-pages/risk-tabs/StopLossMonitorTab.vue` |
+| 10 | `views/monitoring/styles/AlertRulesManagement.scss` |
+| 10 | `views/artdeco-pages/portfolio-tabs/PortfolioOverviewTab.vue` |
+| 10 | `views/artdeco-pages/market-data-tabs/ConceptAnalysis.vue` |
+| 10 | `views/artdeco-pages/analysis-tabs/BacktestAnalysis.vue` |
+| 10 | `views/artdeco-pages/components/FinancialMetrics.vue` |
+| 10 | `views/artdeco-pages/components/PanoramaIndices.vue` |
+| 10 | `views/strategy/styles/StatsAnalysis.scss` |
+| 9 | `views/artdeco-pages/components/AnomalyAlerts.vue` |
+| 8 | `views/artdeco-pages/components/AnomalyPatterns.vue` |
+| 8 | `views/artdeco-pages/components/PanoramaCapitalFlow.vue` |
+| 8 | `components/artdeco/trading/ArtDecoTickerList.vue` |
+| 7 | `views/artdeco-pages/strategy-tabs/styles/ArtDecoBacktestAnalysis.scss` |
+| 7 | `views/artdeco-pages/components/OneilModel.vue` |
+| 7 | `views/artdeco-pages/components/BuffettModel.vue` |
+| 7 | `views/artdeco-pages/components/ArtDecoTradingSignalsControls.vue` |
+| 6 | `views/artdeco-pages/strategy-tabs/components/styles/BacktestKpiGrid.scss` |
+| 6 | `views/artdeco-pages/stock-management-tabs/PortfolioMonitor.vue` |
+| 6 | `views/artdeco-pages/market-data-tabs/AuctionAnalysis.vue` |
+| 6 | `views/artdeco-pages/components/PanoramaCapitalFlow.vue` |
+| 6 | `views/artdeco-pages/components/LynchModel.vue` |
+| 6 | `views/artdeco-pages/components/ArtDecoAttributionControls.vue` |
+| 4 | `views/artdeco-pages/risk-tabs/ArtDecoRiskStatsGrid.vue` |
+| 2 | `views/demo/OpenStockDemo.vue`（仅 media query 部分） |
+| 1 | `components/Charts/styles/AdvancedHeatmap.scss` |
+| 1 | `components/Charts/styles/RelationChart.scss` |
+
+**删除的典型内容示例**:
+
+```scss
+// 每个文件中删除的都是这种格式的块：
+@media (width <= 48rem) {
+  .xxx {
+    flex-direction: column;
+    // ... 响应式样式规则
+  }
+}
+```
+
+---
+
+## B. Code-Simplifier 修复（已提交，3 文件）
+
+| 文件 | 删除内容 | 替换为 |
+|------|----------|--------|
+| `KLineChart.vue` | `_measurePerformance` 导入（未使用） | 直接删除 |
+| `KLineChart.vue` | `style="margin-right: 4px; cursor: pointer;"` 内联样式 | `.indicator-toggle-icon` CSS class |
+| `StockSearchBar.vue` | 冗余 `@media (width <= 48rem)` 重新声明 `width: 100%` | 直接删除（基类已声明） |
+
+---
+
+## C. 非本次会话产生的变更（工作区预存状态）
+
+以下变更在我介入前已存在于工作区，**不是我做的**:
+
+| 文件 | 变更 | 说明 |
+|------|------|------|
+| `views/demo/styles/Wencai.scss` | +170/-172 | 样式重排/格式化 |
+| `views/demo/OpenStockDemo.vue` | +95/-101 | 组件重排 |
+| `components/Charts/styles/AdvancedHeatmap.scss` | +1/-1 | 微调 |
+| `components/Charts/styles/RelationChart.scss` | +1/-1 | 微调 |
+| `components/monitoring/MonitoringStatCard.vue` | +1/-19 | 样式重构 |
+| `api/types/*.ts` (9 文件) | 各 +1/-1 | 类型文件微调 |
+
+---
+
+## 总计
+
+| 类别 | 文件数 | 删除行数 |
+|------|--------|----------|
+| A. 响应式 media query 删除 | 87 | ~1,620 |
+| B. Code-simplifier 修复（已提交） | 3 | ~20 |
+| C. 预存变更（非本次操作） | 14 | ~180 |
+
+**A 类删除的验证状态**: 构建 `✓ built in 24.07s`，单元测试 33 files / 354 tests 全部通过。

--- a/docs/reports/tasks/2026-03-27-local-dirty-worktree-batch-plan.md
+++ b/docs/reports/tasks/2026-03-27-local-dirty-worktree-batch-plan.md
@@ -1,0 +1,624 @@
+# 2026-03-27 本地脏工作区分批计划
+
+> 日期: 2026-03-27
+> 状态: 历史工作计划，仅供回溯，不代表当前主线状态。
+> 说明: 该计划基于 2026-03-27 的本地脏工作区快照整理，后续主线与工作树已发生变化。
+> 目标：把当前主工作树的本地未提交修改，从“混合脏工作区”拆成可理解、可提交、可验证的批次。
+
+## 1. 当前状态
+
+- 当前分支：`main`
+- 当前本地/远端提交点：`00fff0cd6`
+- 当前未提交修改总数：`72` 个文件
+
+已先完成非破坏性备份快照：
+
+- 备份分支：`backup/main-dirty-pre-triage-20260327`
+- 备份提交：`38865cdea7de97cbba6d77e4c604399c932df0cf`
+
+说明：
+
+- 这个备份分支只是快照，不改变当前工作区
+- 后续即使分批时误操作，也还能回到这个快照点
+
+## 2. 总体分布
+
+当前修改主要集中在：
+
+- `web/frontend/src/views`：`69`
+- `web/frontend/src/components`：`45`
+- `.omc/state/sessions/...`：`3`
+- 其余为 `web/frontend` 顶层文档/脚本/报告、少量 `docs/scripts/reports/src`
+
+这说明当前工作区不是单一主题，而是至少混合了：
+
+1. 前端组件/UI 批
+2. 前端页面批
+3. 前端文档/报告批
+4. 脚本/说明批
+5. 运行时状态文件批
+
+已完成批次：
+
+- `Batch 4`：导航与共享壳层组件
+- `Batch 5`：市场共享组件层
+- `Batch 6`：市场 / 技术 / 股票页面层
+
+这些批次已在隔离 worktree 中验证通过，并已合入/推送到 `main`。
+
+## 3. 分批原则
+
+### 3.1 不把生成物和功能改动混在一起
+
+以下内容必须单独处理：
+
+- `.omc/state/sessions/...`
+- 报告/总结类 Markdown
+- 测试 HTML、说明页、theme quick reference
+
+### 3.2 先收低耦合，再碰高耦合
+
+优先处理：
+
+- 文档
+- 报告
+- 运行时状态
+- 独立脚本
+
+后处理：
+
+- `src/components/layout`
+- `src/components/shared`
+- `src/views/market`
+- `src/views/monitoring`
+- `src/views/strategy`
+
+### 3.3 共享层和页面层不要混提
+
+以下两类必须拆开：
+
+- 共享组件/导航组件
+- 使用这些组件的页面视图
+
+否则一旦回归，很难定位问题来自“组件层”还是“页面层”。
+
+## 4. 推荐批次
+
+## Batch 0：运行时状态快照层
+
+### 范围
+
+- `.omc/state/sessions/5ae67728-2aaa-4150-a71f-2b770e97ae82/*`
+
+### 风险
+
+- `低`
+
+### 说明
+
+- 这类文件是会话/运行状态，不应和业务改动混提
+- 如果要保留，只能作为“上下文快照”单独处理
+
+### 建议
+
+- 单独快照
+- 不混入功能提交
+
+## Batch 1：仓库根层必要性复核批
+
+### 范围
+
+- [ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md](/opt/claude/mystocks_spec/docs/guides/web/ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md)
+- [phase7_initialization_summary.md](/opt/claude/mystocks_spec/reports/phase7_initialization_summary.md)
+- [ai-collaboration-setup.sh](/opt/claude/mystocks_spec/scripts/ai-collaboration-setup.sh)
+- [001_create_strategy_tables.sql](/opt/claude/mystocks_spec/scripts/db/migrations/001_create_strategy_tables.sql)
+- [monitor_phase7_progress.sh](/opt/claude/mystocks_spec/scripts/monitor_phase7_progress.sh)
+- [README.md](/opt/claude/mystocks_spec/src/interfaces/README.md)
+
+### 风险
+
+- `低到中`
+
+### 说明
+
+- 这批不在主前端代码路径上
+- 但经逐文件复核后，**不能整体视为“必要更新批”**
+
+### 当前复核结论
+
+- **真实内容更新候选**
+  - [ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md](/opt/claude/mystocks_spec/docs/guides/web/ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md)
+    - 属于文档进展同步
+    - 方向上是更新，不是回退
+    - 但仍是“可选保留”，不是运行必需项
+
+- **假脏 / 无正文变化**
+  - [phase7_initialization_summary.md](/opt/claude/mystocks_spec/reports/phase7_initialization_summary.md)
+  - [monitor_phase7_progress.sh](/opt/claude/mystocks_spec/scripts/monitor_phase7_progress.sh)
+
+- **纯行尾变化，不构成有效更新**
+  - [ai-collaboration-setup.sh](/opt/claude/mystocks_spec/scripts/ai-collaboration-setup.sh)
+  - [001_create_strategy_tables.sql](/opt/claude/mystocks_spec/scripts/db/migrations/001_create_strategy_tables.sql)
+  - [README.md](/opt/claude/mystocks_spec/src/interfaces/README.md)
+
+### 建议
+
+- 不要把 Batch 1 整体直接提交
+- 只把 [ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md](/opt/claude/mystocks_spec/docs/guides/web/ARTDECO_FINTECH_IMPLEMENTATION_AUDIT.md) 保留为候选项
+- 其余 5 个先视为噪音或格式状态，不纳入提交批次
+
+## Batch 2：前端顶层文档/报告/静态辅助资产
+
+### 范围
+
+- `web/frontend/ACCESSIBILITY_*`
+- `web/frontend/PHASE*`
+- `web/frontend/QUICK_THEME_VERIFICATION.md`
+- `web/frontend/THEME_APPLICATION_REPORT.md`
+- `web/frontend/TYPESCRIPT_ERROR_RESOLUTION_FINAL_REPORT.md`
+- `web/frontend/reports/*`
+- `web/frontend/public/accessibility-test.html`
+- `web/frontend/src/theme-test.html`
+- `web/frontend/src/styles/THEME_QUICK_REFERENCE.md`
+
+### 风险
+
+- `低`
+
+### 说明
+
+- 这批大多是说明文档、测试辅助页、报告产物
+- 但经逐文件比对后，**当前这 23 个文件不构成真实更新批**
+
+### 当前复核结论
+
+- **真实内容更新**
+  - `0` 个
+
+- **假脏 / 字节完全一致**
+  - `15` 个
+  - 包含：
+    - `ACCESSIBILITY_*`
+    - `QUICK_THEME_VERIFICATION.md`
+    - `THEME_APPLICATION_REPORT.md`
+    - `TYPESCRIPT_ERROR_RESOLUTION_FINAL_REPORT.md`
+    - `reports/*`
+    - `public/accessibility-test.html`
+    - `src/theme-test.html`
+    - `src/styles/THEME_QUICK_REFERENCE.md`
+
+- **纯行尾变化**
+  - `8` 个
+  - 包含：
+    - `PHASE3_*`
+    - `PHASE4_*`
+
+### 工程判断
+
+- 当前 `Batch 2` 不是“值得直接提交”的真实更新批
+- 如果继续处理，这一批更像：
+  - 假脏刷新
+  - 行尾标准化
+  - 或直接放弃
+
+它们不是功能更新，也不是当前主线必须保留的内容
+
+### 建议
+
+- 不要把 Batch 2 作为下一批直接收口
+- 先把它视为“工作区噪音批”，暂不提交
+
+## Batch 3：前端工具与校验脚本层
+
+### 范围
+
+- `web/frontend/package.json`
+- `web/frontend/scripts/run-lighthouse-audits.sh`
+- `web/frontend/scripts/summarize-lighthouse-reports.js`
+- `web/frontend/test-bb-api.js`
+- `web/frontend/tests/unit/utils/atrading.test.ts`
+- `web/frontend/validate-theme-import.sh`
+
+### 风险
+
+- `中`
+
+### 说明
+
+- 这批会影响本地验证方式、脚本入口和测试口径
+- 不应与 UI 页面改动混提
+
+### 当前复核结论
+
+- **真实内容更新候选**
+  - [package.json](/opt/claude/mystocks_spec/web/frontend/package.json)
+    - 真实改动点只有一处：
+      扩大 `lint:artdeco:changed` 的扫描范围，把大量 `views/components/market/system/monitoring/...` 文件重新纳入 changed-scope 门禁
+
+- **假脏 / 字节完全一致**
+  - [run-lighthouse-audits.sh](/opt/claude/mystocks_spec/web/frontend/scripts/run-lighthouse-audits.sh)
+  - [summarize-lighthouse-reports.js](/opt/claude/mystocks_spec/web/frontend/scripts/summarize-lighthouse-reports.js)
+  - [validate-theme-import.sh](/opt/claude/mystocks_spec/web/frontend/validate-theme-import.sh)
+
+- **纯行尾变化**
+  - [test-bb-api.js](/opt/claude/mystocks_spec/web/frontend/test-bb-api.js)
+  - [atrading.test.ts](/opt/claude/mystocks_spec/web/frontend/tests/unit/utils/atrading.test.ts)
+
+### 工程判断
+
+- `Batch 3` 不再是一个完整的可提交批次
+- 其中只有 `package.json` 值得继续判断是否保留
+- 但这个改动本质上是**门禁范围升级**
+- 它不适合脱离后面的 UI 清理批次单独提交
+
+也就是说：
+
+- 如果后续不保留当前大批前端 UI/样式治理工作，这个 `package.json` 变更就偏**提前**，不值得单独保留
+- 如果后续要继续收口前端 UI/ArtDeco token 债，它就属于**配套更新**
+
+### 建议
+
+- 不直接执行 Batch 3 提交
+- 把 [package.json](/opt/claude/mystocks_spec/web/frontend/package.json) 视为“依附于后续前端治理批次的配套改动”
+- 其余 5 个视为噪音，不纳入提交
+
+## Batch 4：导航与共享壳层组件
+
+### 范围
+
+- `web/frontend/src/components/layout/*`
+- `web/frontend/src/components/menu/*`
+- `web/frontend/src/components/menu_root/*`
+- `web/frontend/src/components/common/*`
+- `web/frontend/src/components/shared/*`
+- `web/frontend/src/views/errors/ServiceUnavailable.vue`
+- `web/frontend/src/views/components/*`
+
+### 风险
+
+- `高`
+
+### 说明
+
+- 这是共享 UI 壳层
+- 影响面广，容易波及大量页面
+
+### 当前复核结论
+
+- 这批文件都是**真实内容变化**，不是假脏
+- 抽查代表文件后，变化模式高度一致：
+  - `@import` -> `@use`
+  - 样式入口标准化
+  - 共享 UI 样式 token 接入
+  - 基本不涉及业务数据流和接口契约
+
+代表样本：
+
+- [ArtDecoHeader.vue](/opt/claude/mystocks_spec/web/frontend/src/components/layout/ArtDecoHeader.vue)
+- [PageHeader.vue](/opt/claude/mystocks_spec/web/frontend/src/components/shared/ui/PageHeader.vue)
+- [CommandPalette.vue](/opt/claude/mystocks_spec/web/frontend/src/components/menu/CommandPalette.vue)
+- [KeyboardShortcuts.vue](/opt/claude/mystocks_spec/web/frontend/src/components/common/KeyboardShortcuts.vue)
+- [RiskOverviewTab.vue](/opt/claude/mystocks_spec/web/frontend/src/views/components/RiskOverviewTab.vue)
+
+### 工程判断
+
+- `Batch 4` 整体方向是**更新，不是倒退**
+- 它更像“共享壳层样式收口批”
+- 风险主要来自“共享范围广”，而不是功能逻辑变化
+
+### 建议
+
+- `Batch 4` 值得保留
+- 但必须单独提交，不能与页面层混提
+- 提交前必须至少补跑共享壳层相关 smoke/页面验证
+
+### 建议
+
+- 不要和页面批混提
+- 后于文档/脚本批处理
+
+## Batch 5：市场共享组件层
+
+### 范围
+
+- `web/frontend/src/components/market/*`
+- `web/frontend/src/components/Charts/*`
+- `web/frontend/src/components/chart/*`
+- `web/frontend/src/components/data/DataCard.vue`
+- `web/frontend/src/components/realtime/*`
+- `web/frontend/src/components/technical/IndicatorPanel.vue`
+- `web/frontend/src/components/sse/DashboardMetrics.vue`
+- `web/frontend/src/components/monitoring/*`
+
+### 风险
+
+- `中到高`
+
+### 说明
+
+- 这是页面下方的业务共享组件层
+- 与 `market/views`、`stocks/views`、`monitoring/views` 强耦合
+
+### 当前复核结论
+
+- 这批文件也都是**真实内容变化**
+- 但相较 `Batch 4`，它不只是样式入口语法收口，还包含：
+  - 内联样式提取为 class
+  - 硬编码颜色替换为 token
+  - 图表配色和 grid 色值改走主题变量
+  - 局部尺寸改为 token 计算
+
+代表样本：
+
+- [FundFlowPanel.vue](/opt/claude/mystocks_spec/web/frontend/src/components/market/FundFlowPanel.vue)
+- [WencaiPanel.scss](/opt/claude/mystocks_spec/web/frontend/src/components/market/styles/WencaiPanel.scss)
+- [AdvancedHeatmap.vue](/opt/claude/mystocks_spec/web/frontend/src/components/Charts/AdvancedHeatmap.vue)
+
+### 工程判断
+
+- `Batch 5` 整体方向仍然偏**更新**
+- 但它已经触到组件呈现逻辑和主题表现层
+- 比 `Batch 4` 更容易引入视觉回归或交互回归
+
+### 建议
+
+- `Batch 5` 可以保留，但不要先于 `Batch 4`
+- 必须绑定更强验证：
+  - `lint:artdeco:changed`
+  - 相关页面 E2E / visual / smoke
+- [package.json](/opt/claude/mystocks_spec/web/frontend/package.json) 的那处 `lint:artdeco:changed` 扩容改动，应视为 `Batch 5` 的配套变更，而不是独立批次
+
+### 当前状态
+
+- `已完成`
+
+### 建议
+
+- 先于对应页面批次单独整理
+
+## Batch 6：市场 / 技术 / 股票页面层
+
+### 范围
+
+- `web/frontend/src/views/market/*`
+- `web/frontend/src/views/technical/*`
+- `web/frontend/src/views/stocks/*`
+- `web/frontend/src/views/announcement/*`
+- `web/frontend/src/views/monitor.vue`
+- `web/frontend/src/views/Market.vue`
+- `web/frontend/src/views/TechnicalAnalysis.vue`
+- `web/frontend/src/views/TdxMarket.vue`
+- `web/frontend/src/views/Wencai.vue`
+
+### 风险
+
+- `高`
+
+### 说明
+
+- 这批页面会直接受 Batch 5 影响
+- 适合在共享组件层稳定后再处理
+
+### 建议
+
+- 不要先于 Batch 5
+
+### 当前复核结论
+
+- 这批 `29` 个页面/样式文件都是**真实内容变化**
+- 抽查代表文件后，主变化模式仍然以：
+  - 页面 `<style>` 从 `@import` 切到 `@use`
+  - 页面样式文件中的 token / 尺寸表达式收口
+  - 少量 SVG/icon/内联样式改为 class 为主
+
+代表样本：
+
+- [MarketDataView.vue](/opt/claude/mystocks_spec/web/frontend/src/views/market/MarketDataView.vue)
+- [Concepts.scss](/opt/claude/mystocks_spec/web/frontend/src/views/market/styles/Concepts.scss)
+- [Screener.vue](/opt/claude/mystocks_spec/web/frontend/src/views/stocks/Screener.vue)
+- [Portfolio.scss](/opt/claude/mystocks_spec/web/frontend/src/views/stocks/styles/Portfolio.scss)
+- [TechnicalAnalysis.vue](/opt/claude/mystocks_spec/web/frontend/src/views/technical/TechnicalAnalysis.vue)
+
+### 工程判断
+
+- `Batch 6` 方向上是**更新，不是倒退**
+- 风险高于 `Batch 4/5`，因为它已经深入到页面层
+- 但经过隔离 worktree 验证，当前这批已经证明可收口
+
+### 当前状态
+
+- `已完成`
+
+## Batch 7：分析 / 仪表板 / Demo / 根层工作台页面
+
+### 范围
+
+- `web/frontend/src/views/Analysis.vue`
+- `web/frontend/src/views/BacktestAnalysis.vue`
+- `web/frontend/src/views/BacktestWizard.vue`
+- `web/frontend/src/views/Dashboard.vue`
+- `web/frontend/src/views/DataVisualizationShowcase.vue`
+- `web/frontend/src/views/EnhancedDashboard.vue`
+- `web/frontend/src/views/IndicatorLibrary.vue`
+- `web/frontend/src/views/IndustryConceptAnalysis.vue`
+- `web/frontend/src/views/Phase4Dashboard.vue`
+- `web/frontend/src/views/PortfolioManagement.vue`
+- `web/frontend/src/views/PyprofilingDemo.vue`
+- `web/frontend/src/views/RealTimeMonitor.vue`
+- `web/frontend/src/views/Settings.vue`
+- `web/frontend/src/views/SkeletonUsage.vue`
+- `web/frontend/src/views/SmartDataSourceTest.vue`
+- `web/frontend/src/views/StockAnalysisDemo.vue`
+- `web/frontend/src/views/StockDetail.vue`
+- `web/frontend/src/views/StrategyManagement.vue`
+- `web/frontend/src/views/TaskManagement.vue`
+- `web/frontend/src/views/TradeManagement.vue`
+- `web/frontend/src/views/TradingDashboard.vue`
+- `web/frontend/src/views/demo/*`
+- `web/frontend/src/views/styles/Analysis.scss`
+- `web/frontend/src/views/styles/BacktestWizard.scss`
+- `web/frontend/src/views/styles/Dashboard.scss`
+- `web/frontend/src/views/styles/IndustryConceptAnalysis.scss`
+- `web/frontend/src/views/styles/Settings.scss`
+- `web/frontend/src/views/styles/TradingDecisionCenter.scss`
+
+### 风险
+
+- `高`
+
+### 当前复核结论
+
+- 这批文件从抽样结果看，仍以页面 `<style>` 入口从 `@import` 到 `@use` 的收口为主
+- 与 `Batch 6` 一致，整体方向偏**更新**
+- 但它覆盖的是根层工作台 / demo / dashboard 类页面，视觉面更大
+
+### 建议
+
+- 值得继续，但不建议和 `Batch 8` 混提
+- 应拆成 `Batch 7a`：根层真实业务页
+- `Batch 7b`：demo / showcase / skeleton 辅助页
+
+## Batch 8：监控 / 系统 / 策略 / 交易页面层
+
+### 范围
+
+- `web/frontend/src/views/monitoring/*`
+- `web/frontend/src/views/system/*`
+- `web/frontend/src/views/strategy/*`
+- `web/frontend/src/views/trade-management/*`
+- `web/frontend/src/views/technical/TechnicalAnalysis.vue`
+- `web/frontend/src/views/technical/styles/TechnicalAnalysis.scss`
+- `web/frontend/src/styles/web3-global.scss`
+- `web/frontend/src/styles/web3-tokens.scss`
+
+### 风险
+
+- `高`
+
+### 当前复核结论
+
+- 这批文件也都属于**真实内容变化**
+- 但比 `Batch 7` 多了一个特殊点：
+  - `views/technical/TechnicalAnalysis.scss` 已开始依赖新的
+    [web3-global.scss](/opt/claude/mystocks_spec/web/frontend/src/styles/web3-global.scss)
+    和
+    [web3-tokens.scss](/opt/claude/mystocks_spec/web/frontend/src/styles/web3-tokens.scss)
+- 这意味着 `technical` 这一支不能被拆成“只改页面不带支撑文件”的批次
+
+### 建议
+
+- 不要直接整体执行 `Batch 8`
+- 更合理的是先拆出一个最小前置批：
+  - `Batch 8a`：`technical + web3 style support`
+- 再决定是否继续推进 `monitoring / system / strategy / trade-management`
+
+## Batch 7：分析 / 仪表板 / Demo / 根层工作台页面
+
+### 范围
+
+- `web/frontend/src/views/Analysis.vue`
+- `web/frontend/src/views/BacktestAnalysis.vue`
+- `web/frontend/src/views/BacktestWizard.vue`
+- `web/frontend/src/views/Dashboard.vue`
+- `web/frontend/src/views/DataVisualizationShowcase.vue`
+- `web/frontend/src/views/EnhancedDashboard.vue`
+- `web/frontend/src/views/IndicatorLibrary.vue`
+- `web/frontend/src/views/IndustryConceptAnalysis.vue`
+- `web/frontend/src/views/Phase4Dashboard.vue`
+- `web/frontend/src/views/PortfolioManagement.vue`
+- `web/frontend/src/views/PyprofilingDemo.vue`
+- `web/frontend/src/views/RealTimeMonitor.vue`
+- `web/frontend/src/views/Settings.vue`
+- `web/frontend/src/views/SmartDataSourceTest.vue`
+- `web/frontend/src/views/StockAnalysisDemo.vue`
+- `web/frontend/src/views/StockDetail.vue`
+- `web/frontend/src/views/TaskManagement.vue`
+- `web/frontend/src/views/TradeManagement.vue`
+- `web/frontend/src/views/TradingDashboard.vue`
+- `web/frontend/src/views/demo/*`
+
+### 风险
+
+- `高`
+
+### 说明
+
+- 这批根层视图和演示页主题混杂
+- 不适合与 domain 页或共享组件层混提
+
+### 建议
+
+- 再拆成“真实业务页 / demo 页 / 工具页”子批次
+
+## Batch 8：监控 / 系统 / 策略 / 交易页面层
+
+### 范围
+
+- `web/frontend/src/views/monitoring/*`
+- `web/frontend/src/views/system/*`
+- `web/frontend/src/views/strategy/*`
+- `web/frontend/src/views/trade-management/*`
+- `web/frontend/src/views/StrategyManagement.vue`
+
+### 风险
+
+- `高`
+
+### 说明
+
+- 这批既有监控页，也有系统页，还有策略执行页
+- 功能链复杂，不应该现在直接混着处理
+
+### 建议
+
+- 最后处理
+- 最好再按 domain 二次拆分
+
+## 5. 推荐执行顺序
+
+### 推荐顺序
+
+1. `Batch 0`：运行时状态快照层
+2. `Batch 1`：仓库根层补充文档与辅助脚本
+3. `Batch 2`：前端顶层文档/报告/静态辅助资产
+4. `Batch 3`：前端工具与校验脚本层
+5. `Batch 4`：导航与共享壳层组件
+6. `Batch 5`：市场共享组件层
+7. `Batch 6`：市场 / 技术 / 股票页面层
+8. `Batch 7`：分析 / 仪表板 / Demo / 根层工作台页面
+9. `Batch 8`：监控 / 系统 / 策略 / 交易页面层
+
+### 最值得先收口的第一个真实批次
+
+如果你要我直接开始处理，我建议从：
+
+`Batch 8a：technical + web3 style support 收口`
+
+开始。
+
+原因：
+
+- `Batch 7` 和 `Batch 8` 都已确认是有效更新方向
+- 但 `Batch 8` 里有一个清晰的最小依赖簇：
+  - `technical/TechnicalAnalysis.vue`
+  - `technical/styles/TechnicalAnalysis.scss`
+  - `src/styles/web3-global.scss`
+  - `src/styles/web3-tokens.scss`
+- 先收这个最小簇，可以把当前剩余风险再压低一层
+
+## 6. 不建议的做法
+
+- 不要直接从 `views` 或 `components` 最大目录开刀
+- 不要把 `package.json` 和 UI 页面改动混提
+- 不要把共享壳层组件和页面层一起收
+- 不要在这一步继续新增功能开发
+
+## 7. 下一步审批口径
+
+如果继续，我建议下一步审批为：
+
+`同意执行 Batch 1：仓库根层补充文档与辅助脚本收口`
+
+如果按当前复核后的更准确口径，建议改为：
+
+`同意执行 Batch 8a：technical + web3 style support 收口`

--- a/docs/reports/tasks/INDEX.md
+++ b/docs/reports/tasks/INDEX.md
@@ -36,6 +36,7 @@
 - 📄 [2026-03-25-directory-governance-batch-b-files](2026-03-25-directory-governance-batch-b-files.txt)
 - 📄 [2026-03-25-directory-governance-batch-staging-plan](2026-03-25-directory-governance-batch-staging-plan.md)
 - 📄 [2026-03-25-directory-governance-isolated-execution-guide](2026-03-25-directory-governance-isolated-execution-guide.md)
+- 📄 [2026-03-27-local-dirty-worktree-batch-plan](2026-03-27-local-dirty-worktree-batch-plan.md)
 - 📄 [HANDOVER_TASK](HANDOVER_TASK.md)
 - 📄 [NEXT_WORK_TASKS](NEXT_WORK_TASKS.md)
 - 📄 [TASK](TASK.md)

--- a/governance/mainline/task-cards/pr-30.yaml
+++ b/governance/mainline/task-cards/pr-30.yaml
@@ -26,8 +26,8 @@ function_tree:
   domain_id: "meta-governance"
   node_id: "meta-governance-mainline"
   affected_entrypoints:
-    - "docs"
     - "governance"
+    - "tests"
   update_status: "not-needed"
   secondary_domains: []
   exemption_reason: "historical-cleanup-reports-are-documentation-only"

--- a/governance/mainline/task-cards/pr-30.yaml
+++ b/governance/mainline/task-cards/pr-30.yaml
@@ -1,0 +1,90 @@
+version: "v0.2"
+
+task:
+  id: "pr-30"
+  title: "preserve historical cleanup reports"
+  owner: "main"
+  created_at: "2026-04-01"
+
+mainline:
+  id: "L1-historical-cleanup-report-preservation"
+  objective: "land the leftover 2026-03-27 and 2026-03-29 cleanup reports on main as clearly historical materials with discoverable entrypoints"
+  milestone_id: "L2-dirty-worktree-salvage"
+  slice_id: "L3-cleanup-report-preservation"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "docs"
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "historical-cleanup-reports-are-documentation-only"
+
+scope:
+  allowed_paths:
+    - "docs/reports/INDEX.md"
+    - "docs/reports/code-cleanup-proposal-2026-03-29.md"
+    - "docs/reports/codebase-cleanup-2026-03-29.md"
+    - "docs/reports/deleted-content-inventory-2026-03-29.md"
+    - "docs/reports/tasks/2026-03-27-local-dirty-worktree-batch-plan.md"
+    - "docs/reports/tasks/INDEX.md"
+    - "governance/mainline/task-cards/pr-30.yaml"
+    - "tests/unit/scripts/test_repository_hygiene_paths.py"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No frontend runtime, styling, or route behavior changes"
+  - "No claim that the preserved reports describe current mainline state"
+
+acceptance:
+  checks:
+    - id: "docs-history-sync-tests"
+      command: "python -m pytest tests/unit/scripts/test_repository_hygiene_paths.py -q -k \"historical_cleanup_reports or historical_dirty_worktree_batch_plan\" --no-cov"
+      required: true
+    - id: "docs-diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-30.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the preserved reports are not clearly marked historical, future cleanup work may misread them as current deletion authority"
+    - "If the new report paths are not indexed, the salvage context remains stranded in the backup worktree and easy to lose"
+  rollback_plan: "git revert <merge-commit-sha> if the preserved reports prove misleading or the indexing/test coverage is incorrect"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "preserve useful cleanup reports from the dirty backup workspace without presenting them as active guidance"
+    modified_scope: "historical cleanup reports, reports indexes, report discoverability tests, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "no runtime behavior changes; only documentation status, indexing, and test coverage are updated"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the docs slice if the historical framing or indexing proves inaccurate after merge"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-01T00:00:00Z"
+    approval_note: "historical cleanup report preservation is documentation-only"
+    secondary_approved: false

--- a/tests/unit/scripts/test_repository_hygiene_paths.py
+++ b/tests/unit/scripts/test_repository_hygiene_paths.py
@@ -1101,6 +1101,41 @@ def test_test_cli_task_doc_is_converged_under_reports_tasks_legacy() -> None:
     assert "phase7-test-contracts-automation" in task_doc
 
 
+def test_historical_cleanup_reports_are_discoverable_and_marked_non_current() -> None:
+    reports_index = (PROJECT_ROOT / "docs" / "reports" / "INDEX.md").read_text(encoding="utf-8")
+
+    names = [
+        "code-cleanup-proposal-2026-03-29.md",
+        "codebase-cleanup-2026-03-29.md",
+        "deleted-content-inventory-2026-03-29.md",
+    ]
+
+    for name in names:
+        report = (PROJECT_ROOT / "docs" / "reports" / name).read_text(encoding="utf-8")
+
+        assert f"({name})" in reports_index
+        assert "仅供回溯，不代表当前主线状态" in report
+
+    deleted_inventory = (PROJECT_ROOT / "docs" / "reports" / "deleted-content-inventory-2026-03-29.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "不能作为当前删除依据" in deleted_inventory
+
+
+def test_historical_dirty_worktree_batch_plan_is_discoverable_under_reports_tasks() -> None:
+    reports_index = (PROJECT_ROOT / "docs" / "reports" / "INDEX.md").read_text(encoding="utf-8")
+    tasks_index = (PROJECT_ROOT / "docs" / "reports" / "tasks" / "INDEX.md").read_text(encoding="utf-8")
+    plan = (
+        PROJECT_ROOT / "docs" / "reports" / "tasks" / "2026-03-27-local-dirty-worktree-batch-plan.md"
+    ).read_text(encoding="utf-8")
+
+    assert "tasks/2026-03-27-local-dirty-worktree-batch-plan.md" in reports_index
+    assert "2026-03-27-local-dirty-worktree-batch-plan.md" in tasks_index
+    assert "历史工作计划" in plan
+    assert "仅供回溯，不代表当前主线状态" in plan
+
+
 def test_low_reference_tdd_and_debt_reports_are_converged_under_reports_completion_reports() -> None:
     reports_index = (PROJECT_ROOT / "docs" / "reports" / "INDEX.md").read_text(encoding="utf-8")
     completion_index = (PROJECT_ROOT / "docs" / "reports" / "completion_reports" / "INDEX.md").read_text(


### PR DESCRIPTION
## Summary
- preserve the 2026-03-27 and 2026-03-29 cleanup reports as historical materials instead of leaving them stranded in the dirty backup worktree
- mark each document as non-current so they cannot be mistaken for active mainline guidance or deletion authority
- add report index entries and documentation sync tests for discoverability

## Test Plan
- python -m pytest tests/unit/scripts/test_repository_hygiene_paths.py -q -k "historical_cleanup_reports or historical_dirty_worktree_batch_plan" --no-cov
- git diff --cached --check

## Known Existing Baseline
- `python -m pytest tests/unit/scripts/test_repository_hygiene_paths.py -q --no-cov` still has 2 pre-existing failures on `main`: `test_page_config_usage_guide_is_converged_under_docs_architecture_family` and `test_artdeco_guides_are_converged_under_guides_web_family`
