### PR TITLE
fix(frontend): route useMarket overview through api

### DIFF
--- a/governance/mainline/task-cards/pr-39.yaml
+++ b/governance/mainline/task-cards/pr-39.yaml
@@ -1,0 +1,85 @@
+version: "v0.2"
+
+task:
+  id: "pr-39"
+  title: "route useMarket overview through api"
+  owner: "main"
+  created_at: "2026-04-01"
+
+mainline:
+  id: "L1-use-market-overview-bridge"
+  objective: "replace the hardcoded market overview placeholder in useMarket with the existing market API path"
+  milestone_id: "L3-mainline-follow-up"
+  slice_id: "L4-use-market-overview-bridge"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-useMarket-overview-bugfix-with-focused-regression"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-39.yaml"
+    - "web/frontend/src/composables/useMarket.ts"
+    - "web/frontend/tests/unit/use-market-overview.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No market overview schema redesign"
+  - "No chip race or long hu bang merge logic in this slice"
+
+acceptance:
+  checks:
+    - id: "use-market-overview-tests"
+      command: "cd web/frontend && npx vitest run tests/unit/use-market-overview.spec.ts tests/unit/composables.test.ts --config vitest.config.mts"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-39.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the overview cache stores the wrong shape, useMarket consumers may render stale or malformed market summary data"
+    - "If the API path is wrong, the composable will regress from placeholder data to runtime errors"
+  rollback_plan: "git revert <merge-commit-sha> if useMarket market overview consumers regress after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "replace the useMarket market overview placeholder with the real market API path"
+    modified_scope: "useMarket composable, one focused market-overview regression test, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "runtime behavior changes only for useMarket market overview fetching and caching"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if useMarket market overview consumers regress"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-01T00:00:00Z"
+    approval_note: "localized composable market-overview bugfix with dedicated regression coverage"
+    secondary_approved: false

--- a/web/frontend/src/composables/useMarket.ts
+++ b/web/frontend/src/composables/useMarket.ts
@@ -8,6 +8,7 @@
 import { ref, readonly, onMounted } from 'vue';
 import { marketService } from '@/api/services/marketService';
 import { MarketAdapter } from '@/api/adapters/marketAdapter';
+import { marketApi } from '@/api/market';
 import { getCache } from '@/utils/cache/part-1';
 import type { MarketOverviewVM, FundFlowChartPoint, KLineChartData } from '@/api/types/extensions';
 
@@ -72,72 +73,7 @@ export function useMarket(options?: {
         }
       }
 
-      // TODO: Implement these methods in marketService
-      // For now, return mock data with minimal required fields
-      const vm = {
-        market_status: 'sideways' as const,
-        market_phase: 'accumulation' as const,
-        indices: {
-          shanghai: {
-            code: 'SH000001',
-            name: '上证指数',
-            current_price: 3000,
-            change_amount: 0,
-            change_percent: 0,
-            volume: 0,
-            amount: 0,
-            open: 3000,
-            high: 3000,
-            low: 3000,
-            close: 3000,
-            prev_close: 3000
-          },
-          shenzhen: {
-            code: 'SZ399001',
-            name: '深证成指',
-            current_price: 10000,
-            change_amount: 0,
-            change_percent: 0,
-            volume: 0,
-            amount: 0,
-            open: 10000,
-            high: 10000,
-            low: 10000,
-            close: 10000,
-            prev_close: 10000
-          },
-          chiNext: {
-            code: 'SZ399006',
-            name: '创业板指',
-            current_price: 2000,
-            change_amount: 0,
-            change_percent: 0,
-            volume: 0,
-            amount: 0,
-            open: 2000,
-            high: 2000,
-            low: 2000,
-            close: 2000,
-            prev_close: 2000
-          }
-        },
-        sentiment: {
-          advance_decline_ratio: 1.0,
-          up_down_volume_ratio: 1.0,
-          new_highs_new_lows_ratio: 1.0
-        },
-        turnover: { total: 0, shanghai: 0, shenzhen: 0 },
-        price_distribution: { up: 0, down: 0, flat: 0 },
-        sector_performance: [],
-        hot_concepts: [],
-        capital_flow: { main_net: 0, retail_net: 0, institution_net: 0 },
-        top_gainers: [],
-        top_losers: [],
-        technical_summary: { trend: 'neutral' as const, support: 0, resistance: 0 },
-        last_update: new Date().toISOString(),
-        market_session: 'closed' as const,
-        timestamp: new Date().toISOString()
-      } as unknown as MarketOverviewVM;
+      const vm = await marketApi.getMarketOverview()
 
       // Merge Chip Race data
       // TODO: MarketOverviewVM interface doesn't have chipRaces field

--- a/web/frontend/tests/unit/use-market-overview.spec.ts
+++ b/web/frontend/tests/unit/use-market-overview.spec.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  getMarketOverviewMock,
+  cacheGetMock,
+  cacheSetMock,
+  cacheClearMock,
+  cacheStatsMock,
+  onMountedMock,
+} = vi.hoisted(() => ({
+  getMarketOverviewMock: vi.fn(),
+  cacheGetMock: vi.fn(),
+  cacheSetMock: vi.fn(),
+  cacheClearMock: vi.fn(),
+  cacheStatsMock: vi.fn(() => ({ size: 0, hits: 0, misses: 0 })),
+  onMountedMock: vi.fn(),
+}))
+
+vi.mock('vue', async () => {
+  const actual = await vi.importActual<typeof import('vue')>('vue')
+  return {
+    ...actual,
+    onMounted: onMountedMock,
+  }
+})
+
+vi.mock('@/api/market', () => ({
+  marketApi: {
+    getMarketOverview: getMarketOverviewMock,
+  },
+}))
+
+vi.mock('@/utils/cache/part-1', () => ({
+  getCache: () => ({
+    get: cacheGetMock,
+    set: cacheSetMock,
+    clear: cacheClearMock,
+    getStats: cacheStatsMock,
+  }),
+}))
+
+import { useMarket } from '@/composables/useMarket'
+
+describe('useMarket market overview bridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cacheGetMock.mockReturnValue(undefined)
+    getMarketOverviewMock.mockResolvedValue({
+      market_status: 'bull',
+      market_phase: 'markup',
+      indices: {
+        shanghai: {
+          code: 'SH000001',
+          name: '上证指数',
+          current_price: 3100,
+          change_amount: 12,
+          change_percent: 0.39,
+          volume: 100,
+          amount: 200,
+          open: 3080,
+          high: 3110,
+          low: 3070,
+          close: 3100,
+          prev_close: 3088,
+        },
+        shenzhen: {
+          code: 'SZ399001',
+          name: '深证成指',
+          current_price: 9800,
+          change_amount: 40,
+          change_percent: 0.41,
+          volume: 100,
+          amount: 200,
+          open: 9750,
+          high: 9820,
+          low: 9730,
+          close: 9800,
+          prev_close: 9760,
+        },
+        chiNext: {
+          code: 'SZ399006',
+          name: '创业板指',
+          current_price: 2000,
+          change_amount: 10,
+          change_percent: 0.5,
+          volume: 100,
+          amount: 200,
+          open: 1988,
+          high: 2010,
+          low: 1980,
+          close: 2000,
+          prev_close: 1990,
+        },
+      },
+      sentiment: {
+        advance_decline_ratio: 1.2,
+        up_down_volume_ratio: 1.1,
+        new_highs_new_lows_ratio: 1.05,
+      },
+      turnover: { total: 1, shanghai: 0.4, shenzhen: 0.6 },
+      price_distribution: { up: 10, down: 5, flat: 2 },
+      sector_performance: [],
+      hot_concepts: [],
+      capital_flow: { main_net: 1, retail_net: -1, institution_net: 2 },
+      top_gainers: [],
+      top_losers: [],
+      technical_summary: { trend: 'bullish', support: 3000, resistance: 3200 },
+      last_update: '2026-04-01T00:00:00Z',
+      market_session: 'open',
+      timestamp: '2026-04-01T00:00:00Z',
+    })
+  })
+
+  it('fetches and caches market overview through marketApi instead of placeholder data', async () => {
+    const market = useMarket({ autoFetch: false })
+
+    await market.fetchMarketOverview()
+
+    expect(getMarketOverviewMock).toHaveBeenCalledTimes(1)
+    expect(cacheSetMock).toHaveBeenCalledWith(
+      'market:overview',
+      expect.objectContaining({
+        market_status: 'bull',
+        market_phase: 'markup',
+      }),
+      { ttl: 300 },
+    )
+    expect(market.marketOverview.value).toEqual(
+      expect.objectContaining({
+        market_status: 'bull',
+        market_phase: 'markup',
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- replace the large placeholder market overview object in `useMarket.fetchMarketOverview()` with the real `marketApi.getMarketOverview()` path
- keep the existing cache behavior while removing the hardcoded fallback payload from the composable itself
- add a focused vitest regression covering the market overview API -> cache -> state bridge

## Test Plan
- npx vitest run tests/unit/use-market-overview.spec.ts tests/unit/composables.test.ts --config vitest.config.mts
- git diff --check
