### PR TITLE
fix(frontend): derive watchlist alert summary

### DIFF
--- a/governance/mainline/task-cards/pr-49.yaml
+++ b/governance/mainline/task-cards/pr-49.yaml
@@ -1,0 +1,87 @@
+version: "v0.2"
+
+task:
+  id: "pr-49"
+  title: "derive watchlist alert summary"
+  owner: "main"
+  created_at: "2026-04-02"
+
+mainline:
+  id: "L1-watchlist-alert-summary"
+  objective: "replace the WatchlistManagement active alert placeholder with a deterministic summary derived from loaded watchlist stock data"
+  milestone_id: "L3-mainline-follow-up"
+  slice_id: "L4-watchlist-alert-summary"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-watchlist-alert-summary-bugfix-with-focused-regression"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-49.yaml"
+    - "web/frontend/src/api/services/watchlistService.ts"
+    - "web/frontend/src/views/monitoring/composables/useWatchlistManagement.ts"
+    - "web/frontend/tests/unit/watchlist-service-stocks.spec.ts"
+    - "web/frontend/tests/unit/watchlist-management-alert-summary.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No monitoring portfolio UX redesign"
+  - "No alert CRUD feature expansion"
+
+acceptance:
+  checks:
+    - id: "watchlist-alert-summary-tests"
+      command: "cd web/frontend && npx vitest run tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/wencai-query-table.spec.ts --config vitest.config.mts"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-49.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If alert counts are mapped incorrectly, WatchlistManagement can display misleading active alert totals"
+    - "If the service field addition breaks consumers, watchlist stock consumers may render incomplete rows"
+  rollback_plan: "git revert <merge-commit-sha> if monitoring watchlist alert totals regress after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "replace the WatchlistManagement active alert random placeholder with a deterministic stock-derived summary"
+    modified_scope: "watchlist service, monitoring watchlist composable, two focused regression tests, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "runtime behavior changes only for monitoring watchlist alert totals and stock mapping metadata"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if monitoring watchlist alert totals or watchlist stock mapping regress"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-02T00:00:00Z"
+    approval_note: "localized WatchlistManagement alert summary bugfix with dedicated regression coverage"
+    secondary_approved: false

--- a/web/frontend/src/api/services/watchlistService.ts
+++ b/web/frontend/src/api/services/watchlistService.ts
@@ -17,6 +17,7 @@ export interface WatchlistStockRecord {
   stop_loss_price?: number | null
   target_price?: number | null
   weight?: number
+  alerts_count?: number
 }
 
 export interface CreateWatchlistPayload {
@@ -74,6 +75,16 @@ function normalizeWatchlistStock(raw: unknown, index: number): WatchlistStockRec
       : {}
   ) as Record<string, unknown>
 
+  const alertsCount = Array.isArray(record.alerts)
+    ? record.alerts.filter(alert => {
+        if (!alert || typeof alert !== 'object') {
+          return false
+        }
+
+        return (alert as Record<string, unknown>).isActive !== false
+      }).length
+    : toOptionalNumber(customFields.alerts_count ?? record.alerts_count)
+
   return {
     id: Number(record.id ?? index + 1),
     stock_code:
@@ -95,6 +106,7 @@ function normalizeWatchlistStock(raw: unknown, index: number): WatchlistStockRec
     ),
     target_price: toOptionalNumber(customFields.target_price ?? record.target_price ?? record.targetPrice),
     weight: toOptionalNumber(customFields.weight ?? record.weight),
+    alerts_count: alertsCount,
   }
 }
 

--- a/web/frontend/src/views/monitoring/composables/useWatchlistManagement.ts
+++ b/web/frontend/src/views/monitoring/composables/useWatchlistManagement.ts
@@ -88,8 +88,7 @@ const winRate = computed(() => {
 })
 
 const activeAlerts = computed(() => {
-  // 计算活跃告警数量（模拟数据）
-  return Math.floor(Math.random() * 5)
+  return watchlistStocks.value.reduce((sum, stock) => sum + (stock.alerts_count || 0), 0)
 })
 
 // 工具函数

--- a/web/frontend/tests/unit/watchlist-management-alert-summary.spec.ts
+++ b/web/frontend/tests/unit/watchlist-management-alert-summary.spec.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  onMountedMock,
+  listWatchlistsMock,
+  listWatchlistStocksMock,
+  createWatchlistMock,
+  deleteWatchlistMock,
+  addStockToWatchlistMock,
+  removeStockFromWatchlistMock,
+  successMock,
+  warningMock,
+  errorMock,
+  randomSpy,
+} = vi.hoisted(() => ({
+  onMountedMock: vi.fn(),
+  listWatchlistsMock: vi.fn(),
+  listWatchlistStocksMock: vi.fn(),
+  createWatchlistMock: vi.fn(),
+  deleteWatchlistMock: vi.fn(),
+  addStockToWatchlistMock: vi.fn(),
+  removeStockFromWatchlistMock: vi.fn(),
+  successMock: vi.fn(),
+  warningMock: vi.fn(),
+  errorMock: vi.fn(),
+  randomSpy: vi.spyOn(Math, 'random'),
+}))
+
+vi.mock('vue', async () => {
+  const actual = await vi.importActual<typeof import('vue')>('vue')
+  return {
+    ...actual,
+    onMounted: onMountedMock,
+  }
+})
+
+vi.mock('element-plus', () => ({
+  ElMessage: {
+    success: successMock,
+    warning: warningMock,
+    error: errorMock,
+    info: vi.fn(),
+  },
+}))
+
+vi.mock('@/api/services/watchlistService', () => ({
+  watchlistService: {
+    listWatchlists: listWatchlistsMock,
+    listWatchlistStocks: listWatchlistStocksMock,
+    createWatchlist: createWatchlistMock,
+    deleteWatchlist: deleteWatchlistMock,
+    addStockToWatchlist: addStockToWatchlistMock,
+    removeStockFromWatchlist: removeStockFromWatchlistMock,
+  },
+}))
+
+import { useWatchlistManagement } from '@/views/monitoring/composables/useWatchlistManagement'
+
+describe('watchlist management alert summary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    randomSpy.mockReturnValue(0.9)
+    listWatchlistsMock.mockResolvedValue({ success: true, data: [] })
+    listWatchlistStocksMock.mockResolvedValue({
+      success: true,
+      data: [
+        {
+          id: 1,
+          stock_code: '600519.SH',
+          entry_price: 1680,
+          current_price: 1800.5,
+          weight: 0.35,
+          alerts_count: 2,
+        },
+        {
+          id: 2,
+          stock_code: '000001.SZ',
+          entry_price: 12.2,
+          current_price: 12.34,
+          weight: 0.2,
+          alerts_count: 1,
+        },
+      ],
+    })
+  })
+
+  it('derives active alerts from loaded watchlist stocks instead of a random placeholder', async () => {
+    const model = useWatchlistManagement()
+
+    model.manageStocks({
+      id: 7,
+      name: '核心观察',
+      watchlist_type: 'manual',
+      risk_profile: {},
+      stocks_count: 2,
+    })
+
+    await vi.waitFor(() => {
+      expect(listWatchlistStocksMock).toHaveBeenCalledWith(7)
+      expect(model.activeAlerts.value).toBe(3)
+    })
+  })
+})

--- a/web/frontend/tests/unit/watchlist-service-stocks.spec.ts
+++ b/web/frontend/tests/unit/watchlist-service-stocks.spec.ts
@@ -37,7 +37,32 @@ describe('watchlistService stock bridge', () => {
           marketCap: 1,
           addedAt: '2026-04-02 09:30:00',
           notes: '白酒龙头',
-          alerts: [],
+          alerts: [
+            {
+              id: 'alert-1',
+              type: 'price',
+              condition: 'above',
+              value: 1900,
+              isActive: true,
+              notificationMethod: 'push',
+            },
+            {
+              id: 'alert-2',
+              type: 'price',
+              condition: 'below',
+              value: 1600,
+              isActive: false,
+              notificationMethod: 'push',
+            },
+            {
+              id: 'alert-3',
+              type: 'volume',
+              condition: 'above',
+              value: 1000000,
+              isActive: true,
+              notificationMethod: 'push',
+            },
+          ],
           customFields: {
             entry_price: 1680,
             stop_loss_price: 1550,
@@ -55,7 +80,16 @@ describe('watchlistService stock bridge', () => {
           volume: 2000,
           marketCap: 1,
           addedAt: '2026-04-02 09:35:00',
-          alerts: [],
+          alerts: [
+            {
+              id: 'alert-4',
+              type: 'price',
+              condition: 'below',
+              value: 11.5,
+              isActive: true,
+              notificationMethod: 'push',
+            },
+          ],
         },
       ],
       statistics: {
@@ -98,6 +132,7 @@ describe('watchlistService stock bridge', () => {
           stop_loss_price: 1550,
           target_price: 1950,
           weight: 0.35,
+          alerts_count: 2,
         },
         {
           id: 2,
@@ -108,6 +143,7 @@ describe('watchlistService stock bridge', () => {
           stop_loss_price: undefined,
           target_price: undefined,
           weight: undefined,
+          alerts_count: 1,
         },
       ],
     })


### PR DESCRIPTION
## Summary
- replace the random `ACTIVE ALERTS` placeholder in `useWatchlistManagement` with a deterministic sum derived from loaded watchlist stocks
- extend `watchlistService.listWatchlistStocks()` to expose `alerts_count` from watchlist detail data
- add focused regression coverage for both the service mapping and the monitoring composable summary

## Testing
- `npx vitest run tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/wencai-query-table.spec.ts --config vitest.config.mts`
- `git diff --check`
