### PR TITLE
docs(core): canonicalize validation api examples

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -138,14 +138,14 @@ CODEBASE-MAP Architecture Remediation Program
 ├── D2.2. Core Validation Wrapper Retirement Readiness
 │   ├── Source evidence:
 │   │   `backend-core-validation-wrapper-retirement-readiness-2026-05-21.md`
-│   ├── State: active-source-migration-complete
+│   ├── State: docs-api-canonicalization-complete
 │   ├── Role: Decide whether `app.core.validation_messages` can retire
 │   ├── Current fact: D2.2a migrated active source consumers in `validators.py`
 │   │                 and `error_codes.py` to `app.core.validation`; wrapper
-│   │                 remains because docs and compatibility tests still use
-│   │                 the legacy path
-│   └── Next gate: D2.2b documentation canonicalization or explicit waiver;
-│                  wrapper deletion stays locked
+│   │                 remains because compatibility-test coverage and explicit
+│   │                 deletion approval still require a separate decision
+│   └── Next gate: D2.2c wrapper-retirement decision or explicit retention;
+│                  wrapper deletion stays locked until then
 │
 ├── D2.2a. Core Validation Active Source Consumer Migration
 │   ├── Source evidence:
@@ -154,8 +154,19 @@ CODEBASE-MAP Architecture Remediation Program
 │   ├── Role: Move active source consumers to canonical `app.core.validation`
 │   ├── Current fact: active source legacy imports excluding the wrapper are `0`;
 │   │                 compatibility wrapper and compatibility test are retained
-│   └── Next gate: D2.2b docs/API examples canonicalization before wrapper
-│                  deletion can be reconsidered
+│   └── Next gate: Completed by D2.2b docs/API examples canonicalization;
+│                  wrapper deletion remains a separate decision
+│
+├── D2.2b. Core Validation Docs/API Example Canonicalization
+│   ├── Source evidence:
+│   │   `backend-core-validation-docs-api-canonicalization-2026-05-21.md`
+│   ├── State: implementation-complete
+│   ├── Role: Move `docs/api/` examples to canonical `app.core.validation`
+│   ├── Current fact: `docs/api/` legacy `validation_messages` references are
+│   │                 `0`; no backend source, tests, OpenSpec, or wrapper files
+│   │                 changed
+│   └── Next gate: D2.2c wrapper-retirement decision or explicit long-term
+│                  retention of `app.core.validation_messages`
 │
 ├── E. Candidate Branch: close-backend-schema-dual-directory
 │   ├── Source evidence: backend-schema-dual-directory-closure-2026-05-19.md
@@ -262,8 +273,9 @@ review, PR review, or OpenSpec archive review.
 | Issue `#92` downstream decision split draft | D2 | Draft split prepared for human review: D2.1 DI pilot candidate, D2.2 Core validation wrapper-retirement readiness, D2.3 route governance, D2.4 backup route ownership, D2.5 control-plane OpenAPI docs, and D2.6 PM2 stateful gate approval | Review-ready draft only: issue `#92` remains `OPEN`; `ready-for-agent` remains absent; no backend, OpenSpec change, route, or test mutation is authorized by the draft | `docs/reports/quality/backend-openspec-issue92-downstream-decision-split-2026-05-21.md` | Human review and explicit acceptance or revision of the split before any child issue/proposal is created |
 | Issue `#92` downstream split accepted | D2 | Human maintainer accepted the split in full: `TechnicalPatternDetectionService` is the first DI design pilot; trading route ownership folds into unified route/OpenAPI governance; backup route ownership becomes a dedicated proposal candidate with `cleanup_old_backups.py` owned by that lane | Reviewed/pass in current thread: acceptance remains decision/proposal-only and does not authorize backend implementation, route mutation, Core file movement, PM2 execution, or any `ready-for-agent` movement | `docs/reports/quality/backend-openspec-issue92-downstream-split-acceptance-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Draft D2.1 design packet for `TechnicalPatternDetectionService`; keep implementation locked behind separate approval |
 | D2.1 `TechnicalPatternDetectionService` DI design packet | D2.1 | First DI design pilot packet prepared with provider shape, dependency override strategy, teardown artifact, rollback path, and implementation verification gates | Review-ready design only: GitNexus impact for `TechnicalPatternDetectionService` is LOW with 0 affected symbols/processes; no source, route, test, PM2, or OpenSpec mutation is authorized | `docs/reports/quality/backend-di-pilot-technical-pattern-detection-design-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate implementation issue or OpenSpec branch before source edits |
-| D2.2 Core validation wrapper retirement readiness | D2.2 | Readiness packet prepared for `app.core.validation_messages` retirement; deletion is not ready because active source consumers and API docs still reference the legacy path | Review-ready readiness only: compatibility test passed `2 passed`; placeholder-env import smoke passed; active source blockers are `web/backend/app/core/validators.py` and `web/backend/app/core/error_codes.py` | `docs/reports/quality/backend-core-validation-wrapper-retirement-readiness-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate D2.2a active-source consumer migration issue before any wrapper deletion |
-| D2.2a Core validation active source migration | D2.2a | Active source imports in `validators.py` and `error_codes.py` migrated from `app.core.validation_messages` to `app.core.validation`; wrapper retained | TDD red/green completed; boundary test `1 passed`; compatibility test `2 passed`; import smoke passed; app import smoke routes=`548`; collect-only smoke `112 tests collected`; ruff passed; active source legacy imports excluding wrapper=`0` | `docs/reports/quality/backend-core-validation-active-source-migration-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | D2.2b docs/API examples canonicalization or explicit waiver; wrapper deletion remains blocked |
+| D2.2 Core validation wrapper retirement readiness | D2.2 | Readiness packet prepared for `app.core.validation_messages` retirement; deletion remains locked pending a separate wrapper-retirement decision | Review-ready readiness only: compatibility test passed `2 passed`; placeholder-env import smoke passed; active source blockers were later closed by D2.2a and docs/API examples were later closed by D2.2b | `docs/reports/quality/backend-core-validation-wrapper-retirement-readiness-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | D2.2c wrapper-retirement decision or explicit long-term retention; no wrapper deletion before that approval |
+| D2.2a Core validation active source migration | D2.2a | Active source imports in `validators.py` and `error_codes.py` migrated from `app.core.validation_messages` to `app.core.validation`; wrapper retained | TDD red/green completed; boundary test `1 passed`; compatibility test `2 passed`; import smoke passed; app import smoke routes=`548`; collect-only smoke `112 tests collected`; ruff passed; active source legacy imports excluding wrapper=`0` | `docs/reports/quality/backend-core-validation-active-source-migration-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Completed by D2.2b docs/API examples canonicalization; wrapper deletion remains a separate decision |
+| D2.2b Core validation docs/API example canonicalization | D2.2b | `docs/api/` examples now point to canonical `app.core.validation`; wrapper retained | Docs-only batch: pre-change `docs/api/` legacy reference count was `10`; post-change count is `0`; no backend source, tests, OpenSpec, route, PM2, or frontend files changed | `docs/reports/quality/backend-core-validation-docs-api-canonicalization-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | D2.2c wrapper-retirement decision or explicit retention; do not delete `app.core.validation_messages` from this batch |
 
 ## OpenSpec Branch Register
 

--- a/docs/api/ERROR_CODE_GUIDE.md
+++ b/docs/api/ERROR_CODE_GUIDE.md
@@ -229,7 +229,7 @@ print(is_server_error(ErrorCode.BAD_REQUEST))  # False
 from fastapi import HTTPException, status
 from app.core.error_codes import ErrorCode, get_http_status, get_error_message
 from app.core.validators import TradingValidator
-from app.core.validation_messages import CommonMessages
+from app.core.validation import CommonMessages
 
 @router.post("/trade/orders")
 async def create_order(order: OrderRequest):
@@ -358,15 +358,15 @@ try {
 
 ---
 
-## 🔄 与validation_messages.py集成
+## 🔄 与 app.core.validation 集成
 
-错误码体系与`validation_messages.py`完全集成:
+错误码体系与 canonical `app.core.validation` 完全集成:
 
 ```python
 from app.core.error_codes import ErrorCode, get_error_message
-from app.core.validation_messages import CommonMessages
+from app.core.validation import CommonMessages
 
-# 错误消息优先从validation_messages获取
+# 错误消息优先从 app.core.validation 获取
 message = get_error_message(ErrorCode.SYMBOL_INVALID_FORMAT)
 # message == CommonMessages.SYMBOL_INVALID_FORMAT
 

--- a/docs/api/EXCEPTION_HANDLER_GUIDE.md
+++ b/docs/api/EXCEPTION_HANDLER_GUIDE.md
@@ -248,7 +248,7 @@ async def create_order(order: OrderRequest):
 
 ```python
 from app.core.validators import TradingValidator
-from app.core.validation_messages import CommonMessages
+from app.core.validation import CommonMessages
 
 @router.post("/trade/orders")
 async def create_order(order: OrderRequest):

--- a/docs/api/VALIDATION_GUIDE.md
+++ b/docs/api/VALIDATION_GUIDE.md
@@ -11,12 +11,12 @@
 
 ## 📦 模块概览
 
-### 1. `validation_messages.py` - 中文错误消息常量
+### 1. `app.core.validation` - 中文错误消息常量
 
 提供统一的中文错误消息，确保用户友好的错误提示。
 
 ```python
-from app.core.validation_messages import (
+from app.core.validation import (
     CommonMessages,
     MarketMessages,
     TechnicalMessages,
@@ -51,7 +51,7 @@ from app.core.validators import (
 ```python
 from pydantic import BaseModel, Field, field_validator
 from app.core.validators import StockSymbolValidator
-from app.core.validation_messages import CommonMessages
+from app.core.validation import CommonMessages
 
 class StockRequest(BaseModel):
     """股票查询请求"""
@@ -118,7 +118,7 @@ class DateRangeRequest(BaseModel):
 from pydantic import BaseModel, Field, field_validator
 from decimal import Decimal
 from app.core.validators import TradingValidator
-from app.core.validation_messages import CommonMessages
+from app.core.validation import CommonMessages
 
 class OrderRequest(BaseModel):
     """下单请求"""

--- a/docs/reports/quality/backend-core-validation-docs-api-canonicalization-2026-05-21.md
+++ b/docs/reports/quality/backend-core-validation-docs-api-canonicalization-2026-05-21.md
@@ -1,0 +1,54 @@
+# Backend Core Validation Docs API Canonicalization
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以
+> `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、
+> 当前代码与最近一次实际验证结果为准。
+
+- Date: 2026-05-21
+- Status: D2.2b documentation batch complete; wrapper retained
+- Parent issue: <https://github.com/chengjon/mystocks/issues/92>
+- Parent readiness packet: `docs/reports/quality/backend-core-validation-wrapper-retirement-readiness-2026-05-21.md`
+- Prior implementation packet: `docs/reports/quality/backend-core-validation-active-source-migration-2026-05-21.md`
+- Track: D2.2b docs/API examples canonicalization
+- Base HEAD: `c54c17e30e0ac25b71ca4358d2816d6f0a9fc78f`
+
+## Boundary
+
+This batch canonicalizes documentation examples under `docs/api/` from the
+legacy `app.core.validation_messages` import path to the canonical
+`app.core.validation` package.
+
+This batch does not delete `web/backend/app/core/validation_messages.py`, does
+not modify backend source, does not modify tests, does not modify OpenSpec
+change files, does not run or change PM2 behavior, and does not move any issue
+to `ready-for-agent`.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `docs/api/VALIDATION_GUIDE.md` | Update module overview and import examples to `app.core.validation` |
+| `docs/api/ERROR_CODE_GUIDE.md` | Update integration wording and import examples to `app.core.validation` |
+| `docs/api/EXCEPTION_HANDLER_GUIDE.md` | Update example import to `app.core.validation` |
+| `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md` | Record D2.2b completion and next gate |
+| `governance/mainline/task-cards/pr-100.yaml` | Scope card for this docs-only batch |
+
+## Evidence
+
+| Check | Result |
+|---|---|
+| Pre-change docs/API scan | `10` legacy `validation_messages` references in `docs/api/` |
+| Post-change docs/API scan | `docs_api_legacy_reference_count=0` |
+| Source boundary | No `web/backend/app/**` files are modified in this batch |
+| Wrapper boundary | `web/backend/app/core/validation_messages.py` remains unchanged and retained |
+
+## Closure Statement
+
+D2.2b closes the docs/API example portion of the validation wrapper retirement
+readiness track. It does not authorize wrapper deletion.
+
+The remaining retirement question is a separate D2.2c decision: either keep the
+compatibility wrapper intentionally, or approve a wrapper deletion batch with
+explicit compatibility-test and consumer-retirement handling.

--- a/governance/mainline/task-cards/pr-100.yaml
+++ b/governance/mainline/task-cards/pr-100.yaml
@@ -1,0 +1,99 @@
+version: "v0.2"
+
+task:
+  id: "pr-100"
+  title: "canonicalize validation docs api examples"
+  owner: "main"
+  created_at: "2026-05-21"
+
+mainline:
+  id: "L1-issue92-d2-2b-validation-docs-api-canonicalization"
+  objective: "canonicalize docs/API examples from app.core.validation_messages to app.core.validation while retaining the wrapper"
+  milestone_id: "L2-architecture-governance-closeout"
+  slice_id: "L3-core-wrapper-docs-api-canonicalization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "split-backend-core-modules-with-compatibility-wrappers"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "api"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Docs/API example canonicalization only; no runtime route, backend source, test, OpenSpec, PM2, frontend, or product behavior changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "docs/api/EXCEPTION_HANDLER_GUIDE.md"
+    - "docs/api/ERROR_CODE_GUIDE.md"
+    - "docs/api/VALIDATION_GUIDE.md"
+    - "docs/reports/quality/backend-core-validation-docs-api-canonicalization-2026-05-21.md"
+    - "governance/mainline/task-cards/pr-100.yaml"
+  forbidden_paths:
+    - "web/backend/app/**"
+    - "web/frontend/**"
+    - "tests/**"
+    - "src/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No deletion of web/backend/app/core/validation_messages.py"
+  - "No backend source modification"
+  - "No test modification"
+  - "No route, OpenAPI runtime, PM2, or frontend behavior changes"
+  - "No movement of issue #92 or D2.2b to ready-for-agent"
+
+acceptance:
+  checks:
+    - id: "docs-api-legacy-scan"
+      command: "! rg -n \"validation_messages|app\\.core\\.validation_messages\" docs/api"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-core-validation-docs-api-canonicalization-2026-05-21.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-100.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Docs/API examples could accidentally keep pointing at the compatibility wrapper and extend retirement ambiguity"
+    - "A docs-only batch could accidentally include backend source changes if path scope is not enforced"
+  rollback_plan: "revert the docs/API import wording changes, the D2.2b evidence report, the task-tree D2.2b row, and this task card"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "canonicalize docs/API validation examples to app.core.validation"
+    modified_scope: "three docs/api files, one evidence report, steward task tree, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "legacy wrapper retained; compatibility path remains available"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "docs-only rollback by reverting this PR"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-21T02:15:49Z"
+    approval_note: "human maintainer formally approved immediate D2.2b docs/API example standardization with docs-only and no code deletion boundaries"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Canonicalize docs/API validation examples from app.core.validation_messages to app.core.validation.
- Record D2.2b completion in the steward task tree, quality report, and PR task card.
- Retain web/backend/app/core/validation_messages.py; this is docs-only and does not authorize wrapper deletion.

Refs #92. Does not close #92.

## Boundaries
- No backend source changes.
- No test changes.
- No OpenSpec change/spec edits.
- No route, OpenAPI runtime, PM2, frontend, or issue-label promotion changes.

## Verification
- docs/api legacy validation_messages scan: 0 matches
- cached changed files: exactly 6 allowed docs/governance paths
- forbidden cached path scan: no output
- markdown_governance_gate targeted docs: checked_files=2, errors=0
- mainline_scope_gate pr-100 after commit: pass=True
- git diff --check HEAD^ HEAD: no output
- GitNexus compare vs origin/wip/root-dirty-20260403: low risk, affected processes=0
- openspec validate --all --strict: 60 passed, 0 failed; PostHog telemetry flush noise only