### PR TITLE
test(api): replace placeholder route contract tests batch 1

### DIFF
--- a/governance/mainline/task-cards/pr-58.yaml
+++ b/governance/mainline/task-cards/pr-58.yaml
@@ -1,0 +1,90 @@
+version: "v0.2"
+
+task:
+  id: "pr-58"
+  title: "replace placeholder api file tests batch 1"
+  owner: "main"
+  created_at: "2026-04-05"
+
+mainline:
+  id: "L1-api-file-tests-contract-batch1"
+  objective: "replace placeholder file-level tests for auth, health, tradingview, and wencai with real route and model contract assertions without pulling unrelated backend or frontend work into the PR"
+  milestone_id: "L3-mainline-follow-up"
+  slice_id: "L4-api-file-tests-contract-batch1"
+
+classification:
+  task_type: "test"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "backend-api-contracts"
+  node_id: "backend-api-file-tests"
+  affected_entrypoints:
+    - "tests"
+    - "backend"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "localized-test-hardening-slice-without-application-code-changes"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-58.yaml"
+    - "tests/api/file_tests/test_auth_api.py"
+    - "tests/api/file_tests/test_health_api.py"
+    - "tests/api/file_tests/test_tradingview_api.py"
+    - "tests/api/file_tests/test_wencai_api.py"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "web/backend/app/**"
+    - "src/**"
+
+non_goals:
+  - "No backend application logic changes"
+  - "No frontend route or page migration work"
+  - "No expansion to the other placeholder api file-tests in this micro-batch"
+
+acceptance:
+  checks:
+    - id: "api-file-tests-batch1"
+      command: "python -m pytest --no-cov tests/api/file_tests/test_auth_api.py tests/api/file_tests/test_health_api.py tests/api/file_tests/test_tradingview_api.py tests/api/file_tests/test_wencai_api.py"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-58.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If any asserted route surface or docstring no longer matches the live backend module, the focused file-tests will fail until the contract is updated"
+    - "If the batch accidentally pulls in unrelated test fixtures or application imports, mainline scope drift could invalidate the PR"
+  rollback_plan: "git revert <merge-commit-sha> if the route-contract assertions prove too brittle on mainline"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "replace four placeholder backend api file-tests with route and model contract assertions against the currently exported modules"
+    modified_scope: "four api file-test files plus this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none in runtime behavior; only the test harness becomes stricter and more truthful"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if these file-tests introduce noisy failures on mainline"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-05T00:00:00Z"
+    approval_note: "focused test-hardening micro-batch with isolated scope and dedicated verification"
+    secondary_approved: false

--- a/governance/mainline/task-cards/pr-58.yaml
+++ b/governance/mainline/task-cards/pr-58.yaml
@@ -13,7 +13,7 @@ mainline:
   slice_id: "L4-api-file-tests-contract-batch1"
 
 classification:
-  task_type: "test"
+  task_type: "cleanup"
   secondary_type: "none"
   secondary_change_budget_percent: 0
   secondary_allowed_paths: []
@@ -23,11 +23,11 @@ openspec:
   approval_status: "not_required"
 
 function_tree:
-  domain_id: "backend-api-contracts"
-  node_id: "backend-api-file-tests"
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
   affected_entrypoints:
     - "tests"
-    - "backend"
+    - "api"
   update_status: "not-needed"
   secondary_domains: []
   exemption_reason: "localized-test-hardening-slice-without-application-code-changes"

--- a/tests/api/file_tests/test_auth_api.py
+++ b/tests/api/file_tests/test_auth_api.py
@@ -1,158 +1,113 @@
 """
-File-level tests for auth.py API endpoints
+File-level route contract tests for auth.py.
 
-Tests all authentication and authorization endpoints including:
-- User login/logout
-- Token refresh and validation
-- User registration and management
-- Password reset functionality
-- CSRF token management
-
-Priority: P0 (Contract-managed)
-Coverage: 100% functional + contract validation
+这里验证当前生效的鉴权路由面和关键元数据，
+避免把文件级测试退化成只检查 fixture 的占位脚手架。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any, Dict, get_origin
 
 import pytest
+from fastapi.security import HTTPBearer
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def auth_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    return importlib.import_module("app.api.auth")
 
 
 class TestAuthAPIFile:
-    """Test suite for auth.py API file"""
+    @pytest.mark.file_test
+    @pytest.mark.contract_test
+    def test_router_registers_expected_auth_routes(self, auth_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in auth_module.router.routes}
+
+        assert ("/login", ("POST",)) in route_methods
+        assert ("/logout", ("POST",)) in route_methods
+        assert ("/me", ("GET",)) in route_methods
+        assert ("/refresh", ("POST",)) in route_methods
+        assert ("/users", ("GET",)) in route_methods
+        assert ("/csrf/token", ("GET",)) in route_methods
+        assert ("/register", ("POST",)) in route_methods
+        assert ("/reset-password/request", ("POST",)) in route_methods
+        assert ("/reset-password/confirm", ("POST",)) in route_methods
+
+    @pytest.mark.file_test
+    def test_register_route_keeps_created_status_code(self, auth_module):
+        register_route = next(route for route in auth_module.router.routes if route.path == "/register")
+
+        assert register_route.status_code == 201
+
+    @pytest.mark.file_test
+    def test_me_route_uses_user_response_model(self, auth_module):
+        me_route = next(route for route in auth_module.router.routes if route.path == "/me")
+
+        assert me_route.response_model is auth_module.User
+
+    @pytest.mark.file_test
+    def test_logout_refresh_and_users_routes_return_mapping_types(self, auth_module):
+        logout_route = next(route for route in auth_module.router.routes if route.path == "/logout")
+        refresh_route = next(route for route in auth_module.router.routes if route.path == "/refresh")
+        users_route = next(route for route in auth_module.router.routes if route.path == "/users")
+
+        assert get_origin(logout_route.response_model) is dict
+        assert logout_route.response_model == Dict[str, Any]
+        assert refresh_route.response_model == Dict[str, Any]
+        assert users_route.response_model == Dict[str, Any]
+
+    @pytest.mark.file_test
+    def test_security_dependency_uses_http_bearer(self, auth_module):
+        assert isinstance(auth_module.security, HTTPBearer)
+
+    @pytest.mark.file_test
+    def test_login_docstring_mentions_rate_limit_and_token_response(self, auth_module):
+        doc = auth_module.login_for_access_token.__doc__ or ""
+
+        assert "速率限制" in doc
+        assert "访问令牌" in doc
+
+    @pytest.mark.file_test
+    def test_csrf_token_endpoint_docstring_mentions_csrf_contract(self, auth_module):
+        doc = auth_module.get_csrf_token.__doc__ or ""
+
+        assert "CSRF" in doc
+        assert "token" in doc.lower()
+
+    @pytest.mark.file_test
+    def test_password_reset_endpoints_expose_stable_function_names(self, auth_module):
+        reset_request_route = next(route for route in auth_module.router.routes if route.path == "/reset-password/request")
+        reset_confirm_route = next(route for route in auth_module.router.routes if route.path == "/reset-password/confirm")
+
+        assert reset_request_route.endpoint.__name__ == "request_password_reset"
+        assert reset_confirm_route.endpoint.__name__ == "confirm_password_reset"
 
     @pytest.mark.file_test
     @pytest.mark.contract_test
-    def test_login_endpoint(self, api_test_fixtures):
-        """Test POST /login - User login"""
-        # Test user authentication
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_route_paths_are_unique(self, auth_module):
+        paths = [route.path for route in auth_module.router.routes]
+
+        assert len(paths) == len(set(paths))
+        assert len(paths) == 9
 
     @pytest.mark.file_test
-    def test_logout_endpoint(self, api_test_fixtures):
-        """Test POST /logout - User logout"""
-        # Test user session termination
-        assert api_test_fixtures["retry_attempts"] >= 1
-
-    @pytest.mark.file_test
-    def test_user_info_endpoint(self, api_test_fixtures):
-        """Test GET /me - Get current user information"""
-        # Test authenticated user info retrieval
-        assert api_test_fixtures["mock_enabled"] is True
-
-    @pytest.mark.file_test
-    def test_token_refresh_endpoint(self, api_test_fixtures):
-        """Test POST /refresh - Refresh access token"""
-        # Test token refresh functionality
-        assert api_test_fixtures["contract_validation"] is True
-
-    @pytest.mark.file_test
-    def test_user_list_endpoint(self, api_test_fixtures):
-        """Test GET /users - Get user list (admin only)"""
-        # Test user management functionality
-        assert api_test_fixtures["test_timeout"] > 0
-
-    @pytest.mark.file_test
-    def test_csrf_token_endpoint(self, api_test_fixtures):
-        """Test GET /csrf/token - Get CSRF token"""
-        # Test CSRF protection token generation
-        assert True
-
-    @pytest.mark.file_test
-    def test_user_registration_endpoint(self, api_test_fixtures):
-        """Test POST /register - User registration"""
-        # Test new user account creation
-        assert True
-
-    @pytest.mark.file_test
-    def test_password_reset_request_endpoint(self, api_test_fixtures):
-        """Test POST /reset-password/request - Password reset request"""
-        # Test password reset initiation
-        assert True
-
-    @pytest.mark.file_test
-    @pytest.mark.contract_test
-    def test_contract_compliance(self, contract_specs):
-        """Test OpenAPI contract compliance for auth.py"""
-        # Authentication endpoints may not have dedicated contract but should be validated
-        assert True  # Contract compliance check
-
-    @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across authentication endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
-
-    @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for auth endpoints"""
-        # Validate response schemas match authentication standards
-        assert True  # Placeholder
-
-    @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for auth endpoints"""
-        # Validate response times are within acceptable limits
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for auth operations
-
-    @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_concurrent_auth_operations(self):
-        """Test concurrent authentication operations"""
-        # Test multiple simultaneous auth operations
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
-
-    @pytest.mark.file_test
-    def test_auth_data_consistency(self):
-        """Test data consistency across auth operations"""
-        # Ensure auth data remains consistent across operations
-        assert True
-
-    @pytest.mark.file_test
-    def test_authentication_workflow(self):
-        """Test complete authentication workflow"""
-        # Test login -> access protected resource -> logout workflow
-        assert True
-
-
-class TestAuthIntegration:
-    """Integration tests for auth.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_auth_api_integration(self):
-        """Test authentication with API access control"""
-        # Test authenticated API access
-        assert True
-
-    @pytest.mark.file_test
-    def test_auth_session_management(self):
-        """Test session management across requests"""
-        # Test session persistence and management
-        assert True
-
-
-class TestAuthSecurityValidation:
-    """Security validation tests for auth API"""
-
-    @pytest.mark.file_test
-    def test_password_security(self):
-        """Test password security requirements"""
-        # Validate password strength requirements
-        assert True
-
-    @pytest.mark.file_test
-    def test_token_security(self):
-        """Test token security and expiration"""
-        # Validate token security measures
-        assert True
-
-    @pytest.mark.file_test
-    def test_brute_force_protection(self):
-        """Test brute force attack protection"""
-        # Validate rate limiting and attack prevention
-        assert True
+    def test_auth_support_functions_are_callable(self, auth_module):
+        assert callable(auth_module.get_current_user)
+        assert callable(auth_module.get_current_active_user)
+        assert callable(auth_module.check_permission)

--- a/tests/api/file_tests/test_health_api.py
+++ b/tests/api/file_tests/test_health_api.py
@@ -1,131 +1,131 @@
 """
-File-level tests for health.py API endpoints
+File-level route and helper contract tests for health.py.
 
-Tests all health check endpoints including:
-- Service availability checks
-- Dependency health monitoring
-- System component status
-- Health status reporting
-
-Priority: P2 (Utility)
-Coverage: 70% functional + smoke testing
+这里覆盖当前实际暴露的健康检查路由，以及几个纯函数分支。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import io
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def health_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    return importlib.import_module("app.api.health")
 
 
 class TestHealthAPIFile:
-    """Test suite for health.py API file"""
+    @pytest.mark.file_test
+    def test_router_registers_expected_health_routes(self, health_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in health_module.router.routes}
+
+        assert health_module.router.tags == ["health"]
+        assert ("/health", ("GET",)) in route_methods
+        assert ("/health/detailed", ("GET",)) in route_methods
+        assert ("/reports/health/{timestamp}", ("GET",)) in route_methods
 
     @pytest.mark.file_test
-    def test_health_check_endpoint(self, api_test_fixtures):
-        """Test GET /api/health - Basic health check"""
-        # Test basic service availability
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_route_names_remain_stable(self, health_module):
+        route_names = {(route.path, tuple(sorted(route.methods or []))): route.name for route in health_module.router.routes}
+
+        assert route_names[("/health", ("GET",))] == "check_system_health"
+        assert route_names[("/health/detailed", ("GET",))] == "detailed_health_check"
+        assert route_names[("/reports/health/{timestamp}", ("GET",))] == "get_health_report"
 
     @pytest.mark.file_test
-    def test_health_detailed_endpoint(self, api_test_fixtures):
-        """Test GET /api/health/detailed - Detailed health status"""
-        # Test comprehensive health assessment
-        assert api_test_fixtures["retry_attempts"] >= 1
+    def test_health_models_expose_expected_fields(self, health_module):
+        health_fields = set(health_module.HealthStatus.model_fields)
+        response_fields = set(health_module.HealthResponse.model_fields)
+
+        assert health_fields == {"service", "status", "details", "response_time"}
+        assert response_fields == {"timestamp", "overall_status", "services", "report_url"}
 
     @pytest.mark.file_test
-    def test_health_database_endpoint(self, api_test_fixtures):
-        """Test GET /api/health/database - Database health"""
-        # Test database connectivity and health
-        assert api_test_fixtures["mock_enabled"] is True
+    def test_resolve_ports_filters_invalid_values(self, health_module, monkeypatch):
+        monkeypatch.setenv("PORT_OK", "8020")
+        monkeypatch.setenv("PORT_BAD", "abc")
+        monkeypatch.setenv("PORT_ZERO", "0")
+        monkeypatch.delenv("PORT_MISSING", raising=False)
+
+        ports = health_module._resolve_ports("PORT_OK", "PORT_BAD", "PORT_ZERO", "PORT_MISSING")
+
+        assert ports == [8020]
 
     @pytest.mark.file_test
-    def test_health_cache_endpoint(self, api_test_fixtures):
-        """Test GET /api/health/cache - Cache health"""
-        # Test cache service availability
-        assert api_test_fixtures["contract_validation"] is True
-
-    @pytest.mark.file_test
-    def test_health_external_endpoint(self, api_test_fixtures):
-        """Test GET /api/health/external - External services health"""
-        # Test external service dependencies
-        assert api_test_fixtures["test_timeout"] > 0
-
-    @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across health endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
-
-    @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for health endpoints"""
-        # Validate health check response formats
-        assert True  # Placeholder
-
-    @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for health endpoints"""
-        # Validate health check response times
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for health checks
-
     @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_health_monitoring(self):
-        """Test continuous health monitoring"""
-        # Test ongoing health status monitoring
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
+    async def test_check_mongodb_service_maps_optional_unavailable_to_warning(self, health_module, monkeypatch):
+        monkeypatch.setattr(
+            health_module,
+            "check_mongodb_readiness",
+            Mock(return_value={"status": "optional_unavailable", "detail": "not configured", "latency_ms": 12.5}),
+        )
+
+        status = await health_module.check_mongodb_service()
+
+        assert status.service == "mongodb"
+        assert status.status == "warning"
+        assert status.details == "not configured"
+        assert status.response_time == 12.5
 
     @pytest.mark.file_test
-    def test_health_data_consistency(self):
-        """Test data consistency in health checks"""
-        # Ensure health check data remains consistent
-        assert True
+    @pytest.mark.asyncio
+    async def test_check_mongodb_service_maps_ready_to_normal(self, health_module, monkeypatch):
+        monkeypatch.setattr(
+            health_module,
+            "check_mongodb_readiness",
+            Mock(return_value={"status": "ready", "detail": "ok", "latency_ms": 4.2}),
+        )
+
+        status = await health_module.check_mongodb_service()
+
+        assert status.status == "normal"
+        assert status.details == "ok"
 
     @pytest.mark.file_test
-    def test_health_workflow(self):
-        """Test complete health monitoring workflow"""
-        # Test health check -> diagnosis -> reporting workflow
-        assert True
+    @pytest.mark.asyncio
+    async def test_get_health_report_returns_loaded_json(self, health_module, monkeypatch):
+        monkeypatch.setattr(health_module.os.path, "exists", Mock(return_value=True))
+        monkeypatch.setattr(health_module, "open", Mock(return_value=io.StringIO('{"status":"ok"}')), raising=False)
 
+        payload = await health_module.get_health_report("20260401", current_user=SimpleNamespace(username="tester"))
 
-class TestHealthIntegration:
-    """Integration tests for health.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_health_system_integration(self):
-        """Test health checks with system monitoring"""
-        # Test health status integration with system monitoring
-        assert True
+        assert payload == {"status": "ok"}
 
     @pytest.mark.file_test
-    def test_health_load_balancer_integration(self):
-        """Test health checks for load balancer compatibility"""
-        # Test health endpoints for load balancer health checks
-        assert True
+    @pytest.mark.asyncio
+    async def test_get_health_report_raises_not_found_when_file_missing(self, health_module, monkeypatch):
+        monkeypatch.setattr(health_module.os.path, "exists", Mock(return_value=False))
 
-
-class TestHealthValidation:
-    """Validation tests for health API"""
+        with pytest.raises(health_module.NotFoundException):
+            await health_module.get_health_report("missing", current_user=SimpleNamespace(username="tester"))
 
     @pytest.mark.file_test
-    def test_health_api_compliance(self):
-        """Test compliance with health check standards"""
-        # Validate health check API compliance (RFC 7231, etc.)
-        assert True
+    def test_health_endpoint_docstrings_cover_report_and_detailed_checks(self, health_module):
+        assert "系统健康检查API端点" in (health_module.check_system_health.__doc__ or "")
+        assert "详细健康检查" in (health_module.detailed_health_check.__doc__ or "")
+        assert "获取健康检查报告" in (health_module.get_health_report.__doc__ or "")
 
     @pytest.mark.file_test
-    def test_health_check_reliability(self):
-        """Test health check reliability and accuracy"""
-        # Validate health check accuracy and reliability
-        assert True
+    def test_route_path_and_method_pairs_are_unique(self, health_module):
+        route_pairs = [(route.path, tuple(sorted(route.methods or []))) for route in health_module.router.routes]
 
-    @pytest.mark.file_test
-    def test_health_endpoint_coverage(self):
-        """Test that all expected health endpoints are implemented"""
-        # Validate health endpoint coverage
-        assert True
+        assert len(route_pairs) == len(set(route_pairs))

--- a/tests/api/file_tests/test_tradingview_api.py
+++ b/tests/api/file_tests/test_tradingview_api.py
@@ -1,131 +1,114 @@
 """
-File-level tests for tradingview.py API endpoints
+File-level route and model contract tests for tradingview.py.
 
-Tests all TradingView integration endpoints including:
-- Chart data synchronization
-- Technical analysis indicators
-- Drawing tools and annotations
-- Real-time price updates
-
-Priority: P2 (Utility)
-Coverage: 70% functional + smoke testing
+这里对齐当前真实的 TradingView 配置端点与请求模型，
+替换掉生成式占位断言。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def tradingview_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    return importlib.import_module("app.api.tradingview")
 
 
 class TestTradingviewAPIFile:
-    """Test suite for tradingview.py API file"""
+    @pytest.mark.file_test
+    def test_router_registers_expected_tradingview_routes(self, tradingview_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in tradingview_module.router.routes}
+
+        assert ("/chart/config", ("POST",)) in route_methods
+        assert ("/mini-chart/config", ("POST",)) in route_methods
+        assert ("/ticker-tape/config", ("POST",)) in route_methods
+        assert ("/market-overview/config", ("GET",)) in route_methods
+        assert ("/screener/config", ("GET",)) in route_methods
+        assert ("/symbol/convert", ("GET",)) in route_methods
 
     @pytest.mark.file_test
-    def test_tradingview_chart_endpoint(self, api_test_fixtures):
-        """Test GET /api/tradingview/chart/{symbol} - Get chart data"""
-        # Test TradingView chart data retrieval
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_router_contains_expected_number_of_routes(self, tradingview_module):
+        route_pairs = [(route.path, tuple(sorted(route.methods or []))) for route in tradingview_module.router.routes]
+
+        assert len(route_pairs) == 6
+        assert len(route_pairs) == len(set(route_pairs))
 
     @pytest.mark.file_test
-    def test_tradingview_indicators_endpoint(self, api_test_fixtures):
-        """Test GET /api/tradingview/indicators/{symbol} - Get indicators"""
-        # Test TradingView indicators data
-        assert api_test_fixtures["retry_attempts"] >= 1
+    def test_all_routes_use_plain_dict_response_model(self, tradingview_module):
+        for route in tradingview_module.router.routes:
+            assert route.response_model == tradingview_module.Dict
 
     @pytest.mark.file_test
-    def test_tradingview_drawing_endpoint(self, api_test_fixtures):
-        """Test POST /api/tradingview/drawing/save - Save drawings"""
-        # Test drawing tools and annotations
-        assert api_test_fixtures["mock_enabled"] is True
+    def test_route_names_remain_stable_for_core_operations(self, tradingview_module):
+        route_names = {(route.path, tuple(sorted(route.methods or []))): route.name for route in tradingview_module.router.routes}
+
+        assert route_names[("/chart/config", ("POST",))] == "get_chart_config"
+        assert route_names[("/mini-chart/config", ("POST",))] == "get_mini_chart_config"
+        assert route_names[("/ticker-tape/config", ("POST",))] == "get_ticker_tape_config"
+        assert route_names[("/symbol/convert", ("GET",))] == "convert_symbol"
 
     @pytest.mark.file_test
-    def test_tradingview_realtime_endpoint(self, api_test_fixtures):
-        """Test GET /api/tradingview/realtime/{symbol} - Real-time updates"""
-        # Test real-time price updates for TradingView
-        assert api_test_fixtures["contract_validation"] is True
+    def test_chart_config_request_fields_and_defaults_are_stable(self, tradingview_module):
+        fields = tradingview_module.ChartConfigRequest.model_fields
+
+        assert set(fields) == {"symbol", "market", "interval", "theme", "locale", "container_id"}
+        assert fields["market"].default == "CN"
+        assert fields["interval"].default == "D"
+        assert fields["theme"].default == "dark"
+        assert fields["locale"].default == "zh_CN"
+        assert fields["container_id"].default == "tradingview_chart"
 
     @pytest.mark.file_test
-    def test_tradingview_sync_endpoint(self, api_test_fixtures):
-        """Test POST /api/tradingview/sync - Sync with TradingView"""
-        # Test data synchronization with TradingView
-        assert api_test_fixtures["test_timeout"] > 0
+    def test_symbol_item_and_ticker_tape_models_expose_expected_fields(self, tradingview_module):
+        symbol_fields = set(tradingview_module.SymbolItem.model_fields)
+        tape_fields = tradingview_module.TickerTapeConfigRequest.model_fields
+
+        assert symbol_fields == {"proName", "title"}
+        assert set(tape_fields) == {"symbols", "theme", "locale", "container_id"}
+        assert tape_fields["theme"].default == "dark"
+        assert tape_fields["locale"].default == "zh_CN"
+        assert tape_fields["container_id"].default == "tradingview_ticker_tape"
 
     @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across TradingView endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
+    def test_router_exposes_three_post_and_three_get_routes(self, tradingview_module):
+        methods = [tuple(sorted(route.methods or [])) for route in tradingview_module.router.routes]
+
+        assert methods.count(("POST",)) == 3
+        assert methods.count(("GET",)) == 3
 
     @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for TradingView endpoints"""
-        # Validate TradingView response formats
-        assert True  # Placeholder
+    def test_module_docstring_mentions_widgets_and_chart_config(self, tradingview_module):
+        doc = tradingview_module.__doc__ or ""
+
+        assert "TradingView Widget API" in doc
+        assert "widgets" in doc
 
     @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for TradingView endpoints"""
-        # Validate TradingView integration performance
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for TradingView operations
-
-    @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_tradingview_integration(self):
-        """Test TradingView data integration and processing"""
-        # Test TradingView data processing and integration
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
+    def test_docstrings_cover_chart_ticker_and_symbol_conversion(self, tradingview_module):
+        assert "获取 TradingView 图表配置" in (tradingview_module.get_chart_config.__doc__ or "")
+        assert "获取 TradingView Ticker Tape 配置" in (tradingview_module.get_ticker_tape_config.__doc__ or "")
+        assert "将股票代码转换为 TradingView 格式" in (tradingview_module.convert_symbol.__doc__ or "")
 
     @pytest.mark.file_test
-    def test_tradingview_data_consistency(self):
-        """Test data consistency in TradingView operations"""
-        # Ensure TradingView data remains consistent
-        assert True
-
-    @pytest.mark.file_test
-    def test_tradingview_workflow(self):
-        """Test complete TradingView integration workflow"""
-        # Test sync -> display -> update workflow
-        assert True
-
-
-class TestTradingviewIntegration:
-    """Integration tests for tradingview.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_tradingview_chart_integration(self):
-        """Test TradingView integration with chart modules"""
-        # Test TradingView charts with internal charting
-        assert True
-
-    @pytest.mark.file_test
-    def test_tradingview_data_integration(self):
-        """Test TradingView data with internal data sources"""
-        # Test TradingView data integration with local data
-        assert True
-
-
-class TestTradingviewValidation:
-    """Validation tests for TradingView API"""
-
-    @pytest.mark.file_test
-    def test_tradingview_api_compliance(self):
-        """Test compliance with TradingView API specifications"""
-        # Validate TradingView API compliance
-        assert True
-
-    @pytest.mark.file_test
-    def test_tradingview_data_accuracy(self):
-        """Test accuracy of TradingView data integration"""
-        # Validate TradingView data accuracy
-        assert True
-
-    @pytest.mark.file_test
-    def test_tradingview_endpoint_coverage(self):
-        """Test that all expected TradingView endpoints are implemented"""
-        # Validate TradingView endpoint coverage
-        assert True
+    def test_tradingview_routes_stay_under_single_namespace(self, tradingview_module):
+        assert all(
+            (route.path.startswith("/") and "config" in route.path) or route.path == "/symbol/convert"
+            for route in tradingview_module.router.routes
+        )

--- a/tests/api/file_tests/test_wencai_api.py
+++ b/tests/api/file_tests/test_wencai_api.py
@@ -1,131 +1,112 @@
 """
-File-level tests for wencai.py API endpoints
+File-level route and model contract tests for wencai.py.
 
-Tests all WenCai natural language query endpoints including:
-- Natural language stock queries
-- Intelligent question answering
-- Query result parsing and formatting
-- Search result ranking and filtering
-
-Priority: P2 (Utility)
-Coverage: 70% functional + smoke testing
+这里对齐当前真实的问财查询路由与响应模型，
+替换掉生成式占位断言。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def wencai_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    return importlib.import_module("app.api.wencai")
 
 
 class TestWencaiAPIFile:
-    """Test suite for wencai.py API file"""
+    @pytest.mark.file_test
+    def test_router_registers_expected_wencai_routes(self, wencai_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in wencai_module.router.routes}
+
+        assert wencai_module.router.prefix == "/api/market/wencai"
+        assert wencai_module.router.tags == ["wencai"]
+        assert ("/api/market/wencai/queries", ("GET",)) in route_methods
+        assert ("/api/market/wencai/queries/{query_name}", ("GET",)) in route_methods
+        assert ("/api/market/wencai/query", ("POST",)) in route_methods
+        assert ("/api/market/wencai/results/{query_name}", ("GET",)) in route_methods
+        assert ("/api/market/wencai/refresh/{query_name}", ("POST",)) in route_methods
+        assert ("/api/market/wencai/history/{query_name}", ("GET",)) in route_methods
+        assert ("/api/market/wencai/custom-query", ("POST",)) in route_methods
+        assert ("/api/market/wencai/health", ("GET",)) in route_methods
 
     @pytest.mark.file_test
-    def test_wencai_query_endpoint(self, api_test_fixtures):
-        """Test POST /api/wencai/query - Natural language query"""
-        # Test natural language stock query processing
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_router_contains_expected_number_of_routes(self, wencai_module):
+        route_pairs = [(route.path, tuple(sorted(route.methods or []))) for route in wencai_module.router.routes]
+
+        assert len(route_pairs) == 8
+        assert len(route_pairs) == len(set(route_pairs))
 
     @pytest.mark.file_test
-    def test_wencai_search_endpoint(self, api_test_fixtures):
-        """Test GET /api/wencai/search - Search stocks by criteria"""
-        # Test structured search queries
-        assert api_test_fixtures["retry_attempts"] >= 1
+    def test_response_models_remain_stable(self, wencai_module):
+        response_models = {(route.path, tuple(sorted(route.methods or []))): route.response_model for route in wencai_module.router.routes}
+
+        assert response_models[("/api/market/wencai/queries", ("GET",))] is wencai_module.WencaiQueryListResponse
+        assert response_models[("/api/market/wencai/queries/{query_name}", ("GET",))] is wencai_module.WencaiQueryInfo
+        assert response_models[("/api/market/wencai/query", ("POST",))] is wencai_module.WencaiQueryResponse
+        assert response_models[("/api/market/wencai/results/{query_name}", ("GET",))] is wencai_module.WencaiResultsResponse
+        assert response_models[("/api/market/wencai/refresh/{query_name}", ("POST",))] is wencai_module.WencaiRefreshResponse
+        assert response_models[("/api/market/wencai/history/{query_name}", ("GET",))] is wencai_module.WencaiHistoryResponse
+        assert response_models[("/api/market/wencai/custom-query", ("POST",))] is wencai_module.WencaiCustomQueryResponse
+        assert response_models[("/api/market/wencai/health", ("GET",))] is None
 
     @pytest.mark.file_test
-    def test_wencai_analyze_endpoint(self, api_test_fixtures):
-        """Test POST /api/wencai/analyze - Analyze query results"""
-        # Test query result analysis and insights
-        assert api_test_fixtures["mock_enabled"] is True
+    def test_route_names_remain_stable(self, wencai_module):
+        route_names = {(route.path, tuple(sorted(route.methods or []))): route.name for route in wencai_module.router.routes}
+
+        assert route_names[("/api/market/wencai/queries", ("GET",))] == "get_all_queries"
+        assert route_names[("/api/market/wencai/query", ("POST",))] == "execute_query"
+        assert route_names[("/api/market/wencai/custom-query", ("POST",))] == "execute_custom_query"
+        assert route_names[("/api/market/wencai/health", ("GET",))] == "health_check"
 
     @pytest.mark.file_test
-    def test_wencai_suggestions_endpoint(self, api_test_fixtures):
-        """Test GET /api/wencai/suggestions - Query suggestions"""
-        # Test intelligent query suggestions
-        assert api_test_fixtures["contract_validation"] is True
-
-    @pytest.mark.file_test
-    def test_wencai_history_endpoint(self, api_test_fixtures):
-        """Test GET /api/wencai/history - Query history"""
-        # Test user query history tracking
-        assert api_test_fixtures["test_timeout"] > 0
-
-    @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across WenCai endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
-
-    @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for WenCai endpoints"""
-        # Validate WenCai response formats
-        assert True  # Placeholder
-
-    @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for WenCai endpoints"""
-        # Validate WenCai query performance
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for WenCai operations
-
     @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_wencai_nlp_processing(self):
-        """Test natural language processing capabilities"""
-        # Test NLP query understanding and processing
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
+    async def test_health_check_returns_expected_static_payload(self, wencai_module):
+        payload = await wencai_module.health_check()
+
+        assert payload == {"status": "healthy", "service": "wencai", "version": "1.0.0"}
 
     @pytest.mark.file_test
-    def test_wencai_data_consistency(self):
-        """Test data consistency in WenCai operations"""
-        # Ensure WenCai data remains consistent
-        assert True
+    def test_router_exposes_four_get_and_three_post_business_routes_plus_health(self, wencai_module):
+        methods = [tuple(sorted(route.methods or [])) for route in wencai_module.router.routes]
+
+        assert methods.count(("GET",)) == 5
+        assert methods.count(("POST",)) == 3
 
     @pytest.mark.file_test
-    def test_wencai_workflow(self):
-        """Test complete WenCai query workflow"""
-        # Test query -> analysis -> results workflow
-        assert True
+    def test_module_docstring_mentions_restful_stock_screening_api(self, wencai_module):
+        doc = wencai_module.__doc__ or ""
 
-
-class TestWencaiIntegration:
-    """Integration tests for wencai.py with related modules"""
+        assert "问财API路由" in doc
+        assert "RESTful API端点" in doc
 
     @pytest.mark.file_test
-    def test_wencai_data_integration(self):
-        """Test WenCai integration with data modules"""
-        # Test WenCai queries with internal data sources
-        assert True
+    def test_docstrings_cover_queries_results_and_custom_query(self, wencai_module):
+        assert "获取所有查询列表" in (wencai_module.get_all_queries.__doc__ or "")
+        assert "获取查询结果" in (wencai_module.get_query_results.__doc__ or "")
+        assert "执行自定义查询" in (wencai_module.execute_custom_query.__doc__ or "")
 
     @pytest.mark.file_test
-    def test_wencai_strategy_integration(self):
-        """Test WenCai with strategy analysis"""
-        # Test natural language strategy queries
-        assert True
-
-
-class TestWencaiValidation:
-    """Validation tests for WenCai API"""
+    def test_background_refresh_task_helper_is_exported_and_callable(self, wencai_module):
+        assert callable(wencai_module._refresh_query_task)
 
     @pytest.mark.file_test
-    def test_wencai_api_compliance(self):
-        """Test compliance with WenCai API specifications"""
-        # Validate WenCai API compliance
-        assert True
-
-    @pytest.mark.file_test
-    def test_wencai_query_accuracy(self):
-        """Test accuracy of WenCai query processing"""
-        # Validate query understanding and result accuracy
-        assert True
-
-    @pytest.mark.file_test
-    def test_wencai_endpoint_coverage(self):
-        """Test that all expected WenCai endpoints are implemented"""
-        # Validate WenCai endpoint coverage
-        assert True
+    def test_all_routes_share_same_wencai_namespace(self, wencai_module):
+        assert all(route.path.startswith("/api/market/wencai") for route in wencai_module.router.routes)


### PR DESCRIPTION
## Summary
- replace placeholder file-level tests for auth, health, tradingview, and wencai with route/model contract assertions
- validate stable route surfaces, response models, and selected helper/docstring contracts without touching application code
- keep the batch scoped to four api file-tests for an isolated low-risk mainline slice

## Test Plan
- python -m pytest --no-cov tests/api/file_tests/test_auth_api.py tests/api/file_tests/test_health_api.py tests/api/file_tests/test_tradingview_api.py tests/api/file_tests/test_wencai_api.py
- git diff --check