### PR TITLE
fix(frontend): wire wencai query watchlist action

### DIFF
--- a/governance/mainline/task-cards/pr-44.yaml
+++ b/governance/mainline/task-cards/pr-44.yaml
@@ -1,0 +1,85 @@
+version: "v0.2"
+
+task:
+  id: "pr-44"
+  title: "wire wencai query watchlist action"
+  owner: "main"
+  created_at: "2026-04-02"
+
+mainline:
+  id: "L1-wencai-watchlist-action"
+  objective: "connect the Wencai query table watchlist action to the existing watchlist service with a safe default-watchlist fallback"
+  milestone_id: "L3-mainline-follow-up"
+  slice_id: "L4-wencai-watchlist-action"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-watchlist-action-bugfix-with-focused-regression"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-44.yaml"
+    - "web/frontend/src/components/market/WencaiQueryTable.vue"
+    - "web/frontend/tests/unit/wencai-query-table.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No watchlist management page refactor"
+  - "No new watchlist selection UI in the Wencai table"
+
+acceptance:
+  checks:
+    - id: "wencai-watchlist-tests"
+      command: "cd web/frontend && npx vitest run tests/unit/wencai-query-table.spec.ts tests/unit/config/wencai-style-normalization.spec.ts --config vitest.config.mts"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-44.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the default-watchlist bootstrap path is wrong, users with no watchlists will still be unable to add Wencai results"
+    - "If the success path targets the wrong watchlist ID, the action will silently mutate the wrong list"
+  rollback_plan: "git revert <merge-commit-sha> if the Wencai watchlist action regresses after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "replace the Wencai query table's placeholder watchlist toast with a real watchlist action path"
+    modified_scope: "WencaiQueryTable, one focused watchlist regression test, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "runtime behavior changes only for the add-to-watchlist action in the Wencai query table"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if the Wencai watchlist action targets the wrong list or fails to bootstrap"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-02T00:00:00Z"
+    approval_note: "localized watchlist action bugfix with dedicated regression coverage"
+    secondary_approved: false

--- a/web/frontend/src/components/market/WencaiQueryTable.vue
+++ b/web/frontend/src/components/market/WencaiQueryTable.vue
@@ -119,10 +119,17 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { ElMessage } from 'element-plus'
 import { Refresh, Download, ArrowLeft } from '@element-plus/icons-vue'
+import { watchlistService } from '@/api/services/watchlistService.ts'
+
+interface WencaiRow {
+  code?: string
+  name?: string
+  [key: string]: unknown
+}
 
 const props = defineProps({
   queryName: String,
@@ -135,9 +142,9 @@ const loading = ref(false)
 const currentPage = ref(1)
 const pageSize = ref(20)
 const total = ref(0)
-const tableData = ref([])
+const tableData = ref<WencaiRow[]>([])
 const detailsVisible = ref(false)
-const selectedStock = ref(null)
+const selectedStock = ref<WencaiRow | null>(null)
 const detailsDialogWidth = 'calc((var(--artdeco-spacing-20) * 7) + var(--artdeco-spacing-10))'
 
 // 计算动态列（排除 code 和 name）
@@ -202,15 +209,53 @@ const exportData = () => {
 }
 
 // 查看详情
-const viewDetails = (row) => {
+const viewDetails = (row: WencaiRow) => {
   selectedStock.value = row
   detailsVisible.value = true
 }
 
+const ensureWatchlistId = async (): Promise<number> => {
+  const response = await watchlistService.listWatchlists()
+  if (response.success && response.data.length > 0) {
+    return response.data[0].id
+  }
+
+  const created = await watchlistService.createWatchlist({
+    name: '问财自选',
+    watchlist_type: 'manual',
+    risk_profile: {}
+  })
+
+  if (!created.success) {
+    throw new Error(created.message || '创建默认自选清单失败')
+  }
+
+  return created.data.id
+}
+
 // 加入自选
-const addToWatchlist = (row) => {
-  ElMessage.success(`已将 ${row.name || row.code} 加入自选`)
-  // TODO: 实现加入自选逻辑
+const addToWatchlist = async (row: WencaiRow) => {
+  if (!row.code) {
+    ElMessage.warning('缺少股票代码，无法加入自选')
+    return
+  }
+
+  try {
+    const watchlistId = await ensureWatchlistId()
+    const response = await watchlistService.addStockToWatchlist(watchlistId, {
+      stock_code: row.code,
+      entry_reason: `来自问财条件：${props.queryName}`
+    })
+
+    if (!response.success) {
+      throw new Error(response.message || '加入自选失败')
+    }
+
+    ElMessage.success(`已将 ${row.name || row.code} 加入自选`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '加入自选失败'
+    ElMessage.error(message)
+  }
 }
 
 // 页面加载时获取数据

--- a/web/frontend/tests/unit/wencai-query-table.spec.ts
+++ b/web/frontend/tests/unit/wencai-query-table.spec.ts
@@ -1,0 +1,154 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  successMock,
+  warningMock,
+  errorMock,
+  listWatchlistsMock,
+  createWatchlistMock,
+  addStockToWatchlistMock,
+} = vi.hoisted(() => ({
+  successMock: vi.fn(),
+  warningMock: vi.fn(),
+  errorMock: vi.fn(),
+  listWatchlistsMock: vi.fn(),
+  createWatchlistMock: vi.fn(),
+  addStockToWatchlistMock: vi.fn(),
+}))
+
+vi.mock('element-plus', () => ({
+  ElMessage: {
+    success: successMock,
+    warning: warningMock,
+    error: errorMock,
+  },
+}))
+
+vi.mock('@/api/services/watchlistService.ts', () => ({
+  watchlistService: {
+    listWatchlists: listWatchlistsMock,
+    createWatchlist: createWatchlistMock,
+    addStockToWatchlist: addStockToWatchlistMock,
+  },
+}))
+
+import WencaiQueryTable from '@/components/market/WencaiQueryTable.vue'
+
+const TableStub = {
+  props: ['data'],
+  template: `
+    <table>
+      <tbody>
+        <tr v-for="row in data" :key="row.code">
+          <slot :row="row" />
+        </tr>
+      </tbody>
+    </table>
+  `,
+}
+
+const TableColumnStub = {
+  template: '<div><slot :row="{ code: `000001`, name: `平安银行` }" /></div>',
+}
+
+describe('WencaiQueryTable watchlist actions', () => {
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [{ code: '000001', name: '平安银行' }],
+        total: 1,
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    listWatchlistsMock.mockResolvedValue({
+      success: true,
+      data: [{ id: 7, name: '默认自选', watchlist_type: 'manual', risk_profile: {}, stocks_count: 0 }],
+    })
+    createWatchlistMock.mockResolvedValue({
+      success: true,
+      data: { id: 11, name: '问财自选', watchlist_type: 'manual', risk_profile: {}, stocks_count: 0 },
+    })
+    addStockToWatchlistMock.mockResolvedValue({ success: true, data: null })
+  })
+
+  it('adds a stock into the first existing watchlist', async () => {
+    const wrapper = mount(WencaiQueryTable as never, {
+      props: {
+        queryName: '银行股',
+        queryDescription: '银行板块筛选',
+      },
+      global: {
+        stubs: {
+          'el-button': { template: '<button @click="$emit(`click`)"><slot /></button>' },
+          'el-icon': { template: '<i><slot /></i>' },
+          'el-pagination': true,
+          'el-dialog': { template: '<div><slot /><slot name="footer" /></div>' },
+          'el-table': TableStub,
+          'el-table-column': TableColumnStub,
+        },
+        directives: {
+          loading: { mounted() {}, updated() {} },
+        },
+      },
+    })
+
+    await flushPromises()
+
+    await (wrapper.vm as any).addToWatchlist({ code: '000001', name: '平安银行' })
+
+    expect(listWatchlistsMock).toHaveBeenCalledTimes(1)
+    expect(createWatchlistMock).not.toHaveBeenCalled()
+    expect(addStockToWatchlistMock).toHaveBeenCalledWith(7, {
+      stock_code: '000001',
+      entry_reason: '来自问财条件：银行股',
+    })
+    expect(successMock).toHaveBeenCalledWith('已将 平安银行 加入自选')
+  })
+
+  it('creates a default watchlist before adding when none exists', async () => {
+    listWatchlistsMock.mockResolvedValueOnce({
+      success: true,
+      data: [],
+    })
+
+    const wrapper = mount(WencaiQueryTable as never, {
+      props: {
+        queryName: '高股息',
+        queryDescription: '高股息筛选',
+      },
+      global: {
+        stubs: {
+          'el-button': { template: '<button @click="$emit(`click`)"><slot /></button>' },
+          'el-icon': { template: '<i><slot /></i>' },
+          'el-pagination': true,
+          'el-dialog': { template: '<div><slot /><slot name="footer" /></div>' },
+          'el-table': TableStub,
+          'el-table-column': TableColumnStub,
+        },
+        directives: {
+          loading: { mounted() {}, updated() {} },
+        },
+      },
+    })
+
+    await flushPromises()
+
+    await (wrapper.vm as any).addToWatchlist({ code: '600000', name: '浦发银行' })
+
+    expect(createWatchlistMock).toHaveBeenCalledWith({
+      name: '问财自选',
+      watchlist_type: 'manual',
+      risk_profile: {},
+    })
+    expect(addStockToWatchlistMock).toHaveBeenCalledWith(11, {
+      stock_code: '600000',
+      entry_reason: '来自问财条件：高股息',
+    })
+    expect(successMock).toHaveBeenCalledWith('已将 浦发银行 加入自选')
+  })
+})


### PR DESCRIPTION
## Summary
- connect `WencaiQueryTable`'s "加入自选" action to the existing watchlist service instead of only showing a success toast
- add a small fallback path that creates a default watchlist when the user has none yet
- add focused unit coverage for both the existing-watchlist and bootstrap-watchlist flows

## Test Plan
- npx vitest run tests/unit/wencai-query-table.spec.ts tests/unit/config/wencai-style-normalization.spec.ts --config vitest.config.mts
- git diff --check
