### PR TITLE
fix(monitoring): wire watchlist edit flow

### DIFF
--- a/governance/mainline/task-cards/pr-51.yaml
+++ b/governance/mainline/task-cards/pr-51.yaml
@@ -1,0 +1,99 @@
+version: "v0.2"
+
+task:
+  id: "pr-51"
+  title: "wire monitoring watchlist edit flow"
+  owner: "main"
+  created_at: "2026-04-02"
+
+mainline:
+  id: "L1-monitoring-watchlist-edit-flow"
+  objective: "replace the monitoring watchlist edit placeholder with a real update flow that keeps backend and frontend contracts aligned"
+  milestone_id: "L3-mainline-follow-up"
+  slice_id: "L4-monitoring-watchlist-edit-flow"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "backend"
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-monitoring-watchlist-edit-bugfix-with-focused-regression"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-51.yaml"
+    - "src/monitoring/infrastructure/postgresql_async_v3.py"
+    - "web/backend/app/api/monitoring_watchlists.py"
+    - "web/backend/tests/test_monitoring_watchlists_runtime_fallback.py"
+    - "web/frontend/src/api/services/watchlistService.ts"
+    - "web/frontend/src/views/monitoring/composables/useWatchlistManagement.ts"
+    - "web/frontend/tests/unit/watchlist-management-alert-summary.spec.ts"
+    - "web/frontend/tests/unit/watchlist-service-update.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No monitoring watchlist list-source migration beyond the dedicated update path"
+  - "No monitoring portfolio page redesign"
+  - "No stock-level edit or alert CRUD expansion"
+
+acceptance:
+  checks:
+    - id: "monitoring-watchlist-edit-tests"
+      command: "cd web/frontend && npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/watchlist-service-update.spec.ts --config vitest.config.mts"
+      required: true
+    - id: "monitoring-watchlist-runtime-fallback-tests"
+      command: "python -m pytest web/backend/tests/test_monitoring_watchlists_runtime_fallback.py -q -n 0 --no-cov"
+      required: true
+    - id: "backend-ruff"
+      command: "ruff check web/backend/app/api/monitoring_watchlists.py src/monitoring/infrastructure/postgresql_async_v3.py web/backend/tests/test_monitoring_watchlists_runtime_fallback.py"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-51.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report /tmp/pr51-mainline-gate.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the monitoring update route and frontend normalization drift, edit submissions can succeed but render stale watchlist metadata"
+    - "If runtime fallback update behavior diverges from database behavior, local or test environments can mask production-only regressions"
+    - "If the new update path breaks shared watchlist service assumptions, monitoring page edits can regress while list and stock reads still appear healthy"
+  rollback_plan: "git revert <merge-commit-sha> if monitoring watchlist editing regresses after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "replace the monitoring watchlist edit placeholder with a real backend-to-frontend update flow"
+    modified_scope: "monitoring postgres access, monitoring watchlist API, monitoring watchlist service/composable, focused backend and frontend regression tests, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "runtime behavior changes only for monitoring watchlist editing and runtime fallback update handling"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if monitoring watchlist edit submissions or fallback updates regress"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-02T00:00:00Z"
+    approval_note: "localized monitoring watchlist edit bugfix with dedicated backend and frontend regression coverage"
+    secondary_approved: false

--- a/governance/mainline/task-cards/pr-51.yaml
+++ b/governance/mainline/task-cards/pr-51.yaml
@@ -26,7 +26,7 @@ function_tree:
   domain_id: "meta-governance"
   node_id: "meta-governance-mainline"
   affected_entrypoints:
-    - "backend"
+    - "api"
     - "frontend"
     - "tests"
   update_status: "not-needed"

--- a/src/monitoring/infrastructure/postgresql_async_v3.py
+++ b/src/monitoring/infrastructure/postgresql_async_v3.py
@@ -63,6 +63,13 @@ class WatchlistCreate:
 
 
 @dataclass
+class WatchlistUpdate:
+    """更新清单参数"""
+
+    changes: Dict[str, object]
+
+
+@dataclass
 class StockToAdd:
     """添加股票参数"""
 
@@ -239,6 +246,53 @@ class MonitoringPostgreSQLAccess:
 
         logger.info("✅ 获取用户 %(user_id)s 的 {len(results)} 个清单")
         return results
+
+    async def update_watchlist(self, watchlist_id: int, params: WatchlistUpdate) -> bool:
+        """更新监控清单"""
+        if not self._connected:
+            raise RuntimeError("数据库连接未初始化")
+
+        column_map = {
+            "name": "name",
+            "watchlist_type": "type",
+            "risk_profile": "risk_profile",
+            "is_active": "is_active",
+        }
+
+        assignments: List[str] = []
+        values: List[object] = [watchlist_id]
+        placeholder_index = 2
+
+        for field_name, raw_value in params.changes.items():
+            column_name = column_map.get(field_name)
+            if column_name is None:
+                continue
+
+            value = raw_value
+            if field_name == "risk_profile":
+                value = json.dumps(raw_value) if raw_value is not None else None
+
+            assignments.append(f"{column_name} = ${placeholder_index}")
+            values.append(value)
+            placeholder_index += 1
+
+        if not assignments:
+            return True
+
+        assignments.append("updated_at = CURRENT_TIMESTAMP")
+
+        async with self.pool.acquire() as conn:
+            result = await conn.execute(
+                f"""
+                UPDATE monitoring_watchlists
+                SET {", ".join(assignments)}
+                WHERE id = $1
+                """,
+                *values,
+            )
+
+        logger.info("✅ 更新监控清单: %(watchlist_id)s")
+        return result.endswith("UPDATE 1")
 
     async def add_stock_to_watchlist(self, params: StockToAdd) -> int:
         """
@@ -682,3 +736,13 @@ from src.monitoring.infrastructure._postgresql_async_v3_singleton import (
     get_postgres_async,
     initialize_postgres_async,
 )
+
+__all__ = [
+    "MonitoringPostgreSQLAccess",
+    "StockToAdd",
+    "WatchlistCreate",
+    "WatchlistUpdate",
+    "close_postgres_async",
+    "get_postgres_async",
+    "initialize_postgres_async",
+]

--- a/web/backend/app/api/monitoring_watchlists.py
+++ b/web/backend/app/api/monitoring_watchlists.py
@@ -22,7 +22,7 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Path, Query
+from fastapi import APIRouter, Body, Path, Query
 from pydantic import BaseModel, Field, field_validator
 
 from app.core.exception_handlers import handle_exceptions
@@ -62,6 +62,17 @@ class UpdateWatchlistRequest(BaseModel):
     watchlist_type: Optional[str] = Field(None, description="清单类型")
     risk_profile: Optional[Dict[str, Any]] = Field(None, description="风控配置")
     is_active: Optional[bool] = Field(None, description="是否激活")
+
+    @field_validator("watchlist_type")
+    @classmethod
+    def validate_type(cls, v: Optional[str]) -> Optional[str]:
+        """验证清单类型"""
+        if v is None:
+            return v
+        valid_types = ["manual", "strategy", "benchmark"]
+        if v not in valid_types:
+            raise ValueError(f"无效的清单类型，支持: {', '.join(valid_types)}")
+        return v
 
 
 class AddStockRequest(BaseModel):
@@ -270,6 +281,37 @@ def _create_runtime_watchlist(request: CreateWatchlistRequest, user_id: int) -> 
     return _clone_model(created)
 
 
+def _update_runtime_watchlist(
+    watchlist_id: int,
+    request: UpdateWatchlistRequest,
+    user_id: int,
+) -> Optional[WatchlistResponse]:
+    watchlists, stocks_by_watchlist = _ensure_runtime_watchlist_state(user_id)
+
+    for index, watchlist in enumerate(watchlists):
+        if watchlist.id != watchlist_id:
+            continue
+
+        updated = _clone_model(watchlist)
+        changes = request.model_dump(exclude_unset=True)
+
+        if "name" in changes:
+            updated.name = request.name
+        if "watchlist_type" in changes:
+            updated.watchlist_type = request.watchlist_type
+        if "risk_profile" in changes:
+            updated.risk_profile = request.risk_profile
+        if "is_active" in changes:
+            updated.is_active = request.is_active
+
+        updated.updated_at = datetime.utcnow()
+        updated.stocks_count = len(stocks_by_watchlist.get(watchlist_id, []))
+        watchlists[index] = updated
+        return _clone_model(updated)
+
+    return None
+
+
 def _add_runtime_stock_to_watchlist(
     watchlist_id: int,
     request: AddStockRequest,
@@ -401,7 +443,7 @@ async def list_watchlists(
     获取用户的所有监控清单
     """
     try:
-        from src.monitoring.infrastructure.postgresql_async_v3 import StockToAdd, get_postgres_async
+        from src.monitoring.infrastructure.postgresql_async_v3 import get_postgres_async
 
         postgres_async = get_postgres_async()
 
@@ -498,13 +540,75 @@ async def get_watchlist(
 @handle_exceptions
 async def update_watchlist(
     watchlist_id: int = Path(..., description="清单ID"),
-    request: UpdateWatchlistRequest = None,
+    request: UpdateWatchlistRequest = Body(...),
     user_id: int = Query(1, description="用户ID"),
 ) -> UnifiedResponse[WatchlistResponse]:
     """
     更新监控清单
     """
-    raise BusinessException(detail="更新功能待实现", status_code=501, error_code="FEATURE_NOT_IMPLEMENTED")
+    try:
+        from src.monitoring.infrastructure.postgresql_async_v3 import WatchlistUpdate, get_postgres_async
+
+        postgres_async = get_postgres_async()
+
+        if not postgres_async.is_connected():
+            if _runtime_fallback_enabled():
+                fallback_watchlist = _update_runtime_watchlist(
+                    watchlist_id=watchlist_id,
+                    request=request,
+                    user_id=user_id,
+                )
+                if fallback_watchlist is not None:
+                    return UnifiedResponse(data=fallback_watchlist, message="更新清单成功")
+                raise NotFoundException(resource="监控清单", identifier="查询条件")
+            raise BusinessException(detail="数据库未连接", status_code=503, error_code="DATABASE_UNAVAILABLE")
+
+        existing = await postgres_async.get_watchlist(watchlist_id)
+        if not existing or existing.get("user_id") != user_id:
+            raise NotFoundException(resource="监控清单", identifier="查询条件")
+
+        changes = request.model_dump(exclude_unset=True)
+        if changes:
+            updated = await postgres_async.update_watchlist(
+                watchlist_id,
+                WatchlistUpdate(changes=changes),
+            )
+            if not updated:
+                raise BusinessException(detail="更新清单失败", status_code=500, error_code="WATCHLIST_UPDATE_FAILED")
+
+        refreshed = await postgres_async.get_watchlist(watchlist_id)
+        stocks = await postgres_async.get_watchlist_stocks(watchlist_id)
+
+        if refreshed is None:
+            raise BusinessException(detail="更新清单失败", status_code=500, error_code="WATCHLIST_UPDATE_FAILED")
+
+        response = WatchlistResponse(
+            id=refreshed["id"],
+            user_id=refreshed["user_id"],
+            name=refreshed["name"],
+            watchlist_type=refreshed["type"],
+            risk_profile=refreshed.get("risk_profile"),
+            is_active=refreshed["is_active"],
+            created_at=refreshed["created_at"],
+            updated_at=refreshed["updated_at"],
+            stocks_count=len(stocks),
+        )
+        return UnifiedResponse(data=response, message="更新清单成功")
+
+    except (BusinessException, NotFoundException):
+        raise
+    except Exception as e:
+        if _runtime_fallback_enabled():
+            logger.warning("更新监控清单降级到 runtime fallback: %s", str(e))
+            fallback_watchlist = _update_runtime_watchlist(
+                watchlist_id=watchlist_id,
+                request=request,
+                user_id=user_id,
+            )
+            if fallback_watchlist is not None:
+                return UnifiedResponse(data=fallback_watchlist, message="更新清单成功")
+        logger.error("更新监控清单失败: %(e)s")
+        raise BusinessException(detail=f"更新失败: {str(e)}", status_code=500, error_code="WATCHLIST_UPDATE_FAILED")
 
 
 @router.delete("/{watchlist_id}", response_model=UnifiedResponse[None])

--- a/web/backend/tests/test_monitoring_watchlists_runtime_fallback.py
+++ b/web/backend/tests/test_monitoring_watchlists_runtime_fallback.py
@@ -32,7 +32,8 @@ def _load_watchlists_api():
     module_path = BACKEND_APP_ROOT / "api/monitoring_watchlists.py"
     spec = spec_from_file_location(module_name, module_path)
     module = module_from_spec(spec)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
     return module
@@ -115,6 +116,31 @@ async def test_get_watchlist_returns_runtime_fallback_when_db_unavailable(monkey
 
     assert payload["data"]["id"] == 1
     assert payload["data"]["name"] == "核心止损监控"
+    assert payload["data"]["stocks_count"] >= 1
+
+
+async def test_update_watchlist_returns_runtime_fallback_when_db_unavailable(monkeypatch):
+    _reset_runtime_state(monkeypatch)
+    monkeypatch.setenv("TESTING", "true")
+    monkeypatch.setattr(postgres_module, "get_postgres_async", lambda: _DisconnectedPostgres())
+
+    result = await watchlists_api.update_watchlist(
+        watchlist_id=1,
+        request=watchlists_api.UpdateWatchlistRequest(
+            name="趋势跟踪池",
+            watchlist_type="strategy",
+            risk_profile={"risk_tolerance": 70},
+            is_active=False,
+        ),
+        user_id=1,
+    )
+    payload = _payload(result)
+
+    assert payload["data"]["id"] == 1
+    assert payload["data"]["name"] == "趋势跟踪池"
+    assert payload["data"]["watchlist_type"] == "strategy"
+    assert payload["data"]["risk_profile"] == {"risk_tolerance": 70}
+    assert payload["data"]["is_active"] is False
     assert payload["data"]["stocks_count"] >= 1
 
 
@@ -205,3 +231,27 @@ def test_watchlist_read_endpoints_keep_unified_response_shape_in_fallback(monkey
     assert stocks_response.status_code == 200
     assert stocks_payload["success"] is True
     assert stocks_payload["data"][0]["stock_code"] == "000001"
+
+
+def test_watchlist_update_endpoint_keeps_unified_response_shape_in_fallback(monkeypatch):
+    _reset_runtime_state(monkeypatch)
+    monkeypatch.setenv("TESTING", "true")
+
+    with _build_client(monkeypatch) as client:
+        update_response = client.put(
+            "/api/v1/monitoring/watchlists/1",
+            json={
+                "name": "趋势跟踪池",
+                "watchlist_type": "strategy",
+                "risk_profile": {"risk_tolerance": 80},
+                "is_active": False,
+            },
+        )
+
+    payload = update_response.json()
+
+    assert update_response.status_code == 200
+    assert payload["success"] is True
+    assert payload["data"]["id"] == 1
+    assert payload["data"]["name"] == "趋势跟踪池"
+    assert payload["data"]["watchlist_type"] == "strategy"

--- a/web/frontend/src/api/services/watchlistService.ts
+++ b/web/frontend/src/api/services/watchlistService.ts
@@ -1,4 +1,5 @@
 import { userApi } from '@/api/user.ts'
+import { request } from '@/utils/request.ts'
 
 export interface WatchlistRecord {
   id: number
@@ -6,6 +7,7 @@ export interface WatchlistRecord {
   watchlist_type: string
   risk_profile: { risk_tolerance?: number }
   stocks_count: number
+  is_active?: boolean
 }
 
 export interface WatchlistStockRecord {
@@ -26,6 +28,13 @@ export interface CreateWatchlistPayload {
   risk_profile: { risk_tolerance?: number }
 }
 
+export interface UpdateWatchlistPayload {
+  name?: string
+  watchlist_type?: string
+  risk_profile?: { risk_tolerance?: number }
+  is_active?: boolean
+}
+
 export interface AddWatchlistStockPayload {
   stock_code: string
   entry_price?: number | null
@@ -41,6 +50,25 @@ interface ServiceResponse<T> {
   message?: string
 }
 
+interface MonitoringRouteResponse<T> {
+  success?: boolean
+  data?: T
+  message?: string
+}
+
+function extractMonitoringRouteResponse<T>(raw: unknown): MonitoringRouteResponse<T> | null {
+  if (!raw || typeof raw !== 'object') {
+    return null
+  }
+
+  const candidate = 'data' in raw ? (raw as { data?: unknown }).data : raw
+  if (!candidate || typeof candidate !== 'object') {
+    return null
+  }
+
+  return candidate as MonitoringRouteResponse<T>
+}
+
 function normalizeWatchlist(raw: unknown, index: number): WatchlistRecord {
   const record = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>
   const statistics = (
@@ -52,13 +80,19 @@ function normalizeWatchlist(raw: unknown, index: number): WatchlistRecord {
   const explicitStockCount = toOptionalNumber(record.stocks_count)
   const derivedStockCount = toOptionalNumber(statistics.totalStocks)
 
-  return {
+  const normalized: WatchlistRecord = {
     id: Number(record.id ?? index + 1),
     name: typeof record.name === 'string' ? record.name : `Watchlist ${index + 1}`,
     watchlist_type: typeof record.watchlist_type === 'string' ? record.watchlist_type : 'manual',
     risk_profile: (record.risk_profile as { risk_tolerance?: number } | undefined) ?? {},
     stocks_count: explicitStockCount ?? (derivedStockCount && derivedStockCount > 0 ? derivedStockCount : inlineStockCount),
   }
+
+  if (typeof record.is_active === 'boolean') {
+    normalized.is_active = record.is_active
+  }
+
+  return normalized
 }
 
 function toOptionalNumber(value: unknown): number | undefined {
@@ -143,6 +177,21 @@ export const watchlistService = {
     return {
       success: true,
       data: normalizeWatchlist(created, 0),
+    }
+  },
+
+  async updateWatchlist(
+    id: number,
+    payload: UpdateWatchlistPayload,
+  ): Promise<ServiceResponse<WatchlistRecord>> {
+    const rawResponse = await request.put(`/api/v1/monitoring/watchlists/${id}`, payload)
+    const body = extractMonitoringRouteResponse<unknown>(rawResponse)
+    const updated = body?.data ?? rawResponse
+
+    return {
+      success: body?.success ?? true,
+      data: normalizeWatchlist(updated, 0),
+      message: body?.message,
     }
   },
 

--- a/web/frontend/src/views/monitoring/composables/useWatchlistManagement.ts
+++ b/web/frontend/src/views/monitoring/composables/useWatchlistManagement.ts
@@ -4,6 +4,7 @@ import {
   watchlistService,
   type AddWatchlistStockPayload,
   type CreateWatchlistPayload,
+  type UpdateWatchlistPayload,
   type WatchlistRecord,
   type WatchlistStockRecord
 } from '@/api/services/watchlistService'
@@ -215,17 +216,47 @@ const showCreateModal = (): void => {
 
 const editWatchlist = (record: Watchlist): void => {
   editingWatchlist.value = record
-  message.warning('编辑组合功能待接线，当前仅开放创建、删除与成分股管理')
+  watchlistForm.name = record.name
+  watchlistForm.watchlist_type = record.watchlist_type
+  watchlistForm.risk_profile = record.risk_profile ? { ...record.risk_profile } : {}
+  riskTolerance.value = record.risk_profile?.risk_tolerance ?? 50
+  createModalVisible.value = true
 }
 
 const handleCreateOrUpdate = async (): Promise<void> => {
-  if (editingWatchlist.value) {
-    message.warning('编辑组合功能待接线，当前仅开放创建、删除与成分股管理')
-    return
-  }
-
   try {
     watchlistForm.risk_profile = { risk_tolerance: riskTolerance.value }
+
+    if (editingWatchlist.value) {
+      const response = await watchlistService.updateWatchlist(editingWatchlist.value.id, {
+        name: watchlistForm.name,
+        watchlist_type: watchlistForm.watchlist_type,
+        risk_profile: watchlistForm.risk_profile
+      } satisfies UpdateWatchlistPayload)
+
+      if (response.success) {
+        const mergedRecord = {
+          ...editingWatchlist.value,
+          ...response.data,
+        }
+
+        watchlists.value = watchlists.value.map(item =>
+          item.id === mergedRecord.id ? { ...item, ...mergedRecord } : item
+        )
+
+        if (currentWatchlist.value?.id === mergedRecord.id) {
+          currentWatchlist.value = { ...currentWatchlist.value, ...mergedRecord }
+        }
+
+        editingWatchlist.value = null
+        createModalVisible.value = false
+        message.success('更新成功')
+      } else {
+        message.error(response.message || '操作失败')
+      }
+      return
+    }
+
     const response = await watchlistService.createWatchlist({
       name: watchlistForm.name,
       watchlist_type: watchlistForm.watchlist_type,

--- a/web/frontend/tests/unit/watchlist-management-alert-summary.spec.ts
+++ b/web/frontend/tests/unit/watchlist-management-alert-summary.spec.ts
@@ -5,6 +5,7 @@ const {
   listWatchlistsMock,
   listWatchlistStocksMock,
   createWatchlistMock,
+  updateWatchlistMock,
   deleteWatchlistMock,
   addStockToWatchlistMock,
   removeStockFromWatchlistMock,
@@ -17,6 +18,7 @@ const {
   listWatchlistsMock: vi.fn(),
   listWatchlistStocksMock: vi.fn(),
   createWatchlistMock: vi.fn(),
+  updateWatchlistMock: vi.fn(),
   deleteWatchlistMock: vi.fn(),
   addStockToWatchlistMock: vi.fn(),
   removeStockFromWatchlistMock: vi.fn(),
@@ -48,6 +50,7 @@ vi.mock('@/api/services/watchlistService', () => ({
     listWatchlists: listWatchlistsMock,
     listWatchlistStocks: listWatchlistStocksMock,
     createWatchlist: createWatchlistMock,
+    updateWatchlist: updateWatchlistMock,
     deleteWatchlist: deleteWatchlistMock,
     addStockToWatchlist: addStockToWatchlistMock,
     removeStockFromWatchlist: removeStockFromWatchlistMock,
@@ -61,6 +64,16 @@ describe('watchlist management alert summary', () => {
     vi.clearAllMocks()
     randomSpy.mockReturnValue(0.9)
     listWatchlistsMock.mockResolvedValue({ success: true, data: [] })
+    updateWatchlistMock.mockResolvedValue({
+      success: true,
+      data: {
+        id: 7,
+        name: '更新后的组合',
+        watchlist_type: 'strategy',
+        risk_profile: { risk_tolerance: 70 },
+        stocks_count: 2,
+      },
+    })
     listWatchlistStocksMock.mockResolvedValue({
       success: true,
       data: [
@@ -128,5 +141,66 @@ describe('watchlist management alert summary', () => {
 
     expect(listWatchlistsMock).toHaveBeenCalled()
     expect(model.totalStocks.value).toBe(5)
+  })
+
+  it('prefills the edit modal from the selected watchlist instead of keeping the create defaults', () => {
+    const model = useWatchlistManagement()
+
+    model.editWatchlist({
+      id: 7,
+      name: '核心观察',
+      watchlist_type: 'benchmark',
+      risk_profile: { risk_tolerance: 80 },
+      stocks_count: 2,
+    })
+
+    expect(model.editingWatchlist.value?.id).toBe(7)
+    expect(model.createModalVisible.value).toBe(true)
+    expect(model.watchlistForm.name).toBe('核心观察')
+    expect(model.watchlistForm.watchlist_type).toBe('benchmark')
+    expect(model.riskTolerance.value).toBe(80)
+    expect(warningMock).not.toHaveBeenCalled()
+  })
+
+  it('submits watchlist edits through the update path and patches the local summary', async () => {
+    const model = useWatchlistManagement()
+    model.watchlists.value = [
+      {
+        id: 7,
+        name: '核心观察',
+        watchlist_type: 'manual',
+        risk_profile: { risk_tolerance: 50 },
+        stocks_count: 2,
+      },
+    ]
+
+    model.editWatchlist({
+      id: 7,
+      name: '核心观察',
+      watchlist_type: 'manual',
+      risk_profile: { risk_tolerance: 50 },
+      stocks_count: 2,
+    })
+    model.watchlistForm.name = '更新后的组合'
+    model.watchlistForm.watchlist_type = 'strategy'
+    model.riskTolerance.value = 70
+
+    await model.handleCreateOrUpdate()
+
+    expect(updateWatchlistMock).toHaveBeenCalledWith(7, {
+      name: '更新后的组合',
+      watchlist_type: 'strategy',
+      risk_profile: { risk_tolerance: 70 },
+    })
+    expect(successMock).toHaveBeenCalledWith('更新成功')
+    expect(model.createModalVisible.value).toBe(false)
+    expect(model.editingWatchlist.value).toBeNull()
+    expect(model.watchlists.value[0]).toMatchObject({
+      id: 7,
+      name: '更新后的组合',
+      watchlist_type: 'strategy',
+      risk_profile: { risk_tolerance: 70 },
+      stocks_count: 2,
+    })
   })
 })

--- a/web/frontend/tests/unit/watchlist-service-update.spec.ts
+++ b/web/frontend/tests/unit/watchlist-service-update.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { putMock } = vi.hoisted(() => ({
+  putMock: vi.fn(),
+}))
+
+vi.mock('@/api/user.ts', () => ({
+  userApi: {},
+}))
+
+vi.mock('@/utils/request.ts', () => ({
+  request: {
+    put: putMock,
+  },
+}))
+
+import { watchlistService } from '@/api/services/watchlistService.ts'
+
+describe('watchlistService update watchlist route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    putMock.mockResolvedValue({
+      data: {
+        success: true,
+        data: {
+          id: 7,
+          name: '趋势跟踪池',
+          watchlist_type: 'strategy',
+          risk_profile: { risk_tolerance: 80 },
+          is_active: false,
+          stocks_count: 2,
+        },
+      },
+    })
+  })
+
+  it('updates monitoring watchlists through the dedicated monitoring route instead of the generic user watchlist API', async () => {
+    const response = await watchlistService.updateWatchlist(7, {
+      name: '趋势跟踪池',
+      watchlist_type: 'strategy',
+      risk_profile: { risk_tolerance: 80 },
+    })
+
+    expect(putMock).toHaveBeenCalledWith('/api/v1/monitoring/watchlists/7', {
+      name: '趋势跟踪池',
+      watchlist_type: 'strategy',
+      risk_profile: { risk_tolerance: 80 },
+    })
+    expect(response).toEqual({
+      success: true,
+      data: {
+        id: 7,
+        name: '趋势跟踪池',
+        watchlist_type: 'strategy',
+        risk_profile: { risk_tolerance: 80 },
+        is_active: false,
+        stocks_count: 2,
+      },
+      message: undefined,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- implement `PUT /api/v1/monitoring/watchlists/{id}` for monitoring watchlist updates, including runtime fallback coverage
- add a dedicated frontend monitoring watchlist update path instead of routing edit state through the generic user watchlist contract
- wire the monitoring watchlist edit modal to prefill, submit updates, and patch the in-memory list with focused regression tests

## Test Plan
- `python -m pytest web/backend/tests/test_monitoring_watchlists_runtime_fallback.py -q -n 0 --no-cov`
- `npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/watchlist-service-update.spec.ts --config vitest.config.mts`
- `ruff check web/backend/app/api/monitoring_watchlists.py src/monitoring/infrastructure/postgresql_async_v3.py web/backend/tests/test_monitoring_watchlists_runtime_fallback.py`
- `git diff --check`

## Risks
- monitoring watchlist update now depends on the dedicated `/api/v1/monitoring/watchlists` contract staying consistent with the UI normalization layer
- runtime fallback state now supports update mutations, so fallback-only regressions would affect local/test environments first
