### PR TITLE
docs(core): prepare validation wrapper decision package

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -138,14 +138,14 @@ CODEBASE-MAP Architecture Remediation Program
 ├── D2.2. Core Validation Wrapper Retirement Readiness
 │   ├── Source evidence:
 │   │   `backend-core-validation-wrapper-retirement-readiness-2026-05-21.md`
-│   ├── State: docs-api-canonicalization-complete
+│   ├── State: wrapper-decision-package-complete
 │   ├── Role: Decide whether `app.core.validation_messages` can retire
 │   ├── Current fact: D2.2a migrated active source consumers in `validators.py`
 │   │                 and `error_codes.py` to `app.core.validation`; wrapper
-│   │                 remains because compatibility-test coverage and explicit
-│   │                 deletion approval still require a separate decision
-│   └── Next gate: D2.2c wrapper-retirement decision or explicit retention;
-│                  wrapper deletion stays locked until then
+│   │                 remains because D2.2c prepared a decision package, not a
+│   │                 deletion implementation
+│   └── Next gate: Human decision: retain wrapper long-term or approve a
+│                  separate D2.2d deletion batch
 │
 ├── D2.2a. Core Validation Active Source Consumer Migration
 │   ├── Source evidence:
@@ -167,6 +167,17 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 changed
 │   └── Next gate: D2.2c wrapper-retirement decision or explicit long-term
 │                  retention of `app.core.validation_messages`
+│
+├── D2.2c. Core Validation Wrapper Retirement / Retention Decision Package
+│   ├── Source evidence:
+│   │   `backend-core-validation-wrapper-retirement-decision-package-2026-05-21.md`
+│   ├── State: review-ready
+│   ├── Role: Present wrapper-retirement vs long-term-retention options
+│   ├── Current fact: active source imports and `docs/api/` legacy references are
+│   │                 `0`; compatibility tests and historical/governance records
+│   │                 still intentionally mention the wrapper path
+│   └── Next gate: Human decision only; wrapper deletion remains locked unless a
+│                  separate D2.2d implementation batch is explicitly approved
 │
 ├── E. Candidate Branch: close-backend-schema-dual-directory
 │   ├── Source evidence: backend-schema-dual-directory-closure-2026-05-19.md
@@ -276,6 +287,7 @@ review, PR review, or OpenSpec archive review.
 | D2.2 Core validation wrapper retirement readiness | D2.2 | Readiness packet prepared for `app.core.validation_messages` retirement; deletion remains locked pending a separate wrapper-retirement decision | Review-ready readiness only: compatibility test passed `2 passed`; placeholder-env import smoke passed; active source blockers were later closed by D2.2a and docs/API examples were later closed by D2.2b | `docs/reports/quality/backend-core-validation-wrapper-retirement-readiness-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | D2.2c wrapper-retirement decision or explicit long-term retention; no wrapper deletion before that approval |
 | D2.2a Core validation active source migration | D2.2a | Active source imports in `validators.py` and `error_codes.py` migrated from `app.core.validation_messages` to `app.core.validation`; wrapper retained | TDD red/green completed; boundary test `1 passed`; compatibility test `2 passed`; import smoke passed; app import smoke routes=`548`; collect-only smoke `112 tests collected`; ruff passed; active source legacy imports excluding wrapper=`0` | `docs/reports/quality/backend-core-validation-active-source-migration-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Completed by D2.2b docs/API examples canonicalization; wrapper deletion remains a separate decision |
 | D2.2b Core validation docs/API example canonicalization | D2.2b | `docs/api/` examples now point to canonical `app.core.validation`; wrapper retained | Docs-only batch: pre-change `docs/api/` legacy reference count was `10`; post-change count is `0`; no backend source, tests, OpenSpec, route, PM2, or frontend files changed | `docs/reports/quality/backend-core-validation-docs-api-canonicalization-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | D2.2c wrapper-retirement decision or explicit retention; do not delete `app.core.validation_messages` from this batch |
+| D2.2c Core validation wrapper retirement / retention decision package | D2.2c | Decision package prepared for whether to retain `app.core.validation_messages` long-term or approve a future deletion batch | Evidence-only: wrapper exists; active source import consumers excluding wrapper=`0`; docs/API legacy references=`0`; compatibility test `2 passed`; boundary test `1 passed`; canonical and wrapper exports remain identity-equivalent; no backend source, tests, OpenSpec, route, PM2, or frontend files changed | `docs/reports/quality/backend-core-validation-wrapper-retirement-decision-package-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human decision: retain wrapper or approve a separate D2.2d deletion implementation batch; wrapper deletion remains locked |
 
 ## OpenSpec Branch Register
 

--- a/docs/reports/quality/backend-core-validation-wrapper-retirement-decision-package-2026-05-21.md
+++ b/docs/reports/quality/backend-core-validation-wrapper-retirement-decision-package-2026-05-21.md
@@ -1,0 +1,113 @@
+# Backend Core Validation Wrapper Retirement Decision Package
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以
+> `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、
+> 当前代码与最近一次实际验证结果为准。
+
+- Date: 2026-05-21
+- Status: D2.2c decision package prepared; no deletion executed
+- Parent issue: <https://github.com/chengjon/mystocks/issues/92>
+- Track: D2.2c validation compatibility-wrapper retirement / retention decision
+- Base HEAD: `7d4e86d71e2f505f698f028b184f59d4da7b43df`
+- Prior implementation evidence:
+  - D2.2a PR `#99`: active source import migration
+  - D2.2b PR `#100`: docs/API example canonicalization
+
+## Boundary
+
+This package is decision and evidence only.
+
+It does not delete `web/backend/app/core/validation_messages.py`, does not modify
+backend source, does not modify tests, does not modify OpenSpec change/spec files,
+does not change route/OpenAPI runtime behavior, does not run PM2, and does not
+move any issue to `ready-for-agent`.
+
+## Decision Question
+
+Should the compatibility wrapper `web/backend/app/core/validation_messages.py`
+remain available as a long-term compatibility path, or should a future approved
+batch retire it?
+
+## Current Evidence Snapshot
+
+| Evidence | Result |
+|---|---|
+| Wrapper file | `web/backend/app/core/validation_messages.py` exists |
+| Canonical package | `app.core.validation` imports successfully |
+| Compatibility identity smoke | `CommonMessages` and `ValidationErrorBuilder` are identity-equivalent from canonical and wrapper paths |
+| Compatibility test | `tests/unit/core/test_validation_messages_compat.py`: `2 passed` |
+| Active source import scan | `active_source_legacy_imports_excluding_wrapper=0` |
+| Active source text-only reference | `web/backend/app/core/error_codes.py` contains one historical comment text reference; it is not an import consumer |
+| Docs/API legacy scan | `docs/api/` legacy `validation_messages` references: `0` |
+| Boundary test | `tests/unit/core/test_validation_import_boundaries.py`: `1 passed` |
+| Current issue state | Issue `#92` remains `OPEN`, with `ready-for-human` and `ready-for-downstream`; no `ready-for-agent` label |
+
+## Consumer Matrix
+
+| Consumer class | Current state | Decision impact |
+|---|---|---|
+| Active backend source imports | `0` import consumers outside the wrapper | No known runtime source blocker to a future deletion batch |
+| Docs/API examples | `0` legacy references | D2.2b closed the public example blocker |
+| Compatibility tests | `tests/unit/core/test_validation_messages_compat.py` still imports the wrapper intentionally | Must be converted, deleted, or replaced in any deletion batch |
+| Boundary tests | `tests/unit/core/test_validation_import_boundaries.py` contains the legacy path as a forbidden import sentinel | Keep or adjust depending on final retirement decision |
+| Wrapper self | `web/backend/app/core/validation_messages.py` documents the historical path | Removed only in an approved deletion batch |
+| Historical/governance docs | 23 historical/governance doc files, 79 text hits | Treat as historical evidence unless a separate documentation cleanup is approved |
+| Mainline task cards | 3 governance task-card files, 12 text hits | Retain as audit trail |
+| Structure baseline reports | 2 baseline files, 5 text hits | Retain as generated historical baseline |
+
+## Option A: Retain Wrapper
+
+Retain `web/backend/app/core/validation_messages.py` as a documented compatibility
+wrapper.
+
+Recommended when:
+
+- avoiding churn in compatibility tests and historical references is preferred;
+- downstream or external consumers might still rely on the legacy import path;
+- the team wants a stable fallback while additional Core split work proceeds.
+
+Required follow-up if selected:
+
+- record explicit long-term retention in the task tree and issue `#92`;
+- keep `tests/unit/core/test_validation_messages_compat.py`;
+- keep active source and docs/API canonicalization guards.
+
+## Option B: Retire Wrapper In A Future Batch
+
+Approve a separate implementation batch to remove
+`web/backend/app/core/validation_messages.py`.
+
+Prerequisites:
+
+- explicit human approval for deletion;
+- path-limited task card for the deletion batch;
+- GitNexus impact analysis before code deletion;
+- compatibility test conversion, removal, or replacement;
+- boundary test review so it continues to enforce canonical imports;
+- active source import scan remains `0`;
+- docs/API legacy scan remains `0`;
+- rollback plan restores the wrapper exactly if downstream imports fail.
+
+Suggested deletion-batch verification:
+
+- `PYTHONPATH=web/backend pytest -o addopts= tests/unit/core/test_validation_import_boundaries.py -q --no-cov`
+- selected replacement or retirement test for compatibility coverage;
+- canonical import smoke for `app.core.validation`;
+- `app.main` import smoke;
+- `git diff --check`;
+- mainline scope gate;
+- GitNexus staged/compare risk check.
+
+## Decision Package Recommendation
+
+Do not delete the wrapper from this package.
+
+For the next human decision, choose exactly one of:
+
+1. retain `app.core.validation_messages` as a long-term compatibility wrapper; or
+2. approve a separate D2.2d deletion implementation batch with the prerequisites
+   above.
+
+Until that decision is recorded, wrapper deletion remains locked.

--- a/governance/mainline/task-cards/pr-101.yaml
+++ b/governance/mainline/task-cards/pr-101.yaml
@@ -1,0 +1,111 @@
+version: "v0.2"
+
+task:
+  id: "pr-101"
+  title: "prepare validation wrapper retirement decision package"
+  owner: "main"
+  created_at: "2026-05-21"
+
+mainline:
+  id: "L1-issue92-d2-2c-validation-wrapper-decision"
+  objective: "prepare an evidence-only decision package for retaining or retiring app.core.validation_messages"
+  milestone_id: "L2-architecture-governance-closeout"
+  slice_id: "L3-core-wrapper-retirement-decision"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-d2-2c-decision-package"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "core"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Evidence-only wrapper retirement/retention decision package; no backend source, tests, docs/api, OpenSpec, PM2, frontend, route, or product behavior changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "docs/reports/quality/backend-core-validation-wrapper-retirement-decision-package-2026-05-21.md"
+    - "governance/mainline/task-cards/pr-101.yaml"
+  forbidden_paths:
+    - "web/backend/app/**"
+    - "docs/api/**"
+    - "web/frontend/**"
+    - "tests/**"
+    - "src/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No deletion of web/backend/app/core/validation_messages.py"
+  - "No backend source modification"
+  - "No docs/api modification"
+  - "No test modification"
+  - "No OpenSpec change/spec modification"
+  - "No route, OpenAPI runtime, PM2, or frontend behavior changes"
+  - "No movement of issue #92 or D2.2c to ready-for-agent"
+
+acceptance:
+  checks:
+    - id: "wrapper-exists"
+      command: "test -f web/backend/app/core/validation_messages.py"
+      required: true
+    - id: "active-source-import-scan"
+      command: "scan web/backend/app for app.core.validation_messages imports excluding the wrapper and require count 0"
+      required: true
+    - id: "docs-api-legacy-scan"
+      command: "! rg -n \"validation_messages|app\\.core\\.validation_messages\" docs/api"
+      required: true
+    - id: "compatibility-test"
+      command: "PYTHONPATH=web/backend pytest -o addopts= tests/unit/core/test_validation_messages_compat.py -q --no-cov"
+      required: true
+    - id: "boundary-test"
+      command: "PYTHONPATH=web/backend pytest -o addopts= tests/unit/core/test_validation_import_boundaries.py -q --no-cov"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-core-validation-wrapper-retirement-decision-package-2026-05-21.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-101.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "A decision package could be misread as authorization to delete the wrapper"
+    - "Historical/governance references could be mistaken for active import consumers"
+  rollback_plan: "revert the decision package report, task-tree D2.2c row, and this task card"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "prepare validation wrapper retirement/retention decision package"
+    modified_scope: "one evidence report, steward task tree, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "legacy wrapper retained; no runtime behavior changes"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "decision-only rollback by reverting this PR"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-21T02:52:38Z"
+    approval_note: "human maintainer formally approved immediate D2.2c wrapper retirement/retention decision package with evidence-only and no-code-deletion boundaries"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Prepare the D2.2c decision package for retaining or retiring app.core.validation_messages.
- Record current evidence: active source imports are canonical, docs/API examples are canonical, wrapper remains, compatibility tests still intentionally cover the wrapper.
- Update the steward task tree and add PR101 task-card governance.

Refs #92. Does not close #92.

## Boundaries
- Decision/evidence only.
- No backend source changes.
- No docs/api changes.
- No test changes.
- No OpenSpec change/spec edits.
- No route, OpenAPI runtime, PM2, frontend, or issue-label promotion changes.
- web/backend/app/core/validation_messages.py is not deleted.

## Verification
- wrapper exists: web/backend/app/core/validation_messages.py
- active source legacy import scan excluding wrapper: 0
- docs/api legacy validation_messages scan: 0 matches
- compatibility test: 2 passed
- boundary test: 1 passed
- canonical/compat identity smoke: passed
- changed files: exactly 3 allowed governance/report paths
- forbidden path scan: no output
- markdown_governance_gate targeted docs: checked_files=2, errors=0
- mainline_scope_gate pr-101 after commit: pass=True
- git diff --check HEAD^ HEAD: no output
- GitNexus compare vs origin/wip/root-dirty-20260403: low risk, affected processes=0
- openspec validate --all --strict: 60 passed, 0 failed; PostHog telemetry flush noise only