### PR TITLE
fix(frontend): derive watchlist stock counts

### DIFF
--- a/governance/mainline/task-cards/pr-50.yaml
+++ b/governance/mainline/task-cards/pr-50.yaml
@@ -1,0 +1,86 @@
+version: "v0.2"
+
+task:
+  id: "pr-50"
+  title: "derive watchlist stock counts"
+  owner: "main"
+  created_at: "2026-04-02"
+
+mainline:
+  id: "L1-watchlist-stock-counts"
+  objective: "derive monitoring watchlist stock counts from the real watchlist response instead of defaulting them to zero"
+  milestone_id: "L3-mainline-follow-up"
+  slice_id: "L4-watchlist-stock-counts"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-watchlist-count-normalization-bugfix-with-focused-regression"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-50.yaml"
+    - "web/frontend/src/api/services/watchlistService.ts"
+    - "web/frontend/tests/unit/watchlist-management-alert-summary.spec.ts"
+    - "web/frontend/tests/unit/watchlist-service-watchlists.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No monitoring watchlist edit flow work"
+  - "No backend watchlist API changes"
+
+acceptance:
+  checks:
+    - id: "watchlist-count-tests"
+      command: "cd web/frontend && npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts --config vitest.config.mts"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-50.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If count derivation is wrong, monitoring watchlist cards and totals can still drift from actual holdings"
+    - "If count fallback order is wrong, generic watchlist responses could report stale counts"
+  rollback_plan: "git revert <merge-commit-sha> if monitoring watchlist stock totals regress after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "replace zeroed monitoring watchlist counts with counts derived from real watchlist response fields"
+    modified_scope: "watchlist service normalization, one focused service regression test, one monitoring summary regression adjustment, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "runtime behavior changes only for monitoring watchlist stock count normalization"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if monitoring watchlist counts regress"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-02T00:00:00Z"
+    approval_note: "localized monitoring watchlist count bugfix with dedicated regression coverage"
+    secondary_approved: false

--- a/web/frontend/src/api/services/watchlistService.ts
+++ b/web/frontend/src/api/services/watchlistService.ts
@@ -43,12 +43,21 @@ interface ServiceResponse<T> {
 
 function normalizeWatchlist(raw: unknown, index: number): WatchlistRecord {
   const record = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>
+  const statistics = (
+    record.statistics && typeof record.statistics === 'object'
+      ? record.statistics
+      : {}
+  ) as Record<string, unknown>
+  const inlineStockCount = Array.isArray(record.stocks) ? record.stocks.length : 0
+  const explicitStockCount = toOptionalNumber(record.stocks_count)
+  const derivedStockCount = toOptionalNumber(statistics.totalStocks)
+
   return {
     id: Number(record.id ?? index + 1),
     name: typeof record.name === 'string' ? record.name : `Watchlist ${index + 1}`,
     watchlist_type: typeof record.watchlist_type === 'string' ? record.watchlist_type : 'manual',
     risk_profile: (record.risk_profile as { risk_tolerance?: number } | undefined) ?? {},
-    stocks_count: typeof record.stocks_count === 'number' ? record.stocks_count : 0,
+    stocks_count: explicitStockCount ?? (derivedStockCount && derivedStockCount > 0 ? derivedStockCount : inlineStockCount),
   }
 }
 

--- a/web/frontend/tests/unit/watchlist-management-alert-summary.spec.ts
+++ b/web/frontend/tests/unit/watchlist-management-alert-summary.spec.ts
@@ -100,4 +100,33 @@ describe('watchlist management alert summary', () => {
       expect(model.activeAlerts.value).toBe(3)
     })
   })
+
+  it('sums portfolio stock counts from fetched watchlists into the monitoring overview', async () => {
+    listWatchlistsMock.mockResolvedValueOnce({
+      success: true,
+      data: [
+        {
+          id: 7,
+          name: '核心观察',
+          watchlist_type: 'manual',
+          risk_profile: {},
+          stocks_count: 3,
+        },
+        {
+          id: 8,
+          name: '趋势跟踪',
+          watchlist_type: 'strategy',
+          risk_profile: {},
+          stocks_count: 2,
+        },
+      ],
+    })
+
+    const model = useWatchlistManagement()
+
+    await model.refreshData()
+
+    expect(listWatchlistsMock).toHaveBeenCalled()
+    expect(model.totalStocks.value).toBe(5)
+  })
 })

--- a/web/frontend/tests/unit/watchlist-service-watchlists.spec.ts
+++ b/web/frontend/tests/unit/watchlist-service-watchlists.spec.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getWatchlistsMock } = vi.hoisted(() => ({
+  getWatchlistsMock: vi.fn(),
+}))
+
+vi.mock('@/api/user.ts', () => ({
+  userApi: {
+    getWatchlists: getWatchlistsMock,
+  },
+}))
+
+import { watchlistService } from '@/api/services/watchlistService.ts'
+
+describe('watchlistService watchlist normalization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getWatchlistsMock.mockResolvedValue([
+      {
+        id: '5',
+        name: '高股息',
+        statistics: {
+          totalStocks: 3,
+        },
+        stocks: [],
+      },
+      {
+        id: '6',
+        name: '成长股',
+        statistics: {
+          totalStocks: 0,
+        },
+        stocks: [
+          { symbol: '300750.SZ' },
+          { symbol: '002594.SZ' },
+        ],
+      },
+    ])
+  })
+
+  it('derives stocks_count from watchlist statistics or stock rows instead of defaulting to zero', async () => {
+    const response = await watchlistService.listWatchlists()
+
+    expect(getWatchlistsMock).toHaveBeenCalledTimes(1)
+    expect(response).toEqual({
+      success: true,
+      data: [
+        {
+          id: 5,
+          name: '高股息',
+          watchlist_type: 'manual',
+          risk_profile: {},
+          stocks_count: 3,
+        },
+        {
+          id: 6,
+          name: '成长股',
+          watchlist_type: 'manual',
+          risk_profile: {},
+          stocks_count: 2,
+        },
+      ],
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- derive `watchlistService.listWatchlists()` stock counts from `statistics.totalStocks` and inline `stocks` rows instead of defaulting them to zero
- keep the monitoring watchlist overview tests locked to the corrected count behavior
- preserve the previously merged stock/alert bridges while tightening the list normalization layer

## Testing
- `npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts --config vitest.config.mts`
- `git diff --check`
