### PR TITLE
test(api): replace placeholder route contract tests batch 5

### DIFF
--- a/governance/mainline/task-cards/pr-62.yaml
+++ b/governance/mainline/task-cards/pr-62.yaml
@@ -1,0 +1,79 @@
+version: "v0.2"
+
+task:
+  id: "pr-62"
+  title: "replace placeholder api file tests with route contract assertions batch 5"
+  owner: "main"
+  created_at: "2026-04-06"
+
+mainline:
+  id: "L1-api-file-tests-contract-salvage"
+  objective: "replace placeholder API file tests with route-aware contract coverage through isolated salvage micro-batches"
+  milestone_id: "L2-api-file-tests-batch-series"
+  slice_id: "L3-batch-5-market-risk-strategy"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+scope:
+  allowed_paths:
+    - "tests/api/file_tests/test_market_api.py"
+    - "tests/api/file_tests/test_risk_management_api.py"
+    - "tests/api/file_tests/test_strategy_management_api.py"
+    - "governance/mainline/task-cards/pr-62.yaml"
+  forbidden_paths:
+    - "web/frontend/src/views/data/Advanced.vue"
+    - "web/frontend/src/views/artdeco-pages/ArtDecoDataAnalysis.vue"
+    - "tests/api/file_tests/test_watchlist_api.py"
+
+non_goals:
+  - "No backend implementation changes; this batch only replaces placeholder file tests with route-aware contract assertions"
+  - "No work on Data-Indicator or Watchlist lines"
+  - "No scope expansion outside the declared 3 test files and governance task card"
+
+acceptance:
+  checks:
+    - id: "api-file-tests-batch-5"
+      command: "python -m pytest --no-cov tests/api/file_tests/test_market_api.py tests/api/file_tests/test_risk_management_api.py tests/api/file_tests/test_strategy_management_api.py"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-62.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report /tmp/pr62-mainline-gate.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If any asserted router metadata drifts from the actual backend route exports, this batch will fail as intended on future runs"
+    - "These tests intentionally codify compatibility behavior in risk_management.py; future shim removal must update this batch accordingly"
+  rollback_plan: "git revert <merge-commit-sha> if these route-aware tests or the PR-62 governance card introduce unexpected mainline gate failures"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "salvage three placeholder API file tests by aligning them to the active market, risk_management, and strategy_management export surfaces"
+    modified_scope: "three tests/api/file_tests modules plus this PR-62 governance task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "no product logic changes; only test expectations now track real route exports, compatibility shims, and package exports"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the PR if the new route-aware assertions or governance scope metadata cause unexpected failures after merge"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-06T00:00:00Z"
+    approval_note: "tests-only cleanup batch does not require a separate OpenSpec proposal"
+    secondary_approved: false

--- a/tests/api/file_tests/test_market_api.py
+++ b/tests/api/file_tests/test_market_api.py
@@ -1,165 +1,102 @@
 """
-File-level tests for market.py API endpoints
+File-level route contract tests for data/market.py.
 
-Tests all market-related endpoints including:
-- Market overview data
-- Fund flow data
-- K-line data
-- ETF data
-- LongHuBang data
-- Chip race data
-
-Priority: P0 (Contract-managed)
-Coverage: 100% functional + contract validation
+这里对齐当前真实的市场概览与热度路由，
+替换掉生成式占位断言。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from typing import Any, Dict
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def market_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    return importlib.import_module("app.api.data.market")
 
 
 class TestMarketAPIFile:
-    """Test suite for market.py API file"""
+    @pytest.mark.file_test
+    def test_router_registers_expected_market_routes(self, market_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in market_module.router.routes}
+
+        assert ("/markets/overview", ("GET",)) in route_methods
+        assert ("/markets/price-distribution", ("GET",)) in route_methods
+        assert ("/markets/hot-industries", ("GET",)) in route_methods
+        assert ("/markets/hot-concepts", ("GET",)) in route_methods
+
+    @pytest.mark.file_test
+    def test_router_contains_expected_number_of_routes(self, market_module):
+        route_pairs = [(route.path, tuple(sorted(route.methods or []))) for route in market_module.router.routes]
+
+        assert len(route_pairs) == 4
+        assert len(route_pairs) == len(set(route_pairs))
+
+    @pytest.mark.file_test
+    def test_all_routes_use_plain_dict_response_model(self, market_module):
+        for route in market_module.router.routes:
+            assert route.response_model == Dict[str, Any]
+
+    @pytest.mark.file_test
+    def test_route_names_remain_stable_for_market_operations(self, market_module):
+        route_names = {(route.path, tuple(sorted(route.methods or []))): route.name for route in market_module.router.routes}
+
+        assert route_names[("/markets/overview", ("GET",))] == "get_market_overview"
+        assert route_names[("/markets/price-distribution", ("GET",))] == "get_price_distribution"
+        assert route_names[("/markets/hot-industries", ("GET",))] == "get_hot_industries"
+        assert route_names[("/markets/hot-concepts", ("GET",))] == "get_hot_concepts"
+
+    @pytest.mark.file_test
+    def test_market_docstring_mentions_overview_and_heat(self, market_module):
+        doc = market_module.__doc__ or ""
+
+        assert "市场概览" in doc
+        assert "热度" in doc
+
+    @pytest.mark.file_test
+    def test_route_docstrings_cover_overview_distribution_industries_and_concepts(self, market_module):
+        assert "获取市场概览数据" in (market_module.get_market_overview.__doc__ or "")
+        assert "获取全市场涨跌分布统计" in (market_module.get_price_distribution.__doc__ or "")
+        assert "获取热门行业表现数据" in (market_module.get_hot_industries.__doc__ or "")
+        assert "获取热门概念表现数据" in (market_module.get_hot_concepts.__doc__ or "")
+
+    @pytest.mark.file_test
+    def test_all_routes_are_get_only(self, market_module):
+        for route in market_module.router.routes:
+            assert tuple(sorted(route.methods or [])) == ("GET",)
 
     @pytest.mark.file_test
     @pytest.mark.contract_test
-    def test_market_overview_endpoint(self, api_test_fixtures, mock_responses):
-        """Test /api/market/overview endpoint"""
-        # Test successful response
-        response = mock_responses["market_overview"]
-        assert response["success"] is True
-        assert "data" in response
-        assert "total_stocks" in response["data"]
+    def test_contract_fixture_still_covers_market_data_domain(self, contract_specs):
+        spec = contract_specs["market-data"]
 
-    @pytest.mark.file_test
-    def test_fund_flow_endpoint(self, api_test_fixtures):
-        """Test /api/market/fund-flow endpoint"""
-        # Test fund flow data structure
-        # This would test the actual endpoint in real implementation
-        assert api_test_fixtures["base_url"].startswith("http")
-
-    @pytest.mark.file_test
-    def test_kline_endpoint(self, api_test_fixtures):
-        """Test /api/market/kline endpoint"""
-        # Test K-line data retrieval
-        assert api_test_fixtures["test_timeout"] > 0
-
-    @pytest.mark.file_test
-    def test_etf_endpoint(self, api_test_fixtures):
-        """Test /api/market/etf/list endpoint"""
-        # Test ETF data endpoints
-        assert api_test_fixtures["retry_attempts"] >= 1
-
-    @pytest.mark.file_test
-    def test_longhubang_endpoint(self, api_test_fixtures):
-        """Test /api/market/lhb endpoint"""
-        # Test LongHuBang data
-        assert api_test_fixtures["mock_enabled"] is True
-
-    @pytest.mark.file_test
-    def test_chip_race_endpoint(self, api_test_fixtures):
-        """Test /api/market/chip-race endpoint"""
-        # Test chip race data
-        assert api_test_fixtures["contract_validation"] is True
-
-    @pytest.mark.file_test
-    @pytest.mark.contract_test
-    def test_contract_compliance(self, contract_specs):
-        """Test OpenAPI contract compliance for market.py"""
-        spec = contract_specs.get("market-data")
-        assert spec is not None
+        assert spec["info"]["version"] == "1.0.0"
         assert spec["openapi"] == "3.0.3"
         assert "/api/market/overview" in spec["paths"]
         assert "/api/market/fund-flow" in spec["paths"]
 
     @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across all endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
+    def test_market_routes_share_single_namespace(self, market_module):
+        assert all(route.path.startswith("/markets/") for route in market_module.router.routes)
 
     @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for all endpoints"""
-        # Validate response schemas match contract specifications
-        # This would validate against OpenAPI schemas in real implementation
-        assert True  # Placeholder
-
-    @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for market endpoints"""
-        # Validate response times are within acceptable limits
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for market data
-
-    @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_concurrent_requests(self):
-        """Test concurrent request handling"""
-        # Test multiple simultaneous requests to market endpoints
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
-
-    @pytest.mark.file_test
-    def test_data_consistency(self):
-        """Test data consistency across related endpoints"""
-        # Ensure data from different market endpoints is consistent
-        assert True
-
-    @pytest.mark.file_test
-    def test_rate_limiting(self):
-        """Test rate limiting for market data endpoints"""
-        # Verify rate limiting is properly implemented
-        assert True
-
-    @pytest.mark.file_test
-    def test_caching_behavior(self):
-        """Test caching behavior for market data"""
-        # Verify caching headers and behavior
-        assert True
-
-
-# Integration tests for market.py
-class TestMarketAPIIntegration:
-    """Integration tests for market.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_market_data_flow(self):
-        """Test complete market data retrieval flow"""
-        # Test the full flow from request to response
-        assert True
-
-    @pytest.mark.file_test
-    def test_market_data_transformation(self):
-        """Test data transformation logic in market endpoints"""
-        # Test data processing and formatting
-        assert True
-
-
-# Contract validation tests
-class TestMarketContractValidation:
-    """Contract validation tests for market-data API"""
-
-    @pytest.mark.contract_test
-    def test_openapi_spec_compliance(self, contract_specs):
-        """Test compliance with OpenAPI 3.0.3 specification"""
-        spec = contract_specs["market-data"]
-        assert spec["info"]["version"] == "1.0.0"
-        assert spec["openapi"] == "3.0.3"
-
-    @pytest.mark.contract_test
-    def test_response_schema_validation(self):
-        """Test response schemas match contract definitions"""
-        # Validate actual responses against contract schemas
-        assert True
-
-    @pytest.mark.contract_test
-    def test_endpoint_coverage(self, contract_specs):
-        """Test that all contract-defined endpoints are implemented"""
-        spec = contract_specs["market-data"]
-        paths = spec["paths"]
-        assert len(paths) >= 6  # Minimum endpoints defined in contract
+    def test_market_module_exports_db_service_and_business_exception_dependencies(self, market_module):
+        assert market_module.db_service is not None
+        assert market_module.BusinessException is not None

--- a/tests/api/file_tests/test_risk_management_api.py
+++ b/tests/api/file_tests/test_risk_management_api.py
@@ -1,181 +1,142 @@
 """
-File-level tests for risk_management.py API endpoints
+File-level compatibility contract tests for risk_management.py.
 
-Tests all risk management endpoints including:
-- VaR/CVaR risk calculations
-- Stop-loss strategy management
-- Risk alerts and monitoring
-- Portfolio risk assessment
-
-Priority: P0 (Contract-managed)
-Coverage: 100% functional + contract validation
+当前文件已经退化为兼容 shim，这里验证它是否仍然正确重导出
+`app.api.risk` 的路由面，并保留弃用提示。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+import warnings
+from pathlib import Path
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def risk_management_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return importlib.import_module("app.api.risk_management")
 
 
 class TestRiskManagementAPIFile:
-    """Test suite for risk_management.py API file"""
+    @pytest.mark.file_test
+    @pytest.mark.contract_test
+    def test_compat_shim_emits_deprecation_warning_on_reload(self, risk_management_module):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            importlib.reload(risk_management_module)
+
+        try:
+            assert any("deprecated" in str(item.message) for item in caught)
+        finally:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                importlib.reload(risk_management_module)
+
+    @pytest.mark.file_test
+    def test_router_exports_expected_number_of_http_and_websocket_routes(self, risk_management_module):
+        http_routes = [route for route in risk_management_module.router.routes if getattr(route, "methods", None)]
+        websocket_routes = [route for route in risk_management_module.router.routes if not getattr(route, "methods", None)]
+
+        assert len(http_routes) == 36
+        assert len(websocket_routes) == 1
+
+    @pytest.mark.file_test
+    def test_router_contains_core_risk_metric_routes(self, risk_management_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in risk_management_module.router.routes if getattr(route, "methods", None)}
+
+        assert ("/api/v1/risk/var-cvar", ("POST",)) in route_methods
+        assert ("/api/v1/risk/beta", ("POST",)) in route_methods
+        assert ("/api/v1/risk/dashboard", ("GET",)) in route_methods
+        assert ("/api/v1/risk/metrics/history", ("GET",)) in route_methods
+        assert ("/api/v1/risk/metrics/calculate", ("POST",)) in route_methods
+        assert ("/api/v1/risk/position/assess", ("POST",)) in route_methods
+
+    @pytest.mark.file_test
+    def test_router_contains_stop_loss_and_alert_routes(self, risk_management_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in risk_management_module.router.routes if getattr(route, "methods", None)}
+
+        assert ("/api/v1/risk/v31/stop-loss/add-position", ("POST",)) in route_methods
+        assert ("/api/v1/risk/v31/stop-loss/update-price", ("POST",)) in route_methods
+        assert ("/api/v1/risk/v31/stop-loss/remove-position/{position_id}", ("DELETE",)) in route_methods
+        assert ("/api/v1/risk/v31/stop-loss/status/{position_id}", ("GET",)) in route_methods
+        assert ("/api/v1/risk/v31/alert/send", ("POST",)) in route_methods
+        assert ("/api/v1/risk/v31/alert/statistics", ("GET",)) in route_methods
+        assert ("/api/v1/risk/alerts", ("GET",)) in route_methods
+        assert ("/api/v1/risk/alerts", ("POST",)) in route_methods
+
+    @pytest.mark.file_test
+    def test_router_contains_v31_health_and_realtime_routes(self, risk_management_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in risk_management_module.router.routes if getattr(route, "methods", None)}
+
+        assert ("/api/v1/risk/v31/risk/realtime/{symbol}", ("GET",)) in route_methods
+        assert ("/api/v1/risk/v31/stock/{symbol}", ("GET",)) in route_methods
+        assert ("/api/v1/risk/v31/portfolio/{portfolio_id}", ("GET",)) in route_methods
+        assert ("/api/v1/risk/v31/health", ("GET",)) in route_methods
+
+    @pytest.mark.file_test
+    def test_route_names_remain_stable_for_key_operations(self, risk_management_module):
+        route_names = {
+            (route.path, tuple(sorted(route.methods or []))): route.name
+            for route in risk_management_module.router.routes
+            if getattr(route, "methods", None)
+        }
+
+        assert route_names[("/api/v1/risk/var-cvar", ("POST",))] == "calculate_var_cvar"
+        assert route_names[("/api/v1/risk/beta", ("POST",))] == "calculate_beta"
+        assert route_names[("/api/v1/risk/dashboard", ("GET",))] == "get_risk_dashboard"
+        assert route_names[("/api/v1/risk/v31/alerts/{alert_id}/acknowledge", ("POST",))] == "acknowledge_alert_v31"
+
+    @pytest.mark.file_test
+    def test_router_contains_expected_response_models_for_core_metrics(self, risk_management_module):
+        response_models = {
+            (route.path, tuple(sorted(route.methods or []))): route.response_model
+            for route in risk_management_module.router.routes
+            if getattr(route, "methods", None)
+        }
+
+        assert response_models[("/api/v1/risk/var-cvar", ("POST",))].__name__ == "VaRCVaRResult"
+        assert response_models[("/api/v1/risk/beta", ("POST",))].__name__ == "BetaResult"
+        assert response_models[("/api/v1/risk/dashboard", ("GET",))].__name__ == "RiskDashboardResponse"
+        assert response_models[("/api/v1/risk/alerts", ("POST",))].__name__ == "RiskAlertResponse"
+
+    @pytest.mark.file_test
+    def test_module_docstring_describes_compatibility_shim_and_split_targets(self, risk_management_module):
+        doc = risk_management_module.__doc__ or ""
+
+        assert "Compatibility shim" in doc
+        assert "risk/metrics.py" in doc
+        assert "risk/stop_loss.py" in doc
+        assert "risk/alerts.py" in doc
+        assert "risk/v31.py" in doc
+
+    @pytest.mark.file_test
+    def test_module_exports_only_router(self, risk_management_module):
+        assert risk_management_module.__all__ == ["router"]
 
     @pytest.mark.file_test
     @pytest.mark.contract_test
-    def test_var_cvar_calculation(self, api_test_fixtures, mock_responses):
-        """Test POST /var-cvar - Calculate VaR and CVaR"""
-        # Test risk metric calculations
-        assert api_test_fixtures["base_url"].startswith("http")
+    def test_contract_fixture_still_covers_risk_management_domain(self, contract_specs):
+        spec = contract_specs["risk-management"]
 
-    @pytest.mark.file_test
-    def test_beta_calculation(self, api_test_fixtures):
-        """Test POST /beta - Calculate beta coefficient"""
-        # Test beta calculation for assets
-        assert api_test_fixtures["retry_attempts"] >= 1
-
-    @pytest.mark.file_test
-    def test_risk_dashboard(self, api_test_fixtures):
-        """Test GET /dashboard - Get risk dashboard data"""
-        # Test comprehensive risk overview
-        assert api_test_fixtures["mock_enabled"] is True
-
-    @pytest.mark.file_test
-    def test_stop_loss_position_add(self, api_test_fixtures):
-        """Test POST /v31/stop-loss/add-position - Add stop-loss position"""
-        # Test adding new stop-loss position
-        assert api_test_fixtures["contract_validation"] is True
-
-    @pytest.mark.file_test
-    def test_stop_loss_position_update(self, api_test_fixtures):
-        """Test POST /v31/stop-loss/update-price - Update stop-loss price"""
-        # Test updating stop-loss parameters
-        assert api_test_fixtures["test_timeout"] > 0
-
-    @pytest.mark.file_test
-    def test_stop_loss_position_remove(self, api_test_fixtures):
-        """Test DELETE /v31/stop-loss/remove-position/{position_id} - Remove position"""
-        # Test removing stop-loss position
-        assert True
-
-    @pytest.mark.file_test
-    def test_stop_loss_status(self, api_test_fixtures):
-        """Test GET /v31/stop-loss/status/{position_id} - Get position status"""
-        # Test retrieving stop-loss status
-        assert True
-
-    @pytest.mark.file_test
-    def test_stop_loss_overview(self, api_test_fixtures):
-        """Test GET /v31/stop-loss/overview - Get stop-loss overview"""
-        # Test comprehensive stop-loss positions overview
-        assert True
-
-    @pytest.mark.file_test
-    def test_risk_alert_create(self, api_test_fixtures):
-        """Test POST /v31/alert/create - Create risk alert"""
-        # Test creating new risk alerts
-        assert True
-
-    @pytest.mark.file_test
-    def test_risk_alert_list(self, api_test_fixtures):
-        """Test GET /v31/alert/list - List risk alerts"""
-        # Test retrieving active alerts
-        assert True
-
-    @pytest.mark.file_test
-    def test_risk_alert_acknowledge(self, api_test_fixtures):
-        """Test PUT /v31/alert/{id}/acknowledge - Acknowledge alert"""
-        # Test acknowledging risk alerts
-        assert True
-
-    @pytest.mark.file_test
-    @pytest.mark.contract_test
-    def test_contract_compliance(self, contract_specs):
-        """Test OpenAPI contract compliance for risk_management.py"""
-        spec = contract_specs.get("risk-management")
-        assert spec is not None
         assert spec["info"]["version"] == "1.0.0"
+        assert spec["openapi"] == "3.0.3"
         assert "/var-cvar" in spec["paths"]
         assert "/beta" in spec["paths"]
         assert "/dashboard" in spec["paths"]
-
-    @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across risk management endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
-
-    @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for risk endpoints"""
-        # Validate response schemas match contract specifications
-        assert True  # Placeholder
-
-    @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for risk management endpoints"""
-        # Validate response times are within acceptable limits
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for risk calculations
-
-    @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_concurrent_risk_calculations(self):
-        """Test concurrent risk metric calculations"""
-        # Test multiple simultaneous risk calculations
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
-
-    @pytest.mark.file_test
-    def test_risk_data_consistency(self):
-        """Test data consistency across risk management operations"""
-        # Ensure risk data remains consistent across operations
-        assert True
-
-    @pytest.mark.file_test
-    def test_risk_workflow_integration(self):
-        """Test complete risk management workflow"""
-        # Test calculate -> monitor -> alert -> respond workflow
-        assert True
-
-
-class TestRiskManagementIntegration:
-    """Integration tests for risk_management.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_risk_strategy_integration(self):
-        """Test risk calculations with strategy performance"""
-        # Test risk assessment for trading strategies
-        assert True
-
-    @pytest.mark.file_test
-    def test_risk_portfolio_integration(self):
-        """Test portfolio-level risk assessment"""
-        # Test comprehensive portfolio risk analysis
-        assert True
-
-
-class TestRiskContractValidation:
-    """Contract validation tests for risk-management API"""
-
-    @pytest.mark.contract_test
-    def test_openapi_spec_compliance(self, contract_specs):
-        """Test compliance with OpenAPI 3.0.3 specification"""
-        spec = contract_specs["risk-management"]
-        assert spec["info"]["version"] == "1.0.0"
-        assert spec["openapi"] == "3.0.3"
-
-    @pytest.mark.contract_test
-    def test_response_schema_validation(self):
-        """Test response schemas match contract definitions"""
-        # Validate actual responses against contract schemas
-        assert True
-
-    @pytest.mark.contract_test
-    def test_endpoint_coverage(self, contract_specs):
-        """Test that all contract-defined endpoints are implemented"""
-        spec = contract_specs["risk-management"]
-        paths = spec["paths"]
-        assert len(paths) >= 36  # Risk management has extensive endpoint coverage

--- a/tests/api/file_tests/test_strategy_management_api.py
+++ b/tests/api/file_tests/test_strategy_management_api.py
@@ -1,183 +1,125 @@
 """
-File-level tests for strategy_management.py API endpoints
+File-level route and export contract tests for strategy_management package.
 
-Tests all strategy management endpoints including:
-- Strategy CRUD operations
-- Model training and status monitoring
-- Backtest execution and results
-- Strategy performance analysis
-
-Priority: P0 (Contract-managed)
-Coverage: 100% functional + contract validation
+这里对齐 `app.api.strategy_management` 当前真实导出面，
+替换掉生成式占位断言。
 """
 
-import asyncio
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
 
 import pytest
 
-from tests.api.file_tests.conftest import api_test_fixtures, assert_file_test_result, mock_responses
+
+ROOT = Path(__file__).resolve().parents[3]
+BACKEND_ROOT = ROOT / "web" / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+
+@pytest.fixture
+def strategy_module(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("POSTGRESQL_HOST", "localhost")
+    monkeypatch.setenv("POSTGRESQL_USER", "postgres")
+    monkeypatch.setenv("POSTGRESQL_PASSWORD", "password")
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key")
+    monkeypatch.setenv("BACKEND_PORT", "8020")
+    monkeypatch.setenv("BACKEND_BACKUP_PORT", "8021")
+    return importlib.import_module("app.api.strategy_management")
 
 
 class TestStrategyManagementAPIFile:
-    """Test suite for strategy_management.py API file"""
+    @pytest.mark.file_test
+    @pytest.mark.contract_test
+    def test_router_registers_expected_strategy_routes(self, strategy_module):
+        route_methods = {(route.path, tuple(sorted(route.methods or []))) for route in strategy_module.router.routes}
+
+        assert strategy_module.router.prefix == "/api/v1/strategy"
+        assert ("/api/v1/strategy/strategies", ("GET",)) in route_methods
+        assert ("/api/v1/strategy/strategies", ("POST",)) in route_methods
+        assert ("/api/v1/strategy/strategies/{strategy_id}", ("GET",)) in route_methods
+        assert ("/api/v1/strategy/strategies/{strategy_id}", ("PUT",)) in route_methods
+        assert ("/api/v1/strategy/strategies/{strategy_id}", ("DELETE",)) in route_methods
+        assert ("/api/v1/strategy/{strategy_id}/start", ("POST",)) in route_methods
+        assert ("/api/v1/strategy/{strategy_id}/pause", ("POST",)) in route_methods
+        assert ("/api/v1/strategy/{strategy_id}/resume", ("POST",)) in route_methods
+        assert ("/api/v1/strategy/{strategy_id}/stop", ("POST",)) in route_methods
+        assert ("/api/v1/strategy/models/train", ("POST",)) in route_methods
+        assert ("/api/v1/strategy/models/training/{task_id}/status", ("GET",)) in route_methods
+        assert ("/api/v1/strategy/models", ("GET",)) in route_methods
+        assert ("/api/v1/strategy/backtest/run", ("POST",)) in route_methods
+        assert ("/api/v1/strategy/backtest/results", ("GET",)) in route_methods
+        assert ("/api/v1/strategy/backtest/results/{backtest_id}", ("GET",)) in route_methods
+        assert ("/api/v1/strategy/backtest/status/{backtest_id}", ("GET",)) in route_methods
+
+    @pytest.mark.file_test
+    def test_router_contains_expected_number_of_route_method_pairs(self, strategy_module):
+        route_pairs = [(route.path, tuple(sorted(route.methods or []))) for route in strategy_module.router.routes]
+
+        assert len(route_pairs) == 16
+        assert len(route_pairs) == len(set(route_pairs))
+
+    @pytest.mark.file_test
+    def test_package_exports_key_functions_and_router(self, strategy_module):
+        assert "router" in strategy_module.__all__
+        assert "get_backtest_result" in strategy_module.__all__
+        assert callable(strategy_module.list_strategies)
+        assert callable(strategy_module.create_strategy)
+        assert callable(strategy_module.train_model)
+        assert callable(strategy_module.get_backtest_result)
+        assert callable(strategy_module.router)
+
+    @pytest.mark.file_test
+    def test_route_names_remain_stable_for_core_operations(self, strategy_module):
+        route_names = {(route.path, tuple(sorted(route.methods or []))): route.name for route in strategy_module.router.routes}
+
+        assert route_names[("/api/v1/strategy/strategies", ("GET",))] == "list_strategies"
+        assert route_names[("/api/v1/strategy/models/train", ("POST",))] == "train_model"
+        assert route_names[("/api/v1/strategy/backtest/run", ("POST",))] == "run_backtest"
+        assert route_names[("/api/v1/strategy/backtest/results/{backtest_id}", ("GET",))] == "get_backtest_result"
+
+    @pytest.mark.file_test
+    def test_chart_data_function_is_exported_but_not_wired_into_package_router(self, strategy_module):
+        route_paths = {route.path for route in strategy_module.router.routes}
+
+        assert callable(strategy_module.get_backtest_chart_data)
+        assert "/api/v1/strategy/backtest/results/{backtest_id}/chart-data" not in route_paths
 
     @pytest.mark.file_test
     @pytest.mark.contract_test
-    def test_strategy_list_endpoint(self, api_test_fixtures, mock_responses):
-        """Test GET /api/strategies - List all strategies"""
-        # Test successful strategy list retrieval
-        response = mock_responses.get("strategy_list", {"success": True, "data": {"strategies": []}})
-        assert response["success"] is True
-        assert "data" in response
-        assert "strategies" in response["data"]
+    def test_contract_fixture_still_matches_strategy_management_surface(self, contract_specs):
+        spec = contract_specs["strategy-management"]
 
-    @pytest.mark.file_test
-    def test_strategy_detail_endpoint(self, api_test_fixtures):
-        """Test GET /api/strategies/{id} - Get strategy details"""
-        # Test strategy detail retrieval
-        assert api_test_fixtures["base_url"].startswith("http")
-
-    @pytest.mark.file_test
-    def test_strategy_create_endpoint(self, api_test_fixtures):
-        """Test POST /api/strategies - Create new strategy"""
-        # Test strategy creation
-        assert api_test_fixtures["retry_attempts"] >= 1
-
-    @pytest.mark.file_test
-    def test_strategy_update_endpoint(self, api_test_fixtures):
-        """Test PUT /api/strategies/{id} - Update strategy"""
-        # Test strategy update
-        assert api_test_fixtures["mock_enabled"] is True
-
-    @pytest.mark.file_test
-    def test_strategy_delete_endpoint(self, api_test_fixtures):
-        """Test DELETE /api/strategies/{id} - Delete strategy"""
-        # Test strategy deletion
-        assert api_test_fixtures["contract_validation"] is True
-
-    @pytest.mark.file_test
-    def test_model_train_endpoint(self, api_test_fixtures):
-        """Test POST /api/models/train - Start model training"""
-        # Test model training initiation
-        assert api_test_fixtures["test_timeout"] > 0
-
-    @pytest.mark.file_test
-    def test_model_training_status_endpoint(self, api_test_fixtures):
-        """Test GET /api/models/training/{task_id}/status - Get training status"""
-        # Test training status monitoring
-        assert api_test_fixtures["base_url"] is not None
-
-    @pytest.mark.file_test
-    def test_model_list_endpoint(self, api_test_fixtures):
-        """Test GET /api/models - List trained models"""
-        # Test model listing
-        assert True  # Placeholder
-
-    @pytest.mark.file_test
-    def test_backtest_execute_endpoint(self, api_test_fixtures):
-        """Test POST /api/backtest/execute - Execute backtest"""
-        # Test backtest execution
-        assert True
-
-    @pytest.mark.file_test
-    def test_backtest_status_endpoint(self, api_test_fixtures):
-        """Test GET /api/backtest/{task_id}/status - Get backtest status"""
-        # Test backtest status monitoring
-        assert True
-
-    @pytest.mark.file_test
-    def test_backtest_result_endpoint(self, api_test_fixtures):
-        """Test GET /api/backtest/{task_id}/result - Get backtest results"""
-        # Test backtest result retrieval
-        assert True
-
-    @pytest.mark.file_test
-    @pytest.mark.contract_test
-    def test_contract_compliance(self, contract_specs):
-        """Test OpenAPI contract compliance for strategy_management.py"""
-        spec = contract_specs.get("strategy-management")
-        assert spec is not None
+        assert spec["openapi"] == "3.0.3"
         assert spec["info"]["version"] == "1.0.0"
         assert "/api/strategies" in spec["paths"]
         assert "/api/models/train" in spec["paths"]
 
     @pytest.mark.file_test
-    def test_error_handling(self, mock_responses):
-        """Test error handling across strategy management endpoints"""
-        error_response = mock_responses["error_response"]
-        assert error_response["success"] is False
-        assert "code" in error_response
-        assert "message" in error_response
+    def test_strategy_router_prefix_is_shared_by_all_paths(self, strategy_module):
+        assert all(route.path.startswith("/api/v1/strategy") for route in strategy_module.router.routes)
 
     @pytest.mark.file_test
-    def test_response_format_validation(self):
-        """Test response format validation for strategy endpoints"""
-        # Validate response schemas match contract specifications
-        assert True  # Placeholder
+    def test_strategy_package_docstring_and_exports_indicate_split_package(self, strategy_module):
+        assert "拆分包" in (strategy_module.__doc__ or "")
+        assert "router" in strategy_module.__all__
 
     @pytest.mark.file_test
-    def test_performance_requirements(self, api_test_fixtures):
-        """Test performance requirements for strategy management endpoints"""
-        # Validate response times are within acceptable limits
-        timeout = api_test_fixtures["test_timeout"]
-        assert timeout <= 30  # Max 30 seconds for strategy operations
+    def test_backtest_related_routes_cover_run_status_and_results(self, strategy_module):
+        backtest_paths = {route.path for route in strategy_module.router.routes if "/backtest/" in route.path}
 
-    @pytest.mark.asyncio
-    @pytest.mark.file_test
-    async def test_concurrent_operations(self):
-        """Test concurrent strategy operations"""
-        # Test multiple simultaneous strategy operations
-        await asyncio.sleep(0.01)  # Simulate async operation
-        assert True
+        assert "/api/v1/strategy/backtest/run" in backtest_paths
+        assert "/api/v1/strategy/backtest/results" in backtest_paths
+        assert "/api/v1/strategy/backtest/results/{backtest_id}" in backtest_paths
+        assert "/api/v1/strategy/backtest/status/{backtest_id}" in backtest_paths
 
     @pytest.mark.file_test
-    def test_data_consistency(self):
-        """Test data consistency across strategy management operations"""
-        # Ensure strategy data remains consistent across operations
-        assert True
+    def test_model_routes_cover_train_status_and_listing(self, strategy_module):
+        model_paths = {route.path for route in strategy_module.router.routes if "/models" in route.path}
 
-    @pytest.mark.file_test
-    def test_strategy_workflow(self):
-        """Test complete strategy lifecycle workflow"""
-        # Test create -> train -> backtest -> analyze workflow
-        assert True
-
-
-class TestStrategyManagementIntegration:
-    """Integration tests for strategy_management.py with related modules"""
-
-    @pytest.mark.file_test
-    def test_strategy_model_integration(self):
-        """Test strategy creation with model training integration"""
-        # Test end-to-end strategy creation and training
-        assert True
-
-    @pytest.mark.file_test
-    def test_strategy_backtest_integration(self):
-        """Test strategy backtest execution integration"""
-        # Test strategy backtest workflow
-        assert True
-
-
-class TestStrategyContractValidation:
-    """Contract validation tests for strategy-management API"""
-
-    @pytest.mark.contract_test
-    def test_openapi_spec_compliance(self, contract_specs):
-        """Test compliance with OpenAPI 3.0.3 specification"""
-        spec = contract_specs["strategy-management"]
-        assert spec["info"]["version"] == "1.0.0"
-        assert spec["openapi"] == "3.0.3"
-
-    @pytest.mark.contract_test
-    def test_response_schema_validation(self):
-        """Test response schemas match contract definitions"""
-        # Validate actual responses against contract schemas
-        assert True
-
-    @pytest.mark.contract_test
-    def test_endpoint_coverage(self, contract_specs):
-        """Test that all contract-defined endpoints are implemented"""
-        spec = contract_specs["strategy-management"]
-        paths = spec["paths"]
-        assert len(paths) >= 9  # Minimum endpoints defined in contract
+        assert "/api/v1/strategy/models/train" in model_paths
+        assert "/api/v1/strategy/models/training/{task_id}/status" in model_paths
+        assert "/api/v1/strategy/models" in model_paths


### PR DESCRIPTION
## Summary
- replace 3 placeholder API file tests with route-aware contract assertions
- align market, risk_management, and strategy_management file tests to active backend exports
- keep the micro-batch scoped to tests/api/file_tests only

## Verification
- git diff --check
- python -m pytest --no-cov tests/api/file_tests/test_market_api.py tests/api/file_tests/test_risk_management_api.py tests/api/file_tests/test_strategy_management_api.py
- gitnexus_detect_changes(scope=staged): changed_files=3, risk_level=low, affected_processes=0