### PR TITLE
fix(frontend): pass useMarket kline query params

### DIFF
--- a/governance/mainline/task-cards/pr-40.yaml
+++ b/governance/mainline/task-cards/pr-40.yaml
@@ -1,0 +1,85 @@
+version: "v0.2"
+
+task:
+  id: "pr-40"
+  title: "pass useMarket kline query params"
+  owner: "main"
+  created_at: "2026-04-02"
+
+mainline:
+  id: "L1-use-market-kline-query-bridge"
+  objective: "ensure useMarket forwards the requested K-line query parameters to the market service instead of silently dropping them"
+  milestone_id: "L3-mainline-follow-up"
+  slice_id: "L4-use-market-kline-query-bridge"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-useMarket-kline-param-bugfix-with-focused-regression"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-40.yaml"
+    - "web/frontend/src/composables/useMarket.ts"
+    - "web/frontend/tests/unit/use-market-kline.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No change to useMarket public K-line row shape"
+  - "No change to market service endpoint selection"
+
+acceptance:
+  checks:
+    - id: "use-market-kline-query-tests"
+      command: "cd web/frontend && npx vitest run tests/unit/use-market-kline.spec.ts tests/unit/composables.test.ts --config vitest.config.mts"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-40.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If query parameters are forwarded incorrectly, K-line consumers may fetch the wrong time range or point count"
+    - "If the composable cache key and forwarded params diverge, callers may observe confusing stale data"
+  rollback_plan: "git revert <merge-commit-sha> if useMarket K-line callers regress after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "restore parameter passthrough for useMarket K-line queries"
+    modified_scope: "useMarket composable, the focused K-line regression test, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "runtime behavior changes only for start/end/limit query propagation in useMarket K-line fetches"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if K-line callers fetch the wrong query window after merge"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-02T00:00:00Z"
+    approval_note: "localized query passthrough bugfix with dedicated regression coverage"
+    secondary_approved: false

--- a/web/frontend/src/composables/useMarket.ts
+++ b/web/frontend/src/composables/useMarket.ts
@@ -190,20 +190,15 @@ export function useMarket(options?: {
         }
       }
 
-      // Adapt parameters for API (startDate -> start_date)
-      const _apiParams = {
-        symbol: params.symbol,
-        interval: params.interval,
+      const requestParams = {
+        stock_code: params.symbol,
+        period: params.interval,
         start_date: params.startDate,
         end_date: params.endDate,
         limit: params.limit
-      };
+      }
 
-      // Use getKline instead of getKLine
-      const response = await marketService.getKline({
-        stock_code: params.symbol,
-        period: params.interval,
-      });
+      const response = await marketService.getKline(requestParams);
 
       const adapted = MarketAdapter.adaptKLineData(response as never)
       const vm: KLineChartData[] = adapted.categoryData.map((date, index) => {

--- a/web/frontend/tests/unit/use-market-kline.spec.ts
+++ b/web/frontend/tests/unit/use-market-kline.spec.ts
@@ -99,6 +99,9 @@ describe('useMarket kline bridge', () => {
     expect(getKlineMock).toHaveBeenCalledWith({
       stock_code: '000001.SZ',
       period: '1d',
+      start_date: '2026-04-01',
+      end_date: '2026-04-10',
+      limit: 50,
     })
     expect(adaptKLineDataMock).toHaveBeenCalledWith({
       success: true,


### PR DESCRIPTION
## Summary
- pass `startDate`, `endDate`, and `limit` through `useMarket.fetchKLineData()` to the existing market service call
- keep the existing adapter/caching path intact while removing the currently unused local request placeholder
- extend the focused K-line regression so it locks the query parameter bridge too

## Test Plan
- npx vitest run tests/unit/use-market-kline.spec.ts tests/unit/composables.test.ts --config vitest.config.mts
- git diff --check
