### PR TITLE
docs(governance): surface deletion evidence gate guide

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -9,6 +9,7 @@
 
 - [📖 项目概述](#overview)
 - [📘 开发指南](#guides)
+- [🛡️ 删除治理](guides/governance/DELETION_EVIDENCE_GATE.md)
 - [🔌 API文档](#api)
 - [🏗️  架构设计](#architecture)
 - [⚙️  运维文档](#operations)

--- a/docs/guides/INDEX.md
+++ b/docs/guides/INDEX.md
@@ -1,8 +1,8 @@
 # Guides
 
-**最后更新**: 2026-04-01 13:57:41
+**最后更新**: 2026-04-08 01:18:00
 
-**文档数量**: 249
+**文档数量**: 250
 
 
 ---
@@ -174,6 +174,9 @@
 
 - [DATA_SOURCE_TOOLS_QUICK_REFERENCE](data-source/DATA_SOURCE_TOOLS_QUICK_REFERENCE.md)
   - *数据源管理工具 - 快速参考卡片*
+
+- [DELETION_EVIDENCE_GATE](governance/DELETION_EVIDENCE_GATE.md)
+  - *目录删除与 >=3 文档删除的证据门禁操作指南*
 
 - [DEVELOPER_GUIDE](onboarding/DEVELOPER_GUIDE.md)
   - *MyStocks 开发指南*

--- a/docs/guides/governance/DELETION_EVIDENCE_GATE.md
+++ b/docs/guides/governance/DELETION_EVIDENCE_GATE.md
@@ -1,0 +1,107 @@
+# Deletion Evidence Gate
+
+本页只说明如何操作删除治理门禁；规范口径仍以 [architecture/STANDARDS.md](../../../architecture/STANDARDS.md) 与机器工件为准。
+
+## 拦截范围
+
+- 已跟踪目录删除
+- 不在已删目录内的 `>=3` 篇文档删除批次
+
+## 执行位置
+
+- staged 门禁：`.githooks/pre-commit` 与 `.pre-commit-config.yaml`
+- worktree 门禁：`.claude/hooks/stop-deletion-evidence-gate.sh`
+- 共享引擎：`scripts/compliance/deletion_evidence_gate.py`
+
+两条门禁都调用同一套判定逻辑，不允许出现“pre-commit 通过、Stop hook 放行”的分叉。
+
+## 唯一治理工件
+
+- 正常删除证据：`governance/deletion-evidence.yaml`
+- 紧急豁免：`governance/waivers/deletion-evidence-waivers.yaml`
+
+要求：
+
+- 必须是预先存在的机器可读 YAML
+- 必须写明被删目录或被删文档的精确路径
+- 不允许 wildcard、模糊父目录、近似匹配
+- 同一次删除提交里新增的证据或豁免不算数；门禁只读取 `HEAD`
+
+## 正常删除证据
+
+`governance/deletion-evidence.yaml` 中，每个删除目标都要单独落一条精确记录。
+
+```yaml
+version: 1
+entries:
+  - path: docs/legacy/reports
+    kind: directory
+    status: approved
+    owner: cli-governance
+    code_path_verdict: safe_to_delete
+    function_tree_verdict: 重复冗余
+```
+
+必填关键字段：
+
+- `path`: 被删目录或文档的精确相对路径
+- `kind`: `directory` 或 `document`
+- `status`: 必须为 `approved`
+- `owner`: 责任人
+- `code_path_verdict`: 必须为 `safe_to_delete`
+- `function_tree_verdict`: 只能是 `重复冗余` 或 `正式下线`
+
+如果删除的是目录，证据应写目录路径本身。
+如果删除的是目录外的 `>=3` 篇文档，证据应逐篇写 `kind: document` 的精确文件路径。
+
+## 紧急豁免
+
+仅在正常证据来不及预落盘时，才使用 `governance/waivers/deletion-evidence-waivers.yaml`。
+
+```yaml
+version: 1
+waivers:
+  - path: docs/legacy/old-runbook.md
+    kind: document
+    owner: cli-governance
+    reason: urgent rollback cleanup
+    ticket_or_context: task-2026-04-08
+    approved_by_user: true
+    approved_on: 2026-04-08
+    expires_on: 2026-04-09
+```
+
+要求：
+
+- 仍然必须是精确路径
+- 仍然必须预先存在于 `HEAD`
+- 必须带 `owner`、`reason`、`ticket_or_context`、`approved_by_user`、`approved_on`、`expires_on`
+- 过期即失效
+
+## 本地自检
+
+查看 staged 删除：
+
+```bash
+python scripts/compliance/deletion_evidence_gate.py --root-dir . --format text --scope staged
+```
+
+查看当前 worktree 删除：
+
+```bash
+python scripts/compliance/deletion_evidence_gate.py --root-dir . --format text --scope worktree
+```
+
+如果需要机器输出：
+
+```bash
+python scripts/compliance/deletion_evidence_gate.py --root-dir . --format json --scope staged
+```
+
+## 操作顺序
+
+1. 先在治理工件里落盘精确删除对象。
+2. 让该证据或豁免先进入 `HEAD`。
+3. 再提交目录删除或 `>=3` 文档删除。
+
+反过来做会被门禁直接拦下。

--- a/docs/guides/governance/INDEX.md
+++ b/docs/guides/governance/INDEX.md
@@ -1,6 +1,6 @@
 # MyStocks 文档索引
 
-**生成时间**: 2026-03-25 00:08:57
+**生成时间**: 2026-04-08 01:18:00
 
 
 ---
@@ -13,7 +13,7 @@
 ## 📊 统计信息
 
 
-- **总文档数**: 2
+- **总文档数**: 3
 - **总目录数**: 0
 - **最后更新**: 2026-03-25
 
@@ -22,5 +22,6 @@
 
 ## 📁 项目根目录
 
+- 📄 [DELETION_EVIDENCE_GATE](DELETION_EVIDENCE_GATE.md)
 - 📄 [FEATURE_MANAGEMENT_WORKFLOW](FEATURE_MANAGEMENT_WORKFLOW.md)
 - 📄 [TECHNICAL_DEBT_MANAGEMENT](TECHNICAL_DEBT_MANAGEMENT.md)

--- a/governance/mainline/README.md
+++ b/governance/mainline/README.md
@@ -83,6 +83,7 @@ PR 创建/更新后，工作流自动执行：
 
 - `governance/mainline/spec/ai-development-mainline-governance-spec.md`
 - `governance/mainline/reports/mainline-governance-v0.2-task-summary.md`
+- `docs/guides/governance/DELETION_EVIDENCE_GATE.md`
 
 ## 常见失败原因
 

--- a/governance/mainline/task-cards/pr-63.yaml
+++ b/governance/mainline/task-cards/pr-63.yaml
@@ -1,0 +1,99 @@
+version: "v0.2"
+
+task:
+  id: "pr-63"
+  title: "surface deletion evidence gate docs and canonical navigation"
+  owner: "main"
+  created_at: "2026-04-08"
+
+mainline:
+  id: "L1-deletion-governance-operability"
+  objective: "make the landed deletion evidence gate discoverable and operable from canonical docs entrypoints without changing gate semantics or touching unrelated product lines"
+  milestone_id: "L2-governance-docs-hardening"
+  slice_id: "L3-deletion-evidence-guide-and-indexes"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "docs-and-test discoverability slice for an already-landed governance gate with no runtime behavior or business-domain changes"
+
+scope:
+  allowed_paths:
+    - "docs/INDEX.md"
+    - "docs/guides/INDEX.md"
+    - "docs/guides/governance/DELETION_EVIDENCE_GATE.md"
+    - "docs/guides/governance/INDEX.md"
+    - "governance/mainline/README.md"
+    - "governance/mainline/task-cards/pr-63.yaml"
+    - "tests/unit/docs/test_deletion_evidence_doc_sync.py"
+  forbidden_paths:
+    - "web/frontend/src/views/data/Advanced.vue"
+    - "web/frontend/src/views/artdeco-pages/ArtDecoDataAnalysis.vue"
+    - "web/frontend/src/views/watchlist/**"
+    - "scripts/compliance/deletion_evidence_gate.py"
+    - "governance/deletion-evidence.yaml"
+    - "governance/waivers/deletion-evidence-waivers.yaml"
+
+non_goals:
+  - "No deletion gate semantics change, schema change, or runtime enforcement change"
+  - "No work on Data-Indicator, Watchlist, Mongo, or other user-owned active lines"
+  - "No duplicate policy layer outside the canonical guide and existing governance entrypoints"
+
+acceptance:
+  checks:
+    - id: "deletion-evidence-doc-sync"
+      command: "python -m pytest --no-cov tests/unit/docs/test_deletion_evidence_doc_sync.py -q"
+      required: true
+    - id: "guides-hooks-convergence"
+      command: "python -m pytest --no-cov tests/unit/docs/test_deletion_evidence_doc_sync.py tests/unit/scripts/test_repository_hygiene_paths.py -q -k \"hook_guides_are_converged_under_guides_hooks_family or deletion_evidence_guide_is_discoverable\""
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-63.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report /tmp/pr63-mainline-gate.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the task card omits any touched path, Mainline Governance Gate will remain red even though the docs themselves are correct"
+    - "If the guide starts restating policy loosely instead of pointing back to canonical artifacts, governance truth can drift again"
+    - "If top-level docs navigation drops this entry in a future cleanup, deletion governance becomes harder to use despite the gate being enforced"
+  rollback_plan: "git revert <merge-commit-sha> if the PR-63 task card or deletion-governance discoverability links create unexpected governance failures or reviewer confusion"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "surface the landed deletion evidence gate through canonical docs entrypoints and explain how to use its exact-path evidence and waiver artifacts"
+    modified_scope: "docs indexes, one governance operating guide, governance/mainline README, one docs sync regression test, and the PR-63 task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none in runtime or enforcement behavior; only operator discoverability and documentation guardrails improve"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert the PR if the added task card or discoverability links introduce governance noise or misleading guidance"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-04-08T00:00:00Z"
+    approval_note: "docs-only governance discoverability batch for an already-landed deletion evidence gate"
+    secondary_approved: false

--- a/tests/unit/docs/test_deletion_evidence_doc_sync.py
+++ b/tests/unit/docs/test_deletion_evidence_doc_sync.py
@@ -8,6 +8,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[3]
 
 def test_deletion_evidence_guide_is_discoverable_and_points_to_canonical_artifacts() -> None:
     guide_path = PROJECT_ROOT / "docs" / "guides" / "governance" / "DELETION_EVIDENCE_GATE.md"
+    docs_index = (PROJECT_ROOT / "docs" / "INDEX.md").read_text(encoding="utf-8")
     guides_index = (PROJECT_ROOT / "docs" / "guides" / "INDEX.md").read_text(encoding="utf-8")
     governance_index = (PROJECT_ROOT / "docs" / "guides" / "governance" / "INDEX.md").read_text(encoding="utf-8")
     mainline_readme = (PROJECT_ROOT / "governance" / "mainline" / "README.md").read_text(encoding="utf-8")
@@ -23,6 +24,7 @@ def test_deletion_evidence_guide_is_discoverable_and_points_to_canonical_artifac
     assert "`HEAD`" in guide
     assert "wildcard" in guide.lower()
 
+    assert "guides/governance/DELETION_EVIDENCE_GATE.md" in docs_index
     assert "governance/DELETION_EVIDENCE_GATE.md" in guides_index
     assert "DELETION_EVIDENCE_GATE" in governance_index
     assert "docs/guides/governance/DELETION_EVIDENCE_GATE.md" in mainline_readme

--- a/tests/unit/docs/test_deletion_evidence_doc_sync.py
+++ b/tests/unit/docs/test_deletion_evidence_doc_sync.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_deletion_evidence_guide_is_discoverable_and_points_to_canonical_artifacts() -> None:
+    guide_path = PROJECT_ROOT / "docs" / "guides" / "governance" / "DELETION_EVIDENCE_GATE.md"
+    guides_index = (PROJECT_ROOT / "docs" / "guides" / "INDEX.md").read_text(encoding="utf-8")
+    governance_index = (PROJECT_ROOT / "docs" / "guides" / "governance" / "INDEX.md").read_text(encoding="utf-8")
+    mainline_readme = (PROJECT_ROOT / "governance" / "mainline" / "README.md").read_text(encoding="utf-8")
+
+    assert guide_path.is_file()
+
+    guide = guide_path.read_text(encoding="utf-8")
+    assert "scripts/compliance/deletion_evidence_gate.py" in guide
+    assert ".githooks/pre-commit" in guide
+    assert ".claude/hooks/stop-deletion-evidence-gate.sh" in guide
+    assert "governance/deletion-evidence.yaml" in guide
+    assert "governance/waivers/deletion-evidence-waivers.yaml" in guide
+    assert "`HEAD`" in guide
+    assert "wildcard" in guide.lower()
+
+    assert "governance/DELETION_EVIDENCE_GATE.md" in guides_index
+    assert "DELETION_EVIDENCE_GATE" in governance_index
+    assert "docs/guides/governance/DELETION_EVIDENCE_GATE.md" in mainline_readme


### PR DESCRIPTION
## Summary
- add a deletion evidence gate operating guide that points to the shared engine, dual gates, and canonical YAML artifacts
- surface the guide from docs root, guides index, governance index, and governance/mainline README without duplicating policy truth
- add a regression test that locks discoverability and canonical references for the deletion governance entrypoint
- add the required `governance/mainline/task-cards/pr-63.yaml` so the PR satisfies Mainline Governance Gate without expanding scope beyond this docs slice

## Test Plan
- python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-63.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha origin/main --head-sha HEAD --report /tmp/pr63-mainline-gate.json
- pytest tests/unit/docs/test_deletion_evidence_doc_sync.py -q --no-cov
- pytest tests/unit/docs/test_deletion_evidence_doc_sync.py tests/unit/scripts/test_repository_hygiene_paths.py -q --no-cov -k "hook_guides_are_converged_under_guides_hooks_family or deletion_evidence_guide_is_discoverable"
- git diff --check
- git diff --cached --check
