### PR TITLE
fix(frontend): route useMarket fund flow through service

### DIFF
--- a/governance/mainline/task-cards/pr-37.yaml
+++ b/governance/mainline/task-cards/pr-37.yaml
@@ -1,0 +1,85 @@
+version: "v0.2"
+
+task:
+  id: "pr-37"
+  title: "route useMarket fund flow through service"
+  owner: "main"
+  created_at: "2026-04-01"
+
+mainline:
+  id: "L1-use-market-fund-flow-bridge"
+  objective: "replace the empty fund-flow placeholder path in useMarket with the existing market service and adapter bridge"
+  milestone_id: "L3-mainline-follow-up"
+  slice_id: "L4-use-market-fund-flow-bridge"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-useMarket-bugfix-with-focused-regression"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-37.yaml"
+    - "web/frontend/src/composables/useMarket.ts"
+    - "web/frontend/tests/unit/use-market-fund-flow.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No market overview refactor"
+  - "No K-line adapter rewrite in useMarket"
+
+acceptance:
+  checks:
+    - id: "use-market-fund-flow-tests"
+      command: "cd web/frontend && npx vitest run tests/unit/use-market-fund-flow.spec.ts tests/unit/composables.test.ts --config vitest.config.mts"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-37.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the service response is not adapted before caching, useMarket consumers could receive the wrong fund-flow shape"
+    - "If cache keys drift, stale or mismatched fund-flow data could be reused"
+  rollback_plan: "git revert <merge-commit-sha> if useMarket fund-flow consumers regress after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "replace the useMarket fund-flow placeholder with the real service and adapter bridge"
+    modified_scope: "useMarket composable, one focused regression test, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "runtime behavior changes only for useMarket fund-flow fetching and caching"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if useMarket fund-flow consumers regress"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-01T00:00:00Z"
+    approval_note: "localized composable bugfix with dedicated regression coverage"
+    secondary_approved: false

--- a/web/frontend/src/composables/useMarket.ts
+++ b/web/frontend/src/composables/useMarket.ts
@@ -7,6 +7,7 @@
 
 import { ref, readonly, onMounted } from 'vue';
 import { marketService } from '@/api/services/marketService';
+import { MarketAdapter } from '@/api/adapters/marketAdapter';
 import { getCache } from '@/utils/cache/part-1';
 import type { MarketOverviewVM, FundFlowChartPoint, KLineChartData } from '@/api/types/extensions';
 
@@ -199,9 +200,13 @@ export function useMarket(options?: {
         }
       }
 
-      // TODO: Implement getFundFlow in marketService
-      // For now, return mock data
-      const vm: FundFlowChartPoint[] = [];
+      const response = await marketService.getFundFlow({
+        symbol: params.symbol,
+        timeframe: params.timeframe,
+        start_date: params.start_date,
+        end_date: params.end_date,
+      })
+      const vm = MarketAdapter.adaptFundFlow(response as never)
 
       // Cache the result
       if (enableCache) {

--- a/web/frontend/tests/unit/use-market-fund-flow.spec.ts
+++ b/web/frontend/tests/unit/use-market-fund-flow.spec.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  getFundFlowMock,
+  cacheGetMock,
+  cacheSetMock,
+  cacheClearMock,
+  cacheStatsMock,
+  adaptFundFlowMock,
+  onMountedMock,
+} = vi.hoisted(() => ({
+  getFundFlowMock: vi.fn(),
+  cacheGetMock: vi.fn(),
+  cacheSetMock: vi.fn(),
+  cacheClearMock: vi.fn(),
+  cacheStatsMock: vi.fn(() => ({ size: 0, hits: 0, misses: 0 })),
+  adaptFundFlowMock: vi.fn(),
+  onMountedMock: vi.fn(),
+}))
+
+vi.mock('vue', async () => {
+  const actual = await vi.importActual<typeof import('vue')>('vue')
+  return {
+    ...actual,
+    onMounted: onMountedMock,
+  }
+})
+
+vi.mock('@/api/services/marketService', () => ({
+  marketService: {
+    getFundFlow: getFundFlowMock,
+  },
+}))
+
+vi.mock('@/utils/cache/part-1', () => ({
+  getCache: () => ({
+    get: cacheGetMock,
+    set: cacheSetMock,
+    clear: cacheClearMock,
+    getStats: cacheStatsMock,
+  }),
+}))
+
+vi.mock('@/api/adapters/marketAdapter', () => ({
+  MarketAdapter: {
+    adaptFundFlow: adaptFundFlowMock,
+  },
+}))
+
+import { useMarket } from '@/composables/useMarket'
+
+describe('useMarket fund flow bridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cacheGetMock.mockReturnValue(undefined)
+    getFundFlowMock.mockResolvedValue({
+      success: true,
+      data: {
+        fund_flow: [
+          {
+            trade_date: '2026-04-01',
+            super_large_net_inflow: 100,
+            large_net_inflow: 50,
+            medium_net_inflow: 25,
+            small_net_inflow: 10,
+          },
+        ],
+      },
+    })
+    adaptFundFlowMock.mockReturnValue([
+      {
+        date: '2026-04-01',
+        timestamp: 1711929600000,
+        main_force: { inflow: 100, outflow: 0, net_flow: 100, ratio: 0 },
+        large_orders: { inflow: 50, outflow: 0, net_flow: 50, ratio: 0 },
+        big_orders: { inflow: 25, outflow: 0, net_flow: 25, ratio: 0 },
+        medium_orders: { inflow: 10, outflow: 0, net_flow: 10, ratio: 0 },
+        small_orders: { inflow: 0, outflow: 0, net_flow: 0, ratio: 0 },
+        total_inflow: 185,
+        total_outflow: 0,
+        total_net_flow: 185,
+      },
+    ])
+  })
+
+  it('fetches, adapts, and caches fund flow data through the market service', async () => {
+    const market = useMarket({ autoFetch: false })
+
+    await market.fetchFundFlow({ symbol: '000001.SZ', timeframe: '5' })
+
+    expect(getFundFlowMock).toHaveBeenCalledWith({
+      symbol: '000001.SZ',
+      timeframe: '5',
+    })
+    expect(adaptFundFlowMock).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        fund_flow: [
+          {
+            trade_date: '2026-04-01',
+            super_large_net_inflow: 100,
+            large_net_inflow: 50,
+            medium_net_inflow: 25,
+            small_net_inflow: 10,
+          },
+        ],
+      },
+    })
+    expect(cacheSetMock).toHaveBeenCalledWith(
+      'market:fund_flow:{"symbol":"000001.SZ","timeframe":"5"}',
+      [
+        expect.objectContaining({
+          date: '2026-04-01',
+          total_net_flow: 185,
+        }),
+      ],
+      { ttl: 600 },
+    )
+    expect(market.fundFlowData.value).toEqual([
+      expect.objectContaining({
+        date: '2026-04-01',
+        total_net_flow: 185,
+      }),
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- route `useMarket.fetchFundFlow()` through the existing market service instead of returning an empty placeholder array
- adapt the service response through `MarketAdapter.adaptFundFlow()` and cache the adapted result
- add a focused vitest regression covering the service -> adapter -> cache bridge

## Test Plan
- npx vitest run tests/unit/use-market-fund-flow.spec.ts tests/unit/composables.test.ts --config vitest.config.mts
- git diff --check
