### PR TITLE
test(api): replace placeholder route contract tests batch 4

### DIFF
--- a/governance/mainline/task-cards/pr-61.yaml
+++ b/governance/mainline/task-cards/pr-61.yaml
@@ -1,0 +1,80 @@
+version: "v0.2"
+
+task:
+  id: "pr-61"
+  title: "replace placeholder api file tests with route contract assertions batch 4"
+  owner: "main"
+  created_at: "2026-04-06"
+
+mainline:
+  id: "L1-api-file-tests-contract-salvage"
+  objective: "replace placeholder API file tests with route-aware contract coverage through isolated salvage micro-batches"
+  milestone_id: "L2-api-file-tests-batch-series"
+  slice_id: "L3-batch-4-backtest-gpu-ml-monitoring"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+scope:
+  allowed_paths:
+    - "tests/api/file_tests/test_backtest_ws_api.py"
+    - "tests/api/file_tests/test_gpu_monitoring_api.py"
+    - "tests/api/file_tests/test_ml_api.py"
+    - "tests/api/file_tests/test_monitoring_api.py"
+    - "governance/mainline/task-cards/pr-61.yaml"
+  forbidden_paths:
+    - "web/frontend/src/views/data/Advanced.vue"
+    - "web/frontend/src/views/artdeco-pages/ArtDecoDataAnalysis.vue"
+    - "tests/api/file_tests/test_watchlist_api.py"
+
+non_goals:
+  - "No backend implementation changes; this batch only replaces placeholder file tests with route-aware contract assertions"
+  - "No work on Data-Indicator or Watchlist lines"
+  - "No scope expansion outside the declared 4 test files and governance task card"
+
+acceptance:
+  checks:
+    - id: "api-file-tests-batch-4"
+      command: "python -m pytest --no-cov tests/api/file_tests/test_backtest_ws_api.py tests/api/file_tests/test_gpu_monitoring_api.py tests/api/file_tests/test_ml_api.py tests/api/file_tests/test_monitoring_api.py"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-61.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report /tmp/pr61-mainline-gate.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If any asserted router metadata drifts from the actual backend route exports, this batch will fail as intended on future runs"
+    - "GPU monitoring endpoints currently emit pre-existing Pydantic dict deprecation warnings during tests; this batch does not change runtime code"
+  rollback_plan: "git revert <merge-commit-sha> if these route-aware tests or the PR-61 governance card introduce unexpected mainline gate failures"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "salvage four placeholder API file tests by aligning them to the active backtest_ws, gpu_monitoring, ml, and monitoring route surfaces"
+    modified_scope: "four tests/api/file_tests modules plus this PR-61 governance task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "no product logic changes; only test expectations now track real route exports and metadata"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the PR if the new route-aware assertions or governance scope metadata cause unexpected failures after merge"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-06T00:00:00Z"
+    approval_note: "tests-only cleanup batch does not require a separate OpenSpec proposal"
+    secondary_approved: false

--- a/tests/api/file_tests/test_backtest_ws_api.py
+++ b/tests/api/file_tests/test_backtest_ws_api.py
@@ -1,161 +1,163 @@
 """
-File-level tests for backtest_ws.py API endpoints
+File-level contract tests for backtest_ws.py.
 
-Tests all backtest WebSocket endpoints including:
-- Backtest progress streaming
-- Real-time result updates
-- Performance metric broadcasting
-- Strategy simulation status
-
-Priority: P1 (Core Business)
-Coverage: 90% functional + integration testing
+这些测试直接验证路由注册和 WebSocket 连接管理逻辑，
+替代原先只检查 fixture 的占位断言。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+from fastapi import WebSocketDisconnect
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def backtest_ws_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+
+    module = importlib.import_module("app.api.backtest_ws")
+    module.manager.connections.clear()
+    return module
+
+
+class DummyWebSocket:
+    def __init__(self, messages: list[object] | None = None):
+        self.accept = AsyncMock()
+        self.send_text = AsyncMock()
+        self.receive_text = AsyncMock(side_effect=messages or [WebSocketDisconnect()])
 
 
 class TestBacktestWsAPIFile:
-    """Test suite for backtest_ws.py API file"""
+    @pytest.mark.file_test
+    def test_router_registers_expected_routes(self, backtest_ws_module):
+        route_map = {
+            (route.path, tuple(sorted(getattr(route, "methods", set()) or [])))
+            for route in backtest_ws_module.router.routes
+        }
+        route_paths = {route.path for route in backtest_ws_module.router.routes}
+
+        assert backtest_ws_module.router.prefix == "/ws"
+        assert "/ws/backtest/{backtest_id}" in route_paths
+        assert ("/ws/status", ("GET",)) in route_map
 
     @pytest.mark.file_test
-    def test_backtest_progress_websocket(self, api_test_fixtures):
-        """Test GET /ws/backtest/{task_id} - Backtest progress WebSocket"""
-        # Test backtest progress streaming
-        assert api_test_fixtures["base_url"].startswith("http")
-
-    @pytest.mark.file_test
-    def test_backtest_subscribe_endpoint(self, api_test_fixtures):
-        """Test POST /ws/backtest/{task_id}/subscribe - Subscribe to backtest"""
-        # Test backtest subscription
-        assert api_test_fixtures["retry_attempts"] >= 1
-
-    @pytest.mark.file_test
-    def test_backtest_unsubscribe_endpoint(self, api_test_fixtures):
-        """Test POST /ws/backtest/{task_id}/unsubscribe - Unsubscribe from backtest"""
-        # Test backtest unsubscription
-        assert api_test_fixtures["mock_enabled"] is True
-
-    @pytest.mark.file_test
-    def test_backtest_results_stream(self, api_test_fixtures):
-        """Test backtest results streaming via WebSocket"""
-        # Test real-time backtest results
-        assert api_test_fixtures["contract_validation"] is True
-
-    @pytest.mark.file_test
-    def test_backtest_performance_stream(self, api_test_fixtures):
-        """Test backtest performance metrics streaming"""
-        # Test performance data broadcasting
-        assert api_test_fixtures["test_timeout"] > 0
-
-    @pytest.mark.file_test
-    def test_backtest_status_updates(self, api_test_fixtures):
-        """Test backtest status update broadcasting"""
-        # Test status change notifications
-        assert True
-
-    @pytest.mark.file_test
-    def test_backtest_error_streaming(self, api_test_fixtures):
-        """Test backtest error and warning streaming"""
-        # Test error message broadcasting
-        assert True
-
-    @pytest.mark.file_test
-    def test_backtest_authentication(self, api_test_fixtures):
-        """Test WebSocket authentication for backtest endpoints"""
-        # Test backtest WebSocket authentication
-        assert True
-
-    @pytest.mark.file_test
-    def test_backtest_connection_limits(self, api_test_fixtures):
-        """Test connection limits for backtest WebSockets"""
-        # Test concurrent connection management
-        assert True
-
-    @pytest.mark.file_test
-    def test_backtest_message_format(self, mock_responses):
-        """Test backtest WebSocket message format validation"""
-        # Validate WebSocket message structure for backtest data
-        assert True
-
-    @pytest.mark.file_test
-    def test_backtest_error_handling(self, mock_responses):
-        """Test error handling in backtest WebSocket connections"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
-
-    @pytest.mark.file_test
-    def test_backtest_reconnection(self):
-        """Test backtest WebSocket reconnection logic"""
-        # Test automatic reconnection for backtest streams
-        assert True  # Placeholder
-
-    @pytest.mark.file_test
-    def test_backtest_performance(self, api_test_fixtures):
-        """Test backtest WebSocket performance and latency"""
-        # Test message delivery performance
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for backtest operations
-
     @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_concurrent_backtest_streams(self):
-        """Test multiple concurrent backtest WebSocket streams"""
-        # Test handling multiple simultaneous backtest streams
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
+    async def test_connection_manager_connect_registers_callback(self, backtest_ws_module, monkeypatch):
+        websocket = DummyWebSocket()
+        register_callback = Mock()
+        monkeypatch.setattr(backtest_ws_module, "register_progress_callback", register_callback)
+        manager = backtest_ws_module.ConnectionManager()
+
+        await manager.connect(websocket, "bt-1")
+
+        websocket.accept.assert_called_once_with()
+        assert websocket in manager.connections["bt-1"]
+        register_callback.assert_called_once()
+        assert register_callback.call_args.args[0] == "bt-1"
+        assert callable(register_callback.call_args.args[1])
 
     @pytest.mark.file_test
-    def test_backtest_data_consistency(self):
-        """Test data consistency in backtest WebSocket messages"""
-        # Ensure backtest data remains consistent across streams
-        assert True
+    def test_connection_manager_disconnect_unregisters_last_subscription(self, backtest_ws_module, monkeypatch):
+        unregister_callback = Mock()
+        monkeypatch.setattr(backtest_ws_module, "unregister_progress_callback", unregister_callback)
+        manager = backtest_ws_module.ConnectionManager()
+        websocket = DummyWebSocket()
+        manager.connections["bt-1"] = {websocket}
+
+        manager.disconnect(websocket, "bt-1")
+
+        assert "bt-1" not in manager.connections
+        unregister_callback.assert_called_once_with("bt-1")
 
     @pytest.mark.file_test
-    def test_backtest_workflow(self):
-        """Test complete backtest WebSocket workflow"""
-        # Test subscribe -> receive progress -> get results workflow
-        assert True
+    @pytest.mark.asyncio
+    async def test_broadcast_serializes_payload_and_prunes_broken_connections(self, backtest_ws_module):
+        healthy = DummyWebSocket()
+        broken = DummyWebSocket()
+        broken.send_text.side_effect = RuntimeError("socket closed")
+        manager = backtest_ws_module.ConnectionManager()
+        manager.connections["bt-1"] = {healthy, broken}
 
+        await manager.broadcast("bt-1", {"type": "progress", "value": 42})
 
-class TestBacktestWsIntegration:
-    """Integration tests for backtest_ws.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_backtest_strategy_integration(self):
-        """Test backtest WebSocket with strategy execution"""
-        # Test backtest streaming with strategy calculations
-        assert True
+        healthy.send_text.assert_called_once_with(json.dumps({"type": "progress", "value": 42}))
+        assert broken not in manager.connections["bt-1"]
 
     @pytest.mark.file_test
-    def test_backtest_monitoring_integration(self):
-        """Test backtest WebSocket with monitoring system"""
-        # Test backtest progress monitoring via WebSocket
-        assert True
+    @pytest.mark.asyncio
+    async def test_websocket_handler_replies_to_ping(self, backtest_ws_module, monkeypatch):
+        websocket = DummyWebSocket(messages=[json.dumps({"type": "ping"}), WebSocketDisconnect()])
+        register_callback = Mock()
+        unregister_callback = Mock()
+        monkeypatch.setattr(backtest_ws_module, "register_progress_callback", register_callback)
+        monkeypatch.setattr(backtest_ws_module, "unregister_progress_callback", unregister_callback)
+        backtest_ws_module.manager = backtest_ws_module.ConnectionManager()
 
+        await backtest_ws_module.websocket_backtest_progress(websocket, "bt-2")
 
-class TestBacktestWsValidation:
-    """Validation tests for backtest WebSocket API"""
-
-    @pytest.mark.file_test
-    def test_backtest_websocket_protocol(self):
-        """Test backtest WebSocket protocol compliance"""
-        # Validate WebSocket protocol for backtest endpoints
-        assert True
-
-    @pytest.mark.file_test
-    def test_backtest_websocket_security(self):
-        """Test backtest WebSocket security measures"""
-        # Validate WebSocket security for backtest data
-        assert True
+        sent_messages = [json.loads(call.args[0]) for call in websocket.send_text.call_args_list]
+        assert sent_messages[0]["type"] == "connected"
+        assert sent_messages[0]["backtest_id"] == "bt-2"
+        assert sent_messages[1] == {"type": "pong"}
+        unregister_callback.assert_called_once_with("bt-2")
 
     @pytest.mark.file_test
-    def test_backtest_websocket_coverage(self):
-        """Test that all expected backtest WebSocket endpoints are implemented"""
-        # Validate backtest WebSocket endpoint coverage
-        assert True
+    @pytest.mark.asyncio
+    async def test_websocket_handler_acknowledges_cancel_and_disconnects(self, backtest_ws_module, monkeypatch):
+        websocket = DummyWebSocket(messages=[json.dumps({"type": "cancel"})])
+        register_callback = Mock()
+        unregister_callback = Mock()
+        monkeypatch.setattr(backtest_ws_module, "register_progress_callback", register_callback)
+        monkeypatch.setattr(backtest_ws_module, "unregister_progress_callback", unregister_callback)
+        backtest_ws_module.manager = backtest_ws_module.ConnectionManager()
+
+        await backtest_ws_module.websocket_backtest_progress(websocket, "bt-3")
+
+        sent_messages = [json.loads(call.args[0]) for call in websocket.send_text.call_args_list]
+        assert sent_messages[-1] == {"type": "cancelled", "message": "回测已取消"}
+        assert "bt-3" not in backtest_ws_module.manager.connections
+        unregister_callback.assert_called_once_with("bt-3")
+
+    @pytest.mark.file_test
+    @pytest.mark.asyncio
+    async def test_status_endpoint_reports_active_connection_counts(self, backtest_ws_module):
+        backtest_ws_module.manager.connections = {
+            "bt-1": {DummyWebSocket(), DummyWebSocket()},
+            "bt-2": {DummyWebSocket()},
+        }
+
+        payload = await backtest_ws_module.get_websocket_status()
+
+        assert payload == {
+            "status": "ok",
+            "total_connections": 3,
+            "backtest_subscriptions": 2,
+            "details": {"bt-1": 2, "bt-2": 1},
+        }
+
+    @pytest.mark.file_test
+    @pytest.mark.asyncio
+    async def test_send_personal_message_forwards_raw_text(self, backtest_ws_module):
+        websocket = DummyWebSocket()
+        manager = backtest_ws_module.ConnectionManager()
+
+        await manager.send_personal_message('{"type":"connected"}', websocket)
+
+        websocket.send_text.assert_called_once_with('{"type":"connected"}')

--- a/tests/api/file_tests/test_gpu_monitoring_api.py
+++ b/tests/api/file_tests/test_gpu_monitoring_api.py
@@ -1,131 +1,147 @@
 """
-File-level tests for gpu_monitoring.py API endpoints
+File-level route and model contract tests for gpu_monitoring.py.
 
-Tests all GPU monitoring endpoints including:
-- GPU resource usage tracking
-- GPU performance metrics
-- GPU health monitoring
-- GPU utilization analytics
-
-Priority: P2 (Utility)
-Coverage: 70% functional + smoke testing
+这里覆盖当前真实的 GPU 监控路由、Pydantic 模型和 mock 响应行为。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def gpu_monitoring_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    return importlib.import_module("app.api.gpu_monitoring")
 
 
 class TestGpuMonitoringAPIFile:
-    """Test suite for gpu_monitoring.py API file"""
+    @pytest.mark.file_test
+    def test_router_registers_expected_gpu_routes(self, gpu_monitoring_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in gpu_monitoring_module.router.routes}
+
+        assert gpu_monitoring_module.router.prefix == "/api/gpu"
+        assert gpu_monitoring_module.router.tags == ["gpu-monitoring"]
+        assert ("/api/gpu/status", ("GET",)) in route_methods
+        assert ("/api/gpu/performance", ("GET",)) in route_methods
+        assert ("/api/gpu/metrics", ("GET",)) in route_methods
+        assert ("/api/gpu/history", ("GET",)) in route_methods
 
     @pytest.mark.file_test
-    def test_gpu_status_endpoint(self, api_test_fixtures):
-        """Test GET /api/gpu/status - GPU status overview"""
-        # Test GPU status and availability
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_router_contains_expected_number_of_routes(self, gpu_monitoring_module):
+        route_pairs = [(route.path, tuple(sorted(route.methods or []))) for route in gpu_monitoring_module.router.routes]
+
+        assert len(route_pairs) == 4
+        assert len(route_pairs) == len(set(route_pairs))
 
     @pytest.mark.file_test
-    def test_gpu_utilization_endpoint(self, api_test_fixtures):
-        """Test GET /api/gpu/utilization - GPU utilization metrics"""
-        # Test GPU utilization tracking
-        assert api_test_fixtures["retry_attempts"] >= 1
+    def test_gpu_status_model_fields_and_ranges_are_stable(self, gpu_monitoring_module):
+        fields = gpu_monitoring_module.GPUStatus.model_fields
+
+        assert set(fields) == {
+            "device_id",
+            "name",
+            "gpu_utilization",
+            "memory_used",
+            "memory_total",
+            "memory_utilization",
+            "temperature",
+            "power_usage",
+            "sm_clock",
+            "memory_clock",
+        }
+        assert any(getattr(meta, "ge", None) == 0 for meta in fields["gpu_utilization"].metadata)
+        assert any(getattr(meta, "le", None) == 100 for meta in fields["gpu_utilization"].metadata)
+        assert any(getattr(meta, "ge", None) == 0 for meta in fields["memory_utilization"].metadata)
+        assert any(getattr(meta, "le", None) == 100 for meta in fields["memory_utilization"].metadata)
 
     @pytest.mark.file_test
-    def test_gpu_memory_endpoint(self, api_test_fixtures):
-        """Test GET /api/gpu/memory - GPU memory usage"""
-        # Test GPU memory monitoring
-        assert api_test_fixtures["mock_enabled"] is True
+    def test_gpu_performance_model_fields_are_stable(self, gpu_monitoring_module):
+        fields = set(gpu_monitoring_module.GPUPerformanceMetrics.model_fields)
+
+        assert fields == {
+            "device_id",
+            "matrix_gflops",
+            "matrix_speedup",
+            "memory_gflops",
+            "memory_speedup",
+            "throughput",
+            "timestamp",
+        }
 
     @pytest.mark.file_test
-    def test_gpu_temperature_endpoint(self, api_test_fixtures):
-        """Test GET /api/gpu/temperature - GPU temperature monitoring"""
-        # Test GPU temperature tracking
-        assert api_test_fixtures["contract_validation"] is True
-
-    @pytest.mark.file_test
-    def test_gpu_performance_endpoint(self, api_test_fixtures):
-        """Test GET /api/gpu/performance - GPU performance metrics"""
-        # Test GPU performance analytics
-        assert api_test_fixtures["test_timeout"] > 0
-
-    @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across GPU monitoring endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
-
-    @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for GPU monitoring endpoints"""
-        # Validate GPU monitoring response formats
-        assert True  # Placeholder
-
-    @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for GPU monitoring endpoints"""
-        # Validate GPU monitoring query performance
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for GPU monitoring
-
     @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_gpu_monitoring_data_collection(self):
-        """Test GPU monitoring data collection and processing"""
-        # Test GPU metrics collection
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
+    async def test_get_gpu_status_returns_unified_response_payload(self, gpu_monitoring_module):
+        request = SimpleNamespace(state=SimpleNamespace(request_id="req-1"))
+
+        payload = await gpu_monitoring_module.get_gpu_status(request, device_id=None)
+
+        assert payload.success is True
+        assert payload.message == "GPU状态查询成功"
+        assert payload.request_id == "req-1"
+        assert payload.data["gpus"][0]["device_id"] == 0
 
     @pytest.mark.file_test
-    def test_gpu_monitoring_data_consistency(self):
-        """Test data consistency in GPU monitoring operations"""
-        # Ensure GPU monitoring data remains consistent
-        assert True
+    @pytest.mark.asyncio
+    async def test_get_gpu_performance_returns_unified_response_payload(self, gpu_monitoring_module):
+        request = SimpleNamespace(state=SimpleNamespace(request_id="req-2"))
+
+        payload = await gpu_monitoring_module.get_gpu_performance(request, device_id=0)
+
+        assert payload.success is True
+        assert payload.message == "GPU性能指标查询成功"
+        assert payload.data["metrics"][0]["device_id"] == 0
 
     @pytest.mark.file_test
-    def test_gpu_monitoring_workflow(self):
-        """Test complete GPU monitoring workflow"""
-        # Test status -> utilization -> performance workflow
-        assert True
+    @pytest.mark.asyncio
+    async def test_get_prometheus_metrics_returns_plain_text_response(self, gpu_monitoring_module):
+        request = SimpleNamespace(state=SimpleNamespace(request_id="req-3"))
 
+        response = await gpu_monitoring_module.get_prometheus_metrics(request)
 
-class TestGpuMonitoringIntegration:
-    """Integration tests for gpu_monitoring.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_gpu_monitoring_system_integration(self):
-        """Test GPU monitoring with system monitoring"""
-        # Test GPU monitoring integration with system metrics
-        assert True
+        assert response.media_type == "text/plain"
+        assert "gpu_utilization" in response.body.decode()
+        assert "gpu_matrix_gflops" in response.body.decode()
 
     @pytest.mark.file_test
-    def test_gpu_monitoring_performance_integration(self):
-        """Test GPU monitoring with performance analysis"""
-        # Test GPU metrics with performance analysis
-        assert True
+    @pytest.mark.asyncio
+    async def test_get_gpu_history_returns_empty_history_structure(self, gpu_monitoring_module):
+        request = SimpleNamespace(state=SimpleNamespace(request_id="req-4"))
 
+        payload = await gpu_monitoring_module.get_gpu_history(request, device_id=0, start_time=None, end_time=None, limit=10)
 
-class TestGpuMonitoringValidation:
-    """Validation tests for GPU monitoring API"""
-
-    @pytest.mark.file_test
-    def test_gpu_monitoring_api_compliance(self):
-        """Test compliance with GPU monitoring API specifications"""
-        # Validate GPU monitoring API compliance
-        assert True
+        assert payload.success is True
+        assert payload.message == "GPU历史数据查询成功"
+        assert payload.data == {"device_id": 0, "records": [], "total": 0}
 
     @pytest.mark.file_test
-    def test_gpu_monitoring_accuracy(self):
-        """Test accuracy of GPU monitoring data"""
-        # Validate GPU monitoring data accuracy
-        assert True
+    def test_route_names_remain_stable(self, gpu_monitoring_module):
+        route_names = {(route.path, tuple(sorted(route.methods or []))): route.name for route in gpu_monitoring_module.router.routes}
+
+        assert route_names[("/api/gpu/status", ("GET",))] == "get_gpu_status"
+        assert route_names[("/api/gpu/performance", ("GET",))] == "get_gpu_performance"
+        assert route_names[("/api/gpu/metrics", ("GET",))] == "get_prometheus_metrics"
+        assert route_names[("/api/gpu/history", ("GET",))] == "get_gpu_history"
 
     @pytest.mark.file_test
-    def test_gpu_monitoring_endpoint_coverage(self):
-        """Test that all expected GPU monitoring endpoints are implemented"""
-        # Validate GPU monitoring endpoint coverage
-        assert True
+    def test_module_docstring_mentions_prometheus_and_hardware_monitoring(self, gpu_monitoring_module):
+        doc = gpu_monitoring_module.__doc__ or ""
+
+        assert "Prometheus" in doc
+        assert "GPU实时状态查询" in doc

--- a/tests/api/file_tests/test_ml_api.py
+++ b/tests/api/file_tests/test_ml_api.py
@@ -1,137 +1,124 @@
 """
-File-level tests for ml.py API endpoints
+File-level route contract tests for ml.py.
 
-Tests all machine learning service endpoints including:
-- Model prediction and inference
-- Model training status monitoring
-- Model management and deployment
-- ML performance metrics
-
-Priority: P2 (Utility)
-Coverage: 70% functional + smoke testing
+这里对齐当前真实的机器学习路由面与响应模型，
+替换掉生成式占位断言。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def ml_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    return importlib.import_module("app.api.ml")
 
 
 class TestMLAPIFile:
-    """Test suite for ml.py API file"""
+    @pytest.mark.file_test
+    def test_router_registers_expected_ml_routes(self, ml_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in ml_module.router.routes}
+
+        assert ml_module.router.prefix == "/ml"
+        assert ml_module.router.tags == ["Machine Learning"]
+        assert ("/ml/tdx/data", ("POST",)) in route_methods
+        assert ("/ml/tdx/stocks/{market}", ("GET",)) in route_methods
+        assert ("/ml/features/generate", ("POST",)) in route_methods
+        assert ("/ml/models/train", ("POST",)) in route_methods
+        assert ("/ml/models/predict", ("POST",)) in route_methods
+        assert ("/ml/models", ("GET",)) in route_methods
+        assert ("/ml/models/{model_name}", ("GET",)) in route_methods
+        assert ("/ml/models/hyperparameter-search", ("POST",)) in route_methods
+        assert ("/ml/models/evaluate", ("POST",)) in route_methods
 
     @pytest.mark.file_test
-    def test_model_predict_endpoint(self, api_test_fixtures):
-        """Test POST /api/ml/predict - Model prediction"""
-        # Test ML model inference
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_router_contains_expected_number_of_route_method_pairs(self, ml_module):
+        route_pairs = [(route.path, tuple(sorted(route.methods or []))) for route in ml_module.router.routes]
+
+        assert len(route_pairs) == 9
+        assert len(route_pairs) == len(set(route_pairs))
 
     @pytest.mark.file_test
-    def test_model_train_endpoint(self, api_test_fixtures):
-        """Test POST /api/ml/train - Model training"""
-        # Test ML model training initiation
-        assert api_test_fixtures["retry_attempts"] >= 1
+    def test_response_models_remain_stable(self, ml_module):
+        response_models = {(route.path, tuple(sorted(route.methods or []))): route.response_model for route in ml_module.router.routes}
+
+        assert response_models[("/ml/tdx/data", ("POST",))] is ml_module.TdxDataResponse
+        assert response_models[("/ml/tdx/stocks/{market}", ("GET",))] == ml_module.List[str]
+        assert response_models[("/ml/features/generate", ("POST",))] is ml_module.FeatureGenerationResponse
+        assert response_models[("/ml/models/train", ("POST",))] is ml_module.ModelTrainResponse
+        assert response_models[("/ml/models/predict", ("POST",))] is ml_module.ModelPredictResponse
+        assert response_models[("/ml/models", ("GET",))] is ml_module.ModelListResponse
+        assert response_models[("/ml/models/{model_name}", ("GET",))] is ml_module.ModelDetailResponse
+        assert response_models[("/ml/models/hyperparameter-search", ("POST",))] is ml_module.HyperparameterSearchResponse
+        assert response_models[("/ml/models/evaluate", ("POST",))] is ml_module.ModelEvaluationResponse
 
     @pytest.mark.file_test
-    def test_model_list_endpoint(self, api_test_fixtures):
-        """Test GET /api/ml/models - Model list"""
-        # Test trained model listing
-        assert api_test_fixtures["mock_enabled"] is True
+    def test_route_names_remain_stable_for_core_operations(self, ml_module):
+        route_names = {(route.path, tuple(sorted(route.methods or []))): route.name for route in ml_module.router.routes}
+
+        assert route_names[("/ml/models/train", ("POST",))] == "train_model"
+        assert route_names[("/ml/models/predict", ("POST",))] == "predict_with_model"
+        assert route_names[("/ml/models", ("GET",))] == "list_models"
+        assert route_names[("/ml/models/evaluate", ("POST",))] == "evaluate_model"
 
     @pytest.mark.file_test
-    def test_model_status_endpoint(self, api_test_fixtures):
-        """Test GET /api/ml/models/{id}/status - Model status"""
-        # Test model training status monitoring
-        assert api_test_fixtures["contract_validation"] is True
+    def test_router_contains_five_model_lifecycle_routes(self, ml_module):
+        model_paths = {route.path for route in ml_module.router.routes if "/ml/models" in route.path}
+
+        assert "/ml/models/train" in model_paths
+        assert "/ml/models/predict" in model_paths
+        assert "/ml/models" in model_paths
+        assert "/ml/models/{model_name}" in model_paths
+        assert "/ml/models/hyperparameter-search" in model_paths
+        assert "/ml/models/evaluate" in model_paths
 
     @pytest.mark.file_test
-    def test_model_delete_endpoint(self, api_test_fixtures):
-        """Test DELETE /api/ml/models/{id} - Delete model"""
-        # Test model cleanup and removal
-        assert api_test_fixtures["test_timeout"] > 0
+    def test_mlprediction_service_builder_exposes_service_unavailable_path(self, ml_module, monkeypatch):
+        monkeypatch.setattr(ml_module, "MLPredictionService", None)
+        monkeypatch.setattr(ml_module, "_ML_PREDICTION_IMPORT_ERROR", ModuleNotFoundError("missing"))
+
+        with pytest.raises(ml_module.HTTPException) as excinfo:
+            ml_module._build_ml_service()
+
+        assert excinfo.value.status_code == 503
+        assert "ML prediction service unavailable" in excinfo.value.detail
 
     @pytest.mark.file_test
-    def test_ml_metrics_endpoint(self, api_test_fixtures):
-        """Test GET /api/ml/metrics - ML performance metrics"""
-        # Test ML model performance metrics
-        assert True
+    def test_module_docstring_mentions_training_prediction_and_evaluation(self, ml_module):
+        doc = ml_module.__doc__ or ""
+
+        assert "模型训练" in doc
+        assert "预测" in doc
+        assert "评估" in doc
 
     @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across ML endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
+    def test_feature_and_tdx_route_docstrings_are_descriptive(self, ml_module):
+        assert "生成特征数据" in (ml_module.generate_features.__doc__ or "")
+        assert "获取通达信股票数据" in (ml_module.get_tdx_data.__doc__ or "")
 
     @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for ML endpoints"""
-        # Validate ML response formats
-        assert True  # Placeholder
+    def test_model_dir_defaults_to_models_directory(self, ml_module):
+        assert ml_module.MODEL_DIR == "./models"
 
     @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for ML endpoints"""
-        # Validate ML operation performance
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for ML operations
+    def test_router_only_exposes_get_and_post_methods(self, ml_module):
+        methods = {method for route in ml_module.router.routes for method in route.methods or []}
 
-    @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_ml_inference(self):
-        """Test ML model inference operations"""
-        # Test model prediction and inference
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
-
-    @pytest.mark.file_test
-    def test_ml_data_consistency(self):
-        """Test data consistency in ML operations"""
-        # Ensure ML data remains consistent
-        assert True
-
-    @pytest.mark.file_test
-    def test_ml_workflow(self):
-        """Test complete ML workflow"""
-        # Test model training -> deployment -> prediction workflow
-        assert True
-
-
-class TestMLIntegration:
-    """Integration tests for ml.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_ml_strategy_integration(self):
-        """Test ML integration with strategy modules"""
-        # Test ML predictions for strategy decisions
-        assert True
-
-    @pytest.mark.file_test
-    def test_ml_monitoring_integration(self):
-        """Test ML model monitoring and metrics"""
-        # Test ML model performance monitoring
-        assert True
-
-
-class TestMLValidation:
-    """Validation tests for ML API"""
-
-    @pytest.mark.file_test
-    def test_ml_api_compliance(self):
-        """Test compliance with ML API specifications"""
-        # Validate ML API compliance
-        assert True
-
-    @pytest.mark.file_test
-    def test_model_accuracy(self):
-        """Test ML model accuracy and reliability"""
-        # Validate model prediction accuracy
-        assert True
-
-    @pytest.mark.file_test
-    def test_ml_endpoint_coverage(self):
-        """Test that all expected ML endpoints are implemented"""
-        # Validate ML endpoint coverage
-        assert True
+        assert methods == {"GET", "POST"}

--- a/tests/api/file_tests/test_monitoring_api.py
+++ b/tests/api/file_tests/test_monitoring_api.py
@@ -1,143 +1,143 @@
 """
-File-level tests for monitoring.py API endpoints
+File-level route and helper contract tests for monitoring.py.
 
-Tests all monitoring-related endpoints including:
-- System health monitoring
-- Performance metrics collection
-- Log management and analysis
-- Resource usage tracking
-
-Priority: P1 (Core Business)
-Coverage: 90% functional + integration testing
+这里校验当前 18 个监控路由、fallback helper 和核心响应模型，
+不触发真实数据库查询。
 """
 
-import asyncio
+from __future__ import annotations
 
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import dotenv
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def monitoring_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    monkeypatch.setattr(dotenv, "load_dotenv", lambda *args, **kwargs: False)
+    return importlib.import_module("app.api.monitoring")
 
 
 class TestMonitoringAPIFile:
-    """Test suite for monitoring.py API file"""
+    @pytest.mark.file_test
+    def test_router_registers_expected_monitoring_routes(self, monitoring_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in monitoring_module.router.routes}
+
+        assert ("/alert-rules", ("GET",)) in route_methods
+        assert ("/alert-rules", ("POST",)) in route_methods
+        assert ("/alert-rules/{rule_id}", ("PUT",)) in route_methods
+        assert ("/alert-rules/{rule_id}", ("DELETE",)) in route_methods
+        assert ("/alerts", ("GET",)) in route_methods
+        assert ("/alerts/{alert_id}/mark-read", ("POST",)) in route_methods
+        assert ("/alerts/mark-all-read", ("POST",)) in route_methods
+        assert ("/realtime/{symbol}", ("GET",)) in route_methods
+        assert ("/realtime", ("GET",)) in route_methods
+        assert ("/realtime/fetch", ("POST",)) in route_methods
+        assert ("/dragon-tiger", ("GET",)) in route_methods
+        assert ("/dragon-tiger/fetch", ("POST",)) in route_methods
+        assert ("/analyze", ("GET",)) in route_methods
+        assert ("/summary", ("GET",)) in route_methods
+        assert ("/stats/today", ("GET",)) in route_methods
+        assert ("/control/start", ("POST",)) in route_methods
+        assert ("/control/stop", ("POST",)) in route_methods
+        assert ("/control/status", ("GET",)) in route_methods
 
     @pytest.mark.file_test
-    def test_health_endpoint(self, api_test_fixtures):
-        """Test GET /api/monitoring/health - System health check"""
-        # Test system health status
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_router_contains_expected_number_of_route_method_pairs(self, monitoring_module):
+        route_pairs = [(route.path, tuple(sorted(route.methods or []))) for route in monitoring_module.router.routes]
+
+        assert len(route_pairs) == 18
+        assert len(route_pairs) == len(set(route_pairs))
 
     @pytest.mark.file_test
-    def test_performance_endpoint(self, api_test_fixtures):
-        """Test GET /api/monitoring/performance - Performance metrics"""
-        # Test performance data collection
-        assert api_test_fixtures["retry_attempts"] >= 1
+    def test_response_models_remain_stable_for_key_routes(self, monitoring_module):
+        response_models = {(route.path, tuple(sorted(route.methods or []))): route.response_model for route in monitoring_module.router.routes}
+
+        assert response_models[("/alert-rules", ("GET",))] == monitoring_module.UnifiedResponse[
+            monitoring_module.List[monitoring_module.AlertRuleResponse]
+        ]
+        assert response_models[("/alerts", ("GET",))] is monitoring_module.AlertRecordsResponse
+        assert response_models[("/realtime/{symbol}", ("GET",))] is monitoring_module.RealtimeMonitoringResponse
+        assert response_models[("/realtime", ("GET",))] == monitoring_module.List[
+            monitoring_module.RealtimeMonitoringResponse
+        ]
+        assert response_models[("/dragon-tiger", ("GET",))] == monitoring_module.List[
+            monitoring_module.DragonTigerListResponse
+        ]
+        assert response_models[("/summary", ("GET",))] is monitoring_module.MonitoringSummaryResponse
 
     @pytest.mark.file_test
-    def test_logs_endpoint(self, api_test_fixtures):
-        """Test GET /api/monitoring/logs - System logs"""
-        # Test log retrieval and filtering
-        assert api_test_fixtures["mock_enabled"] is True
+    def test_route_names_remain_stable_for_core_operations(self, monitoring_module):
+        route_names = {(route.path, tuple(sorted(route.methods or []))): route.name for route in monitoring_module.router.routes}
+
+        assert route_names[("/alert-rules", ("GET",))] == "get_alert_rules"
+        assert route_names[("/alerts", ("GET",))] == "get_alert_records"
+        assert route_names[("/summary", ("GET",))] == "get_monitoring_summary"
+        assert route_names[("/control/status", ("GET",))] == "get_monitoring_status"
 
     @pytest.mark.file_test
-    def test_metrics_endpoint(self, api_test_fixtures):
-        """Test GET /api/monitoring/metrics - System metrics"""
-        # Test metrics collection and reporting
-        assert api_test_fixtures["contract_validation"] is True
+    def test_runtime_fallback_flag_reads_testing_or_development_env(self, monitoring_module, monkeypatch):
+        monkeypatch.setenv("TESTING", "false")
+        monkeypatch.setenv("DEVELOPMENT_MODE", "false")
+        assert monitoring_module._runtime_fallback_enabled() is False
+
+        monkeypatch.setenv("TESTING", "true")
+        assert monitoring_module._runtime_fallback_enabled() is True
+
+        monkeypatch.setenv("TESTING", "false")
+        monkeypatch.setenv("DEVELOPMENT_MODE", "true")
+        assert monitoring_module._runtime_fallback_enabled() is True
 
     @pytest.mark.file_test
-    def test_resources_endpoint(self, api_test_fixtures):
-        """Test GET /api/monitoring/resources - Resource usage"""
-        # Test resource monitoring
-        assert api_test_fixtures["test_timeout"] > 0
+    def test_runtime_fallback_builders_return_consistent_fixture_objects(self, monitoring_module):
+        rules = monitoring_module._build_runtime_alert_rules()
+        records = monitoring_module._build_runtime_alert_records()
+
+        assert len(rules) == 2
+        assert len(records) == 2
+        assert rules[0].id == 9001
+        assert records[0].rule_id == 9001
+        assert rules[1].symbol == "000001"
+        assert records[1].alert_level == "warning"
 
     @pytest.mark.file_test
-    def test_alerts_endpoint(self, api_test_fixtures):
-        """Test GET /api/monitoring/alerts - System alerts"""
-        # Test alert management and notifications
-        assert True
+    def test_resolve_query_int_uses_default_when_query_like_object_is_passed(self, monitoring_module):
+        query_like = SimpleNamespace(default=25)
+
+        assert monitoring_module._resolve_query_int(12, 99) == 12
+        assert monitoring_module._resolve_query_int(query_like, 99) == 25
 
     @pytest.mark.file_test
-    def test_dashboard_endpoint(self, api_test_fixtures):
-        """Test GET /api/monitoring/dashboard - Monitoring dashboard"""
-        # Test dashboard data aggregation
-        assert True
+    def test_alert_records_response_model_fields_remain_stable(self, monitoring_module):
+        fields = set(monitoring_module.AlertRecordsResponse.model_fields)
+
+        assert fields == {"success", "data", "total", "limit", "offset"}
 
     @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across monitoring endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
+    def test_summary_and_analyze_routes_share_same_response_model(self, monitoring_module):
+        response_models = {(route.path, tuple(sorted(route.methods or []))): route.response_model for route in monitoring_module.router.routes}
+
+        assert response_models[("/analyze", ("GET",))] is monitoring_module.MonitoringSummaryResponse
+        assert response_models[("/summary", ("GET",))] is monitoring_module.MonitoringSummaryResponse
 
     @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for monitoring endpoints"""
-        # Validate monitoring data formats
-        assert True  # Placeholder
-
-    @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for monitoring endpoints"""
-        # Validate monitoring query performance
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for monitoring queries
-
-    @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_monitoring_data_collection(self):
-        """Test monitoring data collection and aggregation"""
-        # Test real-time data collection
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
-
-    @pytest.mark.file_test
-    def test_monitoring_data_consistency(self):
-        """Test data consistency across monitoring operations"""
-        # Ensure monitoring data remains consistent
-        assert True
-
-    @pytest.mark.file_test
-    def test_alert_workflow(self):
-        """Test complete alert generation and handling workflow"""
-        # Test alert threshold -> generation -> notification workflow
-        assert True
-
-
-class TestMonitoringIntegration:
-    """Integration tests for monitoring.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_monitoring_system_integration(self):
-        """Test monitoring system with core application"""
-        # Test monitoring integration with main application
-        assert True
-
-    @pytest.mark.file_test
-    def test_monitoring_notification_integration(self):
-        """Test monitoring alerts with notification system"""
-        # Test alert to notification integration
-        assert True
-
-
-class TestMonitoringValidation:
-    """Validation tests for monitoring API"""
-
-    @pytest.mark.file_test
-    def test_monitoring_api_compliance(self):
-        """Test compliance with monitoring API specifications"""
-        # Validate monitoring API compliance
-        assert True
-
-    @pytest.mark.file_test
-    def test_monitoring_data_accuracy(self):
-        """Test accuracy of monitoring data collection"""
-        # Validate monitoring data accuracy
-        assert True
-
-    @pytest.mark.file_test
-    def test_monitoring_coverage(self):
-        """Test that all expected monitoring endpoints are implemented"""
-        # Validate monitoring endpoint coverage
-        assert True
+    def test_docstrings_cover_alerts_realtime_and_summary_operations(self, monitoring_module):
+        assert "获取告警规则列表" in (monitoring_module.get_alert_rules.__doc__ or "")
+        assert "获取实时监控数据列表" in (monitoring_module.get_realtime_monitoring_list.__doc__ or "")
+        assert "获取监控系统摘要" in (monitoring_module.get_monitoring_summary.__doc__ or "")


### PR DESCRIPTION
## Summary
- replace 4 placeholder API file tests with route-aware contract assertions
- align backtest_ws, gpu_monitoring, ml, and monitoring file tests to active backend exports
- keep the micro-batch scoped to tests/api/file_tests only

## Verification
- git diff --check
- python -m pytest --no-cov tests/api/file_tests/test_backtest_ws_api.py tests/api/file_tests/test_gpu_monitoring_api.py tests/api/file_tests/test_ml_api.py tests/api/file_tests/test_monitoring_api.py
- gitnexus_detect_changes(scope=staged): changed_files=4, risk_level=low, affected_processes=0