### PR TITLE
fix(frontend): align watchlist service with monitoring routes

### DIFF
--- a/TASK-REPORT.md
+++ b/TASK-REPORT.md
@@ -1,5 +1,40 @@
 # TASK REPORT
 
+## [WORK] 2026-04-03 Watchlist Service Monitoring Routes（codex/watchlist-service-monitoring-routes-20260403）
+- Scope:
+  - 收敛 `web/frontend/src/api/services/watchlistService.ts`，移除剩余 generic `userApi` watchlist 契约依赖。
+  - 保持 monitoring 自选管理页与问财“加入自选”链路可用，不丢失 `alerts_count` 与 `current_price`。
+- Completed:
+  - `watchlistService.ts`
+    - `listWatchlists` 改走 `GET /api/v1/monitoring/watchlists`
+    - `createWatchlist` 改走 `POST /api/v1/monitoring/watchlists`
+    - `deleteWatchlist` 改走 `DELETE /api/v1/monitoring/watchlists/{id}`
+    - `addStockToWatchlist` 改走 `POST /api/v1/monitoring/watchlists/{id}/stocks`
+    - `removeStockFromWatchlist` 改走 `DELETE /api/v1/monitoring/watchlists/{id}/stocks/{stock_code}`
+    - `listWatchlistStocks` 改为聚合三条链路：
+      - `GET /api/v1/monitoring/watchlists/{id}/stocks`
+      - `GET /api/v1/monitoring/analysis/portfolio/{id}/alerts`
+      - `GET /api/v1/market/quotes`
+  - 新增/更新 focused unit tests：
+    - `web/frontend/tests/unit/watchlist-service-watchlists.spec.ts`
+    - `web/frontend/tests/unit/watchlist-service-stocks.spec.ts`
+    - `web/frontend/tests/unit/watchlist-service-mutations.spec.ts`
+  - 已提交代码变更：
+    - `7e3a10368 fix: align watchlist service with monitoring routes`
+- Verification Evidence:
+  - `cd web/frontend && npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-service-mutations.spec.ts tests/unit/watchlist-service-update.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/wencai-query-table.spec.ts --config vitest.config.mts`
+    - 结果：`6 files, 12 tests passed`
+  - `git diff --check`
+  - `gitnexus_detect_changes(scope="staged")`
+    - 结果：`risk_level: low`
+  - `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-52.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report /tmp/pr52-mainline-gate.json`
+    - 结果：`pass=True`
+- Current Status:
+  - PR 已创建：`#52`
+  - governance task card 已补齐：`governance/mainline/task-cards/pr-52.yaml`
+  - mainline gate 已通过
+  - 下一步：推送治理补丁到 PR 52
+
 ## [WORK] 2026-03-13 ArtDeco Pages Gate-0 + P0-A（dev-artdeco-pages-codex）
 - Scope:
   - 完成 `optimize-artdeco-pages` 的 `Gate-0` 首轮 SSOT 纠偏。

--- a/TASK-REPORT.md
+++ b/TASK-REPORT.md
@@ -33,6 +33,12 @@
       - 删除残留的 mock GET request debug log，收敛到现有 console cleanup 规范
     - `web/frontend/tests/unit/config/console-log-cleanup-batch-12.spec.ts`
       - 修正与 `console-log-cleanup-batch-75` 冲突的过期断言，改为锁定 handler-based 文档示例
+  - 为通过当前 visual regression 门禁，补了 1 处最小可复现根因修复：
+    - `web/frontend/src/mock/backtestWorkbenchMock.ts`
+      - REAL workbench 配置不再用本地当前时钟生成 `lastUpdated` / `runLogs.ts`
+      - 改为优先使用策略 payload 中最新的 `updated_at` 派生稳定时间标签，空态回落到占位值
+    - `web/frontend/src/mock/__tests__/backtestWorkbenchMock.spec.ts`
+      - 新增测试锁定 backtest REAL mock 配置的稳定时间派生规则，防止 visual baseline 再次被秒级时间戳污染
   - 同步治理边界：
     - `governance/function-tree/catalog.yaml`
     - `governance/mainline/task-cards/pr-52.yaml`
@@ -40,6 +46,8 @@
     - `7e3a10368 fix: align watchlist service with monitoring routes`
     - `838a65eea governance: add task card for pr-52`
 - Verification Evidence:
+  - `cd web/frontend && npx vitest run src/mock/__tests__/backtestWorkbenchMock.spec.ts --config vitest.config.mts`
+    - 结果：`1 file, 3 tests passed`
   - `cd web/frontend && npx vitest run tests/unit/config/task-management-style-normalization.spec.ts tests/unit/config/console-log-cleanup-batch-64.spec.ts tests/unit/config/console-log-cleanup-batch-12.spec.ts tests/unit/config/console-log-cleanup-batch-75.spec.ts --config vitest.config.mts`
     - 结果：`4 files, 4 tests passed`
   - `cd web/frontend && npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-service-mutations.spec.ts tests/unit/watchlist-service-update.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/wencai-query-table.spec.ts tests/unit/use-market-overview.spec.ts tests/unit/composables.test.ts --config vitest.config.mts`
@@ -48,6 +56,8 @@
     - 结果：`12 files, 30 tests passed`
   - `cd web/frontend && npm run test:type-ceiling`
     - 结果：`TypeScript errors 0 are within configured ceiling 0`
+  - `cd web/frontend && FRONTEND_PORT=3020 FRONTEND_URL=http://127.0.0.1:3020 BACKEND_PORT=8020 VITE_API_BASE_URL=http://127.0.0.1:8020 USE_MOCK_DATA=true npx playwright test --config tests/visual/config/visual.config.ts tests/visual/components/charts/backtest.spec.ts --project=chromium`
+    - 结果：`2 passed`
   - `git diff --check`
   - `gitnexus_detect_changes(scope="staged")`
     - 结果：`risk_level: low`
@@ -57,6 +67,7 @@
   - PR 已创建：`#52`
   - governance task card 已补齐：`governance/mainline/task-cards/pr-52.yaml`
   - full-unit CI unblockers 已在本地补齐并通过 focused + expanded 回归
+  - visual regression 根因已定位为 backtest REAL mock 配置里的秒级动态时间标签，并已补 deterministic guard
   - mainline gate 已基于扩大的 CI unblock scope 再次通过
   - 下一步：提交 CI unblock follow-up patch 并回推 PR 52
 

--- a/TASK-REPORT.md
+++ b/TASK-REPORT.md
@@ -26,6 +26,13 @@
       - 对 `catch` 分支的 `error` 做 `Error` 窄化
     - `web/frontend/src/composables/useMarket.ts`
       - 让 `marketOverview` state 类型跟随 `marketApi.getMarketOverview()` 的真实返回，消除旧模型漂移
+  - 为通过当前 frontend full-unit 门禁，补了 3 处最小 CI 收尾修复：
+    - `web/frontend/tests/unit/config/task-management-style-normalization.spec.ts`
+      - 对齐 JS 脚本块现状，改为校验语义化 `tone` 字段而非过期的 `as const` 字面量
+    - `web/frontend/src/api/mockApiClient.ts`
+      - 删除残留的 mock GET request debug log，收敛到现有 console cleanup 规范
+    - `web/frontend/tests/unit/config/console-log-cleanup-batch-12.spec.ts`
+      - 修正与 `console-log-cleanup-batch-75` 冲突的过期断言，改为锁定 handler-based 文档示例
   - 同步治理边界：
     - `governance/function-tree/catalog.yaml`
     - `governance/mainline/task-cards/pr-52.yaml`
@@ -33,20 +40,25 @@
     - `7e3a10368 fix: align watchlist service with monitoring routes`
     - `838a65eea governance: add task card for pr-52`
 - Verification Evidence:
+  - `cd web/frontend && npx vitest run tests/unit/config/task-management-style-normalization.spec.ts tests/unit/config/console-log-cleanup-batch-64.spec.ts tests/unit/config/console-log-cleanup-batch-12.spec.ts tests/unit/config/console-log-cleanup-batch-75.spec.ts --config vitest.config.mts`
+    - 结果：`4 files, 4 tests passed`
   - `cd web/frontend && npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-service-mutations.spec.ts tests/unit/watchlist-service-update.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/wencai-query-table.spec.ts tests/unit/use-market-overview.spec.ts tests/unit/composables.test.ts --config vitest.config.mts`
     - 结果：`8 files, 26 tests passed`
+  - `cd web/frontend && npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-service-mutations.spec.ts tests/unit/watchlist-service-update.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/wencai-query-table.spec.ts tests/unit/use-market-overview.spec.ts tests/unit/composables.test.ts tests/unit/config/task-management-style-normalization.spec.ts tests/unit/config/console-log-cleanup-batch-64.spec.ts tests/unit/config/console-log-cleanup-batch-12.spec.ts tests/unit/config/console-log-cleanup-batch-75.spec.ts --config vitest.config.mts`
+    - 结果：`12 files, 30 tests passed`
   - `cd web/frontend && npm run test:type-ceiling`
     - 结果：`TypeScript errors 0 are within configured ceiling 0`
   - `git diff --check`
   - `gitnexus_detect_changes(scope="staged")`
     - 结果：`risk_level: low`
-  - `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-52.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report /tmp/pr52-mainline-gate.json`
+  - `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-52.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report /tmp/pr52-mainline-gate-ci-unblockers.json`
     - 结果：`pass=True`
 - Current Status:
   - PR 已创建：`#52`
   - governance task card 已补齐：`governance/mainline/task-cards/pr-52.yaml`
-  - mainline gate 曾在治理补丁后通过；本轮会基于扩大的前端类型修复 scope 再次复验
-  - 下一步：提交 frontend type-ceiling unblock patch 并回推 PR 52
+  - full-unit CI unblockers 已在本地补齐并通过 focused + expanded 回归
+  - mainline gate 已基于扩大的 CI unblock scope 再次通过
+  - 下一步：提交 CI unblock follow-up patch 并回推 PR 52
 
 ## [WORK] 2026-03-13 ArtDeco Pages Gate-0 + P0-A（dev-artdeco-pages-codex）
 - Scope:

--- a/TASK-REPORT.md
+++ b/TASK-REPORT.md
@@ -19,11 +19,24 @@
     - `web/frontend/tests/unit/watchlist-service-watchlists.spec.ts`
     - `web/frontend/tests/unit/watchlist-service-stocks.spec.ts`
     - `web/frontend/tests/unit/watchlist-service-mutations.spec.ts`
+  - 为通过当前 frontend type ceiling 门禁，补了 3 处最小前端类型修复：
+    - `web/frontend/src/views/TaskManagement.vue`
+      - 移除 JS 脚本块中非法的 `as const` 断言
+    - `web/frontend/src/components/market/WencaiQueryTable.vue`
+      - 对 `catch` 分支的 `error` 做 `Error` 窄化
+    - `web/frontend/src/composables/useMarket.ts`
+      - 让 `marketOverview` state 类型跟随 `marketApi.getMarketOverview()` 的真实返回，消除旧模型漂移
+  - 同步治理边界：
+    - `governance/function-tree/catalog.yaml`
+    - `governance/mainline/task-cards/pr-52.yaml`
   - 已提交代码变更：
     - `7e3a10368 fix: align watchlist service with monitoring routes`
+    - `838a65eea governance: add task card for pr-52`
 - Verification Evidence:
-  - `cd web/frontend && npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-service-mutations.spec.ts tests/unit/watchlist-service-update.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/wencai-query-table.spec.ts --config vitest.config.mts`
-    - 结果：`6 files, 12 tests passed`
+  - `cd web/frontend && npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-service-mutations.spec.ts tests/unit/watchlist-service-update.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/wencai-query-table.spec.ts tests/unit/use-market-overview.spec.ts tests/unit/composables.test.ts --config vitest.config.mts`
+    - 结果：`8 files, 26 tests passed`
+  - `cd web/frontend && npm run test:type-ceiling`
+    - 结果：`TypeScript errors 0 are within configured ceiling 0`
   - `git diff --check`
   - `gitnexus_detect_changes(scope="staged")`
     - 结果：`risk_level: low`
@@ -32,8 +45,8 @@
 - Current Status:
   - PR 已创建：`#52`
   - governance task card 已补齐：`governance/mainline/task-cards/pr-52.yaml`
-  - mainline gate 已通过
-  - 下一步：推送治理补丁到 PR 52
+  - mainline gate 曾在治理补丁后通过；本轮会基于扩大的前端类型修复 scope 再次复验
+  - 下一步：提交 frontend type-ceiling unblock patch 并回推 PR 52
 
 ## [WORK] 2026-03-13 ArtDeco Pages Gate-0 + P0-A（dev-artdeco-pages-codex）
 - Scope:

--- a/governance/function-tree/catalog.yaml
+++ b/governance/function-tree/catalog.yaml
@@ -369,6 +369,8 @@ domains:
           - "src/monitoring/**"
           - "src/core/monitoring.py"
           - "web/backend/app/api/monitoring.py"
+          - "web/frontend/src/api/services/watchlistService.ts"
+          - "web/frontend/tests/unit/watchlist-service-*.spec.ts"
         entrypoints:
           governance:
             - "docs/FUNCTION_TREE.md"
@@ -378,6 +380,7 @@ domains:
           frontend:
             - "web/frontend/src/views/monitoring/**"
             - "web/frontend/src/views/monitor.vue"
+            - "web/frontend/src/api/services/watchlistService.ts"
           core:
             - "src/monitoring/**"
             - "src/core/monitoring.py"
@@ -385,6 +388,7 @@ domains:
             - "tests/monitoring/**"
             - "tests/e2e/monitoring-dashboard.spec.ts"
             - "tests/unit/monitoring/test_monitoring_service.py"
+            - "web/frontend/tests/unit/watchlist-service-*.spec.ts"
           operations:
             - "config/monitoring-stack/README.md"
             - "docs/operations/deployment/SETUP_GRAFANA.md"

--- a/governance/function-tree/catalog.yaml
+++ b/governance/function-tree/catalog.yaml
@@ -12,6 +12,8 @@ domains:
           - "web/backend/app/api/market.py"
           - "web/backend/app/api/market/**"
           - "web/frontend/src/views/market/**"
+          - "web/frontend/src/components/market/**"
+          - "web/frontend/src/composables/useMarket.ts"
         entrypoints:
           governance:
             - "docs/FUNCTION_TREE.md"
@@ -21,6 +23,8 @@ domains:
           frontend:
             - "web/frontend/src/views/market/**"
             - "web/frontend/src/views/artdeco-pages/market-data-tabs/**"
+            - "web/frontend/src/components/market/**"
+            - "web/frontend/src/composables/useMarket.ts"
           core:
             - "src/adapters/tdx/**"
             - "src/application/market_data/**"
@@ -28,6 +32,8 @@ domains:
             - "tests/api/file_tests/test_market_api.py"
             - "tests/e2e/market-data.spec.ts"
             - "web/frontend/tests/e2e/market-data.spec.ts"
+            - "web/frontend/tests/unit/use-market-overview.spec.ts"
+            - "web/frontend/tests/unit/wencai-query-table.spec.ts"
           operations:
             - "docs/testing/E2E_TEST_GUIDE.md"
             - "docs/operations/OPS_MANUAL.md"
@@ -525,6 +531,7 @@ domains:
         coverage_paths:
           - "web/backend/app/api/system.py"
           - "config/**"
+          - "web/frontend/src/views/TaskManagement.vue"
         entrypoints:
           governance:
             - "docs/FUNCTION_TREE.md"
@@ -533,6 +540,7 @@ domains:
           frontend:
             - "web/frontend/src/views/system/**"
             - "web/frontend/src/views/artdeco-pages/system-tabs/**"
+            - "web/frontend/src/views/TaskManagement.vue"
           core:
             - "config/**"
           tests:

--- a/governance/function-tree/catalog.yaml
+++ b/governance/function-tree/catalog.yaml
@@ -226,16 +226,20 @@ domains:
         label: "3.3 回测分析"
         coverage_paths:
           - "src/backtesting/**"
+          - "web/frontend/src/mock/backtestWorkbenchMock.ts"
           - "web/frontend/src/views/artdeco-pages/strategy-tabs/**"
         entrypoints:
           governance:
             - "docs/FUNCTION_TREE.md"
           frontend:
+            - "web/frontend/src/mock/backtestWorkbenchMock.ts"
             - "web/frontend/src/views/artdeco-pages/strategy-tabs/**"
           core:
             - "src/backtesting/**"
           tests:
             - "tests/e2e/strategy-management.spec.ts"
+            - "web/frontend/src/mock/__tests__/backtestWorkbenchMock.spec.ts"
+            - "web/frontend/tests/visual/components/charts/backtest.spec.ts"
           operations:
             - "docs/operations/OPS_MANUAL.md"
 

--- a/governance/function-tree/catalog.yaml
+++ b/governance/function-tree/catalog.yaml
@@ -11,6 +11,8 @@ domains:
           - "src/adapters/tdx/**"
           - "web/backend/app/api/market.py"
           - "web/backend/app/api/market/**"
+          - "web/frontend/src/api/mockApiClient.ts"
+          - "web/frontend/src/composables/useWebSocketWithConfig.ts"
           - "web/frontend/src/views/market/**"
           - "web/frontend/src/components/market/**"
           - "web/frontend/src/composables/useMarket.ts"
@@ -21,6 +23,8 @@ domains:
             - "web/backend/app/api/market.py"
             - "web/backend/app/api/market/**"
           frontend:
+            - "web/frontend/src/api/mockApiClient.ts"
+            - "web/frontend/src/composables/useWebSocketWithConfig.ts"
             - "web/frontend/src/views/market/**"
             - "web/frontend/src/views/artdeco-pages/market-data-tabs/**"
             - "web/frontend/src/components/market/**"
@@ -32,6 +36,9 @@ domains:
             - "tests/api/file_tests/test_market_api.py"
             - "tests/e2e/market-data.spec.ts"
             - "web/frontend/tests/e2e/market-data.spec.ts"
+            - "web/frontend/tests/api/mockApiClient.spec.ts"
+            - "web/frontend/tests/unit/config/console-log-cleanup-batch-12.spec.ts"
+            - "web/frontend/tests/unit/config/console-log-cleanup-batch-64.spec.ts"
             - "web/frontend/tests/unit/use-market-overview.spec.ts"
             - "web/frontend/tests/unit/wencai-query-table.spec.ts"
           operations:
@@ -545,6 +552,7 @@ domains:
             - "config/**"
           tests:
             - "tests/api/system.spec.ts"
+            - "web/frontend/tests/unit/config/task-management-style-normalization.spec.ts"
           operations:
             - "docs/operations/deployment/README.md"
             - "docker/README.md"

--- a/governance/mainline/task-cards/pr-52.yaml
+++ b/governance/mainline/task-cards/pr-52.yaml
@@ -1,0 +1,91 @@
+version: "v0.2"
+
+task:
+  id: "pr-52"
+  title: "align watchlist service with monitoring routes"
+  owner: "main"
+  created_at: "2026-04-03"
+
+mainline:
+  id: "L1-watchlist-service-monitoring-routes"
+  objective: "move the remaining frontend watchlist service flows onto monitoring routes without regressing alert and quote derived UI summaries"
+  milestone_id: "L3-mainline-follow-up"
+  slice_id: "L4-watchlist-service-monitoring-routes"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "domain-06"
+  node_id: "domain-06-node-01"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "required"
+  secondary_domains: []
+  exemption_reason: ""
+
+scope:
+  allowed_paths:
+    - "TASK-REPORT.md"
+    - "governance/function-tree/catalog.yaml"
+    - "governance/mainline/task-cards/pr-52.yaml"
+    - "web/frontend/src/api/services/watchlistService.ts"
+    - "web/frontend/tests/unit/watchlist-service-watchlists.spec.ts"
+    - "web/frontend/tests/unit/watchlist-service-stocks.spec.ts"
+    - "web/frontend/tests/unit/watchlist-service-mutations.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+
+non_goals:
+  - "No backend monitoring route changes"
+  - "No watchlist UI redesign"
+  - "No alert CRUD or portfolio analytics expansion"
+
+acceptance:
+  checks:
+    - id: "watchlist-service-regression"
+      command: "cd web/frontend && npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-service-mutations.spec.ts tests/unit/watchlist-service-update.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/wencai-query-table.spec.ts --config vitest.config.mts"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-52.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report /tmp/pr52-mainline-gate.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If monitoring watchlist stocks drift from alert aggregation, the monitoring summary can silently undercount active alerts"
+    - "If market quote payload parsing regresses, watchlist PnL and value calculations can fall back to stale entry prices"
+    - "If any remaining generic watchlist route slips back in, monitoring and non-monitoring watchlist contracts will diverge again"
+  rollback_plan: "git revert <merge-commit-sha> if monitoring watchlist management regresses after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "finish the frontend migration from generic watchlist routes to monitoring-specific routes"
+    modified_scope: "watchlist service normalization logic, focused watchlist service tests, worker task report, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "monitoring watchlist reads and mutations now use monitoring APIs consistently while preserving alert and quote derived summary fields"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if monitoring watchlist management loses alert counts, quote prices, or route compatibility"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-03T00:00:00Z"
+    approval_note: "localized frontend watchlist service contract fix with focused regression coverage"
+    secondary_approved: false

--- a/governance/mainline/task-cards/pr-52.yaml
+++ b/governance/mainline/task-cards/pr-52.yaml
@@ -30,6 +30,7 @@ function_tree:
     - "tests"
   update_status: "required"
   secondary_domains:
+    - "domain-03"
     - "domain-01"
     - "domain-08"
   exemption_reason: ""
@@ -42,6 +43,8 @@ scope:
     - "web/frontend/src/api/mockApiClient.ts"
     - "web/frontend/src/api/services/watchlistService.ts"
     - "web/frontend/src/components/market/WencaiQueryTable.vue"
+    - "web/frontend/src/mock/__tests__/backtestWorkbenchMock.spec.ts"
+    - "web/frontend/src/mock/backtestWorkbenchMock.ts"
     - "web/frontend/src/composables/useMarket.ts"
     - "web/frontend/src/views/TaskManagement.vue"
     - "web/frontend/tests/unit/config/console-log-cleanup-batch-12.spec.ts"
@@ -64,6 +67,9 @@ acceptance:
     - id: "frontend-ci-unblockers"
       command: "cd web/frontend && npx vitest run tests/unit/config/task-management-style-normalization.spec.ts tests/unit/config/console-log-cleanup-batch-64.spec.ts tests/unit/config/console-log-cleanup-batch-12.spec.ts --config vitest.config.mts"
       required: true
+    - id: "backtest-visual-determinism-guard"
+      command: "cd web/frontend && npx vitest run src/mock/__tests__/backtestWorkbenchMock.spec.ts --config vitest.config.mts"
+      required: true
     - id: "watchlist-service-regression"
       command: "cd web/frontend && npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-service-mutations.spec.ts tests/unit/watchlist-service-update.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/wencai-query-table.spec.ts tests/unit/use-market-overview.spec.ts tests/unit/composables.test.ts --config vitest.config.mts"
       required: true
@@ -83,13 +89,14 @@ risk_and_rollback:
     - "If market quote payload parsing regresses, watchlist PnL and value calculations can fall back to stale entry prices"
     - "If any remaining generic watchlist route slips back in, monitoring and non-monitoring watchlist contracts will diverge again"
     - "If the CI-unblock type fixes widen beyond the exact blocking files, this slice can become a hidden frontend cleanup batch"
+    - "If backtest REAL mock metadata keeps using local clock timestamps, visual baselines can keep failing nondeterministically even when UI structure is unchanged"
   rollback_plan: "git revert <merge-commit-sha> if monitoring watchlist management regresses after merge"
 
 delivery:
   six_line_summary_required: true
   six_line_summary:
     change_purpose: "finish the frontend migration from generic watchlist routes to monitoring-specific routes and remove the frontend CI blockers that prevent the slice from merging"
-    modified_scope: "watchlist service normalization logic, focused frontend CI-unblock source and test files, worker task report, function-tree catalog, and this PR task card"
+    modified_scope: "watchlist service normalization logic, focused frontend CI-unblock source and test files including backtest visual determinism guards, worker task report, function-tree catalog, and this PR task card"
     dependency_changes: "none"
     legacy_logic_impact: "monitoring watchlist reads and mutations now use monitoring APIs consistently while preserving alert and quote derived summary fields; unrelated frontend behavior is unchanged outside minimal type-safe rewrites"
     rollback_ready: "yes"

--- a/governance/mainline/task-cards/pr-52.yaml
+++ b/governance/mainline/task-cards/pr-52.yaml
@@ -8,7 +8,7 @@ task:
 
 mainline:
   id: "L1-watchlist-service-monitoring-routes"
-  objective: "move the remaining frontend watchlist service flows onto monitoring routes and clear the frontend type-ceiling blockers that gate this slice"
+  objective: "move the remaining frontend watchlist service flows onto monitoring routes and clear the frontend CI blockers that gate this slice"
   milestone_id: "L3-mainline-follow-up"
   slice_id: "L4-watchlist-service-monitoring-routes"
 
@@ -39,10 +39,14 @@ scope:
     - "TASK-REPORT.md"
     - "governance/function-tree/catalog.yaml"
     - "governance/mainline/task-cards/pr-52.yaml"
+    - "web/frontend/src/api/mockApiClient.ts"
     - "web/frontend/src/api/services/watchlistService.ts"
     - "web/frontend/src/components/market/WencaiQueryTable.vue"
     - "web/frontend/src/composables/useMarket.ts"
     - "web/frontend/src/views/TaskManagement.vue"
+    - "web/frontend/tests/unit/config/console-log-cleanup-batch-12.spec.ts"
+    - "web/frontend/tests/unit/config/console-log-cleanup-batch-64.spec.ts"
+    - "web/frontend/tests/unit/config/task-management-style-normalization.spec.ts"
     - "web/frontend/tests/unit/watchlist-service-watchlists.spec.ts"
     - "web/frontend/tests/unit/watchlist-service-stocks.spec.ts"
     - "web/frontend/tests/unit/watchlist-service-mutations.spec.ts"
@@ -57,6 +61,9 @@ non_goals:
 
 acceptance:
   checks:
+    - id: "frontend-ci-unblockers"
+      command: "cd web/frontend && npx vitest run tests/unit/config/task-management-style-normalization.spec.ts tests/unit/config/console-log-cleanup-batch-64.spec.ts tests/unit/config/console-log-cleanup-batch-12.spec.ts --config vitest.config.mts"
+      required: true
     - id: "watchlist-service-regression"
       command: "cd web/frontend && npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-service-mutations.spec.ts tests/unit/watchlist-service-update.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/wencai-query-table.spec.ts tests/unit/use-market-overview.spec.ts tests/unit/composables.test.ts --config vitest.config.mts"
       required: true
@@ -81,8 +88,8 @@ risk_and_rollback:
 delivery:
   six_line_summary_required: true
   six_line_summary:
-    change_purpose: "finish the frontend migration from generic watchlist routes to monitoring-specific routes and remove the frontend type-ceiling blockers that prevent the slice from merging"
-    modified_scope: "watchlist service normalization logic, focused watchlist and market/frontend type-fix files, worker task report, function-tree catalog, and this PR task card"
+    change_purpose: "finish the frontend migration from generic watchlist routes to monitoring-specific routes and remove the frontend CI blockers that prevent the slice from merging"
+    modified_scope: "watchlist service normalization logic, focused frontend CI-unblock source and test files, worker task report, function-tree catalog, and this PR task card"
     dependency_changes: "none"
     legacy_logic_impact: "monitoring watchlist reads and mutations now use monitoring APIs consistently while preserving alert and quote derived summary fields; unrelated frontend behavior is unchanged outside minimal type-safe rewrites"
     rollback_ready: "yes"

--- a/governance/mainline/task-cards/pr-52.yaml
+++ b/governance/mainline/task-cards/pr-52.yaml
@@ -8,7 +8,7 @@ task:
 
 mainline:
   id: "L1-watchlist-service-monitoring-routes"
-  objective: "move the remaining frontend watchlist service flows onto monitoring routes without regressing alert and quote derived UI summaries"
+  objective: "move the remaining frontend watchlist service flows onto monitoring routes and clear the frontend type-ceiling blockers that gate this slice"
   milestone_id: "L3-mainline-follow-up"
   slice_id: "L4-watchlist-service-monitoring-routes"
 
@@ -29,7 +29,9 @@ function_tree:
     - "frontend"
     - "tests"
   update_status: "required"
-  secondary_domains: []
+  secondary_domains:
+    - "domain-01"
+    - "domain-08"
   exemption_reason: ""
 
 scope:
@@ -38,6 +40,9 @@ scope:
     - "governance/function-tree/catalog.yaml"
     - "governance/mainline/task-cards/pr-52.yaml"
     - "web/frontend/src/api/services/watchlistService.ts"
+    - "web/frontend/src/components/market/WencaiQueryTable.vue"
+    - "web/frontend/src/composables/useMarket.ts"
+    - "web/frontend/src/views/TaskManagement.vue"
     - "web/frontend/tests/unit/watchlist-service-watchlists.spec.ts"
     - "web/frontend/tests/unit/watchlist-service-stocks.spec.ts"
     - "web/frontend/tests/unit/watchlist-service-mutations.spec.ts"
@@ -48,11 +53,15 @@ non_goals:
   - "No backend monitoring route changes"
   - "No watchlist UI redesign"
   - "No alert CRUD or portfolio analytics expansion"
+  - "No broader frontend type-debt sweep beyond the blockers required to unstick this PR"
 
 acceptance:
   checks:
     - id: "watchlist-service-regression"
-      command: "cd web/frontend && npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-service-mutations.spec.ts tests/unit/watchlist-service-update.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/wencai-query-table.spec.ts --config vitest.config.mts"
+      command: "cd web/frontend && npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-service-mutations.spec.ts tests/unit/watchlist-service-update.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/wencai-query-table.spec.ts tests/unit/use-market-overview.spec.ts tests/unit/composables.test.ts --config vitest.config.mts"
+      required: true
+    - id: "frontend-type-ceiling"
+      command: "cd web/frontend && npm run test:type-ceiling"
       required: true
     - id: "diff-check"
       command: "git diff --check"
@@ -66,17 +75,18 @@ risk_and_rollback:
     - "If monitoring watchlist stocks drift from alert aggregation, the monitoring summary can silently undercount active alerts"
     - "If market quote payload parsing regresses, watchlist PnL and value calculations can fall back to stale entry prices"
     - "If any remaining generic watchlist route slips back in, monitoring and non-monitoring watchlist contracts will diverge again"
+    - "If the CI-unblock type fixes widen beyond the exact blocking files, this slice can become a hidden frontend cleanup batch"
   rollback_plan: "git revert <merge-commit-sha> if monitoring watchlist management regresses after merge"
 
 delivery:
   six_line_summary_required: true
   six_line_summary:
-    change_purpose: "finish the frontend migration from generic watchlist routes to monitoring-specific routes"
-    modified_scope: "watchlist service normalization logic, focused watchlist service tests, worker task report, and this PR task card"
+    change_purpose: "finish the frontend migration from generic watchlist routes to monitoring-specific routes and remove the frontend type-ceiling blockers that prevent the slice from merging"
+    modified_scope: "watchlist service normalization logic, focused watchlist and market/frontend type-fix files, worker task report, function-tree catalog, and this PR task card"
     dependency_changes: "none"
-    legacy_logic_impact: "monitoring watchlist reads and mutations now use monitoring APIs consistently while preserving alert and quote derived summary fields"
+    legacy_logic_impact: "monitoring watchlist reads and mutations now use monitoring APIs consistently while preserving alert and quote derived summary fields; unrelated frontend behavior is unchanged outside minimal type-safe rewrites"
     rollback_ready: "yes"
-    risk_and_rollback_point: "revert the slice if monitoring watchlist management loses alert counts, quote prices, or route compatibility"
+    risk_and_rollback_point: "revert the slice if monitoring watchlist management loses alert counts, quote prices, route compatibility, or if the type-fix follow-up introduces new frontend regressions"
 
 governance:
   phase: "phase_a_pr_hard_gate"

--- a/web/frontend/src/api/mockApiClient.ts
+++ b/web/frontend/src/api/mockApiClient.ts
@@ -52,7 +52,6 @@ const matchesMockRoute = (url: string, route: string): boolean => {
 export const mockApiClient = {
   async get<T = UnifiedResponse<unknown>>(url: string, config?: MockRequestConfig): Promise<T> {
     await simulateNetworkDelay();
-    console.log(`[Mock API] GET ${url}`, config);
 
     const params = getRequestParams(config);
 

--- a/web/frontend/src/api/services/watchlistService.ts
+++ b/web/frontend/src/api/services/watchlistService.ts
@@ -1,4 +1,3 @@
-import { userApi } from '@/api/user.ts'
 import { request } from '@/utils/request.ts'
 
 export interface WatchlistRecord {
@@ -56,17 +55,161 @@ interface MonitoringRouteResponse<T> {
   message?: string
 }
 
+interface QuoteSnapshot {
+  price: number
+  isSynthetic: boolean
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object'
+}
+
+function isTransportWrapper(value: Record<string, unknown>): boolean {
+  return 'status' in value || 'headers' in value || 'config' in value || 'statusText' in value
+}
+
+function isMonitoringRouteEnvelope(value: Record<string, unknown>): boolean {
+  if ('success' in value || 'message' in value) {
+    return true
+  }
+
+  return 'data' in value && !isTransportWrapper(value)
+}
+
+function extractTransportData(raw: unknown): unknown {
+  if (!isRecord(raw)) {
+    return raw
+  }
+
+  if ('data' in raw) {
+    return raw.data
+  }
+
+  return raw
+}
+
 function extractMonitoringRouteResponse<T>(raw: unknown): MonitoringRouteResponse<T> | null {
-  if (!raw || typeof raw !== 'object') {
+  if (!isRecord(raw)) {
     return null
   }
 
-  const candidate = 'data' in raw ? (raw as { data?: unknown }).data : raw
-  if (!candidate || typeof candidate !== 'object') {
-    return null
+  const nestedCandidate = isRecord(raw.data) ? raw.data : null
+  if (nestedCandidate && isMonitoringRouteEnvelope(nestedCandidate)) {
+    return nestedCandidate as MonitoringRouteResponse<T>
   }
 
-  return candidate as MonitoringRouteResponse<T>
+  if (isMonitoringRouteEnvelope(raw)) {
+    return raw as MonitoringRouteResponse<T>
+  }
+
+  return null
+}
+
+function extractMonitoringRouteData<T>(raw: unknown): T | undefined {
+  const body = extractMonitoringRouteResponse<T>(raw)
+  if (body) {
+    return body.data
+  }
+
+  return extractTransportData(raw) as T | undefined
+}
+
+function toObjectRows(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.filter((item): item is Record<string, unknown> => isRecord(item))
+}
+
+function extractCollectionRows(raw: unknown, collectionKeys: string[]): Record<string, unknown>[] {
+  const payload = extractMonitoringRouteData<unknown>(raw)
+  if (Array.isArray(payload)) {
+    return toObjectRows(payload)
+  }
+
+  if (!isRecord(payload)) {
+    return []
+  }
+
+  for (const key of collectionKeys) {
+    const collection = payload[key]
+    if (Array.isArray(collection)) {
+      return toObjectRows(collection)
+    }
+
+    if (isRecord(collection)) {
+      if (Array.isArray(collection.data)) {
+        return toObjectRows(collection.data)
+      }
+
+      if (Array.isArray(collection.items)) {
+        return toObjectRows(collection.items)
+      }
+    }
+  }
+
+  if (Array.isArray(payload.data)) {
+    return toObjectRows(payload.data)
+  }
+
+  if (Array.isArray(payload.items)) {
+    return toObjectRows(payload.items)
+  }
+
+  return []
+}
+
+function buildAlertCountMap(rows: Record<string, unknown>[]): Map<string, number> {
+  const counts = new Map<string, number>()
+
+  for (const row of rows) {
+    const stockCode = typeof row.stock_code === 'string' ? row.stock_code : ''
+    if (!stockCode) {
+      continue
+    }
+
+    counts.set(stockCode, (counts.get(stockCode) ?? 0) + 1)
+  }
+
+  return counts
+}
+
+function buildQuoteSnapshotMap(rows: Record<string, unknown>[]): Map<string, QuoteSnapshot> {
+  const snapshots = new Map<string, QuoteSnapshot>()
+
+  for (const row of rows) {
+    const symbol =
+      typeof row.symbol === 'string'
+        ? row.symbol
+        : typeof row.stock_code === 'string'
+          ? row.stock_code
+          : ''
+    const price = toOptionalNumber((row.current_price ?? row.currentPrice ?? row.price) as unknown)
+    if (!symbol || price === undefined) {
+      continue
+    }
+
+    const name = typeof row.name === 'string' ? row.name : ''
+    snapshots.set(symbol, {
+      price,
+      isSynthetic: name === `股票${symbol}`,
+    })
+  }
+
+  return snapshots
+}
+
+function resolveCurrentPrice(stock: WatchlistStockRecord, quote: QuoteSnapshot | undefined): number | null | undefined {
+  if (quote) {
+    if (quote.isSynthetic && stock.entry_price !== undefined && stock.entry_price !== null) {
+      return stock.entry_price
+    }
+
+    return quote.price
+  }
+
+  return stock.current_price ?? stock.entry_price
 }
 
 function normalizeWatchlist(raw: unknown, index: number): WatchlistRecord {
@@ -155,28 +298,64 @@ function normalizeWatchlistStock(raw: unknown, index: number): WatchlistStockRec
 
 export const watchlistService = {
   async listWatchlists(): Promise<ServiceResponse<WatchlistRecord[]>> {
-    const data = await userApi.getWatchlists()
+    const rawResponse = await request.get('/api/v1/monitoring/watchlists')
+    const body = extractMonitoringRouteResponse<unknown>(rawResponse)
+    const data = extractCollectionRows(rawResponse, ['watchlists', 'items', 'data'])
+
     return {
-      success: true,
+      success: body?.success ?? true,
       data: data.map((item, index) => normalizeWatchlist(item, index)),
+      message: body?.message,
     }
   },
 
   async listWatchlistStocks(watchlistId: number): Promise<ServiceResponse<WatchlistStockRecord[]>> {
-    const data = await userApi.getWatchlist(String(watchlistId))
-    const stocks = Array.isArray(data.stocks) ? data.stocks : []
+    const rawStocksResponse = await request.get(`/api/v1/monitoring/watchlists/${watchlistId}/stocks`)
+    const body = extractMonitoringRouteResponse<unknown>(rawStocksResponse)
+    const stocks = extractCollectionRows(rawStocksResponse, ['stocks', 'items', 'data']).map((item, index) =>
+      normalizeWatchlistStock(item, index),
+    )
+
+    if (stocks.length === 0) {
+      return {
+        success: body?.success ?? true,
+        data: [],
+        message: body?.message,
+      }
+    }
+
+    const symbols = [...new Set(stocks.map(stock => stock.stock_code).filter(Boolean))]
+    const [rawAlertsResponse, rawQuotesResponse] = await Promise.all([
+      request.get(`/api/v1/monitoring/analysis/portfolio/${watchlistId}/alerts`),
+      request.get('/api/v1/market/quotes', {
+        params: {
+          symbols: symbols.join(','),
+        },
+      }),
+    ])
+    const alertCounts = buildAlertCountMap(extractCollectionRows(rawAlertsResponse, ['alerts', 'items', 'data']))
+    const quoteSnapshots = buildQuoteSnapshotMap(extractCollectionRows(rawQuotesResponse, ['quotes', 'items', 'data']))
 
     return {
-      success: true,
-      data: stocks.map((item, index) => normalizeWatchlistStock(item, index)),
+      success: body?.success ?? true,
+      data: stocks.map((stock) => ({
+        ...stock,
+        current_price: resolveCurrentPrice(stock, quoteSnapshots.get(stock.stock_code)),
+        alerts_count: alertCounts.get(stock.stock_code) ?? stock.alerts_count ?? 0,
+      })),
+      message: body?.message,
     }
   },
 
   async createWatchlist(payload: CreateWatchlistPayload): Promise<ServiceResponse<WatchlistRecord>> {
-    const created = await userApi.createWatchlist(payload as unknown as { name: string })
+    const rawResponse = await request.post('/api/v1/monitoring/watchlists', payload)
+    const body = extractMonitoringRouteResponse<unknown>(rawResponse)
+    const created = extractMonitoringRouteData<unknown>(rawResponse)
+
     return {
-      success: true,
+      success: body?.success ?? true,
       data: normalizeWatchlist(created, 0),
+      message: body?.message,
     }
   },
 
@@ -196,20 +375,35 @@ export const watchlistService = {
   },
 
   async deleteWatchlist(id: number): Promise<ServiceResponse<null>> {
-    await userApi.deleteWatchlist(String(id))
-    return { success: true, data: null }
+    const rawResponse = await request.delete(`/api/v1/monitoring/watchlists/${id}`)
+    const body = extractMonitoringRouteResponse<null>(rawResponse)
+
+    return {
+      success: body?.success ?? true,
+      data: null,
+      message: body?.message,
+    }
   },
 
   async addStockToWatchlist(watchlistId: number, payload: AddWatchlistStockPayload): Promise<ServiceResponse<null>> {
-    await userApi.addStockToWatchlist(String(watchlistId), {
-      symbol: payload.stock_code,
-      notes: payload.entry_reason ?? undefined,
-    })
-    return { success: true, data: null }
+    const rawResponse = await request.post(`/api/v1/monitoring/watchlists/${watchlistId}/stocks`, payload)
+    const body = extractMonitoringRouteResponse<null>(rawResponse)
+
+    return {
+      success: body?.success ?? true,
+      data: null,
+      message: body?.message,
+    }
   },
 
   async removeStockFromWatchlist(watchlistId: number, stockCode: string): Promise<ServiceResponse<null>> {
-    await userApi.removeStockFromWatchlist(String(watchlistId), stockCode)
-    return { success: true, data: null }
+    const rawResponse = await request.delete(`/api/v1/monitoring/watchlists/${watchlistId}/stocks/${stockCode}`)
+    const body = extractMonitoringRouteResponse<null>(rawResponse)
+
+    return {
+      success: body?.success ?? true,
+      data: null,
+      message: body?.message,
+    }
   }
 }

--- a/web/frontend/src/components/market/WencaiQueryTable.vue
+++ b/web/frontend/src/components/market/WencaiQueryTable.vue
@@ -172,7 +172,8 @@ const loadResults = async () => {
 
     ElMessage.success('数据加载成功')
   } catch (error) {
-    ElMessage.error('加载数据出错: ' + error.message)
+    const message = error instanceof Error ? error.message : '未知错误'
+    ElMessage.error('加载数据出错: ' + message)
   } finally {
     loading.value = false
   }

--- a/web/frontend/src/composables/useMarket.ts
+++ b/web/frontend/src/composables/useMarket.ts
@@ -10,7 +10,9 @@ import { marketService } from '@/api/services/marketService';
 import { MarketAdapter } from '@/api/adapters/marketAdapter';
 import { marketApi } from '@/api/market';
 import { getCache } from '@/utils/cache/part-1';
-import type { MarketOverviewVM, FundFlowChartPoint, KLineChartData } from '@/api/types/extensions';
+import type { FundFlowChartPoint, KLineChartData } from '@/api/types/extensions';
+
+type MarketOverviewState = Awaited<ReturnType<typeof marketApi.getMarketOverview>>;
 
 /**
  * Cache keys
@@ -43,7 +45,7 @@ export function useMarket(options?: {
   const { autoFetch = true, enableCache = true } = options || {};
 
   // State
-  const marketOverview = ref<MarketOverviewVM | null>(null);
+  const marketOverview = ref<MarketOverviewState | null>(null);
   const fundFlowData = ref<FundFlowChartPoint[]>([]);
   const klineData = ref<KLineChartData[] | null>(null);
   const loading = ref(false);
@@ -66,7 +68,7 @@ export function useMarket(options?: {
     try {
       // Try cache first (if enabled and not forcing refresh)
       if (enableCache && !forceRefresh) {
-        const cached = cache.get(cacheKey) as MarketOverviewVM | undefined;
+        const cached = cache.get(cacheKey) as MarketOverviewState | undefined;
         if (cached) {
           marketOverview.value = cached;
           return;

--- a/web/frontend/src/mock/__tests__/backtestWorkbenchMock.spec.ts
+++ b/web/frontend/src/mock/__tests__/backtestWorkbenchMock.spec.ts
@@ -18,4 +18,26 @@ describe('backtestWorkbenchMock', () => {
     expect(config.backtestTasks).toHaveLength(0)
     expect(config.systemStatus).toContain('暂无策略')
   })
+
+  it('derives stable updated labels and log timestamps from strategy payload metadata', () => {
+    const config = createBacktestWorkbenchRealConfig([
+      {
+        strategy_id: 101,
+        strategy_name: 'Momentum Alpha',
+        status: 'active',
+        parameters: [],
+        updated_at: '2026-03-01T09:00:00Z'
+      },
+      {
+        strategy_id: 102,
+        strategy_name: 'Mean Reversion Beta',
+        status: 'paused',
+        parameters: [],
+        updated_at: '2026-03-01T09:05:00Z'
+      }
+    ])
+
+    expect(config.lastUpdated).toBe('2026-03-01 09:05')
+    expect(config.runLogs[0]?.ts).toBe('09:05:00')
+  })
 })

--- a/web/frontend/src/mock/backtestWorkbenchMock.ts
+++ b/web/frontend/src/mock/backtestWorkbenchMock.ts
@@ -43,6 +43,57 @@ export interface BacktestWorkbenchDataConfig {
   reportSummary: Array<{ label: string; value: string; variant: BacktestMetricVariantWithGold }>
 }
 
+const EMPTY_UPDATED_LABEL = '--'
+const EMPTY_LOG_TIME = '--:--:--'
+
+function toStableDateTimeLabel(rawValue: string | null | undefined): string | null {
+  if (!rawValue) {
+    return null
+  }
+
+  const parsed = new Date(rawValue)
+  if (Number.isNaN(parsed.getTime())) {
+    return null
+  }
+
+  const isoValue = parsed.toISOString()
+  return `${isoValue.slice(0, 10)} ${isoValue.slice(11, 16)}`
+}
+
+function toStableTimeLabel(rawValue: string | null | undefined): string | null {
+  if (!rawValue) {
+    return null
+  }
+
+  const parsed = new Date(rawValue)
+  if (Number.isNaN(parsed.getTime())) {
+    return null
+  }
+
+  return parsed.toISOString().slice(11, 19)
+}
+
+function getLatestStrategyUpdatedAt(strategies: StrategyConfig[]): string | null {
+  let latestUpdatedAt: string | null = null
+  let latestTimestamp = Number.NEGATIVE_INFINITY
+
+  for (const strategy of strategies) {
+    if (typeof strategy.updated_at !== 'string' || !strategy.updated_at.trim()) {
+      continue
+    }
+
+    const parsedTimestamp = new Date(strategy.updated_at).getTime()
+    if (Number.isNaN(parsedTimestamp) || parsedTimestamp <= latestTimestamp) {
+      continue
+    }
+
+    latestTimestamp = parsedTimestamp
+    latestUpdatedAt = strategy.updated_at
+  }
+
+  return latestUpdatedAt
+}
+
 function createBacktestTabs(): Array<{ key: string; label: string }> {
   return [
     { key: 'designer', label: '策略设计器' },
@@ -71,11 +122,10 @@ function createDefaultBenchmarkOptions(): BacktestOption[] {
 }
 
 function createEmptyBacktestWorkbenchConfig(): BacktestWorkbenchDataConfig {
-  const now = new Date()
   return {
     tabs: createBacktestTabs(),
     systemStatus: '运行中 · REAL 数据源待同步',
-    lastUpdated: now.toLocaleString(),
+    lastUpdated: EMPTY_UPDATED_LABEL,
     summary: {
       totalRuns: 0,
       winRate: 0,
@@ -114,7 +164,7 @@ function createEmptyBacktestWorkbenchConfig(): BacktestWorkbenchDataConfig {
         { name: '绩效计算', status: 'queued', statusClass: 'queued' }
       ]
     },
-    runLogs: [{ ts: now.toTimeString().slice(0, 8), msg: 'REAL 模式已就绪，等待策略数据。' }],
+    runLogs: [{ ts: EMPTY_LOG_TIME, msg: 'REAL 模式已就绪，等待策略数据。' }],
     optimizeRows: [],
     optimizeHints: [
       { label: '建议仓位上限', value: '--', variant: '' },
@@ -227,7 +277,9 @@ function mapStatusClass(status?: StrategyStatus): BacktestStatusClass {
 
 export function createBacktestWorkbenchRealConfig(strategies: StrategyConfig[]): BacktestWorkbenchDataConfig {
   const baseConfig = createEmptyBacktestWorkbenchConfig()
-  const currentTimestamp = new Date().toLocaleString()
+  const latestUpdatedAt = getLatestStrategyUpdatedAt(strategies)
+  const stableUpdatedLabel = toStableDateTimeLabel(latestUpdatedAt) ?? EMPTY_UPDATED_LABEL
+  const stableLogTime = toStableTimeLabel(latestUpdatedAt) ?? EMPTY_LOG_TIME
   const getStrategyDisplayName = (item: StrategyConfig, index: number) => item.strategy_name || `策略 ${index + 1}`
   const getParametersCount = (item: StrategyConfig) => item.parameters?.length ?? 0
   const getStrategyStatus = (item: StrategyConfig) => item.status || 'draft'
@@ -235,8 +287,7 @@ export function createBacktestWorkbenchRealConfig(strategies: StrategyConfig[]):
   if (!strategies.length) {
     return {
       ...baseConfig,
-      systemStatus: '运行中 · REAL 策略接口可用（暂无策略）',
-      lastUpdated: currentTimestamp
+      systemStatus: '运行中 · REAL 策略接口可用（暂无策略）'
     }
   }
 
@@ -274,7 +325,7 @@ export function createBacktestWorkbenchRealConfig(strategies: StrategyConfig[]):
   return {
     ...baseConfig,
     systemStatus: '运行中 · REAL 策略接口可用',
-    lastUpdated: currentTimestamp,
+    lastUpdated: stableUpdatedLabel,
     summary: {
       totalRuns: strategies.length,
       winRate: Number(((activeCount / strategies.length) * 100).toFixed(1)),
@@ -317,7 +368,7 @@ export function createBacktestWorkbenchRealConfig(strategies: StrategyConfig[]):
     ],
     runLogs: [
       {
-        ts: new Date().toTimeString().slice(0, 8),
+        ts: stableLogTime,
         msg: `REAL 模式已接入，策略列表同步完成（${strategies.length} 条）。`
       }
     ]

--- a/web/frontend/src/views/TaskManagement.vue
+++ b/web/frontend/src/views/TaskManagement.vue
@@ -181,22 +181,22 @@ const stats = computed(() => [
   {
     title: '总任务数',
     value: tasks.value.length,
-    tone: 'info' as const
+    tone: 'info'
   },
   {
     title: '运行中',
     value: tasks.value.filter(t => t.status === 'running').length,
-    tone: 'success' as const
+    tone: 'success'
   },
   {
     title: '今日执行',
     value: executions.value.length,
-    tone: 'warning' as const
+    tone: 'warning'
   },
   {
     title: '成功率',
     value: calculateSuccessRate() + '%',
-    tone: 'success' as const
+    tone: 'success'
   }
 ])
 

--- a/web/frontend/tests/unit/config/console-log-cleanup-batch-12.spec.ts
+++ b/web/frontend/tests/unit/config/console-log-cleanup-batch-12.spec.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 
 describe('console log cleanup batch 12', () => {
-  it('removes runtime websocket route debug logs while keeping docs examples intact', () => {
+  it('removes runtime websocket route debug logs while keeping handler-based docs examples intact', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/composables/useWebSocketWithConfig.ts'), 'utf8')
 
     expect(source).not.toContain('console.log(`[WebSocket] 订阅路由 ${routeName} 的频道: ${channel}`)')
@@ -13,6 +13,7 @@ describe('console log cleanup batch 12', () => {
     expect(source).not.toContain('console.log(`[WebSocket] 取消所有 ${unsubscribers.length} 个订阅`)')
     expect(source).not.toContain('console.log(`[WebSocket] 路由 ${routeName} 不需要WebSocket`)')
 
-    expect(source).toContain("*   console.log('收到WebSocket消息:', data)")
+    expect(source).toContain('handleRealtimeMessage(data)')
+    expect(source).toContain('notifyRealtimeMessage(data)')
   })
 })

--- a/web/frontend/tests/unit/config/task-management-style-normalization.spec.ts
+++ b/web/frontend/tests/unit/config/task-management-style-normalization.spec.ts
@@ -13,9 +13,12 @@ describe('TaskManagement style normalization', () => {
 
     expect(viewSource).toContain("'stat-icon'")
     expect(viewSource).toContain('`stat-icon--${stat.tone}`')
-    expect(viewSource).toContain("tone: 'info' as const")
-    expect(viewSource).toContain("tone: 'success' as const")
-    expect(viewSource).toContain("tone: 'warning' as const")
+    expect(viewSource).toContain("tone: 'info'")
+    expect(viewSource).toContain("tone: 'success'")
+    expect(viewSource).toContain("tone: 'warning'")
+    expect(viewSource).not.toContain("tone: 'info' as const")
+    expect(viewSource).not.toContain("tone: 'success' as const")
+    expect(viewSource).not.toContain("tone: 'warning' as const")
 
     expect(viewSource).not.toContain(":style=\"{ borderColor: stat.color }\"")
     expect(viewSource).not.toContain("color: '#409eff'")

--- a/web/frontend/tests/unit/watchlist-service-mutations.spec.ts
+++ b/web/frontend/tests/unit/watchlist-service-mutations.spec.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { postMock, deleteMock } = vi.hoisted(() => ({
+  postMock: vi.fn(),
+  deleteMock: vi.fn(),
+}))
+
+vi.mock('@/api/user.ts', () => ({
+  userApi: {},
+}))
+
+vi.mock('@/utils/request.ts', () => ({
+  request: {
+    post: postMock,
+    delete: deleteMock,
+  },
+}))
+
+import { watchlistService } from '@/api/services/watchlistService.ts'
+
+describe('watchlistService monitoring mutations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates watchlists through the monitoring route', async () => {
+    postMock.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: {
+          id: 9,
+          name: '趋势自选',
+          watchlist_type: 'strategy',
+          risk_profile: { risk_tolerance: 70 },
+          stocks_count: 0,
+        },
+        message: '创建清单成功',
+      },
+    })
+
+    const response = await watchlistService.createWatchlist({
+      name: '趋势自选',
+      watchlist_type: 'strategy',
+      risk_profile: { risk_tolerance: 70 },
+    })
+
+    expect(postMock).toHaveBeenCalledWith('/api/v1/monitoring/watchlists', {
+      name: '趋势自选',
+      watchlist_type: 'strategy',
+      risk_profile: { risk_tolerance: 70 },
+    })
+    expect(response).toEqual({
+      success: true,
+      data: {
+        id: 9,
+        name: '趋势自选',
+        watchlist_type: 'strategy',
+        risk_profile: { risk_tolerance: 70 },
+        stocks_count: 0,
+      },
+      message: '创建清单成功',
+    })
+  })
+
+  it('adds and removes stocks through the monitoring routes', async () => {
+    postMock.mockResolvedValueOnce({
+      data: {
+        success: true,
+        data: {
+          id: 1001,
+          watchlist_id: 9,
+          stock_code: '600519.SH',
+        },
+        message: '添加股票成功',
+      },
+    })
+    deleteMock.mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: '移除股票成功',
+      },
+    })
+
+    const addResponse = await watchlistService.addStockToWatchlist(9, {
+      stock_code: '600519.SH',
+      entry_price: 1680,
+      entry_reason: '白酒龙头',
+      stop_loss_price: 1550,
+      target_price: 1950,
+      weight: 0.35,
+    })
+    const removeResponse = await watchlistService.removeStockFromWatchlist(9, '600519.SH')
+
+    expect(postMock).toHaveBeenCalledWith('/api/v1/monitoring/watchlists/9/stocks', {
+      stock_code: '600519.SH',
+      entry_price: 1680,
+      entry_reason: '白酒龙头',
+      stop_loss_price: 1550,
+      target_price: 1950,
+      weight: 0.35,
+    })
+    expect(deleteMock).toHaveBeenCalledWith('/api/v1/monitoring/watchlists/9/stocks/600519.SH')
+    expect(addResponse).toEqual({
+      success: true,
+      data: null,
+      message: '添加股票成功',
+    })
+    expect(removeResponse).toEqual({
+      success: true,
+      data: null,
+      message: '移除股票成功',
+    })
+  })
+
+  it('deletes watchlists through the monitoring route', async () => {
+    deleteMock.mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: '删除清单成功',
+      },
+    })
+
+    const response = await watchlistService.deleteWatchlist(9)
+
+    expect(deleteMock).toHaveBeenCalledWith('/api/v1/monitoring/watchlists/9')
+    expect(response).toEqual({
+      success: true,
+      data: null,
+      message: '删除清单成功',
+    })
+  })
+})

--- a/web/frontend/tests/unit/watchlist-service-stocks.spec.ts
+++ b/web/frontend/tests/unit/watchlist-service-stocks.spec.ts
@@ -1,12 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { getWatchlistMock } = vi.hoisted(() => ({
-  getWatchlistMock: vi.fn(),
+const { getMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
 }))
 
 vi.mock('@/api/user.ts', () => ({
-  userApi: {
-    getWatchlist: getWatchlistMock,
+  userApi: {},
+}))
+
+vi.mock('@/utils/request.ts', () => ({
+  request: {
+    get: getMock,
   },
 }))
 
@@ -15,116 +19,95 @@ import { watchlistService } from '@/api/services/watchlistService.ts'
 describe('watchlistService stock bridge', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    getWatchlistMock.mockResolvedValue({
-      id: '7',
-      name: '核心观察',
-      isDefault: false,
-      isPublic: false,
-      owner: {
-        userId: 'user-1',
-        username: 'tester',
-        displayName: 'Tester',
-      },
-      stocks: [
-        {
-          symbol: '600519.SH',
-          name: '贵州茅台',
-          market: 'A',
-          currentPrice: 1800.5,
-          changeAmount: 12.3,
-          changePercent: '0.69%',
-          volume: 1000,
-          marketCap: 1,
-          addedAt: '2026-04-02 09:30:00',
-          notes: '白酒龙头',
-          alerts: [
+    getMock
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: [
             {
-              id: 'alert-1',
-              type: 'price',
-              condition: 'above',
-              value: 1900,
-              isActive: true,
-              notificationMethod: 'push',
+              id: 301,
+              watchlist_id: 7,
+              stock_code: '600519.SH',
+              entry_price: 1680,
+              entry_reason: '白酒龙头',
+              stop_loss_price: 1550,
+              target_price: 1950,
+              weight: 0.35,
+              is_active: true,
             },
             {
-              id: 'alert-2',
-              type: 'price',
-              condition: 'below',
-              value: 1600,
-              isActive: false,
-              notificationMethod: 'push',
-            },
-            {
-              id: 'alert-3',
-              type: 'volume',
-              condition: 'above',
-              value: 1000000,
-              isActive: true,
-              notificationMethod: 'push',
+              id: 302,
+              watchlist_id: 7,
+              stock_code: '000001.SZ',
+              is_active: true,
             },
           ],
-          customFields: {
-            entry_price: 1680,
-            stop_loss_price: 1550,
-            target_price: 1950,
-            weight: 0.35,
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: [
+            {
+              level: 'warning',
+              type: 'stop_loss',
+              stock_code: '600519.SH',
+              message: '触及止损线',
+              details: {},
+            },
+            {
+              level: 'info',
+              type: 'rebalance',
+              stock_code: '600519.SH',
+              message: '建议调仓',
+              details: {},
+            },
+            {
+              level: 'warning',
+              type: 'stop_loss',
+              stock_code: '000001.SZ',
+              message: '关注支撑位',
+              details: {},
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          success: true,
+          data: {
+            quotes: [
+              {
+                symbol: '600519.SH',
+                name: '贵州茅台',
+                current_price: 1800.5,
+              },
+              {
+                symbol: '000001.SZ',
+                name: '平安银行',
+                current_price: 12.34,
+              },
+            ],
           },
         },
-        {
-          symbol: '000001.SZ',
-          name: '平安银行',
-          market: 'A',
-          currentPrice: 12.34,
-          changeAmount: -0.08,
-          changePercent: '-0.64%',
-          volume: 2000,
-          marketCap: 1,
-          addedAt: '2026-04-02 09:35:00',
-          alerts: [
-            {
-              id: 'alert-4',
-              type: 'price',
-              condition: 'below',
-              value: 11.5,
-              isActive: true,
-              notificationMethod: 'push',
-            },
-          ],
-        },
-      ],
-      statistics: {
-        totalStocks: 2,
-        totalValue: 0,
-        todayChange: 0,
-        todayChangePercent: '0%',
-        bestPerformer: {
-          symbol: '600519.SH',
-          name: '贵州茅台',
-          changePercent: '0.69%',
-        },
-        worstPerformer: {
-          symbol: '000001.SZ',
-          name: '平安银行',
-          changePercent: '-0.64%',
-        },
-        sectors: [],
-      },
-      tags: [],
-      createdAt: '2026-04-01 09:00:00',
-      updatedAt: '2026-04-02 09:00:00',
-      sortOrder: 0,
-    })
+      })
   })
 
-  it('maps watchlist detail stocks into monitoring records instead of returning an empty placeholder list', async () => {
+  it('merges monitoring stock rows with portfolio alerts and quotes instead of reading the generic user watchlist detail API', async () => {
     const response = await watchlistService.listWatchlistStocks(7)
 
-    expect(getWatchlistMock).toHaveBeenCalledWith('7')
+    expect(getMock).toHaveBeenNthCalledWith(1, '/api/v1/monitoring/watchlists/7/stocks')
+    expect(getMock).toHaveBeenNthCalledWith(2, '/api/v1/monitoring/analysis/portfolio/7/alerts')
+    expect(getMock).toHaveBeenNthCalledWith(3, '/api/v1/market/quotes', {
+      params: {
+        symbols: '600519.SH,000001.SZ',
+      },
+    })
     expect(response).toEqual({
       success: true,
       data: [
         {
-          id: 1,
+          id: 301,
           stock_code: '600519.SH',
           entry_price: 1680,
           current_price: 1800.5,
@@ -135,7 +118,7 @@ describe('watchlistService stock bridge', () => {
           alerts_count: 2,
         },
         {
-          id: 2,
+          id: 302,
           stock_code: '000001.SZ',
           entry_price: undefined,
           current_price: 12.34,
@@ -146,6 +129,7 @@ describe('watchlistService stock bridge', () => {
           alerts_count: 1,
         },
       ],
+      message: undefined,
     })
   })
 })

--- a/web/frontend/tests/unit/watchlist-service-watchlists.spec.ts
+++ b/web/frontend/tests/unit/watchlist-service-watchlists.spec.ts
@@ -1,12 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { getWatchlistsMock } = vi.hoisted(() => ({
-  getWatchlistsMock: vi.fn(),
+const { getMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
 }))
 
 vi.mock('@/api/user.ts', () => ({
-  userApi: {
-    getWatchlists: getWatchlistsMock,
+  userApi: {},
+}))
+
+vi.mock('@/utils/request.ts', () => ({
+  request: {
+    get: getMock,
   },
 }))
 
@@ -15,33 +19,35 @@ import { watchlistService } from '@/api/services/watchlistService.ts'
 describe('watchlistService watchlist normalization', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    getWatchlistsMock.mockResolvedValue([
-      {
-        id: '5',
-        name: '高股息',
-        statistics: {
-          totalStocks: 3,
-        },
-        stocks: [],
-      },
-      {
-        id: '6',
-        name: '成长股',
-        statistics: {
-          totalStocks: 0,
-        },
-        stocks: [
-          { symbol: '300750.SZ' },
-          { symbol: '002594.SZ' },
+    getMock.mockResolvedValue({
+      data: {
+        success: true,
+        data: [
+          {
+            id: '5',
+            name: '高股息',
+            watchlist_type: 'manual',
+            risk_profile: {},
+            stocks_count: 3,
+          },
+          {
+            id: '6',
+            name: '成长股',
+            watchlist_type: 'strategy',
+            risk_profile: {
+              risk_tolerance: 80,
+            },
+            stocks_count: 2,
+          },
         ],
       },
-    ])
+    })
   })
 
-  it('derives stocks_count from watchlist statistics or stock rows instead of defaulting to zero', async () => {
+  it('loads watchlists from the monitoring route instead of the generic user watchlist API', async () => {
     const response = await watchlistService.listWatchlists()
 
-    expect(getWatchlistsMock).toHaveBeenCalledTimes(1)
+    expect(getMock).toHaveBeenCalledWith('/api/v1/monitoring/watchlists')
     expect(response).toEqual({
       success: true,
       data: [
@@ -55,11 +61,12 @@ describe('watchlistService watchlist normalization', () => {
         {
           id: 6,
           name: '成长股',
-          watchlist_type: 'manual',
-          risk_profile: {},
+          watchlist_type: 'strategy',
+          risk_profile: { risk_tolerance: 80 },
           stocks_count: 2,
         },
       ],
+      message: undefined,
     })
   })
 })


### PR DESCRIPTION
## Summary
- switch the remaining `watchlistService` list and mutation methods from the generic user watchlist API to the monitoring routes
- merge monitoring watchlist stocks with monitoring alerts and market quotes so `alerts_count` and `current_price` stay available to existing consumers
- add focused vitest coverage for monitoring watchlist list, stock, and mutation contracts

## Testing
- cd web/frontend && npx vitest run tests/unit/watchlist-service-watchlists.spec.ts tests/unit/watchlist-service-stocks.spec.ts tests/unit/watchlist-service-mutations.spec.ts tests/unit/watchlist-service-update.spec.ts tests/unit/watchlist-management-alert-summary.spec.ts tests/unit/wencai-query-table.spec.ts --config vitest.config.mts
- git diff --check