### PR TITLE
refactor(core): migrate validation source imports

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -138,13 +138,24 @@ CODEBASE-MAP Architecture Remediation Program
 ├── D2.2. Core Validation Wrapper Retirement Readiness
 │   ├── Source evidence:
 │   │   `backend-core-validation-wrapper-retirement-readiness-2026-05-21.md`
-│   ├── State: readiness-packet-prepared
+│   ├── State: active-source-migration-complete
 │   ├── Role: Decide whether `app.core.validation_messages` can retire
-│   ├── Current fact: wrapper deletion is not ready; active source imports remain
-│   │                 in `validators.py` and `error_codes.py`, and docs still
-│   │                 teach the legacy path
-│   └── Next gate: Human review before creating a separate D2.2a active-source
-│                  consumer migration issue; wrapper deletion stays locked
+│   ├── Current fact: D2.2a migrated active source consumers in `validators.py`
+│   │                 and `error_codes.py` to `app.core.validation`; wrapper
+│   │                 remains because docs and compatibility tests still use
+│   │                 the legacy path
+│   └── Next gate: D2.2b documentation canonicalization or explicit waiver;
+│                  wrapper deletion stays locked
+│
+├── D2.2a. Core Validation Active Source Consumer Migration
+│   ├── Source evidence:
+│   │   `backend-core-validation-active-source-migration-2026-05-21.md`
+│   ├── State: implementation-complete
+│   ├── Role: Move active source consumers to canonical `app.core.validation`
+│   ├── Current fact: active source legacy imports excluding the wrapper are `0`;
+│   │                 compatibility wrapper and compatibility test are retained
+│   └── Next gate: D2.2b docs/API examples canonicalization before wrapper
+│                  deletion can be reconsidered
 │
 ├── E. Candidate Branch: close-backend-schema-dual-directory
 │   ├── Source evidence: backend-schema-dual-directory-closure-2026-05-19.md
@@ -252,6 +263,7 @@ review, PR review, or OpenSpec archive review.
 | Issue `#92` downstream split accepted | D2 | Human maintainer accepted the split in full: `TechnicalPatternDetectionService` is the first DI design pilot; trading route ownership folds into unified route/OpenAPI governance; backup route ownership becomes a dedicated proposal candidate with `cleanup_old_backups.py` owned by that lane | Reviewed/pass in current thread: acceptance remains decision/proposal-only and does not authorize backend implementation, route mutation, Core file movement, PM2 execution, or any `ready-for-agent` movement | `docs/reports/quality/backend-openspec-issue92-downstream-split-acceptance-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Draft D2.1 design packet for `TechnicalPatternDetectionService`; keep implementation locked behind separate approval |
 | D2.1 `TechnicalPatternDetectionService` DI design packet | D2.1 | First DI design pilot packet prepared with provider shape, dependency override strategy, teardown artifact, rollback path, and implementation verification gates | Review-ready design only: GitNexus impact for `TechnicalPatternDetectionService` is LOW with 0 affected symbols/processes; no source, route, test, PM2, or OpenSpec mutation is authorized | `docs/reports/quality/backend-di-pilot-technical-pattern-detection-design-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate implementation issue or OpenSpec branch before source edits |
 | D2.2 Core validation wrapper retirement readiness | D2.2 | Readiness packet prepared for `app.core.validation_messages` retirement; deletion is not ready because active source consumers and API docs still reference the legacy path | Review-ready readiness only: compatibility test passed `2 passed`; placeholder-env import smoke passed; active source blockers are `web/backend/app/core/validators.py` and `web/backend/app/core/error_codes.py` | `docs/reports/quality/backend-core-validation-wrapper-retirement-readiness-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate D2.2a active-source consumer migration issue before any wrapper deletion |
+| D2.2a Core validation active source migration | D2.2a | Active source imports in `validators.py` and `error_codes.py` migrated from `app.core.validation_messages` to `app.core.validation`; wrapper retained | TDD red/green completed; boundary test `1 passed`; compatibility test `2 passed`; import smoke passed; app import smoke routes=`548`; collect-only smoke `112 tests collected`; ruff passed; active source legacy imports excluding wrapper=`0` | `docs/reports/quality/backend-core-validation-active-source-migration-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | D2.2b docs/API examples canonicalization or explicit waiver; wrapper deletion remains blocked |
 
 ## OpenSpec Branch Register
 
@@ -262,7 +274,7 @@ review, PR review, or OpenSpec archive review.
 | `split-backend-core-modules-with-compatibility-wrappers` | `archived-merged` | Existing OpenSpec line | Core split reconciliation | Core helper split continuation | Archived by PR `#90`; future Core split work requires a new concrete implementation plan and approval |
 | `github-issue-92-backend-openspec-issue15` | `downstream-split-accepted` | Current review-thread approval, issue `#83` acceptance, downstream split draft, and human split acceptance | Post-approval implementation decision boundary | Decision/design issue only; no implementation work | Draft D2.1 `TechnicalPatternDetectionService` DI design packet; keep implementation locked behind separate approval |
 | `select-backend-technical-pattern-di-pilot` | `design-packet-prepared` | Issue `#92` downstream split acceptance | First DI lifecycle pilot design packet | Provider shape, dependency override strategy, teardown, rollback, and verification gates for `TechnicalPatternDetectionService` | Human review before creating any implementation issue or OpenSpec branch |
-| `decide-backend-core-validation-wrapper-retirement` | `readiness-packet-prepared` | Issue `#92` downstream split acceptance and validation helper split archive | Core validation compatibility wrapper retirement readiness | Consumer scan, import smoke, compatibility tests, retirement blockers, and rollback path for `app.core.validation_messages` | Human review before creating D2.2a active-source consumer migration; wrapper deletion remains blocked |
+| `decide-backend-core-validation-wrapper-retirement` | `active-source-migration-complete` | Issue `#92` downstream split acceptance and validation helper split archive | Core validation compatibility wrapper retirement readiness and staged migration | D2.2a active source migration is complete; docs/API examples and compatibility-test conversion remain separate gates | D2.2b docs/API examples canonicalization or explicit waiver; wrapper deletion remains blocked |
 | `close-backend-schema-dual-directory` | `candidate` | Master execution plan | Schema dual-directory closure | Schema exports, consumer migration, shim retirement decision | Create only after `sequence-backend-architecture-unblocks` schema tasks are accepted |
 | `refresh-backend-route-openapi-governance` | `candidate-unblocked` | Master execution plan | API flat/package closure records | Route table, OpenAPI, operationId, probe matrix | Can be prepared after Task 5.x route/OpenAPI refresh evidence is recorded |
 | `define-backend-service-seams-and-singleton-pilots` | `candidate` | Master execution plan | Singleton lifecycle routing matrix | Service seam definition, interface/test-double pilot strategy | Create as a design proposal after complete classification |

--- a/docs/reports/quality/backend-core-validation-active-source-migration-2026-05-21.md
+++ b/docs/reports/quality/backend-core-validation-active-source-migration-2026-05-21.md
@@ -1,0 +1,115 @@
+# Backend Core Validation Active Source Migration
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以
+> `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、
+> 当前代码与最近一次实际验证结果为准。
+
+- Date: 2026-05-21
+- Status: D2.2a implementation batch complete; wrapper retained
+- Parent issue: <https://github.com/chengjon/mystocks/issues/92>
+- Parent readiness packet: `docs/reports/quality/backend-core-validation-wrapper-retirement-readiness-2026-05-21.md`
+- Track: D2.2a active-source consumer migration
+- Base HEAD: `ac6c209cc5254a4616e527d65a844f01020d6655`
+
+## Boundary
+
+This batch migrates active source consumers from the legacy
+`app.core.validation_messages` import path to the canonical `app.core.validation`
+package.
+
+This batch does not delete `web/backend/app/core/validation_messages.py`, does
+not convert compatibility tests, does not update `docs/api/`, does not create a
+new Core Batch 2, and does not move any issue to `ready-for-agent`.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `web/backend/app/core/validators.py` | Import `CommonMessages`, `MarketMessages`, and `TechnicalMessages` from `app.core.validation` |
+| `web/backend/app/core/error_codes.py` | Import validation message classes from `app.core.validation` |
+| `tests/unit/core/test_validation_import_boundaries.py` | Add an AST boundary test to keep active source consumers on the canonical package |
+| `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md` | Record D2.2a completion and next gate |
+| `governance/mainline/task-cards/pr-99.yaml` | Scope card for this implementation batch |
+
+## TDD Evidence
+
+RED:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= tests/unit/core/test_validation_import_boundaries.py -q --no-cov
+```
+
+Result: failed as expected because `validators.py` and `error_codes.py` still
+imported `app.core.validation_messages`.
+
+GREEN:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= tests/unit/core/test_validation_import_boundaries.py -q --no-cov
+```
+
+Result: `1 passed in 0.08s`.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| GitNexus impact, `web/backend/app/core/validators.py` | `LOW`, `impactedCount=0` |
+| GitNexus impact, `web/backend/app/core/error_codes.py` | `MEDIUM`; direct upstream importer is `exception_handler.py`; no affected execution processes |
+| Boundary test | `tests/unit/core/test_validation_import_boundaries.py`: `1 passed` |
+| Compatibility test | `tests/unit/core/test_validation_messages_compat.py`: `2 passed` |
+| Placeholder-env import smoke | Passed; canonical and compatibility imports resolve; source imports load |
+| Active source consumer scan | `active_source_legacy_imports_excluding_wrapper=0` |
+| App import smoke | `app.main` imports with `routes 548`; startup emits existing environment/library warnings unrelated to this import migration |
+| Health route collection smoke | `web/backend/tests/test_health_route_conflicts.py --collect-only`: `112 tests collected` |
+| Ruff touched files | `All checks passed!` |
+
+## Consumer Scan After Migration
+
+The legacy import scan still finds historical, documentation, test, and wrapper
+references, but no active source consumer outside the wrapper itself.
+
+Post-migration summary:
+
+```json
+{
+  "active_source_legacy_imports_excluding_wrapper": 0,
+  "active": []
+}
+```
+
+Remaining non-active references are expected:
+
+- `web/backend/app/core/validation_messages.py` remains the compatibility
+  wrapper.
+- `tests/unit/core/test_validation_messages_compat.py` intentionally verifies
+  old-path compatibility while the wrapper exists.
+- `docs/api/` still contains legacy import examples and should be handled in a
+  later D2.2b documentation-canonicalization batch.
+- historical reports remain historical evidence.
+
+## Rollback
+
+Rollback is limited and direct:
+
+1. Change the two active source imports in `validators.py` and `error_codes.py`
+   back to `app.core.validation_messages`.
+2. Remove or update `test_validation_import_boundaries.py`.
+3. Re-run the compatibility test and import smoke.
+
+The compatibility wrapper was not changed, so runtime rollback does not require
+restoring a deleted file.
+
+## Next Gate
+
+D2.2b should update `docs/api/` examples to canonical `app.core.validation`
+imports or record explicit compatibility-doc waivers.
+
+Wrapper deletion remains blocked until:
+
+- active source legacy imports stay at `0`;
+- docs are canonicalized or waived;
+- compatibility-test conversion is explicitly approved;
+- a separate wrapper-deletion approval exists.

--- a/governance/mainline/task-cards/pr-99.yaml
+++ b/governance/mainline/task-cards/pr-99.yaml
@@ -1,0 +1,102 @@
+version: "v0.2"
+
+task:
+  id: "pr-99"
+  title: "migrate validation active source imports"
+  owner: "main"
+  created_at: "2026-05-21"
+
+mainline:
+  id: "L1-issue92-d2-2a-validation-source-migration"
+  objective: "migrate active source imports from app.core.validation_messages to app.core.validation while retaining the wrapper"
+  milestone_id: "L2-architecture-governance-closeout"
+  slice_id: "L3-core-wrapper-active-source-migration"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "split-backend-core-modules-with-compatibility-wrappers"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "core"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow active-source import migration within the accepted D2.2a validation wrapper track; no runtime route, page, or product surface changes are introduced, and the changed core/test files stay inside the recorded validation wrapper lane"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "docs/reports/quality/backend-core-validation-active-source-migration-2026-05-21.md"
+    - "governance/mainline/task-cards/pr-99.yaml"
+    - "tests/unit/core/test_validation_import_boundaries.py"
+    - "web/backend/app/core/error_codes.py"
+    - "web/backend/app/core/validators.py"
+  forbidden_paths:
+    - "web/backend/app/core/validation_messages.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No deletion of web/backend/app/core/validation_messages.py"
+  - "No docs/api canonicalization in this batch"
+  - "No compatibility test conversion or deletion"
+  - "No route, OpenAPI, or PM2 behavior changes"
+  - "No movement of issue #92 or D2.2a to ready-for-agent"
+
+acceptance:
+  checks:
+    - id: "boundary-test"
+      command: "PYTHONPATH=web/backend pytest -o addopts= tests/unit/core/test_validation_import_boundaries.py -q --no-cov"
+      required: true
+    - id: "compatibility-test"
+      command: "PYTHONPATH=web/backend pytest -o addopts= tests/unit/core/test_validation_messages_compat.py -q --no-cov"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/core/validators.py web/backend/app/core/error_codes.py tests/unit/core/test_validation_import_boundaries.py tests/unit/core/test_validation_messages_compat.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-core-validation-active-source-migration-2026-05-21.md"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "error_codes.py has MEDIUM GitNexus impact through exception_handler.py and app.main import flows"
+    - "If validation_messages.py is deleted in this batch, compatibility guarantees are broken"
+  rollback_plan: "revert the two active source imports to app.core.validation_messages and remove or revise the boundary test"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "migrate active validation source consumers to canonical app.core.validation imports"
+    modified_scope: "two active source import lines, one boundary test, steward task tree, implementation report, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "legacy wrapper retained; compatibility path remains available"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert import changes and boundary test if import smoke or compatibility tests fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-21T01:26:00Z"
+    approval_note: "human maintainer formally approved entering D2.2a active-source consumer migration"
+    secondary_approved: false

--- a/tests/unit/core/test_validation_import_boundaries.py
+++ b/tests/unit/core/test_validation_import_boundaries.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _import_modules(path: str) -> list[str]:
+    tree = ast.parse((PROJECT_ROOT / path).read_text(encoding="utf-8"))
+    modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module is not None:
+            modules.append(node.module)
+    return modules
+
+
+def test_active_validation_consumers_use_canonical_validation_package() -> None:
+    checked_paths = [
+        "web/backend/app/core/validators.py",
+        "web/backend/app/core/error_codes.py",
+    ]
+
+    legacy_imports = {
+        path: [module for module in _import_modules(path) if module == "app.core.validation_messages"]
+        for path in checked_paths
+    }
+
+    assert legacy_imports == {path: [] for path in checked_paths}

--- a/web/backend/app/core/error_codes.py
+++ b/web/backend/app/core/error_codes.py
@@ -8,7 +8,7 @@
 from enum import IntEnum
 from typing import Dict
 
-from app.core.validation_messages import (
+from app.core.validation import (
     CommonMessages,
     MarketMessages,
     TechnicalMessages,

--- a/web/backend/app/core/validators.py
+++ b/web/backend/app/core/validators.py
@@ -8,7 +8,7 @@ from datetime import date, datetime
 from decimal import Decimal
 from typing import Any, List, Optional
 
-from app.core.validation_messages import (
+from app.core.validation import (
     CommonMessages,
     MarketMessages,
     TechnicalMessages,


### PR DESCRIPTION
## Summary
- Migrate active backend source consumers from app.core.validation_messages to canonical app.core.validation.
- Keep web/backend/app/core/validation_messages.py as the compatibility wrapper.
- Add AST boundary coverage plus D2.2a steward/report/task-card records.

Refs #92. Does not close #92.

## Verification
- PYTHONPATH=web/backend pytest -o addopts= tests/unit/core/test_validation_import_boundaries.py -q --no-cov: 1 passed
- PYTHONPATH=web/backend pytest -o addopts= tests/unit/core/test_validation_messages_compat.py -q --no-cov: 2 passed
- ruff check touched validation files/tests: passed
- markdown_governance_gate targeted docs: checked_files=2, errors=0
- mainline_scope_gate pr-99: pass=True
- health route collect-only: 112 tests collected
- app.main import smoke: routes 548
- active source legacy import scan excluding wrapper: 0
- OpenSpec validate --all --strict: 60 passed, 0 failed; PostHog telemetry flush noise only