### PR TITLE
refactor(frontend): tokenize openstock demo panels

### DIFF
--- a/governance/mainline/task-cards/pr-36.yaml
+++ b/governance/mainline/task-cards/pr-36.yaml
@@ -1,0 +1,90 @@
+version: "v0.2"
+
+task:
+  id: "pr-36"
+  title: "tokenize openstock demo panels"
+  owner: "main"
+  created_at: "2026-04-01"
+
+mainline:
+  id: "L1-openstock-demo-tokenization"
+  objective: "move selected low-risk OpenStock demo panels onto the ArtDeco token vocabulary without touching previously rejected regression-prone files"
+  milestone_id: "L2-dirty-worktree-salvage"
+  slice_id: "L3-openstock-demo-tokenization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-demo-tokenization-slice-with-source-level-guardrails"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-36.yaml"
+    - "web/frontend/src/views/demo/openstock/components/FeatureStatus.vue"
+    - "web/frontend/src/views/demo/openstock/components/KlineChart.vue"
+    - "web/frontend/src/views/demo/openstock/components/StockNews.vue"
+    - "web/frontend/src/views/demo/openstock/components/StockQuote.vue"
+    - "web/frontend/tests/unit/openstock-demo-tokenization.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/views/demo/openstock/components/HeatmapChart.vue"
+    - "web/frontend/src/views/demo/openstock/components/StockSearch.vue"
+    - "web/frontend/src/views/demo/openstock/components/WatchlistManagement.vue"
+
+non_goals:
+  - "No tooltip HTML rewrite for HeatmapChart"
+  - "No watchlist/search button class changes"
+
+acceptance:
+  checks:
+    - id: "openstock-demo-tokenization-test"
+      command: "cd web/frontend && npx vitest run tests/unit/openstock-demo-tokenization.spec.ts --config vitest.config.mts"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-36.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If legacy OpenStock demo files keep the old bg/text/border token set, they will continue drifting away from the ArtDeco styling baseline"
+    - "If this slice accidentally includes the previously rejected search/watchlist files, it could reintroduce known regressions"
+  rollback_plan: "git revert <merge-commit-sha> if the tokenization slice regresses OpenStock demo rendering"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "tokenize four low-risk OpenStock demo panels while keeping known regression-prone files out of scope"
+    modified_scope: "four demo components, one focused vitest regression, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "no intended runtime logic changes; the slice is limited to style/token vocabulary alignment"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if demo rendering regresses or forbidden files were accidentally implicated"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-01T00:00:00Z"
+    approval_note: "localized OpenStock demo tokenization with explicit forbidden paths"
+    secondary_approved: false

--- a/web/frontend/src/views/demo/openstock/components/FeatureStatus.vue
+++ b/web/frontend/src/views/demo/openstock/components/FeatureStatus.vue
@@ -87,17 +87,18 @@ defineExpose({
 </script>
 
 <style scoped lang="scss">
+@use '../../../../styles/artdeco-tokens.scss' as *;
 
 .status-section {
-  padding: 10px 0;
+  padding: var(--artdeco-spacing-3) 0;
 
   h3 {
-    margin: 0 0 16px 0;
-    font-size: 16px;
-    font-weight: 600;
-    color: var(--text-primary);
-    border-left: 3px solid var(--warning);
-    padding-left: 12px;
+    margin: 0 0 var(--artdeco-spacing-4) 0;
+    padding-left: var(--artdeco-spacing-3);
+    border-left: calc(var(--artdeco-spacing-px) * 3) solid var(--artdeco-warning);
+    color: var(--artdeco-fg-primary);
+    font-size: var(--artdeco-text-base);
+    font-weight: var(--artdeco-font-semibold);
   }
 }
 
@@ -105,9 +106,9 @@ defineExpose({
   display: flex;
   flex-direction: column;
   gap: 0;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--artdeco-gold-primary) 4%, var(--artdeco-bg-card));
+  border: 1px solid color-mix(in srgb, var(--artdeco-gold-primary) 20%, transparent);
+  border-radius: var(--artdeco-radius-none);
   overflow: hidden;
 }
 
@@ -115,8 +116,8 @@ defineExpose({
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 14px 20px;
-  border-bottom: 1px solid var(--border-light);
+  padding: calc(var(--artdeco-spacing-4) - var(--artdeco-spacing-px)) var(--artdeco-spacing-5);
+  border-bottom: 1px solid color-mix(in srgb, var(--artdeco-gold-primary) 12%, transparent);
 
   &:last-child {
     border-bottom: none;
@@ -124,34 +125,34 @@ defineExpose({
 }
 
 .info-label {
-  font-size: 14px;
-  color: var(--text-primary);
-  font-weight: 500;
+  color: var(--artdeco-fg-primary);
+  font-size: var(--artdeco-text-sm);
+  font-weight: var(--artdeco-font-medium);
 }
 
 .suggestions-section {
-  margin-top: 24px;
+  margin-top: var(--artdeco-spacing-6);
 }
 
 .alert-content {
   .alert-title {
-    margin-bottom: 12px;
-    color: var(--text-primary);
-    font-weight: 500;
+    margin-bottom: var(--artdeco-spacing-3);
+    color: var(--artdeco-gold-primary);
+    font-weight: var(--artdeco-font-medium);
   }
 }
 
 .suggestion-list {
   margin: 0;
-  padding-left: 20px;
+  padding-left: var(--artdeco-spacing-5);
   line-height: 1.9;
-  color: var(--text-secondary);
+  color: var(--artdeco-fg-muted);
 
   li {
-    margin: 6px 0;
+    margin: var(--artdeco-spacing-2) 0;
 
     strong {
-      color: var(--text-primary);
+      color: var(--artdeco-fg-primary);
     }
   }
 }

--- a/web/frontend/src/views/demo/openstock/components/KlineChart.vue
+++ b/web/frontend/src/views/demo/openstock/components/KlineChart.vue
@@ -120,74 +120,64 @@ const loadKlineChart = async () => {
 </script>
 
 <style scoped lang="scss">
+@use '../../../../styles/artdeco-tokens.scss' as *;
 
 .klinechart-section {
-  padding: 10px 0;
+  padding: var(--artdeco-spacing-3) 0;
 }
 
 .controls-row {
   display: flex;
-  gap: 15px;
+  gap: var(--artdeco-spacing-4);
   align-items: flex-end;
-  margin-bottom: 20px;
+  margin-bottom: var(--artdeco-spacing-5);
 }
 
 .input-group {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  min-width: 150px;
+  gap: var(--artdeco-spacing-2);
+  min-width: calc(var(--artdeco-spacing-20) + var(--artdeco-spacing-10));
 
   .input-label {
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--text-secondary);
+    color: var(--artdeco-fg-muted);
+    font-size: calc(var(--artdeco-text-sm) - var(--artdeco-spacing-px));
+    font-weight: var(--artdeco-font-medium);
   }
 }
 
-.input {
-  padding: 10px 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  font-size: 14px;
-  color: var(--text-primary);
-  background: var(--bg-primary);
-  transition: border-color 0.2s;
+.input,
+.select {
+  padding: calc(var(--artdeco-spacing-5) / 2) calc(var(--artdeco-spacing-4) - var(--artdeco-spacing-px));
+  border: 1px solid color-mix(in srgb, var(--artdeco-gold-primary) 20%, transparent);
+  border-radius: var(--artdeco-radius-none);
+  font-size: var(--artdeco-text-sm);
+  color: var(--artdeco-fg-primary);
+  background: var(--artdeco-bg-global);
+  transition: border-color var(--artdeco-transition-quick) var(--artdeco-ease-out);
 
   &:focus {
     outline: none;
-    border-color: var(--primary);
+    border-color: var(--artdeco-gold-primary);
   }
+}
 
-  &::placeholder {
-    color: var(--text-muted);
-  }
+.input::placeholder {
+  color: var(--artdeco-fg-muted);
 }
 
 .select {
-  padding: 10px 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  font-size: 14px;
-  color: var(--text-primary);
-  background: var(--bg-primary);
   cursor: pointer;
-  transition: border-color 0.2s;
-
-  &:focus {
-    outline: none;
-    border-color: var(--primary);
-  }
 }
 
 .klinechart-container {
-  width: 100%;
-  height: 600px;
-  background: var(--bg-primary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
   position: relative;
+  width: 100%;
+  height: 37.5rem;
   overflow: hidden;
+  background: var(--artdeco-bg-global);
+  border: 1px solid color-mix(in srgb, var(--artdeco-gold-primary) 20%, transparent);
+  border-radius: var(--artdeco-radius-none);
 
   &.loading {
     opacity: 70%;
@@ -195,29 +185,29 @@ const loadKlineChart = async () => {
 
   .loading-overlay {
     position: absolute;
-    inset: 0 0 0 0;
+    inset: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgb(255 255 255 / 80%);
+    background: color-mix(in srgb, var(--artdeco-bg-global) 80%, transparent);
     z-index: 10;
 
     .loading-text {
-      font-size: 16px;
-      color: var(--text-secondary);
+      font-size: var(--artdeco-text-base);
+      color: var(--artdeco-fg-muted);
     }
   }
 }
 
 .loading-spinner {
   display: inline-block;
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgb(255 255 255 / 30%);
-  border-top-color: white;
+  width: var(--artdeco-spacing-4);
+  height: var(--artdeco-spacing-4);
+  margin-right: var(--artdeco-spacing-2);
+  border: calc(var(--artdeco-spacing-px) * 2) solid color-mix(in srgb, var(--artdeco-fg-primary) 30%, transparent);
+  border-top-color: var(--artdeco-fg-primary);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
-  margin-right: 8px;
 }
 
 @keyframes spin {
@@ -227,19 +217,19 @@ const loadKlineChart = async () => {
 .alert-content {
   strong {
     display: block;
-    margin-bottom: 8px;
-    color: var(--text-primary);
+    margin-bottom: var(--artdeco-spacing-2);
+    color: var(--artdeco-fg-primary);
   }
 
   p {
     margin: 0;
-    color: var(--text-secondary);
+    color: var(--artdeco-fg-muted);
   }
 
   .tip {
-    margin-top: 8px;
-    font-size: 12px;
-    color: var(--text-muted);
+    margin-top: var(--artdeco-spacing-2);
+    font-size: var(--artdeco-text-xs);
+    color: var(--artdeco-fg-muted);
   }
 }
 </style>

--- a/web/frontend/src/views/demo/openstock/components/StockNews.vue
+++ b/web/frontend/src/views/demo/openstock/components/StockNews.vue
@@ -123,83 +123,77 @@ defineExpose({
 </script>
 
 <style scoped lang="scss">
+@use '../../../../styles/artdeco-tokens.scss' as *;
 
 .news-section {
-  padding: 10px 0;
+  padding: var(--artdeco-spacing-3) 0;
 }
 
 .controls-row {
   display: flex;
-  gap: 15px;
+  gap: calc(var(--artdeco-spacing-4) - var(--artdeco-spacing-px));
   align-items: flex-end;
 }
 
 .input-group {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  min-width: 140px;
+  gap: calc(var(--artdeco-spacing-2) - (var(--artdeco-spacing-px) * 2));
+  min-width: calc(var(--artdeco-spacing-20) + var(--artdeco-spacing-10) + var(--artdeco-spacing-5));
 
   .input-label {
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--text-secondary);
+    color: var(--artdeco-fg-muted);
+    font-size: calc(var(--artdeco-text-sm) - var(--artdeco-spacing-px));
+    font-weight: var(--artdeco-font-medium);
   }
 }
 
-.input {
-  padding: 10px 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  font-size: 14px;
-  color: var(--text-primary);
-  background: var(--bg-primary);
-  transition: border-color 0.2s;
+.input,
+.select {
+  padding: calc(var(--artdeco-spacing-5) / 2) calc(var(--artdeco-spacing-4) - var(--artdeco-spacing-px));
+  border: 1px solid color-mix(in srgb, var(--artdeco-gold-primary) 20%, transparent);
+  border-radius: var(--artdeco-radius-none);
+  background: var(--artdeco-bg-global);
+  color: var(--artdeco-fg-primary);
+  font-size: var(--artdeco-text-sm);
+  transition: border-color var(--artdeco-transition-quick) var(--artdeco-ease-out);
 
   &:focus {
     outline: none;
-    border-color: var(--primary);
+    border-color: var(--artdeco-gold-primary);
   }
+}
+
+.input::placeholder {
+  color: var(--artdeco-fg-muted);
 }
 
 .select {
-  padding: 10px 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  font-size: 14px;
-  color: var(--text-primary);
-  background: var(--bg-primary);
   cursor: pointer;
-  transition: border-color 0.2s;
-
-  &:focus {
-    outline: none;
-    border-color: var(--primary);
-  }
 }
 
 .news-list {
-  margin-top: 20px;
+  margin-top: var(--artdeco-spacing-5);
 }
 
 .timeline {
   position: relative;
-  padding-left: 30px;
+  padding-left: calc(var(--artdeco-spacing-5) + var(--artdeco-spacing-2) + (var(--artdeco-spacing-px) * 2));
 
   &::before {
     content: '';
     position: absolute;
-    left: 6px;
     top: 0;
     bottom: 0;
-    width: 2px;
-    background: var(--border-light);
+    left: calc(var(--artdeco-spacing-2) - (var(--artdeco-spacing-px) * 2));
+    width: calc(var(--artdeco-spacing-px) * 2);
+    background: color-mix(in srgb, var(--artdeco-gold-primary) 20%, transparent);
   }
 }
 
 .timeline-item {
   position: relative;
-  padding-bottom: 24px;
+  padding-bottom: var(--artdeco-spacing-6);
 
   &:last-child {
     padding-bottom: 0;
@@ -208,43 +202,43 @@ defineExpose({
 
 .timeline-marker {
   position: absolute;
-  left: -30px;
   top: 0;
-  width: 14px;
-  height: 14px;
-  background: var(--primary);
-  border-radius: 50%;
-  border: 3px solid var(--bg-primary);
+  left: calc((var(--artdeco-spacing-5) + var(--artdeco-spacing-2) + (var(--artdeco-spacing-px) * 2)) * -1);
+  width: calc(var(--artdeco-spacing-3) + (var(--artdeco-spacing-px) * 2));
+  height: calc(var(--artdeco-spacing-3) + (var(--artdeco-spacing-px) * 2));
+  background: var(--artdeco-gold-primary);
+  border: calc(var(--artdeco-spacing-px) * 3) solid var(--artdeco-bg-global);
+  border-radius: var(--artdeco-radius-full);
 }
 
 .timeline-content {
-  padding-left: 10px;
+  padding-left: calc(var(--artdeco-spacing-2) + (var(--artdeco-spacing-px) * 2));
 }
 
 .timeline-time {
-  font-size: 12px;
-  color: var(--text-muted);
-  margin-bottom: 8px;
+  margin-bottom: var(--artdeco-spacing-2);
+  color: var(--artdeco-fg-muted);
+  font-size: var(--artdeco-text-xs);
 }
 
 .news-card {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius-md);
-  padding: 16px;
+  padding: var(--artdeco-spacing-4);
+  background: color-mix(in srgb, var(--artdeco-gold-primary) 4%, var(--artdeco-bg-card));
+  border: 1px solid color-mix(in srgb, var(--artdeco-gold-primary) 20%, transparent);
+  border-radius: var(--artdeco-radius-none);
 
   h4 {
-    margin: 0 0 10px 0;
-    font-size: 15px;
-    font-weight: 600;
-    color: var(--text-primary);
+    margin: 0 0 calc(var(--artdeco-spacing-2) + (var(--artdeco-spacing-px) * 2)) 0;
+    color: var(--artdeco-fg-primary);
+    font-size: calc(var(--artdeco-text-sm) + var(--artdeco-spacing-px));
+    font-weight: var(--artdeco-font-semibold);
     line-height: 1.4;
   }
 
   p {
-    margin: 0 0 12px 0;
-    font-size: 13px;
-    color: var(--text-secondary);
+    margin: 0 0 var(--artdeco-spacing-3) 0;
+    color: var(--artdeco-fg-muted);
+    font-size: calc(var(--artdeco-text-sm) - var(--artdeco-spacing-px));
     line-height: 1.6;
   }
 }
@@ -256,10 +250,10 @@ defineExpose({
 }
 
 .news-link {
-  font-size: 13px;
-  color: var(--primary);
+  color: var(--artdeco-gold-primary);
+  font-size: calc(var(--artdeco-text-sm) - var(--artdeco-spacing-px));
+  font-weight: var(--artdeco-font-medium);
   text-decoration: none;
-  font-weight: 500;
 
   &:hover {
     text-decoration: underline;
@@ -268,13 +262,13 @@ defineExpose({
 
 .loading-spinner {
   display: inline-block;
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgb(255 255 255 / 30%);
-  border-top-color: white;
+  width: var(--artdeco-spacing-4);
+  height: var(--artdeco-spacing-4);
+  margin-right: var(--artdeco-spacing-2);
+  border: calc(var(--artdeco-spacing-px) * 2) solid color-mix(in srgb, var(--artdeco-fg-primary) 30%, transparent);
+  border-top-color: var(--artdeco-fg-primary);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
-  margin-right: 8px;
 }
 
 @keyframes spin {

--- a/web/frontend/src/views/demo/openstock/components/StockQuote.vue
+++ b/web/frontend/src/views/demo/openstock/components/StockQuote.vue
@@ -163,72 +163,62 @@ defineExpose({
 </script>
 
 <style scoped lang="scss">
+@use '../../../../styles/artdeco-tokens.scss' as *;
 
 .quote-section {
-  padding: 10px 0;
+  padding: var(--artdeco-spacing-3) 0;
 }
 
 .controls-row {
   display: flex;
-  gap: 15px;
+  gap: var(--artdeco-spacing-4);
   align-items: flex-end;
 }
 
 .input-group {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  min-width: 150px;
+  gap: var(--artdeco-spacing-2);
+  min-width: calc(var(--artdeco-spacing-20) + var(--artdeco-spacing-10));
 
   .input-label {
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--text-secondary);
+    color: var(--artdeco-fg-muted);
+    font-size: calc(var(--artdeco-text-sm) - var(--artdeco-spacing-px));
+    font-weight: var(--artdeco-font-medium);
   }
 }
 
-.input {
-  padding: 10px 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  font-size: 14px;
-  color: var(--text-primary);
-  background: var(--bg-primary);
-  transition: border-color 0.2s;
+.input,
+.select {
+  padding: calc(var(--artdeco-spacing-5) / 2) calc(var(--artdeco-spacing-4) - var(--artdeco-spacing-px));
+  border: 1px solid color-mix(in srgb, var(--artdeco-gold-primary) 20%, transparent);
+  border-radius: var(--artdeco-radius-none);
+  font-size: var(--artdeco-text-sm);
+  color: var(--artdeco-fg-primary);
+  background: var(--artdeco-bg-global);
+  transition: border-color var(--artdeco-transition-quick) var(--artdeco-ease-out);
 
   &:focus {
     outline: none;
-    border-color: var(--primary);
+    border-color: var(--artdeco-gold-primary);
   }
 }
 
 .select {
-  padding: 10px 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  font-size: 14px;
-  color: var(--text-primary);
-  background: var(--bg-primary);
   cursor: pointer;
-  transition: border-color 0.2s;
-
-  &:focus {
-    outline: none;
-    border-color: var(--primary);
-  }
 }
 
 .quote-display {
-  margin-top: 20px;
+  margin-top: var(--artdeco-spacing-5);
 }
 
 .info-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 0;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-light);
-  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--artdeco-gold-primary) 4%, var(--artdeco-bg-card));
+  border: 1px solid color-mix(in srgb, var(--artdeco-gold-primary) 20%, transparent);
+  border-radius: var(--artdeco-radius-none);
   overflow: hidden;
 }
 
@@ -236,9 +226,9 @@ defineExpose({
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 14px 20px;
-  border-bottom: 1px solid var(--border-light);
-  border-right: 1px solid var(--border-light);
+  padding: calc(var(--artdeco-spacing-4) - var(--artdeco-spacing-px)) var(--artdeco-spacing-5);
+  border-bottom: 1px solid color-mix(in srgb, var(--artdeco-gold-primary) 12%, transparent);
+  border-right: 1px solid color-mix(in srgb, var(--artdeco-gold-primary) 12%, transparent);
 
   &:nth-child(2n) {
     border-right: none;
@@ -251,44 +241,44 @@ defineExpose({
 }
 
 .info-label {
-  font-size: 14px;
-  color: var(--text-secondary);
+  color: var(--artdeco-fg-muted);
+  font-size: var(--artdeco-text-sm);
 }
 
 .info-value {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--text-primary);
+  color: var(--artdeco-fg-primary);
+  font-size: var(--artdeco-text-sm);
+  font-weight: var(--artdeco-font-medium);
 
   code {
-    padding: 2px 8px;
-    background: var(--bg-dark);
-    border-radius: var(--radius-sm);
-    font-family: 'SF Mono', Monaco, Consolas, monospace;
+    padding: calc(var(--artdeco-spacing-px) * 2) var(--artdeco-spacing-2);
+    background: var(--artdeco-bg-elevated);
+    border-radius: var(--artdeco-radius-none);
+    font-family: var(--artdeco-font-accent, var(--font-mono));
   }
 }
 
 .price {
-  font-weight: 700;
+  font-weight: var(--artdeco-font-bold);
 }
 
 .price-up {
-  color: var(--up);
+  color: var(--artdeco-rise);
 }
 
 .price-down {
-  color: var(--down);
+  color: var(--artdeco-down);
 }
 
 .loading-spinner {
   display: inline-block;
-  width: 14px;
-  height: 14px;
-  border: 2px solid rgb(255 255 255 / 30%);
-  border-top-color: white;
+  width: var(--artdeco-spacing-4);
+  height: var(--artdeco-spacing-4);
+  margin-right: var(--artdeco-spacing-2);
+  border: calc(var(--artdeco-spacing-px) * 2) solid color-mix(in srgb, var(--artdeco-fg-primary) 30%, transparent);
+  border-top-color: var(--artdeco-fg-primary);
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
-  margin-right: 8px;
 }
 
 @keyframes spin {

--- a/web/frontend/tests/unit/openstock-demo-tokenization.spec.ts
+++ b/web/frontend/tests/unit/openstock-demo-tokenization.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+function readSource(pathFromFrontendRoot: string): string {
+  return readFileSync(resolve(process.cwd(), pathFromFrontendRoot), 'utf8')
+}
+
+describe('OpenStock demo tokenization hygiene', () => {
+  it('moves selected OpenStock demo panels onto the ArtDeco token vocabulary', () => {
+    const files = [
+      'src/views/demo/openstock/components/FeatureStatus.vue',
+      'src/views/demo/openstock/components/KlineChart.vue',
+      'src/views/demo/openstock/components/StockNews.vue',
+      'src/views/demo/openstock/components/StockQuote.vue',
+    ]
+
+    for (const file of files) {
+      const source = readSource(file)
+
+      expect(source).toContain("@use '../../../../styles/artdeco-tokens.scss' as *;")
+      expect(source).not.toContain('var(--bg-primary)')
+      expect(source).not.toContain('var(--bg-secondary)')
+      expect(source).not.toContain('var(--text-primary)')
+      expect(source).not.toContain('var(--text-secondary)')
+      expect(source).not.toContain('var(--border)')
+      expect(source).not.toContain('var(--border-light)')
+      expect(source).not.toContain('var(--radius-sm)')
+      expect(source).not.toContain('var(--radius-md)')
+      expect(source).not.toContain('var(--primary)')
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- move four low-risk OpenStock demo panels onto the ArtDeco token vocabulary without touching the previously rejected watchlist/search button regressions
- add a focused source-level regression to keep those files off the legacy bg/text/border token set
- leave HeatmapChart, StockSearch, and WatchlistManagement out of scope because they have known regression risks

## Test Plan
- npx vitest run tests/unit/openstock-demo-tokenization.spec.ts --config vitest.config.mts
- git diff --check
