### PR TITLE
test(api): replace placeholder route contract tests batch 3

### DIFF
--- a/governance/mainline/task-cards/pr-60.yaml
+++ b/governance/mainline/task-cards/pr-60.yaml
@@ -1,0 +1,80 @@
+version: "v0.2"
+
+task:
+  id: "pr-60"
+  title: "replace placeholder api file tests with route contract assertions batch 3"
+  owner: "main"
+  created_at: "2026-04-06"
+
+mainline:
+  id: "L1-api-file-tests-contract-salvage"
+  objective: "replace placeholder API file tests with route-aware contract coverage through isolated salvage micro-batches"
+  milestone_id: "L2-api-file-tests-batch-series"
+  slice_id: "L3-batch-3-cache-contract-data-tdx"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+scope:
+  allowed_paths:
+    - "tests/api/file_tests/test_cache_api.py"
+    - "tests/api/file_tests/test_contract_routes_api.py"
+    - "tests/api/file_tests/test_data_api.py"
+    - "tests/api/file_tests/test_tdx_api.py"
+    - "governance/mainline/task-cards/pr-60.yaml"
+  forbidden_paths:
+    - "web/frontend/src/views/data/Advanced.vue"
+    - "web/frontend/src/views/artdeco-pages/ArtDecoDataAnalysis.vue"
+    - "web/frontend/src/views/watchlist"
+
+non_goals:
+  - "No backend implementation changes; this batch only replaces placeholder file tests with route-aware contract assertions"
+  - "No work on Data-Indicator or Watchlist lines"
+  - "No scope expansion outside the declared 4 test files and governance task card"
+
+acceptance:
+  checks:
+    - id: "api-file-tests-batch-3"
+      command: "python -m pytest --no-cov tests/api/file_tests/test_cache_api.py tests/api/file_tests/test_contract_routes_api.py tests/api/file_tests/test_data_api.py tests/api/file_tests/test_tdx_api.py"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-60.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report /tmp/pr60-mainline-gate.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If any asserted router metadata drifts from the actual backend route exports, this batch will fail as intended on future runs"
+    - "If the task card function tree mapping is wrong, the governance gate will fail even though the code diff is correct"
+  rollback_plan: "git revert <merge-commit-sha> if these route-aware tests or the PR-60 governance card introduce unexpected mainline gate failures"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "salvage four placeholder API file tests by aligning them to the active cache, contract, data, and tdx router surfaces"
+    modified_scope: "four tests/api/file_tests modules plus this PR-60 governance task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "no product logic changes; only test expectations now track real route exports and metadata"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the PR if the new route-aware assertions or governance scope metadata cause unexpected failures after merge"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-06T00:00:00Z"
+    approval_note: "tests-only cleanup batch does not require a separate OpenSpec proposal"
+    secondary_approved: false

--- a/tests/api/file_tests/test_cache_api.py
+++ b/tests/api/file_tests/test_cache_api.py
@@ -1,131 +1,128 @@
 """
-File-level tests for cache.py API endpoints
+File-level route aggregation tests for the active cache API.
 
-Tests all cache management endpoints including:
-- Cache status and statistics
-- Cache invalidation and clearing
-- Cache configuration management
-- Cache performance monitoring
-
-Priority: P2 (Utility)
-Coverage: 70% functional + smoke testing
+这里覆盖缓存聚合入口的真实路由面，以及清缓存入口的关键行为。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def cache_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    return importlib.import_module("app.api.cache")
 
 
 class TestCacheAPIFile:
-    """Test suite for cache.py API file"""
+    @pytest.mark.file_test
+    def test_router_registers_expected_cache_routes(self, cache_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in cache_module.router.routes}
+
+        assert cache_module.router.prefix == "/cache"
+        assert cache_module.router.tags == ["cache"]
+        assert ("/cache", ("DELETE",)) in route_methods
+        assert ("/cache/status", ("GET",)) in route_methods
+        assert ("/cache/{symbol}/{data_type}", ("GET",)) in route_methods
+        assert ("/cache/{symbol}/{data_type}", ("POST",)) in route_methods
+        assert ("/cache/{symbol}", ("DELETE",)) in route_methods
+        assert ("/cache/{symbol}/{data_type}/fresh", ("GET",)) in route_methods
+        assert ("/cache/evict/manual", ("POST",)) in route_methods
+        assert ("/cache/eviction/stats", ("GET",)) in route_methods
+        assert ("/cache/prewarming/trigger", ("POST",)) in route_methods
+        assert ("/cache/prewarming/status", ("GET",)) in route_methods
+        assert ("/cache/monitoring/metrics", ("GET",)) in route_methods
+        assert ("/cache/monitoring/health", ("GET",)) in route_methods
 
     @pytest.mark.file_test
-    def test_cache_stats_endpoint(self, api_test_fixtures):
-        """Test GET /api/cache/stats - Cache statistics"""
-        # Test cache performance statistics
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_router_contains_expected_number_of_route_method_pairs(self, cache_module):
+        route_pairs = [(route.path, tuple(sorted(route.methods or []))) for route in cache_module.router.routes]
+
+        assert len(route_pairs) == 12
+        assert len(route_pairs) == len(set(route_pairs))
 
     @pytest.mark.file_test
-    def test_cache_status_endpoint(self, api_test_fixtures):
-        """Test GET /api/cache/status - Cache status"""
-        # Test cache health and status
-        assert api_test_fixtures["retry_attempts"] >= 1
+    def test_clear_all_cache_rejects_missing_confirmation(self, cache_module):
+        user = SimpleNamespace(username="tester")
+
+        with pytest.raises(cache_module.BusinessException) as excinfo:
+            import asyncio
+
+            asyncio.run(cache_module.clear_all_cache(confirm=False, current_user=user))
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.error_code == "INVALID_CACHE_REQUEST"
 
     @pytest.mark.file_test
-    def test_cache_clear_endpoint(self, api_test_fixtures):
-        """Test POST /api/cache/clear - Clear cache"""
-        # Test cache invalidation
-        assert api_test_fixtures["mock_enabled"] is True
+    def test_clear_all_cache_returns_deleted_count_when_confirmed(self, cache_module, monkeypatch):
+        cache_manager = Mock()
+        cache_manager.invalidate_cache.return_value = 7
+        monkeypatch.setattr(cache_module, "get_cache_manager", Mock(return_value=cache_manager))
+        monkeypatch.setattr(cache_module, "_timestamp", Mock(return_value="2026-04-01T00:00:00+00:00"))
+        user = SimpleNamespace(username="tester")
+
+        import asyncio
+
+        payload = asyncio.run(cache_module.clear_all_cache(confirm=True, current_user=user))
+
+        assert payload == {
+            "success": True,
+            "message": "所有缓存已清除",
+            "deleted_count": 7,
+            "timestamp": "2026-04-01T00:00:00+00:00",
+        }
 
     @pytest.mark.file_test
-    def test_cache_preheat_endpoint(self, api_test_fixtures):
-        """Test POST /api/cache/preheat - Preheat cache"""
-        # Test cache warming
-        assert api_test_fixtures["contract_validation"] is True
+    def test_timestamp_helper_returns_iso8601_string(self, cache_module):
+        value = cache_module._timestamp()
+
+        assert "T" in value
+        assert value.endswith("+00:00")
 
     @pytest.mark.file_test
-    def test_cache_config_endpoint(self, api_test_fixtures):
-        """Test GET /api/cache/config - Cache configuration"""
-        # Test cache configuration retrieval
-        assert api_test_fixtures["test_timeout"] > 0
+    def test_router_contains_manual_eviction_and_prewarming_domains(self, cache_module):
+        route_paths = {route.path for route in cache_module.router.routes}
+
+        assert any(path.startswith("/cache/evict/") for path in route_paths)
+        assert any(path.startswith("/cache/prewarming/") for path in route_paths)
+        assert any(path.startswith("/cache/monitoring/") for path in route_paths)
 
     @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across cache endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
+    def test_route_names_remain_stable_for_key_operations(self, cache_module):
+        route_names = {(route.path, tuple(sorted(route.methods or []))): route.name for route in cache_module.router.routes}
+
+        assert route_names[("/cache", ("DELETE",))] == "clear_all_cache"
+        assert route_names[("/cache/status", ("GET",))] == "get_cache_status"
+        assert route_names[("/cache/prewarming/trigger", ("POST",))] == "trigger_cache_prewarming"
 
     @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for cache endpoints"""
-        # Validate cache response formats
-        assert True  # Placeholder
+    def test_package_exports_router_in___all__(self, cache_module):
+        assert cache_module.__all__ == ["router"]
 
     @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for cache endpoints"""
-        # Validate cache operation performance
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for cache operations
-
-    @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_cache_operations(self):
-        """Test cache operations and management"""
-        # Test cache read/write operations
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
+    def test_docstring_mentions_cache_aggregation_entry(self, cache_module):
+        assert "聚合入口" in (cache_module.__doc__ or "")
 
     @pytest.mark.file_test
-    def test_cache_data_consistency(self):
-        """Test data consistency in cache operations"""
-        # Ensure cache data remains consistent
-        assert True
+    def test_symbol_data_type_path_supports_read_and_write(self, cache_module):
+        methods = [tuple(sorted(route.methods or [])) for route in cache_module.router.routes if route.path == "/cache/{symbol}/{data_type}"]
 
-    @pytest.mark.file_test
-    def test_cache_workflow(self):
-        """Test complete cache management workflow"""
-        # Test cache monitoring -> optimization -> maintenance workflow
-        assert True
-
-
-class TestCacheIntegration:
-    """Integration tests for cache.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_cache_data_integration(self):
-        """Test cache integration with data modules"""
-        # Test cache with data retrieval operations
-        assert True
-
-    @pytest.mark.file_test
-    def test_cache_monitoring_integration(self):
-        """Test cache monitoring and metrics"""
-        # Test cache performance monitoring
-        assert True
-
-
-class TestCacheValidation:
-    """Validation tests for cache API"""
-
-    @pytest.mark.file_test
-    def test_cache_api_compliance(self):
-        """Test compliance with cache API specifications"""
-        # Validate cache API compliance
-        assert True
-
-    @pytest.mark.file_test
-    def test_cache_performance(self):
-        """Test cache performance and efficiency"""
-        # Validate cache performance metrics
-        assert True
-
-    @pytest.mark.file_test
-    def test_cache_endpoint_coverage(self):
-        """Test that all expected cache endpoints are implemented"""
-        # Validate cache endpoint coverage
-        assert True
+        assert sorted(methods) == [("GET",), ("POST",)]

--- a/tests/api/file_tests/test_contract_routes_api.py
+++ b/tests/api/file_tests/test_contract_routes_api.py
@@ -1,151 +1,142 @@
 """
-File-level tests for contract/routes.py API endpoints
+File-level route contract tests for `app.api.contract.routes`.
 
-Tests all contract management endpoints including:
-- Contract version management
-- Contract validation and diff checking
-- Contract registration and updates
-- Contract testing and compliance
-
-Priority: P0 (Contract-managed)
-Coverage: 100% functional + contract validation
+这份测试只验证当前实际导出的契约管理路由面和响应模型元数据，
+不触发数据库访问。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import List
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def contract_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    package = importlib.import_module("app.api.contract")
+    routes = importlib.import_module("app.api.contract.routes")
+    return package, routes
 
 
 class TestContractRoutesAPIFile:
-    """Test suite for contract/routes.py API file"""
+    @pytest.mark.file_test
+    @pytest.mark.contract_test
+    def test_router_registers_expected_contract_routes(self, contract_module):
+        package, routes = contract_module
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in routes.router.routes}
+
+        assert package.router is routes.router
+        assert routes.router.prefix == "/api/contracts"
+        assert routes.router.tags == ["contract-management"]
+        assert ("/api/contracts/versions", ("POST",)) in route_methods
+        assert ("/api/contracts/versions", ("GET",)) in route_methods
+        assert ("/api/contracts/versions/{version_id}", ("GET",)) in route_methods
+        assert ("/api/contracts/versions/{version_id}", ("PUT",)) in route_methods
+        assert ("/api/contracts/versions/{version_id}", ("DELETE",)) in route_methods
+        assert ("/api/contracts/versions/{name}/active", ("GET",)) in route_methods
+        assert ("/api/contracts/versions/{version_id}/activate", ("POST",)) in route_methods
+        assert ("/api/contracts/contracts", ("GET",)) in route_methods
+        assert ("/api/contracts/diff", ("POST",)) in route_methods
+        assert ("/api/contracts/validate", ("POST",)) in route_methods
+        assert ("/api/contracts/sync", ("POST",)) in route_methods
+        assert ("/api/contracts/sync/report", ("GET",)) in route_methods
+
+    @pytest.mark.file_test
+    def test_router_contains_expected_number_of_route_method_pairs(self, contract_module):
+        _, routes = contract_module
+        route_pairs = [(route.path, tuple(sorted(route.methods or []))) for route in routes.router.routes]
+
+        assert len(route_pairs) == 12
+        assert len(route_pairs) == len(set(route_pairs))
+
+    @pytest.mark.file_test
+    def test_version_management_routes_keep_response_models(self, contract_module):
+        _, routes = contract_module
+        create_route = next(route for route in routes.router.routes if route.path == "/api/contracts/versions" and "POST" in route.methods)
+        get_route = next(route for route in routes.router.routes if route.path == "/api/contracts/versions/{version_id}" and "GET" in route.methods)
+        list_route = next(route for route in routes.router.routes if route.path == "/api/contracts/versions" and "GET" in route.methods)
+
+        assert create_route.response_model is routes.ContractVersionResponse
+        assert get_route.response_model is routes.ContractVersionResponse
+        assert list_route.response_model == List[routes.ContractVersionResponse]
+
+    @pytest.mark.file_test
+    def test_contract_list_diff_and_validate_routes_keep_response_models(self, contract_module):
+        _, routes = contract_module
+        contracts_route = next(route for route in routes.router.routes if route.path == "/api/contracts/contracts")
+        diff_route = next(route for route in routes.router.routes if route.path == "/api/contracts/diff")
+        validate_route = next(route for route in routes.router.routes if route.path == "/api/contracts/validate")
+
+        assert contracts_route.response_model is routes.ContractListResponse
+        assert diff_route.response_model is routes.ContractDiffResponse
+        assert validate_route.response_model is routes.ContractValidateResponse
+
+    @pytest.mark.file_test
+    def test_package_exports_router_in___all__(self, contract_module):
+        package, routes = contract_module
+
+        assert package.__all__ == ["router"]
+        assert package.router is routes.router
+
+    @pytest.mark.file_test
+    def test_route_names_remain_stable_for_key_operations(self, contract_module):
+        _, routes = contract_module
+        route_names = {(route.path, tuple(sorted(route.methods or []))): route.name for route in routes.router.routes}
+
+        assert route_names[("/api/contracts/versions", ("POST",))] == "create_version"
+        assert route_names[("/api/contracts/diff", ("POST",))] == "compare_versions"
+        assert route_names[("/api/contracts/validate", ("POST",))] == "validate_contract"
+        assert route_names[("/api/contracts/sync", ("POST",))] == "sync_contract"
+
+    @pytest.mark.file_test
+    def test_docstrings_cover_version_diff_validate_and_sync_operations(self, contract_module):
+        _, routes = contract_module
+
+        assert "创建新的契约版本" in (routes.create_version.__doc__ or "")
+        assert "对比两个契约版本的差异" in (routes.compare_versions.__doc__ or "")
+        assert "验证OpenAPI规范" in (routes.validate_contract.__doc__ or "")
+        assert "同步契约" in (routes.sync_contract.__doc__ or "")
+
+    @pytest.mark.file_test
+    def test_http_methods_match_route_semantics(self, contract_module):
+        _, routes = contract_module
+        method_map = {route.path: sorted(route.methods or []) for route in routes.router.routes if route.path in {"/api/contracts/sync/report", "/api/contracts/diff", "/api/contracts/contracts"}}
+
+        assert method_map["/api/contracts/sync/report"] == ["GET"]
+        assert method_map["/api/contracts/diff"] == ["POST"]
+        assert method_map["/api/contracts/contracts"] == ["GET"]
 
     @pytest.mark.file_test
     @pytest.mark.contract_test
-    def test_contract_versions_endpoint(self, api_test_fixtures):
-        """Test GET /api/contracts/versions - List contract versions"""
-        # Test contract version listing
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_route_paths_are_unique_even_when_shared_by_different_methods(self, contract_module):
+        _, routes = contract_module
+        version_routes = [tuple(sorted(route.methods or [])) for route in routes.router.routes if route.path == "/api/contracts/versions"]
+        version_id_routes = [tuple(sorted(route.methods or [])) for route in routes.router.routes if route.path == "/api/contracts/versions/{version_id}"]
+
+        assert sorted(version_routes) == [("GET",), ("POST",)]
+        assert sorted(version_id_routes) == [("DELETE",), ("GET",), ("PUT",)]
 
     @pytest.mark.file_test
-    def test_contract_validation_endpoint(self, api_test_fixtures):
-        """Test POST /api/contracts/validate - Validate contract"""
-        # Test contract validation
-        assert api_test_fixtures["retry_attempts"] >= 1
+    def test_support_functions_and_dependencies_are_callable(self, contract_module):
+        _, routes = contract_module
 
-    @pytest.mark.file_test
-    def test_contract_diff_endpoint(self, api_test_fixtures):
-        """Test POST /api/contracts/diff - Generate contract diff"""
-        # Test contract diff generation
-        assert api_test_fixtures["mock_enabled"] is True
-
-    @pytest.mark.file_test
-    def test_contract_registration_endpoint(self, api_test_fixtures):
-        """Test POST /api/contracts/register - Register new contract"""
-        # Test contract registration
-        assert api_test_fixtures["contract_validation"] is True
-
-    @pytest.mark.file_test
-    def test_contract_update_endpoint(self, api_test_fixtures):
-        """Test PUT /api/contracts/{id} - Update contract"""
-        # Test contract update
-        assert api_test_fixtures["test_timeout"] > 0
-
-    @pytest.mark.file_test
-    def test_contract_deletion_endpoint(self, api_test_fixtures):
-        """Test DELETE /api/contracts/{id} - Delete contract"""
-        # Test contract deletion
-        assert True
-
-    @pytest.mark.file_test
-    def test_contract_testing_endpoint(self, api_test_fixtures):
-        """Test POST /api/contracts/test - Test contract implementation"""
-        # Test contract implementation testing
-        assert True
-
-    @pytest.mark.file_test
-    @pytest.mark.contract_test
-    def test_contract_compliance(self, contract_specs):
-        """Test OpenAPI contract compliance for contract/routes.py"""
-        # Contract management itself should be self-consistent
-        assert True  # Contract compliance check
-
-    @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across contract management endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
-
-    @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for contract endpoints"""
-        # Validate response schemas match contract specifications
-        assert True  # Placeholder
-
-    @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for contract management endpoints"""
-        # Validate response times are within acceptable limits
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for contract operations
-
-    @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_concurrent_contract_operations(self):
-        """Test concurrent contract management operations"""
-        # Test multiple simultaneous contract operations
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
-
-    @pytest.mark.file_test
-    def test_contract_data_consistency(self):
-        """Test data consistency across contract operations"""
-        # Ensure contract data remains consistent across operations
-        assert True
-
-    @pytest.mark.file_test
-    def test_contract_lifecycle(self):
-        """Test complete contract lifecycle management"""
-        # Test register -> validate -> test -> deploy workflow
-        assert True
-
-
-class TestContractIntegration:
-    """Integration tests for contract/routes.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_contract_api_validation_integration(self):
-        """Test contract validation with actual API endpoints"""
-        # Test contract validation against real API implementations
-        assert True
-
-    @pytest.mark.file_test
-    def test_contract_diff_tracking_integration(self):
-        """Test contract diff tracking with version control"""
-        # Test contract change tracking and versioning
-        assert True
-
-
-class TestContractSelfValidation:
-    """Self-validation tests for contract management system"""
-
-    @pytest.mark.contract_test
-    def test_contract_system_consistency(self):
-        """Test that contract management system is internally consistent"""
-        # Validate the contract system itself
-        assert True
-
-    @pytest.mark.contract_test
-    def test_contract_validation_accuracy(self):
-        """Test that contract validation produces accurate results"""
-        # Validate contract validation logic
-        assert True
-
-    @pytest.mark.contract_test
-    def test_contract_endpoint_coverage(self):
-        """Test that all contract management endpoints are properly tested"""
-        # Validate contract system endpoint coverage
-        assert True
+        assert callable(routes.get_db)
+        assert callable(routes.VersionManager.create_version)
+        assert callable(routes.DiffEngine.compare_versions)
+        assert callable(routes.ContractValidator.validate)

--- a/tests/api/file_tests/test_data_api.py
+++ b/tests/api/file_tests/test_data_api.py
@@ -1,149 +1,121 @@
 """
-File-level tests for data.py API endpoints
+File-level route aggregation tests for the active data API facade.
 
-Tests all data management endpoints including:
-- Stock data queries and retrieval
-- Financial data access
-- Data validation and quality checks
-- Bulk data operations
-
-Priority: P1 (Core Business)
-Coverage: 90% functional + integration testing
+这里验证 `app.api.data` 是否正确聚合 7 个领域子路由，
+替换掉原先与真实实现脱节的生成式占位断言。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def data_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    return importlib.import_module("app.api.data")
 
 
 class TestDataAPIFile:
-    """Test suite for data.py API file"""
+    @pytest.mark.file_test
+    def test_router_exposes_data_service_tag_and_no_prefix(self, data_module):
+        assert data_module.router.tags == ["Data Service"]
+        assert data_module.router.prefix == ""
 
     @pytest.mark.file_test
-    def test_symbols_endpoint(self, api_test_fixtures):
-        """Test GET /api/data/symbols - Get stock symbols list"""
-        # Test stock symbol retrieval
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_router_aggregates_all_subrouter_paths(self, data_module):
+        route_paths = {route.path for route in data_module.router.routes}
+
+        assert "/stocks/basic" in route_paths
+        assert "/stocks/industries" in route_paths
+        assert "/stocks/concepts" in route_paths
+        assert "/stocks/search" in route_paths
+        assert "/stocks/{symbol}/detail" in route_paths
+        assert "/markets/overview" in route_paths
+        assert "/markets/price-distribution" in route_paths
+        assert "/markets/hot-industries" in route_paths
+        assert "/markets/hot-concepts" in route_paths
+        assert "/stocks/daily" in route_paths
+        assert "/kline" in route_paths
+        assert "/stocks/kline" in route_paths
+        assert "/stocks/intraday" in route_paths
+        assert "/margin/account-info" in route_paths
+        assert "/margin/detail/sse" in route_paths
+        assert "/margin/detail/szse" in route_paths
+        assert "/dragon-tiger/detail" in route_paths
+        assert "/dragon-tiger/institution-stats" in route_paths
+        assert "/futures/index/daily" in route_paths
+        assert "/futures/index/realtime" in route_paths
+        assert "/financial" in route_paths
 
     @pytest.mark.file_test
-    def test_quote_endpoint(self, api_test_fixtures):
-        """Test GET /api/data/quote/{symbol} - Get stock quote"""
-        # Test individual stock quote retrieval
-        assert api_test_fixtures["retry_attempts"] >= 1
+    def test_router_contains_expected_number_of_routes(self, data_module):
+        assert len(data_module.router.routes) == 21
 
     @pytest.mark.file_test
-    def test_financials_endpoint(self, api_test_fixtures):
-        """Test GET /api/data/financials/{symbol} - Get financial data"""
-        # Test financial statement data
-        assert api_test_fixtures["mock_enabled"] is True
+    def test_all_aggregated_routes_are_get_only(self, data_module):
+        for route in data_module.router.routes:
+            assert tuple(sorted(route.methods or [])) == ("GET",)
 
     @pytest.mark.file_test
-    def test_historical_data_endpoint(self, api_test_fixtures):
-        """Test GET /api/data/historical/{symbol} - Get historical data"""
-        # Test historical price data
-        assert api_test_fixtures["contract_validation"] is True
+    def test_route_path_and_method_pairs_are_unique(self, data_module):
+        route_pairs = [(route.path, tuple(sorted(route.methods or []))) for route in data_module.router.routes]
+
+        assert len(route_pairs) == len(set(route_pairs))
 
     @pytest.mark.file_test
-    def test_bulk_data_endpoint(self, api_test_fixtures):
-        """Test POST /api/data/bulk - Bulk data retrieval"""
-        # Test bulk data operations
-        assert api_test_fixtures["test_timeout"] > 0
+    def test_router_includes_all_imported_subrouters(self, data_module):
+        subrouters = [
+            data_module.stocks_router,
+            data_module.market_router,
+            data_module.kline_router,
+            data_module.margin_router,
+            data_module.lhb_router,
+            data_module.futures_router,
+            data_module.financial_router,
+        ]
+
+        assert sum(len(router.routes) for router in subrouters) == len(data_module.router.routes)
 
     @pytest.mark.file_test
-    def test_data_validation_endpoint(self, api_test_fixtures):
-        """Test POST /api/data/validate - Data validation"""
-        # Test data quality validation
-        assert True
+    def test_representative_route_names_remain_stable(self, data_module):
+        route_names = {route.path: route.name for route in data_module.router.routes}
+
+        assert route_names["/stocks/basic"] == "get_stocks_basic"
+        assert route_names["/markets/overview"] == "get_market_overview"
+        assert route_names["/kline"] == "get_kline"
+        assert route_names["/financial"] == "get_financial_data"
 
     @pytest.mark.file_test
-    def test_data_search_endpoint(self, api_test_fixtures):
-        """Test GET /api/data/search - Data search"""
-        # Test data search functionality
-        assert True
+    def test_package_exports_router_in___all__(self, data_module):
+        assert data_module.__all__ == ["router"]
 
     @pytest.mark.file_test
-    def test_data_export_endpoint(self, api_test_fixtures):
-        """Test GET /api/data/export - Data export"""
-        # Test data export functionality
-        assert True
+    def test_router_does_not_expose_generated_placeholder_endpoints(self, data_module):
+        route_paths = {route.path for route in data_module.router.routes}
+
+        assert "/api/data/bulk" not in route_paths
+        assert "/api/data/validate" not in route_paths
+        assert "/api/data/export" not in route_paths
 
     @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across data endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
+    def test_futures_and_margin_domains_are_both_present(self, data_module):
+        route_paths = {route.path for route in data_module.router.routes}
 
-    @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for data endpoints"""
-        # Validate data response formats
-        assert True  # Placeholder
-
-    @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for data endpoints"""
-        # Validate data query performance
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for data queries
-
-    @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_data_caching(self):
-        """Test data caching and retrieval optimization"""
-        # Test caching mechanisms for data queries
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
-
-    @pytest.mark.file_test
-    def test_data_consistency(self):
-        """Test data consistency across data operations"""
-        # Ensure data remains consistent across operations
-        assert True
-
-    @pytest.mark.file_test
-    def test_data_workflow(self):
-        """Test complete data retrieval and processing workflow"""
-        # Test data query -> validation -> export workflow
-        assert True
-
-
-class TestDataIntegration:
-    """Integration tests for data.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_data_strategy_integration(self):
-        """Test data access with strategy calculations"""
-        # Test data integration with strategy modules
-        assert True
-
-    @pytest.mark.file_test
-    def test_data_monitoring_integration(self):
-        """Test data operations with monitoring"""
-        # Test data access monitoring and logging
-        assert True
-
-
-class TestDataValidation:
-    """Validation tests for data API"""
-
-    @pytest.mark.file_test
-    def test_data_api_compliance(self):
-        """Test compliance with data API specifications"""
-        # Validate data API compliance
-        assert True
-
-    @pytest.mark.file_test
-    def test_data_quality_assurance(self):
-        """Test data quality and integrity"""
-        # Validate data quality assurance
-        assert True
-
-    @pytest.mark.file_test
-    def test_data_endpoint_coverage(self):
-        """Test that all expected data endpoints are implemented"""
-        # Validate data endpoint coverage
-        assert True
+        assert any(path.startswith("/futures/") for path in route_paths)
+        assert any(path.startswith("/margin/") for path in route_paths)

--- a/tests/api/file_tests/test_tdx_api.py
+++ b/tests/api/file_tests/test_tdx_api.py
@@ -1,137 +1,114 @@
 """
-File-level tests for tdx.py API endpoints
+File-level route contract tests for tdx.py.
 
-Tests all TDX (TongDaXin) interface endpoints including:
-- Stock data retrieval from TDX
-- Market data access
-- Technical indicators calculation
-- Real-time data streaming
-
-Priority: P2 (Utility)
-Coverage: 70% functional + smoke testing
+这里对齐当前实际暴露的 TDX 路由和响应模型，
+替换掉生成式占位断言。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def tdx_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    return importlib.import_module("app.api.tdx")
 
 
 class TestTdxAPIFile:
-    """Test suite for tdx.py API file"""
+    @pytest.mark.file_test
+    def test_router_registers_expected_tdx_routes(self, tdx_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in tdx_module.router.routes}
+
+        assert ("/quote/{symbol}", ("GET",)) in route_methods
+        assert ("/kline", ("GET",)) in route_methods
+        assert ("/index/quote/{symbol}", ("GET",)) in route_methods
+        assert ("/index/kline", ("GET",)) in route_methods
+        assert ("/health", ("GET",)) in route_methods
 
     @pytest.mark.file_test
-    def test_tdx_connection_endpoint(self, api_test_fixtures):
-        """Test POST /api/tdx/connect - Connect to TDX"""
-        # Test TDX connection establishment
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_router_contains_expected_number_of_routes(self, tdx_module):
+        route_pairs = [(route.path, tuple(sorted(route.methods or []))) for route in tdx_module.router.routes]
+
+        assert len(route_pairs) == 5
+        assert len(route_pairs) == len(set(route_pairs))
 
     @pytest.mark.file_test
-    def test_tdx_stock_data_endpoint(self, api_test_fixtures):
-        """Test GET /api/tdx/stock/{code} - Get stock data"""
-        # Test stock data retrieval from TDX
-        assert api_test_fixtures["retry_attempts"] >= 1
+    def test_response_models_remain_stable(self, tdx_module):
+        response_models = {(route.path, tuple(sorted(route.methods or []))): route.response_model for route in tdx_module.router.routes}
+
+        assert response_models[("/quote/{symbol}", ("GET",))] is tdx_module.RealTimeQuoteResponse
+        assert response_models[("/kline", ("GET",))] is tdx_module.KlineResponse
+        assert response_models[("/index/quote/{symbol}", ("GET",))] is tdx_module.IndexQuoteResponse
+        assert response_models[("/index/kline", ("GET",))] is tdx_module.KlineResponse
+        assert response_models[("/health", ("GET",))] is tdx_module.TdxHealthResponse
 
     @pytest.mark.file_test
-    def test_tdx_market_data_endpoint(self, api_test_fixtures):
-        """Test GET /api/tdx/market - Get market data"""
-        # Test market overview data from TDX
-        assert api_test_fixtures["mock_enabled"] is True
+    def test_route_names_remain_stable_for_core_operations(self, tdx_module):
+        route_names = {(route.path, tuple(sorted(route.methods or []))): route.name for route in tdx_module.router.routes}
+
+        assert route_names[("/quote/{symbol}", ("GET",))] == "get_stock_quote"
+        assert route_names[("/kline", ("GET",))] == "get_stock_kline"
+        assert route_names[("/index/quote/{symbol}", ("GET",))] == "get_index_quote"
+        assert route_names[("/index/kline", ("GET",))] == "get_index_kline"
+        assert route_names[("/health", ("GET",))] == "health_check"
 
     @pytest.mark.file_test
-    def test_tdx_kline_endpoint(self, api_test_fixtures):
-        """Test GET /api/tdx/kline/{code} - Get K-line data"""
-        # Test K-line data from TDX
-        assert api_test_fixtures["contract_validation"] is True
+    def test_all_routes_are_get_only(self, tdx_module):
+        for route in tdx_module.router.routes:
+            assert tuple(sorted(route.methods or [])) == ("GET",)
 
     @pytest.mark.file_test
-    def test_tdx_realtime_endpoint(self, api_test_fixtures):
-        """Test GET /api/tdx/realtime/{code} - Get real-time data"""
-        # Test real-time price data from TDX
-        assert api_test_fixtures["test_timeout"] > 0
+    def test_stock_and_index_docstrings_remain_descriptive(self, tdx_module):
+        assert "获取股票实时行情" in (tdx_module.get_stock_quote.__doc__ or "")
+        assert "获取股票K线数据" in (tdx_module.get_stock_kline.__doc__ or "")
+        assert "获取指数实时行情" in (tdx_module.get_index_quote.__doc__ or "")
+        assert "获取指数K线数据" in (tdx_module.get_index_kline.__doc__ or "")
 
     @pytest.mark.file_test
-    def test_tdx_disconnect_endpoint(self, api_test_fixtures):
-        """Test POST /api/tdx/disconnect - Disconnect from TDX"""
-        # Test TDX connection termination
-        assert True
+    def test_health_route_summary_and_description_are_present(self, tdx_module):
+        health_route = next(route for route in tdx_module.router.routes if route.path == "/health")
+
+        assert health_route.summary == "TDX服务健康检查"
+        assert "检查TDX服务器连接状态" in (health_route.description or "")
 
     @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across TDX endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
+    def test_kline_route_description_mentions_supported_periods(self, tdx_module):
+        kline_route = next(route for route in tdx_module.router.routes if route.path == "/kline")
+        index_kline_route = next(route for route in tdx_module.router.routes if route.path == "/index/kline")
+
+        assert "1m/5m/15m/30m/1h/1d" in (kline_route.description or "")
+        assert "多种周期" in (index_kline_route.description or "")
 
     @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for TDX endpoints"""
-        # Validate TDX response formats
-        assert True  # Placeholder
+    def test_quote_routes_require_symbol_path_parameter(self, tdx_module):
+        quote_paths = {route.path for route in tdx_module.router.routes if "quote" in route.path}
+
+        assert "/quote/{symbol}" in quote_paths
+        assert "/index/quote/{symbol}" in quote_paths
 
     @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for TDX endpoints"""
-        # Validate TDX query performance
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for TDX operations
+    def test_module_docstring_describes_five_supported_endpoints(self, tdx_module):
+        doc = tdx_module.__doc__ or ""
 
-    @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_tdx_data_retrieval(self):
-        """Test TDX data retrieval and processing"""
-        # Test TDX data access and processing
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
-
-    @pytest.mark.file_test
-    def test_tdx_data_consistency(self):
-        """Test data consistency in TDX operations"""
-        # Ensure TDX data remains consistent
-        assert True
-
-    @pytest.mark.file_test
-    def test_tdx_workflow(self):
-        """Test complete TDX data access workflow"""
-        # Test connect -> query -> disconnect workflow
-        assert True
-
-
-class TestTdxIntegration:
-    """Integration tests for tdx.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_tdx_market_integration(self):
-        """Test TDX integration with market data modules"""
-        # Test TDX data with market analysis
-        assert True
-
-    @pytest.mark.file_test
-    def test_tdx_strategy_integration(self):
-        """Test TDX data with strategy calculations"""
-        # Test TDX data feeding into strategies
-        assert True
-
-
-class TestTdxValidation:
-    """Validation tests for TDX API"""
-
-    @pytest.mark.file_test
-    def test_tdx_api_compliance(self):
-        """Test compliance with TDX API specifications"""
-        # Validate TDX API compliance
-        assert True
-
-    @pytest.mark.file_test
-    def test_tdx_data_accuracy(self):
-        """Test accuracy of TDX data retrieval"""
-        # Validate TDX data accuracy
-        assert True
-
-    @pytest.mark.file_test
-    def test_tdx_endpoint_coverage(self):
-        """Test that all expected TDX endpoints are implemented"""
-        # Validate TDX endpoint coverage
-        assert True
+        assert "GET /api/tdx/quote/{symbol}" in doc
+        assert "GET /api/tdx/kline" in doc
+        assert "GET /api/tdx/index/quote/{symbol}" in doc
+        assert "GET /api/tdx/index/kline" in doc
+        assert "GET /api/tdx/health" in doc


### PR DESCRIPTION
## Summary
- replace 4 placeholder API file tests with route-aware contract assertions
- align cache, contract, data, and tdx file tests to active backend routers
- keep the micro-batch scoped to tests/api/file_tests only

## Verification
- git diff --check
- python -m pytest --no-cov tests/api/file_tests/test_cache_api.py tests/api/file_tests/test_contract_routes_api.py tests/api/file_tests/test_data_api.py tests/api/file_tests/test_tdx_api.py
- gitnexus_detect_changes(scope=staged): changed_files=4, risk_level=low, affected_processes=0