### PR TITLE
fix(frontend): type strategy dialog request payloads

### DIFF
--- a/governance/mainline/task-cards/pr-57.yaml
+++ b/governance/mainline/task-cards/pr-57.yaml
@@ -1,0 +1,92 @@
+version: "v0.2"
+
+task:
+  id: "pr-57"
+  title: "type strategy dialog request payloads"
+  owner: "main"
+  created_at: "2026-04-05"
+
+mainline:
+  id: "L1-strategy-dialog-request-typing"
+  objective: "remove the StrategyDialog ts-nocheck escape hatch and align create/update payloads with the generated strategy request types without pulling unrelated frontend work into the PR"
+  milestone_id: "L3-mainline-follow-up"
+  slice_id: "L4-strategy-dialog-request-typing"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "frontend"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-strategy-dialog-type-hardening-with-focused-regression"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-57.yaml"
+    - "web/frontend/src/components/StrategyDialog.vue"
+    - "web/frontend/tests/unit/config/strategy-dialog-types-cleanup.spec.ts"
+  forbidden_paths:
+    - "web/frontend/src/App.vue"
+    - "web/frontend/src/views/**"
+
+non_goals:
+  - "No strategy page redesign or route migration"
+  - "No broader strategy service/composable refactor beyond the dialog payload contract"
+
+acceptance:
+  checks:
+    - id: "strategy-dialog-vitest"
+      command: "cd web/frontend && npx vitest run tests/unit/config/strategy-dialog-types-cleanup.spec.ts"
+      required: true
+    - id: "strategy-dialog-eslint"
+      command: "cd web/frontend && npx eslint src/components/StrategyDialog.vue"
+      required: true
+    - id: "strategy-dialog-vue-tsc"
+      command: "cd web/frontend && npx vue-tsc --noEmit --pretty false"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-57.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the default constraints or risk limits do not match backend expectations, create-strategy submissions can fail at runtime"
+    - "If the update payload id requirement diverges from the dialog caller contract, save events can break for edit flows"
+  rollback_plan: "git revert <merge-commit-sha> if strategy dialog create or update flows regress after merge"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "remove the StrategyDialog type escape hatch and align emitted request payloads with the generated frontend API contract"
+    modified_scope: "StrategyDialog component, one focused frontend regression test, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "runtime behavior changes only in the dialog payload construction path by supplying required defaults and update ids"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if strategy dialog create or edit submission behavior regresses"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-05T00:00:00Z"
+    approval_note: "localized frontend request-typing fix with dedicated regression coverage"
+    secondary_approved: false

--- a/web/frontend/src/components/StrategyDialog.vue
+++ b/web/frontend/src/components/StrategyDialog.vue
@@ -91,10 +91,14 @@
 </template>
 
 <script setup lang="ts">
-// @ts-nocheck
-
 import { ref, computed, watch } from 'vue';
-import type { StrategyVM as Strategy, CreateStrategyRequestVM as CreateStrategyRequest, UpdateStrategyRequestVM as UpdateStrategyRequest } from '@/api/types/extensions';
+import type {
+  StrategyVM as Strategy,
+  CreateStrategyRequestVM as CreateStrategyRequest,
+  UpdateStrategyRequestVM as UpdateStrategyRequest,
+  StrategyConstraintsVM,
+  RiskLimitsVM,
+} from '@/api/types/extensions';
 
 const props = defineProps<{
   strategy?: Strategy | null;
@@ -110,6 +114,26 @@ const show = computed(() => !!props.strategy);
 const isEditing = computed(() => !!props.strategy);
 
 const isSubmitting = ref(false);
+
+const defaultConstraints: StrategyConstraintsVM = {
+  allowed_symbols: [],
+  allowed_sectors: [],
+  forbidden_symbols: [],
+  trading_hours: {
+    start: '09:30',
+    end: '15:00',
+  },
+  market_conditions: [],
+};
+
+const defaultRiskLimits: RiskLimitsVM = {
+  daily_pnl_limit: 0,
+  single_stock_loss_limit: 0,
+  total_drawdown_limit: 0,
+  max_holding_period_days: 0,
+  max_consecutive_losses: 0,
+  max_loss_per_trade: 0,
+};
 
 const formData = ref<{
   name: string;
@@ -130,7 +154,7 @@ watch(
     if (strategy) {
       formData.value = {
         name: strategy.name,
-        description: strategy.description,
+        description: strategy.description ?? '',
         type: strategy.type,
         parameters: { ...strategy.parameters },
       };
@@ -158,6 +182,7 @@ const addParameter = () => {
 const handleSubmit = () => {
   if (isEditing.value && props.strategy) {
     const data: UpdateStrategyRequest = {
+      id: props.strategy.id,
       name: formData.value.name,
       description: formData.value.description,
       parameters: formData.value.parameters,
@@ -169,6 +194,8 @@ const handleSubmit = () => {
       description: formData.value.description,
       type: formData.value.type,
       parameters: formData.value.parameters,
+      constraints: defaultConstraints,
+      risk_limits: defaultRiskLimits,
     };
     emit('save', data);
   }

--- a/web/frontend/tests/unit/config/strategy-dialog-types-cleanup.spec.ts
+++ b/web/frontend/tests/unit/config/strategy-dialog-types-cleanup.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+describe('strategy dialog type cleanup', () => {
+  it('keeps the strategy dialog free of ts-nocheck', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/components/StrategyDialog.vue'), 'utf8')
+    const tsNoCheckDirective = '@ts-' + 'nocheck'
+
+    expect(source).not.toContain(tsNoCheckDirective)
+  })
+})


### PR DESCRIPTION
## Summary
- remove `@ts-nocheck` from `StrategyDialog.vue`
- align create/update payloads with generated strategy request types
- add a focused regression test to keep the component free of `ts-nocheck`

## Test Plan
- `cd web/frontend && npx vitest run tests/unit/config/strategy-dialog-types-cleanup.spec.ts`
- `cd web/frontend && npx eslint src/components/StrategyDialog.vue`
- `cd web/frontend && npx vue-tsc --noEmit --pretty false`
- `git -C /opt/claude/mystocks_spec/.worktrees/strategy-dialog-types-cleanup-20260405 diff --check`
- `gitnexus_detect_changes(scope=staged)` -> `changed_files=2`, `risk=low`, `affected_processes=0`
