### PR TITLE
fix(frontend): derive stock detail trading summary

### DIFF
--- a/governance/mainline/task-cards/pr-47.yaml
+++ b/governance/mainline/task-cards/pr-47.yaml
@@ -1,0 +1,85 @@
+version: "v0.2"
+
+task:
+  id: "pr-47"
+  title: "derive stock detail trading summary"
+  owner: "main"
+  created_at: "2026-04-02"
+
+mainline:
+  id: "L1-stock-detail-trading-summary"
+  objective: "replace the random StockDetail trading summary fallback with a deterministic summary derived from existing K-line data"
+  milestone_id: "L3-mainline-follow-up"
+  slice_id: "L4-stock-detail-trading-summary"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-stock-detail-summary-bugfix-with-focused-regression"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-47.yaml"
+    - "web/frontend/src/views/StockDetail.vue"
+    - "web/frontend/tests/unit/stock-detail-trading-summary.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No new backend summary endpoint"
+  - "No ProKLineChart refactor"
+
+acceptance:
+  checks:
+    - id: "stock-detail-summary-tests"
+      command: "cd web/frontend && npx vitest run tests/unit/stock-detail-trading-summary.spec.ts tests/unit/config/console-log-cleanup-batch-28.spec.ts tests/unit/config/console-log-cleanup-batch-72.spec.ts --config vitest.config.mts"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-47.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the summary calculation is wrong, StockDetail will display misleading trading metrics"
+    - "If the K-line request window is wrong, the summary can drift from the selected period semantics"
+  rollback_plan: "git revert <merge-commit-sha> if StockDetail trading summary values regress after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "replace the StockDetail trading summary random fallback with a deterministic K-line-based summary"
+    modified_scope: "StockDetail view, one focused trading-summary regression test, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "runtime behavior changes only for StockDetail trading summary loading and calculation"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if StockDetail trading summary metrics regress"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-02T00:00:00Z"
+    approval_note: "localized StockDetail bugfix with dedicated regression coverage"
+    secondary_approved: false

--- a/web/frontend/src/views/StockDetail.vue
+++ b/web/frontend/src/views/StockDetail.vue
@@ -264,6 +264,8 @@ interface _KlineDataItem {
   close: number
   low: number
   high: number
+  volume: number
+  amount?: number
 }
 
 interface _IntradayDataItem {
@@ -328,6 +330,112 @@ const tradeForm: Ref<TradeForm> = ref({
   quantity: ''
 })
 
+const roundMetric = (value: number): number => Number(value.toFixed(2))
+
+const resolveSummaryDateRange = (period: TimeRange, now: Date = new Date()): { startDate: string; endDate: string } => {
+  const dayMap: Record<TimeRange, number> = {
+    '1w': 7,
+    '1m': 30,
+    '3m': 90,
+    '6m': 180,
+    '1y': 365
+  }
+
+  const end = new Date(now)
+  const start = new Date(now)
+  start.setDate(start.getDate() - dayMap[period])
+
+  const toDateString = (value: Date): string => value.toISOString().slice(0, 10)
+
+  return {
+    startDate: toDateString(start),
+    endDate: toDateString(end)
+  }
+}
+
+const normalizeSummaryRows = (payload: unknown): _KlineDataItem[] => {
+  const rows = Array.isArray(payload)
+    ? payload
+    : payload && typeof payload === 'object' && Array.isArray((payload as { data?: unknown[] }).data)
+      ? (payload as { data: unknown[] }).data
+      : []
+
+  return rows.map((row, index) => {
+    const item = (row && typeof row === 'object' ? row : {}) as Record<string, unknown>
+    return {
+      date: String(item.date ?? item.datetime ?? index),
+      open: Number(item.open ?? 0),
+      close: Number(item.close ?? 0),
+      low: Number(item.low ?? 0),
+      high: Number(item.high ?? 0),
+      volume: Number(item.volume ?? 0),
+      amount: Number(item.amount ?? 0)
+    }
+  })
+}
+
+const calculateTradingSummary = (rows: _KlineDataItem[]): TradingSummary => {
+  if (rows.length === 0) {
+    return {
+      price_change: 0,
+      price_change_pct: 0,
+      highest_price: 0,
+      lowest_price: 0,
+      total_volume: 0,
+      total_turnover: 0,
+      volatility: 0,
+      win_rate: 0,
+      sharpe_ratio: 0,
+      max_drawdown: 0
+    }
+  }
+
+  const first = rows[0]
+  const last = rows[rows.length - 1]
+  const priceChange = last.close - first.close
+  const priceChangePct = first.close ? (priceChange / first.close) * 100 : 0
+  const highestPrice = Math.max(...rows.map((row) => row.high))
+  const lowestPrice = Math.min(...rows.map((row) => row.low))
+  const totalVolume = rows.reduce((sum, row) => sum + row.volume, 0)
+  const totalTurnover = rows.reduce((sum, row) => sum + (row.amount || row.close * row.volume), 0)
+
+  const returns = rows.slice(1).map((row, index) => {
+    const previousClose = rows[index].close
+    return previousClose ? (row.close - previousClose) / previousClose : 0
+  })
+
+  const meanReturn = returns.length > 0 ? returns.reduce((sum, value) => sum + value, 0) / returns.length : 0
+  const variance = returns.length > 0
+    ? returns.reduce((sum, value) => sum + Math.pow(value - meanReturn, 2), 0) / returns.length
+    : 0
+  const standardDeviation = Math.sqrt(variance)
+  const volatility = standardDeviation * 100
+  const winRate = returns.length > 0 ? (returns.filter((value) => value > 0).length / returns.length) * 100 : 0
+  const sharpeRatio = standardDeviation > 0 ? (meanReturn / standardDeviation) * Math.sqrt(returns.length) : 0
+
+  let peak = rows[0].close
+  let maxDrawdown = 0
+  for (const row of rows) {
+    peak = Math.max(peak, row.close)
+    if (peak > 0) {
+      maxDrawdown = Math.min(maxDrawdown, (row.close - peak) / peak)
+    }
+  }
+
+  return {
+    price_change: roundMetric(priceChange),
+    price_change_pct: roundMetric(priceChangePct),
+    highest_price: roundMetric(highestPrice),
+    lowest_price: roundMetric(lowestPrice),
+    total_volume: Math.round(totalVolume),
+    total_turnover: Math.round(totalTurnover),
+    volatility: roundMetric(volatility),
+    win_rate: roundMetric(winRate),
+    sharpe_ratio: roundMetric(sharpeRatio),
+    max_drawdown: roundMetric(maxDrawdown * 100)
+  }
+}
+
 const loadStockDetail = async (): Promise<void> => {
   try {
     const symbol = route.params.symbol as string || route.query.symbol as string
@@ -387,20 +495,20 @@ const loadTradingSummary = async (): Promise<void> => {
     const symbol = stockDetail.value.symbol
     if (!symbol) return
 
-    // TODO: Implement getTradingSummary API endpoint
-    // For now, use mock data as the API is not yet available
-    tradingSummary.value = {
-      price_change: parseFloat((Math.random() * 20 - 10).toFixed(2)),
-      price_change_pct: parseFloat((Math.random() * 10 - 5).toFixed(2)),
-      highest_price: parseFloat((parseFloat(stockDetail.value.price as string) + Math.random() * 10).toFixed(2)),
-      lowest_price: parseFloat((parseFloat(stockDetail.value.price as string) - Math.random() * 10).toFixed(2)),
-      total_volume: Math.floor(Math.random() * 10000000 + 1000000),
-      total_turnover: Math.floor(Math.random() * 100000000 + 10000000),
-      volatility: parseFloat((Math.random() * 20 + 5).toFixed(2)),
-      win_rate: parseFloat((Math.random() * 40 + 30).toFixed(2)),
-      sharpe_ratio: parseFloat((Math.random() * 4 - 2).toFixed(2)),
-      max_drawdown: parseFloat((Math.random() * -20 - 5).toFixed(2))
+    const { startDate, endDate } = resolveSummaryDateRange(summaryPeriod.value)
+    const response = await dataApi.getKline({
+      stock_code: symbol,
+      period: 'daily',
+      adjust: 'qfq',
+      start_date: startDate,
+      end_date: endDate
+    })
+
+    if (!response.success) {
+      throw new Error(response.message || 'FAILED TO LOAD K-LINE DATA')
     }
+
+    tradingSummary.value = calculateTradingSummary(normalizeSummaryRows(response.data))
   } catch (error) {
     console.error('Failed to load trading summary:', error)
     ElMessage.error('FAILED TO LOAD TRADING SUMMARY')

--- a/web/frontend/tests/unit/stock-detail-trading-summary.spec.ts
+++ b/web/frontend/tests/unit/stock-detail-trading-summary.spec.ts
@@ -1,0 +1,115 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getStockDetailMock, getKlineMock, successMock, errorMock } = vi.hoisted(() => ({
+  getStockDetailMock: vi.fn(),
+  getKlineMock: vi.fn(),
+  successMock: vi.fn(),
+  errorMock: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    params: { symbol: '600519' },
+    query: {},
+  }),
+}))
+
+vi.mock('@/api', () => ({
+  dataApi: {
+    getStockDetail: getStockDetailMock,
+    getKline: getKlineMock,
+  },
+}))
+
+vi.mock('element-plus', async () => {
+  const actual = await vi.importActual<typeof import('element-plus')>('element-plus')
+  return {
+    ...actual,
+    ElMessage: {
+      success: successMock,
+      error: errorMock,
+      info: vi.fn(),
+      warning: vi.fn(),
+    },
+  }
+})
+
+import StockDetail from '@/views/StockDetail.vue'
+
+describe('StockDetail trading summary', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-02T00:00:00Z'))
+    vi.clearAllMocks()
+
+    getStockDetailMock.mockResolvedValue({
+      success: true,
+      data: {
+        symbol: '600519',
+        name: '贵州茅台',
+        price: '1800.00',
+        change: '10.00',
+        change_pct: '0.56',
+        market: 'SH',
+        industry: '白酒',
+        concepts: ['消费'],
+        area: '贵州',
+        list_date: '2001-08-27',
+      },
+    })
+
+    getKlineMock.mockResolvedValue({
+      success: true,
+      data: [
+        { date: '2026-03-01', open: 9, high: 11, low: 8, close: 10, volume: 100, amount: 1000 },
+        { date: '2026-03-15', open: 10, high: 13, low: 10, close: 12, volume: 200, amount: 2400 },
+        { date: '2026-04-01', open: 12, high: 12, low: 8, close: 9, volume: 150, amount: 1350 },
+      ],
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('derives trading summary metrics from kline data instead of random fallback data', async () => {
+    const wrapper = mount(StockDetail as never, {
+      global: {
+        stubs: {
+          ProKLineChart: true,
+          'el-card': { template: '<div><slot name="header" /><slot /></div>' },
+          'el-button': { template: '<button><slot /></button>' },
+          'el-input': { template: '<input />' },
+          'el-icon': { template: '<i><slot /></i>' },
+          'el-dialog': { template: '<div><slot /><slot name="footer" /></div>' },
+          'el-descriptions': { template: '<div><slot /></div>' },
+          'el-descriptions-item': { template: '<div><slot /></div>' },
+        },
+        directives: {
+          loading: { mounted() {}, updated() {} },
+        },
+      },
+    })
+
+    await flushPromises()
+
+    expect(getKlineMock).toHaveBeenCalledWith({
+      stock_code: '600519',
+      period: 'daily',
+      adjust: 'qfq',
+      start_date: '2026-03-03',
+      end_date: '2026-04-02',
+    })
+
+    const summaryText = wrapper.find('.summary-content').text()
+    expect(summaryText).toContain('-1')
+    expect(summaryText).toContain('-10')
+    expect(summaryText).toContain('13')
+    expect(summaryText).toContain('8')
+    expect(summaryText).toContain('450')
+    expect(summaryText).toContain('4750')
+    expect(summaryText).toContain('50')
+    expect(summaryText).toContain('-25')
+  })
+})


### PR DESCRIPTION
## Summary
- replace the StockDetail trading summary random fallback with a calculation derived from existing K-line data
- reuse the existing `dataApi.getKline()` path instead of introducing a new summary endpoint
- add a focused unit test that verifies the summary values are computed from returned K-line samples

## Test Plan
- npx vitest run tests/unit/stock-detail-trading-summary.spec.ts tests/unit/config/console-log-cleanup-batch-28.spec.ts tests/unit/config/console-log-cleanup-batch-72.spec.ts --config vitest.config.mts
- git diff --check
