### PR TITLE
test(api): replace placeholder route contract tests batch 2

### DIFF
--- a/governance/mainline/task-cards/pr-59.yaml
+++ b/governance/mainline/task-cards/pr-59.yaml
@@ -1,0 +1,89 @@
+version: "v0.2"
+
+task:
+  id: "pr-59"
+  title: "replace placeholder api file tests batch 2"
+  owner: "main"
+  created_at: "2026-04-06"
+
+mainline:
+  id: "L1-api-file-tests-contract-batch2"
+  objective: "replace placeholder file-level tests for announcement, data_source_config, indicator_registry, and multi_source with real route and model contract assertions without pulling unrelated backend or frontend work into the PR"
+  milestone_id: "L3-mainline-follow-up"
+  slice_id: "L4-api-file-tests-contract-batch2"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "domain-10"
+  node_id: "domain-10-node-01"
+  affected_entrypoints:
+    - "tests"
+  update_status: "required"
+  secondary_domains: []
+  exemption_reason: "localized-test-hardening-slice-without-application-code-changes"
+
+scope:
+  allowed_paths:
+    - "governance/mainline/task-cards/pr-59.yaml"
+    - "tests/api/file_tests/test_announcement_api.py"
+    - "tests/api/file_tests/test_data_source_config_api.py"
+    - "tests/api/file_tests/test_indicator_registry_api.py"
+    - "tests/api/file_tests/test_multi_source_api.py"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "web/backend/app/**"
+    - "src/**"
+
+non_goals:
+  - "No backend application logic changes"
+  - "No frontend route or page migration work"
+  - "No expansion to the other placeholder api file-tests in this micro-batch"
+
+acceptance:
+  checks:
+    - id: "api-file-tests-batch2"
+      command: "python -m pytest --no-cov tests/api/file_tests/test_announcement_api.py tests/api/file_tests/test_data_source_config_api.py tests/api/file_tests/test_indicator_registry_api.py tests/api/file_tests/test_multi_source_api.py"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-59.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report governance/mainline/reports/mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If any asserted route surface or docstring no longer matches the live backend module, the focused file-tests will fail until the contract is updated"
+    - "If the batch accidentally pulls in unrelated fixtures or application imports, mainline scope drift could invalidate the PR"
+  rollback_plan: "git revert <merge-commit-sha> if the route-contract assertions prove too brittle on mainline"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "replace four placeholder backend api file-tests with route and model contract assertions against the currently exported modules"
+    modified_scope: "four api file-test files plus this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none in runtime behavior; only the test harness becomes stricter and more truthful"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the slice if these file-tests introduce noisy failures on mainline"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-06T00:00:00Z"
+    approval_note: "focused test-hardening micro-batch with isolated scope and dedicated verification"
+    secondary_approved: false

--- a/tests/api/file_tests/test_announcement_api.py
+++ b/tests/api/file_tests/test_announcement_api.py
@@ -1,152 +1,148 @@
 """
-File-level tests for announcement.py API endpoints
+File-level route contract tests for the active announcement API package.
 
-Tests all announcement-related endpoints including:
-- Announcement listing and details
-- Monitor rules management
-- Statistics and analytics
-- Triggered alerts and notifications
-
-Priority: P0 (Contract-managed)
-Coverage: 100% functional + contract validation
+这里对齐 `app.api.announcement.routes` 当前真实导出的路由集合，
+替换掉生成式占位断言。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def announcement_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    package = importlib.import_module("app.api.announcement")
+    routes = importlib.import_module("app.api.announcement.routes")
+    return package, routes
 
 
 class TestAnnouncementAPIFile:
-    """Test suite for announcement.py API file"""
-
     @pytest.mark.file_test
     @pytest.mark.contract_test
-    def test_announcement_stats_endpoint(self, api_test_fixtures):
-        """Test GET /api/announcement/stats - Get announcement statistics"""
-        # Test announcement statistics retrieval
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_router_registers_base_announcement_routes(self, announcement_module):
+        package, routes = announcement_module
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in routes.router.routes}
+
+        assert package.router is routes.router
+        assert routes.router.prefix == "/announcement"
+        assert ("/announcement/health", ("GET",)) in route_methods
+        assert ("/announcement/status", ("GET",)) in route_methods
+        assert ("/announcement/analyze", ("POST",)) in route_methods
 
     @pytest.mark.file_test
-    def test_announcement_list_endpoint(self, api_test_fixtures):
-        """Test GET /api/announcement/list - Get announcement list"""
-        # Test announcement list retrieval
-        assert api_test_fixtures["retry_attempts"] >= 1
+    def test_router_registers_service_routes_when_service_is_available(self, announcement_module):
+        _, routes = announcement_module
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in routes.router.routes}
+
+        if routes.HAS_ANNOUNCEMENT_SERVICE:
+            assert ("/announcement/fetch", ("POST",)) in route_methods
+            assert ("/announcement/list", ("GET",)) in route_methods
+            assert ("/announcement/today", ("GET",)) in route_methods
+            assert ("/announcement/important", ("GET",)) in route_methods
+            assert ("/announcement/stats", ("GET",)) in route_methods
+            assert ("/announcement/monitor-rules", ("GET",)) in route_methods
+            assert ("/announcement/monitor-rules", ("POST",)) in route_methods
+            assert ("/announcement/monitor-rules/{rule_id}", ("PUT",)) in route_methods
+            assert ("/announcement/monitor-rules/{rule_id}", ("DELETE",)) in route_methods
+            assert ("/announcement/triggered-records", ("GET",)) in route_methods
+            assert ("/announcement/monitor/evaluate", ("POST",)) in route_methods
+        else:
+            assert len(route_methods) == 3
 
     @pytest.mark.file_test
-    def test_announcement_today_endpoint(self, api_test_fixtures):
-        """Test GET /api/announcement/today - Get today's announcements"""
-        # Test today's announcement retrieval
-        assert api_test_fixtures["mock_enabled"] is True
-
-    @pytest.mark.file_test
-    def test_announcement_important_endpoint(self, api_test_fixtures):
-        """Test GET /api/announcement/important - Get important announcements"""
-        # Test important announcement filtering
-        assert api_test_fixtures["contract_validation"] is True
-
-    @pytest.mark.file_test
-    def test_monitor_rules_endpoint(self, api_test_fixtures):
-        """Test GET /api/announcement/monitor-rules - Get monitor rules"""
-        # Test monitor rules retrieval
-        assert api_test_fixtures["test_timeout"] > 0
-
-    @pytest.mark.file_test
-    def test_triggered_records_endpoint(self, api_test_fixtures):
-        """Test GET /api/announcement/triggered-records - Get triggered records"""
-        # Test triggered alert records
-        assert True
-
-    @pytest.mark.file_test
-    def test_evaluate_monitor_endpoint(self, api_test_fixtures):
-        """Test POST /api/announcement/monitor/evaluate - Evaluate monitor rules"""
-        # Test monitor rule evaluation
-        assert True
-
-    @pytest.mark.file_test
-    @pytest.mark.contract_test
-    def test_contract_compliance(self, contract_specs):
-        """Test OpenAPI contract compliance for announcement.py"""
-        # Announcement endpoints are used by frontend but may not have dedicated contract
-        # This test validates any existing contract compliance
-        assert True  # Contract compliance check
-
-    @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across announcement endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
-
-    @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for announcement endpoints"""
-        # Validate response schemas match expected formats
-        assert True  # Placeholder
-
-    @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for announcement endpoints"""
-        # Validate response times are within acceptable limits
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for announcement operations
-
     @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_concurrent_announcement_queries(self):
-        """Test concurrent announcement data queries"""
-        # Test multiple simultaneous announcement queries
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
+    async def test_health_check_returns_service_status(self, announcement_module):
+        _, routes = announcement_module
+
+        payload = await routes.health_check()
+
+        assert payload == {"status": "ok", "service": "announcement"}
 
     @pytest.mark.file_test
-    def test_announcement_data_consistency(self):
-        """Test data consistency across announcement operations"""
-        # Ensure announcement data remains consistent across operations
-        assert True
+    @pytest.mark.asyncio
+    async def test_status_endpoint_returns_active_service_marker(self, announcement_module):
+        _, routes = announcement_module
+
+        payload = await routes.get_status()
+
+        assert payload == {"status": "active", "endpoint": "announcement"}
 
     @pytest.mark.file_test
-    def test_monitor_workflow(self):
-        """Test complete announcement monitoring workflow"""
-        # Test setup rules -> monitor announcements -> trigger alerts workflow
-        assert True
+    @pytest.mark.asyncio
+    async def test_analyze_endpoint_returns_placeholder_result_for_minimal_payload(self, announcement_module):
+        _, routes = announcement_module
 
+        payload = await routes.analyze_data({"symbol": "600519"})
 
-class TestAnnouncementIntegration:
-    """Integration tests for announcement.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_announcement_strategy_integration(self):
-        """Test announcement monitoring with strategy execution"""
-        # Test announcement-driven strategy adjustments
-        assert True
+        assert payload == {"result": "分析完成", "endpoint": "announcement"}
 
     @pytest.mark.file_test
-    def test_announcement_risk_integration(self):
-        """Test announcement impact on risk assessment"""
-        # Test how announcements affect risk calculations
-        assert True
+    @pytest.mark.asyncio
+    async def test_analyze_endpoint_accepts_extended_request_shape(self, announcement_module):
+        _, routes = announcement_module
 
+        payload = await routes.analyze_data(
+            {
+                "symbol": "600519",
+                "keywords": ["回购", "增持"],
+                "categories": ["important", "finance"],
+                "analysis_depth": "advanced",
+            }
+        )
 
-class TestAnnouncementValidation:
-    """Validation tests for announcement API"""
-
-    @pytest.mark.file_test
-    def test_openapi_spec_compliance(self):
-        """Test compliance with API specifications"""
-        # Validate announcement API compliance
-        assert True
-
-    @pytest.mark.file_test
-    def test_response_schema_validation(self):
-        """Test response schemas are properly formatted"""
-        # Validate announcement response schemas
-        assert True
+        assert payload["endpoint"] == "announcement"
+        assert payload["result"] == "分析完成"
 
     @pytest.mark.file_test
-    def test_endpoint_coverage(self):
-        """Test that all expected endpoints are implemented"""
-        # Validate announcement endpoint coverage
-        assert True
+    def test_package_exports_router_in___all__(self, announcement_module):
+        package, routes = announcement_module
+
+        assert package.__all__ == ["router"]
+        assert package.router is routes.router
+
+    @pytest.mark.file_test
+    def test_analyze_docstring_mentions_ai_analysis(self, announcement_module):
+        _, routes = announcement_module
+
+        assert "AI分析" in (routes.analyze_data.__doc__ or "")
+
+    @pytest.mark.file_test
+    def test_health_and_status_handlers_have_stable_names(self, announcement_module):
+        _, routes = announcement_module
+
+        assert routes.health_check.__name__ == "health_check"
+        assert routes.get_status.__name__ == "get_status"
+
+    @pytest.mark.file_test
+    def test_monitor_rules_path_exposes_two_methods_when_service_enabled(self, announcement_module):
+        _, routes = announcement_module
+        methods = [tuple(sorted(route.methods or [])) for route in routes.router.routes if route.path == "/announcement/monitor-rules"]
+
+        if routes.HAS_ANNOUNCEMENT_SERVICE:
+            assert sorted(methods) == [("GET",), ("POST",)]
+        else:
+            assert methods == []
+
+    @pytest.mark.file_test
+    def test_route_paths_remain_unique_per_path_method_pair(self, announcement_module):
+        _, routes = announcement_module
+        route_methods = [(route.path, tuple(sorted(route.methods or []))) for route in routes.router.routes]
+
+        assert len(route_methods) == len(set(route_methods))

--- a/tests/api/file_tests/test_data_source_config_api.py
+++ b/tests/api/file_tests/test_data_source_config_api.py
@@ -1,137 +1,121 @@
 """
-File-level tests for data_source_config.py API endpoints
+File-level route and helper contract tests for data_source_config.py.
 
-Tests all data source configuration endpoints including:
-- Data source registration and management
-- Configuration validation and updates
-- Source priority and routing
-- Configuration persistence and recovery
-
-Priority: P2 (Utility)
-Coverage: 70% functional + smoke testing
+这里对齐当前真实的 CRUD、版本历史、回滚和热重载路由，
+替换掉生成式占位断言。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def data_source_config_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    return importlib.import_module("app.api.data_source_config")
 
 
 class TestDataSourceConfigAPIFile:
-    """Test suite for data_source_config.py API file"""
+    @pytest.mark.file_test
+    def test_router_registers_expected_config_routes(self, data_source_config_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in data_source_config_module.router.routes}
+
+        assert data_source_config_module.router.prefix == "/api/v1/data-sources/config"
+        assert data_source_config_module.router.tags == ["数据源配置管理"]
+        assert ("/api/v1/data-sources/config/", ("POST",)) in route_methods
+        assert ("/api/v1/data-sources/config/", ("GET",)) in route_methods
+        assert ("/api/v1/data-sources/config/{endpoint_name}", ("PUT",)) in route_methods
+        assert ("/api/v1/data-sources/config/{endpoint_name}", ("DELETE",)) in route_methods
+        assert ("/api/v1/data-sources/config/{endpoint_name}", ("GET",)) in route_methods
+        assert ("/api/v1/data-sources/config/batch", ("POST",)) in route_methods
+        assert ("/api/v1/data-sources/config/{endpoint_name}/versions", ("GET",)) in route_methods
+        assert ("/api/v1/data-sources/config/{endpoint_name}/rollback/{version}", ("POST",)) in route_methods
+        assert ("/api/v1/data-sources/config/reload", ("POST",)) in route_methods
 
     @pytest.mark.file_test
-    def test_data_source_list_endpoint(self, api_test_fixtures):
-        """Test GET /api/data-source/config - List data sources"""
-        # Test data source configuration listing
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_router_contains_expected_number_of_route_method_pairs(self, data_source_config_module):
+        route_pairs = [(route.path, tuple(sorted(route.methods or []))) for route in data_source_config_module.router.routes]
+
+        assert len(route_pairs) == 9
+        assert len(route_pairs) == len(set(route_pairs))
 
     @pytest.mark.file_test
-    def test_data_source_register_endpoint(self, api_test_fixtures):
-        """Test POST /api/data-source/register - Register data source"""
-        # Test data source registration
-        assert api_test_fixtures["retry_attempts"] >= 1
+    def test_all_routes_use_unified_response_model(self, data_source_config_module):
+        for route in data_source_config_module.router.routes:
+            assert route.response_model is data_source_config_module.UnifiedResponse
 
     @pytest.mark.file_test
-    def test_data_source_update_endpoint(self, api_test_fixtures):
-        """Test PUT /api/data-source/{id}/config - Update configuration"""
-        # Test data source configuration updates
-        assert api_test_fixtures["mock_enabled"] is True
+    def test_create_route_keeps_created_status_code(self, data_source_config_module):
+        create_route = next(route for route in data_source_config_module.router.routes if route.path == "/api/v1/data-sources/config/" and "POST" in route.methods)
+
+        assert create_route.status_code == 201
 
     @pytest.mark.file_test
-    def test_data_source_validate_endpoint(self, api_test_fixtures):
-        """Test POST /api/data-source/validate - Validate configuration"""
-        # Test configuration validation
-        assert api_test_fixtures["contract_validation"] is True
+    def test_route_names_remain_stable_for_core_operations(self, data_source_config_module):
+        route_names = {(route.path, tuple(sorted(route.methods or []))): route.name for route in data_source_config_module.router.routes}
+
+        assert route_names[("/api/v1/data-sources/config/", ("POST",))] == "create_data_source"
+        assert route_names[("/api/v1/data-sources/config/{endpoint_name}", ("PUT",))] == "update_data_source"
+        assert route_names[("/api/v1/data-sources/config/batch", ("POST",))] == "batch_operations"
+        assert route_names[("/api/v1/data-sources/config/reload", ("POST",))] == "reload_config"
 
     @pytest.mark.file_test
-    def test_data_source_priorities_endpoint(self, api_test_fixtures):
-        """Test GET /api/data-source/priorities - Get priorities"""
-        # Test data source priority management
-        assert api_test_fixtures["test_timeout"] > 0
+    def test_get_current_user_returns_system_in_testing_mode(self, data_source_config_module, monkeypatch):
+        monkeypatch.setattr(data_source_config_module.settings, "testing", True)
+
+        assert data_source_config_module.get_current_user() == "system"
 
     @pytest.mark.file_test
-    def test_data_source_routing_endpoint(self, api_test_fixtures):
-        """Test GET /api/data-source/routing - Get routing rules"""
-        # Test data source routing configuration
-        assert True
+    def test_get_current_user_rejects_missing_authorization_outside_testing(self, data_source_config_module, monkeypatch):
+        monkeypatch.setattr(data_source_config_module.settings, "testing", False)
+
+        with pytest.raises(data_source_config_module.HTTPException) as excinfo:
+            data_source_config_module.get_current_user(None)
+
+        assert excinfo.value.status_code == 401
 
     @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across data source config endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
+    def test_handle_config_error_maps_duplicate_and_not_found(self, data_source_config_module):
+        duplicate = data_source_config_module.handle_config_error("endpoint already exists", "req-1")
+        not_found = data_source_config_module.handle_config_error("record not found", "req-2")
+        generic = data_source_config_module.handle_config_error("boom", "req-3")
+
+        assert duplicate.code == data_source_config_module.BusinessCode.CONFLICT
+        assert duplicate.message == "数据源配置已存在"
+        assert not_found.code == data_source_config_module.BusinessCode.NOT_FOUND
+        assert not_found.message == "数据源配置不存在"
+        assert generic.code == data_source_config_module.BusinessCode.INTERNAL_ERROR
+        assert generic.message == "boom"
 
     @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for data source config endpoints"""
-        # Validate data source config response formats
-        assert True  # Placeholder
+    def test_module_docstring_mentions_crud_versioning_and_hot_reload(self, data_source_config_module):
+        doc = data_source_config_module.__doc__ or ""
+
+        assert "CRUD" in doc
+        assert "版本管理" in doc
+        assert "热重载" in doc
 
     @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for data source config endpoints"""
-        # Validate data source config performance
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for config operations
+    def test_router_response_descriptions_include_success_and_conflict(self, data_source_config_module):
+        responses = data_source_config_module.router.responses
 
-    @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_data_source_config_management(self):
-        """Test data source configuration management"""
-        # Test complete configuration lifecycle
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
-
-    @pytest.mark.file_test
-    def test_data_source_config_consistency(self):
-        """Test data consistency in data source configurations"""
-        # Ensure configuration data remains consistent
-        assert True
-
-    @pytest.mark.file_test
-    def test_data_source_config_workflow(self):
-        """Test complete data source configuration workflow"""
-        # Test register -> validate -> update -> route workflow
-        assert True
-
-
-class TestDataSourceConfigIntegration:
-    """Integration tests for data_source_config.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_data_source_config_data_integration(self):
-        """Test data source config with data modules"""
-        # Test configuration integration with data sources
-        assert True
-
-    @pytest.mark.file_test
-    def test_data_source_config_monitoring_integration(self):
-        """Test data source config with monitoring"""
-        # Test configuration monitoring and alerts
-        assert True
-
-
-class TestDataSourceConfigValidation:
-    """Validation tests for data source config API"""
-
-    @pytest.mark.file_test
-    def test_data_source_config_api_compliance(self):
-        """Test compliance with data source config API specifications"""
-        # Validate data source config API compliance
-        assert True
-
-    @pytest.mark.file_test
-    def test_data_source_config_validation_accuracy(self):
-        """Test accuracy of configuration validation"""
-        # Validate configuration validation logic
-        assert True
-
-    @pytest.mark.file_test
-    def test_data_source_config_endpoint_coverage(self):
-        """Test that all expected data source config endpoints are implemented"""
-        # Validate data source config endpoint coverage
-        assert True
+        assert responses[200]["description"] == "成功"
+        assert responses[201]["description"] == "创建成功"
+        assert responses[409]["description"] == "资源冲突"

--- a/tests/api/file_tests/test_indicator_registry_api.py
+++ b/tests/api/file_tests/test_indicator_registry_api.py
@@ -1,131 +1,120 @@
 """
-File-level tests for indicator_registry.py API endpoints
+File-level route and model contract tests for indicator_registry.py.
 
-Tests all indicator registry endpoints including:
-- Technical indicator registration and management
-- Indicator metadata and configuration
-- Indicator validation and compatibility
-- Custom indicator support
-
-Priority: P2 (Utility)
-Coverage: 70% functional + smoke testing
+这里对齐当前真实的 3 个端点、工厂单例和请求/响应模型，
+替换掉生成式占位断言。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def indicator_registry_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    return importlib.import_module("app.api.indicator_registry")
 
 
 class TestIndicatorRegistryAPIFile:
-    """Test suite for indicator_registry.py API file"""
+    @pytest.mark.file_test
+    def test_router_registers_expected_indicator_registry_routes(self, indicator_registry_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in indicator_registry_module.router.routes}
+
+        assert indicator_registry_module.router.prefix == "/api/indicator-registry"
+        assert indicator_registry_module.router.tags == ["Indicator Registry"]
+        assert ("/api/indicator-registry/indicators", ("GET",)) in route_methods
+        assert ("/api/indicator-registry/indicators/{indicator_id}", ("GET",)) in route_methods
+        assert ("/api/indicator-registry/calculate", ("POST",)) in route_methods
 
     @pytest.mark.file_test
-    def test_indicator_list_endpoint(self, api_test_fixtures):
-        """Test GET /api/indicators - List registered indicators"""
-        # Test indicator registry listing
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_router_contains_expected_number_of_routes(self, indicator_registry_module):
+        route_pairs = [(route.path, tuple(sorted(route.methods or []))) for route in indicator_registry_module.router.routes]
+
+        assert len(route_pairs) == 3
+        assert len(route_pairs) == len(set(route_pairs))
 
     @pytest.mark.file_test
-    def test_indicator_detail_endpoint(self, api_test_fixtures):
-        """Test GET /api/indicators/{id} - Get indicator details"""
-        # Test individual indicator metadata
-        assert api_test_fixtures["retry_attempts"] >= 1
+    def test_response_models_remain_stable(self, indicator_registry_module):
+        response_models = {(route.path, tuple(sorted(route.methods or []))): route.response_model for route in indicator_registry_module.router.routes}
+
+        assert response_models[("/api/indicator-registry/indicators", ("GET",))] == indicator_registry_module.List[
+            indicator_registry_module.IndicatorInfo
+        ]
+        assert response_models[("/api/indicator-registry/indicators/{indicator_id}", ("GET",))] is None
+        assert response_models[("/api/indicator-registry/calculate", ("POST",))] is indicator_registry_module.CalculationResponse
 
     @pytest.mark.file_test
-    def test_indicator_register_endpoint(self, api_test_fixtures):
-        """Test POST /api/indicators/register - Register new indicator"""
-        # Test indicator registration process
-        assert api_test_fixtures["mock_enabled"] is True
+    def test_route_names_remain_stable(self, indicator_registry_module):
+        route_names = {(route.path, tuple(sorted(route.methods or []))): route.name for route in indicator_registry_module.router.routes}
+
+        assert route_names[("/api/indicator-registry/indicators", ("GET",))] == "list_indicators"
+        assert route_names[("/api/indicator-registry/indicators/{indicator_id}", ("GET",))] == "get_indicator_details"
+        assert route_names[("/api/indicator-registry/calculate", ("POST",))] == "calculate_indicator"
 
     @pytest.mark.file_test
-    def test_indicator_validate_endpoint(self, api_test_fixtures):
-        """Test POST /api/indicators/validate - Validate indicator"""
-        # Test indicator validation logic
-        assert api_test_fixtures["contract_validation"] is True
+    def test_get_factory_behaves_as_singleton(self, indicator_registry_module, monkeypatch):
+        fake_factory = Mock()
+        factory_class = Mock(return_value=fake_factory)
+        monkeypatch.setattr(indicator_registry_module, "IndicatorFactory", factory_class)
+        monkeypatch.setattr(indicator_registry_module, "_factory", None)
+
+        first = indicator_registry_module.get_factory()
+        second = indicator_registry_module.get_factory()
+
+        assert first is fake_factory
+        assert second is fake_factory
+        factory_class.assert_called_once_with()
 
     @pytest.mark.file_test
-    def test_indicator_update_endpoint(self, api_test_fixtures):
-        """Test PUT /api/indicators/{id} - Update indicator"""
-        # Test indicator configuration updates
-        assert api_test_fixtures["test_timeout"] > 0
+    def test_indicator_info_model_fields_remain_stable(self, indicator_registry_module):
+        fields = set(indicator_registry_module.IndicatorInfo.model_fields)
+
+        assert fields == {
+            "indicator_id",
+            "indicator_name",
+            "indicator_category",
+            "use_case",
+            "description",
+            "status",
+        }
 
     @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across indicator registry endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
+    def test_calculation_models_expose_expected_fields(self, indicator_registry_module):
+        request_fields = set(indicator_registry_module.CalculationRequest.model_fields)
+        response_fields = set(indicator_registry_module.CalculationResponse.model_fields)
+
+        assert request_fields == {"indicator_id", "data", "parameters"}
+        assert response_fields == {"indicator_id", "result", "length"}
 
     @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for indicator registry endpoints"""
-        # Validate indicator registry response formats
-        assert True  # Placeholder
+    def test_calculation_request_default_parameters_is_empty_mapping(self, indicator_registry_module):
+        req = indicator_registry_module.CalculationRequest(indicator_id="sma", data=[{"close": 1.0}])
+
+        assert req.parameters == {}
 
     @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for indicator registry endpoints"""
-        # Validate indicator registry performance
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for registry operations
-
-    @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_indicator_registration(self):
-        """Test indicator registration and management"""
-        # Test complete indicator lifecycle
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
+    def test_docstrings_cover_listing_details_and_calculation(self, indicator_registry_module):
+        assert "List all registered indicators." in (indicator_registry_module.list_indicators.__doc__ or "")
+        assert "Get detailed configuration" in (indicator_registry_module.get_indicator_details.__doc__ or "")
+        assert "Run a batch calculation." in (indicator_registry_module.calculate_indicator.__doc__ or "")
 
     @pytest.mark.file_test
-    def test_indicator_data_consistency(self):
-        """Test data consistency in indicator registry operations"""
-        # Ensure indicator registry data remains consistent
-        assert True
-
-    @pytest.mark.file_test
-    def test_indicator_workflow(self):
-        """Test complete indicator registry workflow"""
-        # Test register -> validate -> use workflow
-        assert True
-
-
-class TestIndicatorRegistryIntegration:
-    """Integration tests for indicator_registry.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_indicator_technical_analysis_integration(self):
-        """Test indicator registry with technical analysis modules"""
-        # Test indicator registry integration with TA modules
-        assert True
-
-    @pytest.mark.file_test
-    def test_indicator_strategy_integration(self):
-        """Test indicator registry with strategy modules"""
-        # Test custom indicators in strategies
-        assert True
-
-
-class TestIndicatorRegistryValidation:
-    """Validation tests for indicator registry API"""
-
-    @pytest.mark.file_test
-    def test_indicator_registry_api_compliance(self):
-        """Test compliance with indicator registry API specifications"""
-        # Validate indicator registry API compliance
-        assert True
-
-    @pytest.mark.file_test
-    def test_indicator_validation_accuracy(self):
-        """Test accuracy of indicator validation"""
-        # Validate indicator validation logic accuracy
-        assert True
-
-    @pytest.mark.file_test
-    def test_indicator_registry_endpoint_coverage(self):
-        """Test that all expected indicator registry endpoints are implemented"""
-        # Validate indicator registry endpoint coverage
-        assert True
+    def test_module_prefix_implies_all_routes_share_same_namespace(self, indicator_registry_module):
+        assert all(route.path.startswith("/api/indicator-registry") for route in indicator_registry_module.router.routes)

--- a/tests/api/file_tests/test_multi_source_api.py
+++ b/tests/api/file_tests/test_multi_source_api.py
@@ -1,155 +1,129 @@
 """
-File-level tests for multi_source.py API endpoints
+File-level contract tests for the active multi_source API package.
 
-Tests all multi-source data management endpoints including:
-- Data source configuration and management
-- Multi-source data aggregation
-- Source prioritization and failover
-- Data consistency across sources
-
-Priority: P2 (Utility)
-Coverage: 70% functional + smoke testing
+仓库里同时存在包路由和遗留单文件定义，运行时实际导出的是
+`app.api.multi_source.routes`。这里对齐当前生效的接口面。
 """
 
-import asyncio
+from __future__ import annotations
+
+import sys
+from pathlib import Path
 
 import pytest
+import importlib
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def multi_source_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    package = importlib.import_module("app.api.multi_source")
+    routes = importlib.import_module("app.api.multi_source.routes")
+    return package, routes
 
 
 class TestMultiSourceAPIFile:
-    """Test suite for multi_source.py API file"""
+    @pytest.mark.file_test
+    def test_router_registers_expected_paths(self, multi_source_module):
+        package, routes = multi_source_module
+        paths = {(route.path, tuple(sorted(route.methods or []))) for route in routes.router.routes}
+
+        assert package.router is routes.router
+        assert routes.router.prefix == ""
+        assert ("/health", ("GET",)) in paths
+        assert ("/status", ("GET",)) in paths
+        assert ("/analyze", ("POST",)) in paths
 
     @pytest.mark.file_test
-    def test_source_list_endpoint(self, api_test_fixtures):
-        """Test GET /api/multi-source/sources - List data sources"""
-        # Test data source listing and status
-        assert api_test_fixtures["base_url"].startswith("http")
-
-    @pytest.mark.file_test
-    def test_source_config_endpoint(self, api_test_fixtures):
-        """Test GET /api/multi-source/config - Source configuration"""
-        # Test source configuration retrieval
-        assert api_test_fixtures["retry_attempts"] >= 1
-
-    @pytest.mark.file_test
-    def test_source_add_endpoint(self, api_test_fixtures):
-        """Test POST /api/multi-source/add - Add data source"""
-        # Test new data source registration
-        assert api_test_fixtures["mock_enabled"] is True
-
-    @pytest.mark.file_test
-    def test_source_update_endpoint(self, api_test_fixtures):
-        """Test PUT /api/multi-source/{id} - Update source config"""
-        # Test data source configuration updates
-        assert api_test_fixtures["contract_validation"] is True
-
-    @pytest.mark.file_test
-    def test_source_remove_endpoint(self, api_test_fixtures):
-        """Test DELETE /api/multi-source/{id} - Remove data source"""
-        # Test data source removal
-        assert api_test_fixtures["test_timeout"] > 0
-
-    @pytest.mark.file_test
-    def test_source_health_endpoint(self, api_test_fixtures):
-        """Test GET /api/multi-source/health - Source health status"""
-        # Test multi-source health monitoring
-        assert True
-
-    @pytest.mark.file_test
-    def test_data_aggregation_endpoint(self, api_test_fixtures):
-        """Test GET /api/multi-source/aggregate - Data aggregation"""
-        # Test data aggregation from multiple sources
-        assert True
-
-    @pytest.mark.file_test
-    def test_source_failover_endpoint(self, api_test_fixtures):
-        """Test POST /api/multi-source/failover - Trigger failover"""
-        # Test source failover mechanisms
-        assert True
-
-    @pytest.mark.file_test
-    def test_source_priorities_endpoint(self, api_test_fixtures):
-        """Test GET /api/multi-source/priorities - Source priorities"""
-        # Test source prioritization logic
-        assert True
-
-    @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across multi-source endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
-
-    @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for multi-source endpoints"""
-        # Validate multi-source response formats
-        assert True  # Placeholder
-
-    @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for multi-source endpoints"""
-        # Validate multi-source operation performance
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for multi-source operations
-
     @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_multi_source_aggregation(self):
-        """Test multi-source data aggregation and processing"""
-        # Test data aggregation from multiple sources
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
+    async def test_health_check_returns_service_status(self, multi_source_module):
+        _, routes = multi_source_module
+
+        payload = await routes.health_check()
+
+        assert payload == {"status": "ok", "service": "multi_source"}
 
     @pytest.mark.file_test
-    def test_multi_source_data_consistency(self):
-        """Test data consistency across multi-source operations"""
-        # Ensure multi-source data remains consistent
-        assert True
+    @pytest.mark.asyncio
+    async def test_status_endpoint_returns_active_service_marker(self, multi_source_module):
+        _, routes = multi_source_module
+
+        payload = await routes.get_status()
+
+        assert payload == {"status": "active", "endpoint": "multi_source"}
 
     @pytest.mark.file_test
-    def test_multi_source_workflow(self):
-        """Test complete multi-source management workflow"""
-        # Test source setup -> aggregation -> failover workflow
-        assert True
+    @pytest.mark.asyncio
+    async def test_analyze_endpoint_returns_placeholder_result_for_minimal_payload(self, multi_source_module):
+        _, routes = multi_source_module
 
+        payload = await routes.analyze_data({"symbol": "600519"})
 
-class TestMultiSourceIntegration:
-    """Integration tests for multi_source.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_multi_source_data_integration(self):
-        """Test multi-source integration with data modules"""
-        # Test multi-source data with core data modules
-        assert True
+        assert payload == {"result": "分析完成", "endpoint": "multi_source"}
 
     @pytest.mark.file_test
-    def test_multi_source_monitoring_integration(self):
-        """Test multi-source with monitoring systems"""
-        # Test source health monitoring integration
-        assert True
+    @pytest.mark.asyncio
+    async def test_analyze_endpoint_accepts_extended_request_shape(self, multi_source_module):
+        _, routes = multi_source_module
 
+        payload = await routes.analyze_data(
+            {
+                "symbol": "600519",
+                "data_sources": ["technical", "fundamental", "sentiment"],
+                "analysis_depth": "advanced",
+                "weights": {"technical": 0.3, "fundamental": 0.5, "sentiment": 0.2},
+                "time_range": "3m",
+            }
+        )
 
-class TestMultiSourceValidation:
-    """Validation tests for multi-source API"""
-
-    @pytest.mark.file_test
-    def test_multi_source_api_compliance(self):
-        """Test compliance with multi-source API specifications"""
-        # Validate multi-source API compliance
-        assert True
-
-    @pytest.mark.file_test
-    def test_multi_source_data_accuracy(self):
-        """Test accuracy of multi-source data aggregation"""
-        # Validate data aggregation accuracy
-        assert True
+        assert payload["endpoint"] == "multi_source"
+        assert payload["result"] == "分析完成"
 
     @pytest.mark.file_test
-    def test_multi_source_endpoint_coverage(self):
-        """Test that all expected multi-source endpoints are implemented"""
-        # Validate multi-source endpoint coverage
-        assert True
+    def test_router_contains_unique_paths_only(self, multi_source_module):
+        _, routes = multi_source_module
+        route_paths = [route.path for route in routes.router.routes]
+
+        assert route_paths == ["/health", "/status", "/analyze"]
+        assert len(route_paths) == len(set(route_paths))
+
+    @pytest.mark.file_test
+    def test_router_methods_match_expected_contract(self, multi_source_module):
+        _, routes = multi_source_module
+        route_methods = {route.path: tuple(sorted(route.methods or [])) for route in routes.router.routes}
+
+        assert route_methods["/health"] == ("GET",)
+        assert route_methods["/status"] == ("GET",)
+        assert route_methods["/analyze"] == ("POST",)
+
+    @pytest.mark.file_test
+    def test_package_exports_router_in___all__(self, multi_source_module):
+        package, routes = multi_source_module
+
+        assert package.__all__ == ["router"]
+        assert package.router is routes.router
+
+    @pytest.mark.file_test
+    def test_analyze_endpoint_docstring_mentions_ai_analysis(self, multi_source_module):
+        _, routes = multi_source_module
+
+        assert "AI综合分析" in (routes.analyze_data.__doc__ or "")
+        assert "多数据源" in (routes.analyze_data.__doc__ or "")
+
+    @pytest.mark.file_test
+    def test_health_and_status_handlers_have_stable_names(self, multi_source_module):
+        _, routes = multi_source_module
+
+        assert routes.health_check.__name__ == "health_check"
+        assert routes.get_status.__name__ == "get_status"


### PR DESCRIPTION
## Summary
- replace placeholder file tests for announcement, data_source_config, indicator_registry, and multi_source with route/model contract assertions
- keep scope limited to backend api file-level tests only
- avoid touching frontend migration lines and unrelated backend application code

## Test Plan
- python -m pytest --no-cov tests/api/file_tests/test_announcement_api.py tests/api/file_tests/test_data_source_config_api.py tests/api/file_tests/test_indicator_registry_api.py tests/api/file_tests/test_multi_source_api.py
- git diff --check
