### PR TITLE
fix(frontend): tighten api typing boundaries

### DIFF
--- a/governance/mainline/task-cards/pr-35.yaml
+++ b/governance/mainline/task-cards/pr-35.yaml
@@ -1,0 +1,86 @@
+version: "v0.2"
+
+task:
+  id: "pr-35"
+  title: "tighten api typing boundaries"
+  owner: "main"
+  created_at: "2026-04-01"
+
+mainline:
+  id: "L1-frontend-api-typing-hygiene"
+  objective: "replace temporary frontend API typing workarounds with explicit type boundaries in monitoring and strategy API adapters"
+  milestone_id: "L2-dirty-worktree-salvage"
+  slice_id: "L3-frontend-api-typing-hygiene"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-frontend-api-typing-fix-with-focused-regression"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-35.yaml"
+    - "web/frontend/src/api/monitoring.ts"
+    - "web/frontend/src/api/strategy.ts"
+    - "web/frontend/tests/unit/api-typing-hygiene.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No generated type timestamp refresh"
+  - "No monitoring or strategy API behavior redesign beyond explicit typing boundaries"
+
+acceptance:
+  checks:
+    - id: "frontend-api-typing-tests"
+      command: "cd web/frontend && npx vitest run tests/unit/api-typing-hygiene.spec.ts src/api/__tests__/monitoringApi.spec.ts src/api/__tests__/strategy.test.ts --config vitest.config.mts"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-35.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the explicit casts are misplaced, monitoring adapter calls could receive the wrong payload shape"
+    - "If strategy request assertions move before await boundaries, type assumptions can drift away from resolved payloads again"
+  rollback_plan: "git revert <merge-commit-sha> if monitoring or strategy frontend APIs regress after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "replace temporary frontend API typing workarounds with explicit boundaries"
+    modified_scope: "monitoring API, strategy API, one focused vitest regression, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "runtime behavior should remain equivalent; the main change is typing hygiene and explicit await/cast boundaries"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if monitoring or strategy API handling regresses"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-01T00:00:00Z"
+    approval_note: "localized frontend API typing cleanup with focused regression coverage"
+    secondary_approved: false

--- a/web/frontend/src/api/monitoring.ts
+++ b/web/frontend/src/api/monitoring.ts
@@ -7,19 +7,15 @@
 import { request } from '@/utils/request.ts'
 import { MonitoringAdapter } from '@/utils/monitoring-adapters.ts'
 import type {
+  DataQualityResponse,
+  LogEntryResponse,
+  MonitoringAlertResponse,
   SystemStatusVM,
+  SystemStatusResponse,
   MonitoringAlertVM,
   LogEntryVM,
   DataQualityVM
-} from '@/utils/monitoring-adapters.ts'
-
-// Temporary: Use any for missing generated types
-// TODO: Fix type generation to include these types
-// Type aliases currently unused - comment out to avoid ESLint error
-// type SystemStatusResponse = Record<string, unknown>
-// type MonitoringAlertResponse = Record<string, unknown>
-// type LogEntryResponse = Record<string, unknown>
-// type DataQualityResponse = Record<string, unknown>
+} from '@/utils/monitoring-adapters.types.ts'
 
 class MonitoringApiService {
   private baseUrl = '/api/monitoring'
@@ -28,7 +24,7 @@ class MonitoringApiService {
    * Get system status overview
    */
   async getSystemStatus(): Promise<SystemStatusVM> {
-    const rawData = await request.get(`${this.baseUrl}/system/status`)
+    const rawData = await request.get(`${this.baseUrl}/system/status`) as unknown as SystemStatusResponse
     return MonitoringAdapter.toSystemStatusVM(rawData)
   }
 
@@ -61,7 +57,7 @@ class MonitoringApiService {
     limit?: number
     offset?: number
   }): Promise<MonitoringAlertVM[]> {
-    const rawData = await request.get(`${this.baseUrl}/alerts`, { params })
+    const rawData = await request.get(`${this.baseUrl}/alerts`, { params }) as unknown as MonitoringAlertResponse[]
     return MonitoringAdapter.toMonitoringAlertVM(rawData)
   }
 
@@ -69,7 +65,7 @@ class MonitoringApiService {
    * Get alert details
    */
   async getAlert(alertId: string): Promise<MonitoringAlertVM> {
-    const rawData = await request.get(`${this.baseUrl}/alerts/${alertId}`)
+    const rawData = await request.get(`${this.baseUrl}/alerts/${alertId}`) as unknown as MonitoringAlertResponse
     const alerts = MonitoringAdapter.toMonitoringAlertVM([rawData])
     return alerts[0]
   }
@@ -101,7 +97,7 @@ class MonitoringApiService {
     limit?: number
     offset?: number
   }): Promise<LogEntryVM[]> {
-    const rawData = await request.get(`${this.baseUrl}/logs`, { params })
+    const rawData = await request.get(`${this.baseUrl}/logs`, { params }) as unknown as LogEntryResponse[]
     return MonitoringAdapter.toLogEntryVM(rawData)
   }
 
@@ -109,7 +105,7 @@ class MonitoringApiService {
    * Get log details
    */
   async getLog(logId: string): Promise<LogEntryVM> {
-    const rawData = await request.get(`${this.baseUrl}/logs/${logId}`)
+    const rawData = await request.get(`${this.baseUrl}/logs/${logId}`) as unknown as LogEntryResponse
     const logs = MonitoringAdapter.toLogEntryVM([rawData])
     return logs[0]
   }
@@ -130,7 +126,7 @@ class MonitoringApiService {
     }
     limit?: number
   }): Promise<LogEntryVM[]> {
-    const rawData = await request.post(`${this.baseUrl}/logs/search`, query)
+    const rawData = await request.post(`${this.baseUrl}/logs/search`, query) as unknown as LogEntryResponse[]
     return MonitoringAdapter.toLogEntryVM(rawData)
   }
 
@@ -142,7 +138,7 @@ class MonitoringApiService {
     startTime?: string
     endTime?: string
   }): Promise<DataQualityVM> {
-    const rawData = await request.get(`${this.baseUrl}/data-quality`, { params })
+    const rawData = await request.get(`${this.baseUrl}/data-quality`, { params }) as unknown as DataQualityResponse
     return MonitoringAdapter.toDataQualityVM(rawData)
   }
 
@@ -274,7 +270,7 @@ class MonitoringApiService {
       params,
       responseType: 'blob'
     })
-    return response
+    return response as unknown as Blob
   }
 
   /**

--- a/web/frontend/src/api/strategy.ts
+++ b/web/frontend/src/api/strategy.ts
@@ -174,7 +174,7 @@ class StrategyApiService {
    * Get available strategy templates
    */
   async getStrategyTemplates(): Promise<unknown[]> {
-    return request.get(`${this.baseUrl}/templates`) as unknown[]
+    return (await request.get(`${this.baseUrl}/templates`)) as unknown[]
   }
 
   /**
@@ -208,7 +208,7 @@ class StrategyApiService {
     limit?: number
     since?: string
   }): Promise<unknown[]> {
-    return request.get(`${this.baseUrl}/${id}/logs`, { params }) as unknown[]
+    return (await request.get(`${this.baseUrl}/${id}/logs`, { params })) as unknown[]
   }
 
   /**
@@ -233,7 +233,7 @@ class StrategyApiService {
       headers: {
         'Content-Type': 'multipart/form-data'
       }
-    })
+    }) as StrategyConfigResponse
     return StrategyAdapter.toStrategyConfigVM(rawData)
   }
 }

--- a/web/frontend/tests/unit/api-typing-hygiene.spec.ts
+++ b/web/frontend/tests/unit/api-typing-hygiene.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+function readSource(pathFromFrontendRoot: string): string {
+  return readFileSync(resolve(process.cwd(), pathFromFrontendRoot), 'utf8')
+}
+
+describe('frontend api typing hygiene', () => {
+  it('uses explicit monitoring response types instead of temporary placeholder comments', () => {
+    const source = readSource('src/api/monitoring.ts')
+
+    expect(source).toContain("from '@/utils/monitoring-adapters.types.ts'")
+    expect(source).not.toContain('Temporary: Use any for missing generated types')
+    expect(source).not.toContain('TODO: Fix type generation to include these types')
+    expect(source).toContain('as unknown as SystemStatusResponse')
+    expect(source).toContain('as unknown as MonitoringAlertResponse[]')
+    expect(source).toContain('as unknown as LogEntryResponse[]')
+    expect(source).toContain('as unknown as DataQualityResponse')
+  })
+
+  it('awaits strategy request results before applying array and config assertions', () => {
+    const source = readSource('src/api/strategy.ts')
+
+    expect(source).toContain("return (await request.get(`${this.baseUrl}/templates`)) as unknown[]")
+    expect(source).toContain("return (await request.get(`${this.baseUrl}/${id}/logs`, { params })) as unknown[]")
+    expect(source).toContain("}) as StrategyConfigResponse")
+  })
+})


### PR DESCRIPTION
## Summary
- replace temporary monitoring API placeholder comments with explicit adapter response types
- await strategy API request results before applying array/config assertions on the resolved payloads
- add a focused vitest hygiene regression for the affected frontend API files

## Test Plan
- npx vitest run tests/unit/api-typing-hygiene.spec.ts src/api/__tests__/monitoringApi.spec.ts src/api/__tests__/strategy.test.ts --config vitest.config.mts
- git diff --check
