### PR TITLE
fix(frontend): bridge watchlist service stocks

### DIFF
--- a/governance/mainline/task-cards/pr-48.yaml
+++ b/governance/mainline/task-cards/pr-48.yaml
@@ -1,0 +1,85 @@
+version: "v0.2"
+
+task:
+  id: "pr-48"
+  title: "bridge watchlist service stocks"
+  owner: "main"
+  created_at: "2026-04-02"
+
+mainline:
+  id: "L1-watchlist-service-stocks-bridge"
+  objective: "replace the watchlist service stock placeholder with a real bridge from watchlist detail data"
+  milestone_id: "L3-mainline-follow-up"
+  slice_id: "L4-watchlist-service-stocks-bridge"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-watchlist-service-bugfix-with-focused-regression"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-48.yaml"
+    - "web/frontend/src/api/services/watchlistService.ts"
+    - "web/frontend/tests/unit/watchlist-service-stocks.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No monitoring portfolio page refactor"
+  - "No watchlist API contract expansion"
+
+acceptance:
+  checks:
+    - id: "watchlist-service-tests"
+      command: "cd web/frontend && npx vitest run tests/unit/watchlist-service-stocks.spec.ts tests/unit/wencai-query-table.spec.ts --config vitest.config.mts"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-48.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If stock mapping is wrong, monitoring watchlist drawers can render incomplete rows or misleading price fields"
+    - "If the bridge breaks existing service consumers, Wencai watchlist insertion feedback can regress"
+  rollback_plan: "git revert <merge-commit-sha> if watchlist stock loading regresses after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "replace the empty watchlist stock placeholder with a real watchlist detail bridge"
+    modified_scope: "watchlist service, one focused service regression test, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "runtime behavior changes only for watchlist stock loading through watchlistService"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if watchlist stock loading or Wencai service usage regresses"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-02T00:00:00Z"
+    approval_note: "localized watchlist service bugfix with dedicated regression coverage"
+    secondary_approved: false

--- a/web/frontend/src/api/services/watchlistService.ts
+++ b/web/frontend/src/api/services/watchlistService.ts
@@ -9,6 +9,7 @@ export interface WatchlistRecord {
 }
 
 export interface WatchlistStockRecord {
+  id?: number
   stock_code: string
   entry_price?: number | null
   current_price?: number | null
@@ -50,6 +51,53 @@ function normalizeWatchlist(raw: unknown, index: number): WatchlistRecord {
   }
 }
 
+function toOptionalNumber(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value)
+    if (Number.isFinite(parsed)) {
+      return parsed
+    }
+  }
+
+  return undefined
+}
+
+function normalizeWatchlistStock(raw: unknown, index: number): WatchlistStockRecord {
+  const record = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>
+  const customFields = (
+    record.customFields && typeof record.customFields === 'object'
+      ? record.customFields
+      : {}
+  ) as Record<string, unknown>
+
+  return {
+    id: Number(record.id ?? index + 1),
+    stock_code:
+      typeof record.symbol === 'string'
+        ? record.symbol
+        : typeof record.stock_code === 'string'
+          ? record.stock_code
+          : '',
+    entry_price: toOptionalNumber(customFields.entry_price ?? record.entry_price ?? record.entryPrice),
+    current_price: toOptionalNumber(record.currentPrice ?? record.current_price),
+    entry_reason:
+      typeof record.notes === 'string'
+        ? record.notes
+        : typeof record.entry_reason === 'string'
+          ? record.entry_reason
+          : null,
+    stop_loss_price: toOptionalNumber(
+      customFields.stop_loss_price ?? record.stop_loss_price ?? record.stopLossPrice,
+    ),
+    target_price: toOptionalNumber(customFields.target_price ?? record.target_price ?? record.targetPrice),
+    weight: toOptionalNumber(customFields.weight ?? record.weight),
+  }
+}
+
 export const watchlistService = {
   async listWatchlists(): Promise<ServiceResponse<WatchlistRecord[]>> {
     const data = await userApi.getWatchlists()
@@ -59,8 +107,14 @@ export const watchlistService = {
     }
   },
 
-  async listWatchlistStocks(_watchlistId: number): Promise<ServiceResponse<WatchlistStockRecord[]>> {
-    return { success: true, data: [] }
+  async listWatchlistStocks(watchlistId: number): Promise<ServiceResponse<WatchlistStockRecord[]>> {
+    const data = await userApi.getWatchlist(String(watchlistId))
+    const stocks = Array.isArray(data.stocks) ? data.stocks : []
+
+    return {
+      success: true,
+      data: stocks.map((item, index) => normalizeWatchlistStock(item, index)),
+    }
   },
 
   async createWatchlist(payload: CreateWatchlistPayload): Promise<ServiceResponse<WatchlistRecord>> {

--- a/web/frontend/tests/unit/watchlist-service-stocks.spec.ts
+++ b/web/frontend/tests/unit/watchlist-service-stocks.spec.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getWatchlistMock } = vi.hoisted(() => ({
+  getWatchlistMock: vi.fn(),
+}))
+
+vi.mock('@/api/user.ts', () => ({
+  userApi: {
+    getWatchlist: getWatchlistMock,
+  },
+}))
+
+import { watchlistService } from '@/api/services/watchlistService.ts'
+
+describe('watchlistService stock bridge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getWatchlistMock.mockResolvedValue({
+      id: '7',
+      name: '核心观察',
+      isDefault: false,
+      isPublic: false,
+      owner: {
+        userId: 'user-1',
+        username: 'tester',
+        displayName: 'Tester',
+      },
+      stocks: [
+        {
+          symbol: '600519.SH',
+          name: '贵州茅台',
+          market: 'A',
+          currentPrice: 1800.5,
+          changeAmount: 12.3,
+          changePercent: '0.69%',
+          volume: 1000,
+          marketCap: 1,
+          addedAt: '2026-04-02 09:30:00',
+          notes: '白酒龙头',
+          alerts: [],
+          customFields: {
+            entry_price: 1680,
+            stop_loss_price: 1550,
+            target_price: 1950,
+            weight: 0.35,
+          },
+        },
+        {
+          symbol: '000001.SZ',
+          name: '平安银行',
+          market: 'A',
+          currentPrice: 12.34,
+          changeAmount: -0.08,
+          changePercent: '-0.64%',
+          volume: 2000,
+          marketCap: 1,
+          addedAt: '2026-04-02 09:35:00',
+          alerts: [],
+        },
+      ],
+      statistics: {
+        totalStocks: 2,
+        totalValue: 0,
+        todayChange: 0,
+        todayChangePercent: '0%',
+        bestPerformer: {
+          symbol: '600519.SH',
+          name: '贵州茅台',
+          changePercent: '0.69%',
+        },
+        worstPerformer: {
+          symbol: '000001.SZ',
+          name: '平安银行',
+          changePercent: '-0.64%',
+        },
+        sectors: [],
+      },
+      tags: [],
+      createdAt: '2026-04-01 09:00:00',
+      updatedAt: '2026-04-02 09:00:00',
+      sortOrder: 0,
+    })
+  })
+
+  it('maps watchlist detail stocks into monitoring records instead of returning an empty placeholder list', async () => {
+    const response = await watchlistService.listWatchlistStocks(7)
+
+    expect(getWatchlistMock).toHaveBeenCalledWith('7')
+    expect(response).toEqual({
+      success: true,
+      data: [
+        {
+          id: 1,
+          stock_code: '600519.SH',
+          entry_price: 1680,
+          current_price: 1800.5,
+          entry_reason: '白酒龙头',
+          stop_loss_price: 1550,
+          target_price: 1950,
+          weight: 0.35,
+        },
+        {
+          id: 2,
+          stock_code: '000001.SZ',
+          entry_price: undefined,
+          current_price: 12.34,
+          entry_reason: null,
+          stop_loss_price: undefined,
+          target_price: undefined,
+          weight: undefined,
+        },
+      ],
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- bridge `watchlistService.listWatchlistStocks()` through `userApi.getWatchlist()` instead of returning an empty placeholder list
- normalize returned stocks into the monitoring watchlist record shape expected by `useWatchlistManagement`
- add a focused unit test for the service bridge and keep the existing Wencai watchlist flow covered

## Testing
- `npx vitest run tests/unit/watchlist-service-stocks.spec.ts tests/unit/wencai-query-table.spec.ts --config vitest.config.mts`
- `git diff --check`
