### PR TITLE
fix(frontend): route useMarket kline through adapter

### DIFF
--- a/governance/mainline/task-cards/pr-38.yaml
+++ b/governance/mainline/task-cards/pr-38.yaml
@@ -1,0 +1,85 @@
+version: "v0.2"
+
+task:
+  id: "pr-38"
+  title: "route useMarket kline through adapter"
+  owner: "main"
+  created_at: "2026-04-01"
+
+mainline:
+  id: "L1-use-market-kline-bridge"
+  objective: "replace the broken hand-written K-line mapping in useMarket with the existing market adapter while preserving the composable's public row shape"
+  milestone_id: "L3-mainline-follow-up"
+  slice_id: "L4-use-market-kline-bridge"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-useMarket-kline-bugfix-with-focused-regression"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-38.yaml"
+    - "web/frontend/src/composables/useMarket.ts"
+    - "web/frontend/tests/unit/use-market-kline.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No market overview refactor"
+  - "No change to the public K-line row contract returned by useMarket"
+
+acceptance:
+  checks:
+    - id: "use-market-kline-tests"
+      command: "cd web/frontend && npx vitest run tests/unit/use-market-kline.spec.ts tests/unit/composables.test.ts --config vitest.config.mts"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-38.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the adapter output is flattened incorrectly, consumers may receive malformed K-line rows"
+    - "If the cache stores the wrong shape, stale invalid rows could be reused by later reads"
+  rollback_plan: "git revert <merge-commit-sha> if useMarket K-line consumers regress after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "replace the broken useMarket K-line bridge with the existing market adapter path"
+    modified_scope: "useMarket composable, one focused K-line regression test, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "runtime behavior changes only for useMarket K-line fetching, adaptation, and caching"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if useMarket K-line consumers regress"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-01T00:00:00Z"
+    approval_note: "localized composable K-line bugfix with dedicated regression coverage"
+    secondary_approved: false

--- a/web/frontend/src/composables/useMarket.ts
+++ b/web/frontend/src/composables/useMarket.ts
@@ -269,29 +269,22 @@ export function useMarket(options?: {
         period: params.interval,
       });
 
-      // For now, create a simple adapter since response format may not match
-      interface KLineItem {
-        timestamp?: string | number
-        date?: string | number
-        open?: number
-        high?: number
-        low?: number
-        close?: number
-        volume?: number
-        amount?: number
-      }
-      const vm: KLineChartData[] = ((response as unknown as { data?: KLineItem[] }).data || []).map((item) => ({
-        timestamp: String(item.timestamp || item.date || ''),
-        date: String(item.date || item.timestamp || ''),
-        open: item.open || 0,
-        high: item.high || 0,
-        low: item.low || 0,
-        close: item.close || 0,
-        volume: item.volume || 0,
-        amount: item.amount || 0,
-        symbol: params.symbol,
-        interval: params.interval
-      }));
+      const adapted = MarketAdapter.adaptKLineData(response as never)
+      const vm: KLineChartData[] = adapted.categoryData.map((date, index) => {
+        const point = adapted.values[index]
+        return {
+          timestamp: date,
+          date,
+          open: point?.open ?? 0,
+          high: point?.high ?? 0,
+          low: point?.low ?? 0,
+          close: point?.close ?? 0,
+          volume: adapted.volumes[index] ?? point?.volume ?? 0,
+          amount: adapted.volumes[index] ?? point?.volume ?? 0,
+          symbol: params.symbol,
+          interval: params.interval
+        }
+      })
 
       // Cache the result
       if (enableCache) {

--- a/web/frontend/tests/unit/use-market-kline.spec.ts
+++ b/web/frontend/tests/unit/use-market-kline.spec.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  getKlineMock,
+  cacheGetMock,
+  cacheSetMock,
+  cacheClearMock,
+  cacheStatsMock,
+  adaptKLineDataMock,
+  onMountedMock,
+} = vi.hoisted(() => ({
+  getKlineMock: vi.fn(),
+  cacheGetMock: vi.fn(),
+  cacheSetMock: vi.fn(),
+  cacheClearMock: vi.fn(),
+  cacheStatsMock: vi.fn(() => ({ size: 0, hits: 0, misses: 0 })),
+  adaptKLineDataMock: vi.fn(),
+  onMountedMock: vi.fn(),
+}))
+
+vi.mock('vue', async () => {
+  const actual = await vi.importActual<typeof import('vue')>('vue')
+  return {
+    ...actual,
+    onMounted: onMountedMock,
+  }
+})
+
+vi.mock('@/api/services/marketService', () => ({
+  marketService: {
+    getKline: getKlineMock,
+  },
+}))
+
+vi.mock('@/utils/cache/part-1', () => ({
+  getCache: () => ({
+    get: cacheGetMock,
+    set: cacheSetMock,
+    clear: cacheClearMock,
+    getStats: cacheStatsMock,
+  }),
+}))
+
+vi.mock('@/api/adapters/marketAdapter', () => ({
+  MarketAdapter: {
+    adaptKLineData: adaptKLineDataMock,
+  },
+}))
+
+import { useMarket } from '@/composables/useMarket'
+
+describe('useMarket kline bridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cacheGetMock.mockReturnValue(undefined)
+    getKlineMock.mockResolvedValue({
+      success: true,
+      data: {
+        symbol: '000001.SZ',
+        period: '1d',
+        data: [
+          {
+            datetime: '2026-04-01',
+            open: 10,
+            high: 12,
+            low: 9,
+            close: 11,
+            volume: 1000,
+          },
+        ],
+      },
+    })
+    adaptKLineDataMock.mockReturnValue({
+      categoryData: ['2026-04-01'],
+      values: [
+        {
+          open: 10,
+          close: 11,
+          low: 9,
+          high: 12,
+          volume: 1000,
+        },
+      ],
+      volumes: [1000],
+    })
+  })
+
+  it('fetches, adapts, and caches kline data through the market service', async () => {
+    const market = useMarket({ autoFetch: false })
+
+    await market.fetchKLineData({
+      symbol: '000001.SZ',
+      interval: '1d',
+      startDate: '2026-04-01',
+      endDate: '2026-04-10',
+      limit: 50,
+    })
+
+    expect(getKlineMock).toHaveBeenCalledWith({
+      stock_code: '000001.SZ',
+      period: '1d',
+    })
+    expect(adaptKLineDataMock).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        symbol: '000001.SZ',
+        period: '1d',
+        data: [
+          {
+            datetime: '2026-04-01',
+            open: 10,
+            high: 12,
+            low: 9,
+            close: 11,
+            volume: 1000,
+          },
+        ],
+      },
+    })
+    expect(cacheSetMock).toHaveBeenCalledWith(
+      'market:kline:000001.SZ:1d',
+      [
+        {
+          timestamp: '2026-04-01',
+          date: '2026-04-01',
+          open: 10,
+          close: 11,
+          low: 9,
+          high: 12,
+          volume: 1000,
+          amount: 1000,
+          symbol: '000001.SZ',
+          interval: '1d',
+        },
+      ],
+      { ttl: 180 },
+    )
+    expect(market.klineData.value).toEqual([
+      {
+        timestamp: '2026-04-01',
+        date: '2026-04-01',
+        open: 10,
+        close: 11,
+        low: 9,
+        high: 12,
+        volume: 1000,
+        amount: 1000,
+        symbol: '000001.SZ',
+        interval: '1d',
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- replace the hand-written `response.data.map(...)` path in `useMarket.fetchKLineData()` with the existing market adapter
- keep the composable's public K-line array shape by flattening the adapted chart payload back into row items
- add a focused vitest regression covering the service -> adapter -> cache bridge for K-line data

## Test Plan
- npx vitest run tests/unit/use-market-kline.spec.ts tests/unit/composables.test.ts --config vitest.config.mts
- git diff --check
