### PR TITLE
fix(frontend): clean up indicator selector typing

### DIFF
--- a/governance/mainline/task-cards/pr-34.yaml
+++ b/governance/mainline/task-cards/pr-34.yaml
@@ -1,0 +1,85 @@
+version: "v0.2"
+
+task:
+  id: "pr-34"
+  title: "clean up indicator selector typing"
+  owner: "main"
+  created_at: "2026-04-01"
+
+mainline:
+  id: "L1-indicator-selector-type-hygiene"
+  objective: "remove broad type suppression from the market IndicatorSelector component while preserving existing chart component behavior"
+  milestone_id: "L2-dirty-worktree-salvage"
+  slice_id: "L3-indicator-selector-type-hygiene"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-frontend-type-hygiene-fix-with-focused-regression"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-34.yaml"
+    - "web/frontend/src/components/market/IndicatorSelector.vue"
+    - "web/frontend/tests/unit/indicator-selector-type-hygiene.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No broader market component refactor"
+  - "No style-token or layout behavior changes outside IndicatorSelector"
+
+acceptance:
+  checks:
+    - id: "indicator-selector-hygiene-tests"
+      command: "cd web/frontend && npx vitest run tests/unit/indicator-selector-type-hygiene.spec.ts tests/unit/config/chart-component-style-normalization.spec.ts --config vitest.config.mts"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-34.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If checkbox value narrowing is wrong, indicator selection may stop toggling correctly"
+    - "If template icon handling changes unexpectedly, the trigger button could regress visually"
+  rollback_plan: "git revert <merge-commit-sha> if indicator selection or trigger rendering regresses after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "remove type suppression in IndicatorSelector and keep its checkbox typing explicit"
+    modified_scope: "market IndicatorSelector component, one focused vitest regression, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "runtime behavior should remain equivalent; the main change is type hygiene and explicit value narrowing"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if checkbox handling or trigger rendering changes unexpectedly"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-01T00:00:00Z"
+    approval_note: "localized frontend type-hygiene fix with dedicated test coverage"
+    secondary_approved: false

--- a/web/frontend/src/components/market/IndicatorSelector.vue
+++ b/web/frontend/src/components/market/IndicatorSelector.vue
@@ -6,10 +6,10 @@
       placement="bottom-start"
     >
       <template #reference>
-        <el-button
-          size="small"
-          :icon="TrendCharts"
-        >
+        <el-button size="small">
+          <el-icon class="indicator-trigger-icon">
+            <TrendCharts />
+          </el-icon>
           技术指标
           <el-badge
             v-if="selectedCount > 0"
@@ -25,7 +25,6 @@
           <!-- 趋势指标 -->
           <el-tab-pane label="趋势" name="trend">
             <div class="indicator-list">
-              <!-- @ts-expect-error Element Plus CheckboxValueType type limitation -->
               <el-checkbox
                 v-for="(indicator, idx) in trendIndicators"
                 :key="idx"
@@ -43,7 +42,6 @@
           <!-- 动量指标 -->
           <el-tab-pane label="动量" name="momentum">
             <div class="indicator-list">
-              <!-- @ts-expect-error Element Plus CheckboxValueType type limitation -->
               <el-checkbox
                 v-for="(indicator, idx) in momentumIndicators"
                 :key="idx"
@@ -61,7 +59,6 @@
           <!-- 波动率指标 -->
           <el-tab-pane label="波动率" name="volatility">
             <div class="indicator-list">
-              <!-- @ts-expect-error Element Plus CheckboxValueType type limitation -->
               <el-checkbox
                 v-for="(indicator, idx) in volatilityIndicators"
                 :key="idx"
@@ -79,7 +76,6 @@
           <!-- 成交量指标 -->
           <el-tab-pane label="成交量" name="volume">
             <div class="indicator-list">
-              <!-- @ts-expect-error Element Plus CheckboxValueType type limitation -->
               <el-checkbox
                 v-for="(indicator, idx) in volumeIndicators"
                 :key="idx"
@@ -130,10 +126,9 @@
 </template>
 
 <script setup lang="ts">
-// @ts-nocheck
-
 import { ref, computed, watch } from 'vue'
 import { TrendCharts } from '@element-plus/icons-vue'
+import type { CheckboxValueType } from 'element-plus'
 
 /**
  * 指标元数据
@@ -227,8 +222,8 @@ const selectedCount = computed(() => selectedIndicators.value.length)
 /**
  * 检查指标是否已选中
  */
-const isIndicatorSelected = (indicator: string): CheckboxValueType => {
-  return selectedIndicators.value.includes(indicator) as CheckboxValueType
+const isIndicatorSelected = (indicator: string): boolean => {
+  return selectedIndicators.value.includes(indicator)
 }
 
 /**

--- a/web/frontend/tests/unit/indicator-selector-type-hygiene.spec.ts
+++ b/web/frontend/tests/unit/indicator-selector-type-hygiene.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+function readSource(pathFromFrontendRoot: string): string {
+  return readFileSync(resolve(process.cwd(), pathFromFrontendRoot), 'utf8')
+}
+
+describe('market IndicatorSelector type hygiene', () => {
+  it('does not suppress type checking and keeps checkbox value handling explicit', () => {
+    const source = readSource('src/components/market/IndicatorSelector.vue')
+
+    expect(source).not.toContain('@ts-nocheck')
+    expect(source).not.toContain('@ts-expect-error')
+    expect(source).toContain("import type { CheckboxValueType } from 'element-plus'")
+    expect(source).toContain('const isIndicatorSelected = (indicator: string): boolean => {')
+    expect(source).toContain('const onCheckboxChange = (indicator: string, value: CheckboxValueType): void => {')
+  })
+})


### PR DESCRIPTION
## Summary
- remove broad type-suppression directives from the market IndicatorSelector component
- keep checkbox value handling explicit with a boolean selector and a typed CheckboxValueType bridge
- add a focused vitest hygiene regression for the component source

## Test Plan
- npx vitest run tests/unit/indicator-selector-type-hygiene.spec.ts tests/unit/config/chart-component-style-normalization.spec.ts --config vitest.config.mts
- git diff --check
