### PR TITLE
fix(frontend): adapt pro kline chart payloads

### DIFF
--- a/governance/mainline/task-cards/pr-33.yaml
+++ b/governance/mainline/task-cards/pr-33.yaml
@@ -1,0 +1,85 @@
+version: "v0.2"
+
+task:
+  id: "pr-33"
+  title: "adapt pro kline chart payloads"
+  owner: "main"
+  created_at: "2026-04-01"
+
+mainline:
+  id: "L1-pro-kline-payload-adapter"
+  objective: "fix the market ProKLineChart path so it consumes the actual KLineChartData payload and uses a supported adjustment value"
+  milestone_id: "L2-dirty-worktree-salvage"
+  slice_id: "L3-pro-kline-payload-adapter"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "frontend"
+  node_id: "frontend-market-kline"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "single-market-chart-adapter-fix-with-localized-test-coverage"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-33.yaml"
+    - "web/frontend/src/components/market/composables/useProKLineChart.ts"
+    - "web/frontend/tests/unit/pro-kline-chart-market-data.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No broad market API refactor"
+  - "No OpenStock demo cleanup or styling changes"
+
+acceptance:
+  checks:
+    - id: "pro-kline-regression-tests"
+      command: "cd web/frontend && npx vitest run tests/unit/pro-kline-chart-market-data.spec.ts src/api/__tests__/market-integration.test.ts --config vitest.config.mts"
+      required: true
+    - id: "docs-diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-33.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the KLine payload mapping is wrong, charts in TechnicalAnalysis and StockDetail can still render empty or malformed data"
+    - "If the adjustment flag mapping is wrong, the forward-adjusted toggle will keep sending an unsupported literal"
+  rollback_plan: "git revert <merge-commit-sha> if the ProKLineChart regression fix introduces incorrect chart data or request parameters"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "align the ProKLineChart composable with the real market API payload and supported adjustment values"
+    modified_scope: "market ProKLineChart composable, focused vitest regression, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "runtime behavior changes only for the chart data adapter path and forward-adjusted request parameter"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if chart rendering or request semantics regress after merge"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-01T00:00:00Z"
+    approval_note: "localized frontend bugfix with dedicated regression coverage"
+    secondary_approved: false

--- a/governance/mainline/task-cards/pr-33.yaml
+++ b/governance/mainline/task-cards/pr-33.yaml
@@ -23,8 +23,8 @@ openspec:
   approval_status: "not_required"
 
 function_tree:
-  domain_id: "frontend"
-  node_id: "frontend-market-kline"
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
   affected_entrypoints:
     - "frontend"
     - "tests"

--- a/web/frontend/src/components/market/composables/useProKLineChart.ts
+++ b/web/frontend/src/components/market/composables/useProKLineChart.ts
@@ -2,6 +2,7 @@ import { ref, onMounted, onUnmounted, watch } from 'vue'
 import { init, dispose, type Chart } from 'klinecharts'
 import { ElMessage } from 'element-plus'
 import { marketApi } from '@/api/market'
+import type { KLineChartData } from '@/utils/adapters'
 import type { KLineDataPoint } from '@/utils/indicators'
 import { applyChartContainerHeight, createProKLineChartStyleConfig } from './useProKLineChart.chart-config.ts'
 import {
@@ -56,6 +57,39 @@ export function useProKLineChart() {
   // Available indicators (for selector)
   const availableIndicators = ref<Indicator[]>(props.indicators)
 
+  const parseCategoryTimestamp = (value: string | undefined, index: number): number => {
+    if (!value) {
+      return Date.now() + index
+    }
+
+    const parsed = Date.parse(value)
+    if (!Number.isNaN(parsed)) {
+      return parsed
+    }
+
+    const numeric = Number(value)
+    if (Number.isFinite(numeric) && numeric > 0) {
+      return numeric
+    }
+
+    return Date.now() + index
+  }
+
+  const toChartData = (payload: KLineChartData): KLineDataPoint[] => {
+    return payload.categoryData.map((category, index) => {
+      const [open = 0, close = 0, low = 0, high = 0] = payload.values[index] ?? []
+
+      return {
+        timestamp: parseCategoryTimestamp(category, index),
+        open,
+        high,
+        low,
+        close,
+        volume: payload.volumes[index] ?? 0
+      }
+    })
+  }
+
   /**
    * 初始化图表
    */
@@ -94,37 +128,17 @@ export function useProKLineChart() {
     loading.value = true
 
     try {
-      // Call existing market API
-      // @ts-ignore - adjust property exists in runtime but missing in API type definition
-      const klineData = await marketApi.getKLineData({
+      const requestParams: Parameters<typeof marketApi.getKLineData>[0] & { adjust: 'qfq' | 'none' } = {
         symbol: props.symbol,
         interval: selectedPeriod.value as '1m' | '5m' | '15m' | '30m' | '1h' | '1d' | '1w' | '1M',
         limit: 1000, // Load last 1000 candles by default
-        adjust: useForwardAdjusted.value ? 'forward' : 'none'
-      } as unknown)
+        adjust: useForwardAdjusted.value ? 'qfq' : 'none'
+      }
 
-      // @ts-ignore - response has data property at runtime but missing in type definition
-      const rawData = (klineData as unknown).data
-      if (klineData && rawData && rawData.length > 0) {
-        // Convert to klinecharts format
-        interface RawKLineItem {
-          timestamp?: number
-          date?: number
-          open: number
-          high: number
-          low: number
-          close: number
-          volume: number
-        }
-        const chartData: KLineDataPoint[] = (rawData as RawKLineItem[]).map((item) => ({
-          timestamp: item.timestamp || item.date || Date.now(),
-          open: item.open,
-          high: item.high,
-          low: item.low,
-          close: item.close,
-          volume: item.volume
-        }))
+      const klineData = await marketApi.getKLineData(requestParams)
+      const chartData = toChartData(klineData)
 
+      if (chartData.length > 0) {
         // Save current K-line data for indicator calculation
         currentKLineData.value = chartData
 

--- a/web/frontend/tests/unit/pro-kline-chart-market-data.spec.ts
+++ b/web/frontend/tests/unit/pro-kline-chart-market-data.spec.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  getKLineDataMock,
+  initMock,
+  disposeMock,
+  applyNewDataMock,
+  setStylesMock,
+  applySelectedIndicatorsMock,
+  onMountedMock,
+  onUnmountedMock,
+  watchMock,
+} = vi.hoisted(() => ({
+  getKLineDataMock: vi.fn(),
+  initMock: vi.fn(),
+  disposeMock: vi.fn(),
+  applyNewDataMock: vi.fn(),
+  setStylesMock: vi.fn(),
+  applySelectedIndicatorsMock: vi.fn(),
+  onMountedMock: vi.fn(),
+  onUnmountedMock: vi.fn(),
+  watchMock: vi.fn(),
+}))
+
+vi.mock('vue', async () => {
+  const actual = await vi.importActual<typeof import('vue')>('vue')
+  return {
+    ...actual,
+    onMounted: onMountedMock,
+    onUnmounted: onUnmountedMock,
+    watch: watchMock,
+  }
+})
+
+vi.mock('@/api/market', () => ({
+  marketApi: {
+    getKLineData: getKLineDataMock,
+  },
+}))
+
+vi.mock('klinecharts', () => ({
+  init: initMock.mockImplementation(() => ({
+    applyNewData: applyNewDataMock,
+    setStyles: setStylesMock,
+    getTimeScaleVisibleRange: vi.fn(() => ({ from: 0, to: 100 })),
+    getVisibleRange: vi.fn(() => ({ from: 0, to: 100 })),
+  })),
+  dispose: disposeMock,
+}))
+
+vi.mock('@/components/market/composables/useProKLineChart.chart-config.ts', () => ({
+  applyChartContainerHeight: vi.fn(),
+  createProKLineChartStyleConfig: vi.fn(() => ({})),
+}))
+
+vi.mock('@/components/market/composables/useProKLineChart.indicators.ts', () => ({
+  applyKDJIndicator: vi.fn(),
+  applyMACDIndicator: vi.fn(),
+  applyMAIndicator: vi.fn(),
+  applyRSIIndicator: vi.fn(),
+  applySelectedIndicators: applySelectedIndicatorsMock,
+  applyVolumeIndicator: vi.fn(),
+}))
+
+vi.mock('@/components/market/composables/useProKLineChart.price-limits.ts', () => ({
+  applyPriceLimitOverlay: vi.fn(),
+  calculatePriceLimitMarkers: vi.fn(() => []),
+}))
+
+vi.mock('element-plus', () => ({
+  ElMessage: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}))
+
+import { useProKLineChart } from '@/components/market/composables/useProKLineChart'
+
+describe('useProKLineChart market data adapter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ;(globalThis as Record<string, unknown>).defineProps = () => ({
+      symbol: '000001.SZ',
+      forwardAdjusted: true,
+    })
+    ;(globalThis as Record<string, unknown>).withDefaults = (props: Record<string, unknown>, defaults: Record<string, unknown>) => ({
+      ...defaults,
+      ...props,
+    })
+    ;(globalThis as Record<string, unknown>).defineEmits = () => vi.fn()
+
+    getKLineDataMock.mockResolvedValue({
+      categoryData: ['2026-04-01T09:30:00Z', '2026-04-01T09:31:00Z'],
+      values: [
+        [10, 11, 9, 12],
+        [11, 10.5, 10, 11.5],
+      ],
+      volumes: [1000, 1200],
+    })
+  })
+
+  afterEach(() => {
+    delete (globalThis as Record<string, unknown>).defineProps
+    delete (globalThis as Record<string, unknown>).withDefaults
+    delete (globalThis as Record<string, unknown>).defineEmits
+  })
+
+  it('converts KLineChartData payloads into klinecharts data with qfq adjustment', async () => {
+    const chart = useProKLineChart()
+    chart.chartContainer.value = document.createElement('div')
+    chart.initChart()
+
+    await chart.loadHistoricalData()
+
+    expect(getKLineDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        symbol: '000001.SZ',
+        interval: '1d',
+        limit: 1000,
+        adjust: 'qfq',
+      }),
+    )
+    expect(applyNewDataMock).toHaveBeenCalledWith([
+      {
+        timestamp: Date.parse('2026-04-01T09:30:00Z'),
+        open: 10,
+        high: 12,
+        low: 9,
+        close: 11,
+        volume: 1000,
+      },
+      {
+        timestamp: Date.parse('2026-04-01T09:31:00Z'),
+        open: 11,
+        high: 11.5,
+        low: 10,
+        close: 10.5,
+        volume: 1200,
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- adapt the market ProKLineChart composable to consume the real `KLineChartData` payload shape instead of reading a missing `.data` array
- map the forward-adjusted toggle to the supported `qfq` request value instead of the invalid `forward` literal
- add a focused vitest regression covering request parameters and chart data conversion

## Test Plan
- npx vitest run tests/unit/pro-kline-chart-market-data.spec.ts src/api/__tests__/market-integration.test.ts --config vitest.config.mts
- git diff --check
