### PR TITLE
docs(openspec): draft validation wrapper readiness

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -135,6 +135,17 @@ CODEBASE-MAP Architecture Remediation Program
 │   └── Next gate: Human review of the design packet before creating any
 │                  implementation issue or moving any issue to `ready-for-agent`
 │
+├── D2.2. Core Validation Wrapper Retirement Readiness
+│   ├── Source evidence:
+│   │   `backend-core-validation-wrapper-retirement-readiness-2026-05-21.md`
+│   ├── State: readiness-packet-prepared
+│   ├── Role: Decide whether `app.core.validation_messages` can retire
+│   ├── Current fact: wrapper deletion is not ready; active source imports remain
+│   │                 in `validators.py` and `error_codes.py`, and docs still
+│   │                 teach the legacy path
+│   └── Next gate: Human review before creating a separate D2.2a active-source
+│                  consumer migration issue; wrapper deletion stays locked
+│
 ├── E. Candidate Branch: close-backend-schema-dual-directory
 │   ├── Source evidence: backend-schema-dual-directory-closure-2026-05-19.md
 │   ├── State: blocked
@@ -240,6 +251,7 @@ review, PR review, or OpenSpec archive review.
 | Issue `#92` downstream decision split draft | D2 | Draft split prepared for human review: D2.1 DI pilot candidate, D2.2 Core validation wrapper-retirement readiness, D2.3 route governance, D2.4 backup route ownership, D2.5 control-plane OpenAPI docs, and D2.6 PM2 stateful gate approval | Review-ready draft only: issue `#92` remains `OPEN`; `ready-for-agent` remains absent; no backend, OpenSpec change, route, or test mutation is authorized by the draft | `docs/reports/quality/backend-openspec-issue92-downstream-decision-split-2026-05-21.md` | Human review and explicit acceptance or revision of the split before any child issue/proposal is created |
 | Issue `#92` downstream split accepted | D2 | Human maintainer accepted the split in full: `TechnicalPatternDetectionService` is the first DI design pilot; trading route ownership folds into unified route/OpenAPI governance; backup route ownership becomes a dedicated proposal candidate with `cleanup_old_backups.py` owned by that lane | Reviewed/pass in current thread: acceptance remains decision/proposal-only and does not authorize backend implementation, route mutation, Core file movement, PM2 execution, or any `ready-for-agent` movement | `docs/reports/quality/backend-openspec-issue92-downstream-split-acceptance-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Draft D2.1 design packet for `TechnicalPatternDetectionService`; keep implementation locked behind separate approval |
 | D2.1 `TechnicalPatternDetectionService` DI design packet | D2.1 | First DI design pilot packet prepared with provider shape, dependency override strategy, teardown artifact, rollback path, and implementation verification gates | Review-ready design only: GitNexus impact for `TechnicalPatternDetectionService` is LOW with 0 affected symbols/processes; no source, route, test, PM2, or OpenSpec mutation is authorized | `docs/reports/quality/backend-di-pilot-technical-pattern-detection-design-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate implementation issue or OpenSpec branch before source edits |
+| D2.2 Core validation wrapper retirement readiness | D2.2 | Readiness packet prepared for `app.core.validation_messages` retirement; deletion is not ready because active source consumers and API docs still reference the legacy path | Review-ready readiness only: compatibility test passed `2 passed`; placeholder-env import smoke passed; active source blockers are `web/backend/app/core/validators.py` and `web/backend/app/core/error_codes.py` | `docs/reports/quality/backend-core-validation-wrapper-retirement-readiness-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate D2.2a active-source consumer migration issue before any wrapper deletion |
 
 ## OpenSpec Branch Register
 
@@ -250,6 +262,7 @@ review, PR review, or OpenSpec archive review.
 | `split-backend-core-modules-with-compatibility-wrappers` | `archived-merged` | Existing OpenSpec line | Core split reconciliation | Core helper split continuation | Archived by PR `#90`; future Core split work requires a new concrete implementation plan and approval |
 | `github-issue-92-backend-openspec-issue15` | `downstream-split-accepted` | Current review-thread approval, issue `#83` acceptance, downstream split draft, and human split acceptance | Post-approval implementation decision boundary | Decision/design issue only; no implementation work | Draft D2.1 `TechnicalPatternDetectionService` DI design packet; keep implementation locked behind separate approval |
 | `select-backend-technical-pattern-di-pilot` | `design-packet-prepared` | Issue `#92` downstream split acceptance | First DI lifecycle pilot design packet | Provider shape, dependency override strategy, teardown, rollback, and verification gates for `TechnicalPatternDetectionService` | Human review before creating any implementation issue or OpenSpec branch |
+| `decide-backend-core-validation-wrapper-retirement` | `readiness-packet-prepared` | Issue `#92` downstream split acceptance and validation helper split archive | Core validation compatibility wrapper retirement readiness | Consumer scan, import smoke, compatibility tests, retirement blockers, and rollback path for `app.core.validation_messages` | Human review before creating D2.2a active-source consumer migration; wrapper deletion remains blocked |
 | `close-backend-schema-dual-directory` | `candidate` | Master execution plan | Schema dual-directory closure | Schema exports, consumer migration, shim retirement decision | Create only after `sequence-backend-architecture-unblocks` schema tasks are accepted |
 | `refresh-backend-route-openapi-governance` | `candidate-unblocked` | Master execution plan | API flat/package closure records | Route table, OpenAPI, operationId, probe matrix | Can be prepared after Task 5.x route/OpenAPI refresh evidence is recorded |
 | `define-backend-service-seams-and-singleton-pilots` | `candidate` | Master execution plan | Singleton lifecycle routing matrix | Service seam definition, interface/test-double pilot strategy | Create as a design proposal after complete classification |

--- a/docs/reports/quality/backend-core-validation-wrapper-retirement-readiness-2026-05-21.md
+++ b/docs/reports/quality/backend-core-validation-wrapper-retirement-readiness-2026-05-21.md
@@ -1,0 +1,155 @@
+# Backend Core Validation Wrapper Retirement Readiness
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以
+> `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、
+> 当前代码与最近一次实际验证结果为准。
+
+- Date: 2026-05-21
+- Status: readiness packet prepared; wrapper retirement not authorized
+- Parent issue: <https://github.com/chengjon/mystocks/issues/92>
+- Parent split acceptance: `docs/reports/quality/backend-openspec-issue92-downstream-split-acceptance-2026-05-21.md`
+- Track: D2.2 `decide-backend-core-validation-wrapper-retirement`
+- Base HEAD: `458acb27888bfca6a024a03d778ae73061b02898`
+
+## Boundary
+
+This is a readiness packet only. It does not authorize deleting
+`web/backend/app/core/validation_messages.py`, editing active imports, changing
+tests, moving Core files, creating a new Core Batch 2, or moving any issue to
+`ready-for-agent`.
+
+The compatibility wrapper must remain until a separate implementation issue or
+OpenSpec branch is explicitly approved and its gates pass.
+
+## Current State
+
+| Item | State |
+|---|---|
+| Canonical implementation | `web/backend/app/core/validation/messages.py` exists |
+| Canonical package re-export | `web/backend/app/core/validation/__init__.py` exists |
+| Legacy compatibility wrapper | `web/backend/app/core/validation_messages.py` exists |
+| Compatibility test | `tests/unit/core/test_validation_messages_compat.py` exists and passes |
+| Validation helper split commit | `caa5a6bd6339d2dea6ed5d55a3be28dae40c64fe` was previously recorded as reachable |
+| GitNexus impact for `ValidationErrorBuilder` | `LOW`; `impactedCount=0`; `processes_affected=0` |
+
+## Consumer Scan
+
+Scan command:
+
+```bash
+rg -n "app\.core\.validation_messages|core\.validation_messages" web/backend tests docs/api docs/reports/quality
+```
+
+Classified results at this readiness review:
+
+| Category | Count | Disposition |
+|---|---:|---|
+| Active source references, including the wrapper docstring | 3 | Not ready for wrapper deletion |
+| Active source references, excluding the wrapper itself | 2 | Must migrate before retirement |
+| Compatibility test references | 2 | Intentional while wrapper exists |
+| API documentation examples | 6 | Must update or explicitly waive before retirement |
+| Quality report historical references | 10 | Historical evidence; not a blocker |
+
+Active source references that block deletion:
+
+- `web/backend/app/core/validators.py:11`
+- `web/backend/app/core/error_codes.py:11`
+
+Documentation examples that should be updated before final retirement:
+
+- `docs/api/VALIDATION_GUIDE.md`
+- `docs/api/EXCEPTION_HANDLER_GUIDE.md`
+- `docs/api/ERROR_CODE_GUIDE.md`
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| Compatibility test | `PYTHONPATH=web/backend pytest -o addopts= tests/unit/core/test_validation_messages_compat.py -q --no-cov` passed: `2 passed in 0.08s` |
+| Import smoke without required env | Blocked by expected configuration validation: missing `POSTGRESQL_HOST`, `POSTGRESQL_USER`, `POSTGRESQL_PASSWORD`, `JWT_SECRET_KEY`, `BACKEND_PORT`, `BACKEND_BACKUP_PORT` |
+| Import smoke with placeholder required env | Passed; canonical exports resolve and legacy wrapper symbols are identical to canonical symbols |
+
+Placeholder-env import smoke:
+
+```bash
+POSTGRESQL_HOST=localhost \
+POSTGRESQL_USER=placeholder \
+POSTGRESQL_PASSWORD=placeholder \
+JWT_SECRET_KEY=placeholder-placeholder-placeholder-placeholder \
+BACKEND_PORT=8888 \
+BACKEND_BACKUP_PORT=8889 \
+PYTHONPATH=web/backend \
+python -c "from app.core.logger import logger; from app.core.validation import CommonMessages; from app.core.validation_messages import CommonMessages as CompatCommonMessages; print(logger is not None, CommonMessages is CompatCommonMessages)"
+```
+
+Observed output:
+
+```text
+logger True
+canonical CommonMessages MarketMessages TechnicalMessages TradeMessages ErrorMessages ValidationErrorBuilder
+compat_identity True True True True True True
+```
+
+## Readiness Decision
+
+`app.core.validation_messages` is **not ready for deletion** at this point.
+
+Reason:
+
+- active source imports remain in `validators.py` and `error_codes.py`;
+- public API documentation still teaches the legacy import path;
+- the compatibility test still intentionally asserts the old path;
+- no implementation issue has approved source edits or wrapper deletion.
+
+## Proposed Retirement Sequence
+
+1. D2.2a: migrate active source consumers from
+   `app.core.validation_messages` to `app.core.validation`.
+2. D2.2b: update `docs/api/` examples to canonical import paths or record a
+   deliberate compatibility-doc waiver.
+3. D2.2c: keep `tests/unit/core/test_validation_messages_compat.py` while the
+   wrapper exists; replace it only when wrapper deletion is explicitly approved.
+4. D2.2d: rerun consumer scan and require zero active source legacy imports
+   before wrapper deletion is considered.
+5. D2.2e: create a separate wrapper-deletion approval only after all previous
+   gates pass.
+
+## Future Implementation Gate
+
+Any future implementation issue for D2.2 must include:
+
+| Gate | Required command or evidence |
+|---|---|
+| Pre-edit GitNexus | `impact(target="ValidationErrorBuilder", direction="upstream")`; if editing source consumers, also analyze the edited symbols/files |
+| Consumer scan before edit | `rg -n "app\.core\.validation_messages|core\.validation_messages" web/backend tests docs/api` |
+| Active source migration check | active source legacy imports excluding the wrapper itself must reach `0` before deletion |
+| Import smoke | logger-inclusive import smoke with required placeholder env |
+| Compatibility test | `PYTHONPATH=web/backend pytest -o addopts= tests/unit/core/test_validation_messages_compat.py -q --no-cov` while wrapper exists |
+| Lint touched files | `ruff check` for touched source, docs helper scripts if any, and tests |
+| Staged scope | `detect_changes(scope="staged")` after staging only the intended batch |
+
+## Rollback
+
+Rollback for a future source-consumer migration:
+
+1. Revert source consumer imports back to `app.core.validation_messages`.
+2. Keep `web/backend/app/core/validation_messages.py` in place.
+3. Re-run compatibility import smoke and `test_validation_messages_compat.py`.
+
+Rollback for a future wrapper deletion, if separately approved later:
+
+1. Restore `web/backend/app/core/validation_messages.py` from the prior commit.
+2. Restore compatibility tests.
+3. Re-run canonical and compatibility import smoke.
+
+## Next Gate
+
+Human review of this readiness packet.
+
+If accepted, create a separate implementation issue or OpenSpec branch for
+D2.2a active source consumer migration only. Do not combine source migration,
+documentation update, test conversion, and wrapper deletion into one unreviewed
+batch.
+

--- a/governance/mainline/task-cards/pr-98.yaml
+++ b/governance/mainline/task-cards/pr-98.yaml
@@ -1,0 +1,92 @@
+version: "v0.2"
+
+task:
+  id: "pr-98"
+  title: "draft validation wrapper retirement readiness"
+  owner: "main"
+  created_at: "2026-05-21"
+
+mainline:
+  id: "L1-issue92-d2-2-validation-wrapper-readiness"
+  objective: "draft D2.2 readiness packet for app.core.validation_messages wrapper retirement without source edits"
+  milestone_id: "L2-architecture-governance-closeout"
+  slice_id: "L3-core-wrapper-retirement-readiness"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "split-backend-core-modules-with-compatibility-wrappers"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "D2.2 validation wrapper retirement readiness packet only; no runtime entrypoint, route, page, shim, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "docs/reports/quality/backend-core-validation-wrapper-retirement-readiness-2026-05-21.md"
+    - "governance/mainline/task-cards/pr-98.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, or runtime behavior changes"
+  - "No deletion of web/backend/app/core/validation_messages.py"
+  - "No source consumer import migration"
+  - "No movement of issue #92 or D2.2 to ready-for-agent"
+  - "No downstream implementation issue creation"
+  - "No new OpenSpec proposal creation"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-core-validation-wrapper-retirement-readiness-2026-05-21.md"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If readiness is interpreted as wrapper deletion approval, active source consumers can break"
+    - "If source paths enter this PR, the governance-only boundary is broken"
+  rollback_plan: "revert this PR and return D2.2 to accepted-but-undrafted state from PR #96"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "draft D2.2 validation wrapper retirement readiness"
+    modified_scope: "steward task tree, D2.2 readiness packet, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance/readiness planning only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if readiness boundary or mainline scope gate fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-21T01:02:26Z"
+    approval_note: "human maintainer accepted D2.2 as wrapper-retirement readiness track; this PR records readiness only and does not authorize source migration or wrapper deletion"
+    secondary_approved: false
+


### PR DESCRIPTION
Draft D2.2 readiness packet for app.core.validation_messages wrapper retirement.

Scope:
- add wrapper-retirement readiness report
- update the codebase OpenSpec task tree with D2.2 readiness-packet-prepared
- add a PR98 mainline task card

Key finding:
- wrapper deletion is not ready
- active source references remain in web/backend/app/core/validators.py and web/backend/app/core/error_codes.py
- docs/api still contains legacy import examples
- compatibility test passes and placeholder-env import smoke passes

Boundary:
- no backend implementation authorization
- no deletion of validation_messages.py
- no source consumer import migration
- no test conversion
- no ready-for-agent movement
- no new OpenSpec proposal creation

Verification:
- GitNexus impact for ValidationErrorBuilder: LOW, 0 affected symbols/processes
- consumer scan completed and classified
- compatibility test passed: 2 passed
- placeholder-env import smoke passed
- git diff --check passed
- markdown governance gate passed
- GitNexus staged detect_changes reported low risk with 0 changed symbols
- local mainline scope gate passed

Related:
- issue #92: https://github.com/chengjon/mystocks/issues/92