### PR TITLE
docs(openspec): record issue92 split acceptance

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -112,16 +112,16 @@ CODEBASE-MAP Architecture Remediation Program
 │
 ├── D2. Published Decision Issue: backend OpenSpec issue15
 │   ├── Source: https://github.com/chengjon/mystocks/issues/92
-│   ├── State: downstream-split-draft-prepared
+│   ├── State: downstream-split-accepted
 │   ├── Role: Human decision/design issue for post-approval implementation planning
 │   ├── Current fact: issue #83 accepted and closed; Core split OpenSpec archived;
 │   │                 issue #92 has `ready-for-downstream`, no `ready-for-agent`,
-│   │                 and no implementation authority; downstream split draft is
-│   │                 recorded in
-│   │                 `backend-openspec-issue92-downstream-decision-split-2026-05-21.md`
-│   └── Next gate: Human review of the downstream split draft before creating
-│                  child decision issues, OpenSpec proposals, or any
-│                  implementation issue marked `ready-for-agent`
+│   │                 and no implementation authority; downstream split is
+│   │                 accepted in
+│   │                 `backend-openspec-issue92-downstream-split-acceptance-2026-05-21.md`
+│   └── Next gate: Draft D2.1 `TechnicalPatternDetectionService` DI design
+│                  packet; keep all downstream tracks decision/proposal-only
+│                  until separate implementation approval exists
 │
 ├── E. Candidate Branch: close-backend-schema-dual-directory
 │   ├── Source evidence: backend-schema-dual-directory-closure-2026-05-19.md
@@ -226,6 +226,7 @@ review, PR review, or OpenSpec archive review.
 | Issue15 publication as GitHub issue `#92` | D2 | The previously blocked issue15 decision/design issue is now published for human decision after issue `#83` acceptance and Core split archive | Reviewed/pass in current thread: issue `#92` is `OPEN`; labels are exactly `enhancement`, `ready-for-human`; body contains `UNBLOCKED_BY`; body does not contain `BLOCKED_BY_TODO`; `ready-for-agent` label is absent | `https://github.com/chengjon/mystocks/issues/92`; `docs/reports/quality/backend-openspec-issue15-publication-status-2026-05-21.md`; Graphiti episode `1d858c24-68b3-4ee0-9f9b-4b870fdc6000` | Await human decision record; do not move issue `#92` to `ready-for-agent` before a concrete downstream implementation scope is approved |
 | Issue `#92` approval for downstream decision work | D2 | Human maintainer approval recorded in the current review thread and commented on issue `#92`; downstream decision splitting may proceed | Reviewed/pass in current thread: issue `#92` remains `OPEN`; labels now include `enhancement`, `ready-for-human`, `ready-for-downstream`; `ready-for-agent` remains absent; approval comment is `https://github.com/chengjon/mystocks/issues/92#issuecomment-4503757722` | `docs/reports/quality/backend-openspec-issue92-approval-record-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Draft decision record / split downstream issues; no implementation issue may be moved to `ready-for-agent` before that decision record |
 | Issue `#92` downstream decision split draft | D2 | Draft split prepared for human review: D2.1 DI pilot candidate, D2.2 Core validation wrapper-retirement readiness, D2.3 route governance, D2.4 backup route ownership, D2.5 control-plane OpenAPI docs, and D2.6 PM2 stateful gate approval | Review-ready draft only: issue `#92` remains `OPEN`; `ready-for-agent` remains absent; no backend, OpenSpec change, route, or test mutation is authorized by the draft | `docs/reports/quality/backend-openspec-issue92-downstream-decision-split-2026-05-21.md` | Human review and explicit acceptance or revision of the split before any child issue/proposal is created |
+| Issue `#92` downstream split accepted | D2 | Human maintainer accepted the split in full: `TechnicalPatternDetectionService` is the first DI design pilot; trading route ownership folds into unified route/OpenAPI governance; backup route ownership becomes a dedicated proposal candidate with `cleanup_old_backups.py` owned by that lane | Reviewed/pass in current thread: acceptance remains decision/proposal-only and does not authorize backend implementation, route mutation, Core file movement, PM2 execution, or any `ready-for-agent` movement | `docs/reports/quality/backend-openspec-issue92-downstream-split-acceptance-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Draft D2.1 design packet for `TechnicalPatternDetectionService`; keep implementation locked behind separate approval |
 
 ## OpenSpec Branch Register
 
@@ -234,7 +235,7 @@ review, PR review, or OpenSpec archive review.
 | `sequence-backend-architecture-unblocks` | `archived-merged` | Master execution plan | Runtime triage, schema closure, freshness, singleton matrix, error-contract verification | First gate branch for runtime unblock and evidence refresh | Archived by PR `#86`; future work must use the archived evidence as baseline and open a follow-up branch for new implementation |
 | `canonicalize-backend-route-unified-response-contracts` | `archived-merged` | `sequence-backend-architecture-unblocks` Task 8.8 | UnifiedResponse contract guard blocker: 27 errors across 4 changed route files now reduced to 0 | Dedicated route-contract migration for `data_quality.py`, `indicator_cache.py`, `signal_history_response.py`, and `technical_analysis.py`; implementation merged via PR `#85` | Archived by PR `#86`; keep implementation notes as follow-up candidates, not blockers |
 | `split-backend-core-modules-with-compatibility-wrappers` | `archived-merged` | Existing OpenSpec line | Core split reconciliation | Core helper split continuation | Archived by PR `#90`; future Core split work requires a new concrete implementation plan and approval |
-| `github-issue-92-backend-openspec-issue15` | `downstream-split-draft-prepared` | Current review-thread approval, issue `#83` acceptance, and downstream split draft | Post-approval implementation decision boundary | Decision/design issue only; no implementation work | Human review of the split draft before creating or moving any child issue/proposal |
+| `github-issue-92-backend-openspec-issue15` | `downstream-split-accepted` | Current review-thread approval, issue `#83` acceptance, downstream split draft, and human split acceptance | Post-approval implementation decision boundary | Decision/design issue only; no implementation work | Draft D2.1 `TechnicalPatternDetectionService` DI design packet; keep implementation locked behind separate approval |
 | `close-backend-schema-dual-directory` | `candidate` | Master execution plan | Schema dual-directory closure | Schema exports, consumer migration, shim retirement decision | Create only after `sequence-backend-architecture-unblocks` schema tasks are accepted |
 | `refresh-backend-route-openapi-governance` | `candidate-unblocked` | Master execution plan | API flat/package closure records | Route table, OpenAPI, operationId, probe matrix | Can be prepared after Task 5.x route/OpenAPI refresh evidence is recorded |
 | `define-backend-service-seams-and-singleton-pilots` | `candidate` | Master execution plan | Singleton lifecycle routing matrix | Service seam definition, interface/test-double pilot strategy | Create as a design proposal after complete classification |

--- a/docs/reports/quality/backend-openspec-issue92-downstream-split-acceptance-2026-05-21.md
+++ b/docs/reports/quality/backend-openspec-issue92-downstream-split-acceptance-2026-05-21.md
@@ -1,0 +1,72 @@
+# Backend OpenSpec Issue92 Downstream Split Acceptance
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以
+> `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、
+> 当前代码与最近一次实际验证结果为准。
+
+- Date: 2026-05-21
+- Status: accepted decision split
+- Parent issue: <https://github.com/chengjon/mystocks/issues/92>
+- Accepted draft: `docs/reports/quality/backend-openspec-issue92-downstream-decision-split-2026-05-21.md`
+- Draft PR: <https://github.com/chengjon/mystocks/pull/95>
+- Draft merge commit: `6e9ebea25008bbe167e6db287c4c1a45f724a895`
+- Acceptance source: current review thread, human maintainer approval
+- Acceptance timestamp: `2026-05-21T01:02:26Z`
+
+## Decision
+
+The downstream decision split for issue `#92` is accepted in full.
+
+The accepted split remains a decision-governance boundary. It does not authorize
+backend implementation, route mutation, Core file movement, PM2 workflow
+execution, or movement of any downstream implementation issue to
+`ready-for-agent`.
+
+## Accepted Points
+
+| Decision point | Accepted disposition |
+|---|---|
+| First DI design pilot | `TechnicalPatternDetectionService` is accepted as the first DI design pilot candidate. The purpose is to establish the dependency injection pattern, lifecycle ownership vocabulary, teardown rule, and rollback pattern before broader service migration. |
+| Trading route ownership | Trading route ownership is folded into the unified route/OpenAPI governance lane. It should not be split into a standalone iteration line unless later evidence contradicts the governance fit. |
+| Backup route ownership | Backup route ownership is split into its own dedicated proposal candidate. `backup_recovery_secure/cleanup_old_backups.py` and backup-related route/logic ownership belong to this dedicated lane, with separate authorization, security, and operational rules. |
+
+## Accepted Downstream Tracks
+
+| Track | Accepted state | Next gate |
+|---|---|---|
+| D2.1 `select-backend-technical-pattern-di-pilot` | Accepted as first DI design pilot track | Draft a concrete design packet; no source edits until the implementation plan is approved |
+| D2.2 `decide-backend-core-validation-wrapper-retirement` | Accepted as wrapper-retirement readiness track | Prepare readiness evidence for `app.core.validation_messages` retirement or explicit deferral |
+| D2.3 `refresh-backend-route-openapi-governance` | Accepted as the unified route/OpenAPI governance parent for trading route ownership | Draft route governance proposal candidate using route table/OpenAPI/probe evidence |
+| D2.4 `settle-backend-backup-route-ownership` | Accepted as dedicated backup route ownership proposal candidate | Draft backup ownership proposal candidate, including `cleanup_old_backups.py` |
+| D2.5 `stabilize-backend-control-plane-openapi-docs` | Accepted as residual-tail documentation stabilization track | Draft residual-tail decision issue after D2.3 scope is clear |
+| D2.6 `approve-backend-pm2-stateful-gate` | Accepted as residual-tail stateful approval track | Draft approval issue or named equivalent for PM2 stateful gate; do not execute from issue `#92` |
+
+## Implementation Boundary
+
+Allowed after this acceptance:
+
+- Update governance documents and issue comments to reflect the accepted split.
+- Draft downstream decision/design packets or proposal candidates.
+- Create child decision issues only when their scope remains decision/design-only
+  or proposal-only.
+
+Still not allowed from this acceptance alone:
+
+- Backend implementation.
+- Route mutation.
+- Core file movement.
+- Compatibility wrapper retirement.
+- PM2 stateful workflow execution.
+- Moving any downstream issue to `ready-for-agent`.
+- Treating issue `#92` as a blanket approval for architecture refactoring.
+
+## Steward Update Requirement
+
+The steward tree should show issue `#92` as `downstream-split-accepted`.
+
+The next operational step is D2.1 design-packet drafting for
+`TechnicalPatternDetectionService`. That packet must remain design-only until a
+separate implementation approval exists.
+

--- a/governance/mainline/task-cards/pr-96.yaml
+++ b/governance/mainline/task-cards/pr-96.yaml
@@ -1,0 +1,91 @@
+version: "v0.2"
+
+task:
+  id: "pr-96"
+  title: "record backend OpenSpec issue92 downstream split acceptance"
+  owner: "main"
+  created_at: "2026-05-21"
+
+mainline:
+  id: "L1-issue92-split-acceptance"
+  objective: "record human acceptance of backend OpenSpec issue92 downstream split without implementation authorization"
+  milestone_id: "L2-architecture-governance-closeout"
+  slice_id: "L3-decision-issue-split-acceptance"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "split-backend-core-modules-with-compatibility-wrappers"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Issue92 downstream split acceptance record only; no runtime entrypoint, route, page, shim, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "docs/reports/quality/backend-openspec-issue92-downstream-split-acceptance-2026-05-21.md"
+    - "governance/mainline/task-cards/pr-96.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, or runtime behavior changes"
+  - "No movement of issue #92 or child tracks to ready-for-agent"
+  - "No downstream implementation issue creation"
+  - "No new OpenSpec proposal creation"
+  - "No PM2 stateful workflow execution"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-openspec-issue92-downstream-split-acceptance-2026-05-21.md"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the acceptance record is interpreted as implementation authorization, downstream gates are weakened"
+    - "If source paths enter this PR, the governance-only boundary is broken"
+  rollback_plan: "revert this PR and return issue #92 to downstream-split-draft-prepared state from PR #95"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record backend OpenSpec issue92 downstream split acceptance"
+    modified_scope: "steward task tree, issue92 split acceptance record, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance/evidence planning only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if acceptance boundary or mainline scope gate fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-21T01:02:26Z"
+    approval_note: "human maintainer accepted the issue #92 downstream split in full; this PR records acceptance only and does not authorize implementation"
+    secondary_approved: false
+


### PR DESCRIPTION
Record human acceptance of the issue #92 downstream decision split.

Accepted decisions:
- TechnicalPatternDetectionService is accepted as the first DI design pilot candidate.
- Trading route ownership is folded into unified route/OpenAPI governance.
- Backup route ownership becomes a dedicated proposal candidate, with cleanup_old_backups.py owned by that lane.

Scope:
- add the issue92 downstream split acceptance record
- update the codebase OpenSpec task tree to downstream-split-accepted
- add a PR96 mainline task card

Boundary:
- no backend implementation authorization
- no route mutation or Core movement
- no new OpenSpec proposal creation
- no downstream implementation issue creation
- no ready-for-agent movement
- no PM2 stateful workflow execution

Verification:
- git diff --check passed
- markdown governance gate passed
- GitNexus staged detect_changes reported low risk with 0 changed symbols
- local mainline scope gate passed

Related:
- issue #92: https://github.com/chengjon/mystocks/issues/92
- draft PR #95: https://github.com/chengjon/mystocks/pull/95