### PR TITLE
docs(route): plan D2.3 trading governance package

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -138,14 +138,16 @@ CODEBASE-MAP Architecture Remediation Program
 ├── D2.2. Core Validation Wrapper Retirement Readiness
 │   ├── Source evidence:
 │   │   `backend-core-validation-wrapper-retirement-readiness-2026-05-21.md`
-│   ├── State: wrapper-decision-package-complete
+│   ├── State: formally-closed-decision-package
 │   ├── Role: Decide whether `app.core.validation_messages` can retire
 │   ├── Current fact: D2.2a migrated active source consumers in `validators.py`
 │   │                 and `error_codes.py` to `app.core.validation`; wrapper
 │   │                 remains because D2.2c prepared a decision package, not a
-│   │                 deletion implementation
-│   └── Next gate: Human decision: retain wrapper long-term or approve a
-│                  separate D2.2d deletion batch
+│   │                 deletion implementation; D2.2 is closed as a planning /
+│   │                 decision lane
+│   └── Next gate: Move to D2.3 trading route/OpenAPI governance planning;
+│                  wrapper deletion remains locked unless a separate D2.2d
+│                  implementation batch is explicitly approved
 │
 ├── D2.2a. Core Validation Active Source Consumer Migration
 │   ├── Source evidence:
@@ -171,13 +173,27 @@ CODEBASE-MAP Architecture Remediation Program
 ├── D2.2c. Core Validation Wrapper Retirement / Retention Decision Package
 │   ├── Source evidence:
 │   │   `backend-core-validation-wrapper-retirement-decision-package-2026-05-21.md`
-│   ├── State: review-ready
+│   ├── State: closed-decision-package
 │   ├── Role: Present wrapper-retirement vs long-term-retention options
 │   ├── Current fact: active source imports and `docs/api/` legacy references are
 │   │                 `0`; compatibility tests and historical/governance records
 │   │                 still intentionally mention the wrapper path
-│   └── Next gate: Human decision only; wrapper deletion remains locked unless a
-│                  separate D2.2d implementation batch is explicitly approved
+│   └── Next gate: D2.2 is formally closed; wrapper deletion remains locked
+│                  unless a separate D2.2d implementation batch is explicitly
+│                  approved
+│
+├── D2.3. Trading Route/OpenAPI Governance Planning Package
+│   ├── Source evidence:
+│   │   `backend-trading-route-openapi-governance-planning-package-2026-05-21.md`
+│   ├── State: planning-package-prepared
+│   ├── Role: Fold trading route ownership into unified route/OpenAPI governance
+│   ├── Current fact: current smoke at HEAD `c24f43016` reports routes=`548`,
+│   │                 OpenAPI paths=`500`, trading candidate routes=`41`,
+│   │                 trading schema-exposed routes=`41`, trading schema paths=`32`,
+│   │                 and duplicate trading operationIds=`0`
+│   └── Next gate: Human review; if accepted, decide whether to create a
+│                  separate OpenSpec proposal or implementation issue under
+│                  unified route/OpenAPI governance before any route mutation
 │
 ├── E. Candidate Branch: close-backend-schema-dual-directory
 │   ├── Source evidence: backend-schema-dual-directory-closure-2026-05-19.md
@@ -287,7 +303,8 @@ review, PR review, or OpenSpec archive review.
 | D2.2 Core validation wrapper retirement readiness | D2.2 | Readiness packet prepared for `app.core.validation_messages` retirement; deletion remains locked pending a separate wrapper-retirement decision | Review-ready readiness only: compatibility test passed `2 passed`; placeholder-env import smoke passed; active source blockers were later closed by D2.2a and docs/API examples were later closed by D2.2b | `docs/reports/quality/backend-core-validation-wrapper-retirement-readiness-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | D2.2c wrapper-retirement decision or explicit long-term retention; no wrapper deletion before that approval |
 | D2.2a Core validation active source migration | D2.2a | Active source imports in `validators.py` and `error_codes.py` migrated from `app.core.validation_messages` to `app.core.validation`; wrapper retained | TDD red/green completed; boundary test `1 passed`; compatibility test `2 passed`; import smoke passed; app import smoke routes=`548`; collect-only smoke `112 tests collected`; ruff passed; active source legacy imports excluding wrapper=`0` | `docs/reports/quality/backend-core-validation-active-source-migration-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Completed by D2.2b docs/API examples canonicalization; wrapper deletion remains a separate decision |
 | D2.2b Core validation docs/API example canonicalization | D2.2b | `docs/api/` examples now point to canonical `app.core.validation`; wrapper retained | Docs-only batch: pre-change `docs/api/` legacy reference count was `10`; post-change count is `0`; no backend source, tests, OpenSpec, route, PM2, or frontend files changed | `docs/reports/quality/backend-core-validation-docs-api-canonicalization-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | D2.2c wrapper-retirement decision or explicit retention; do not delete `app.core.validation_messages` from this batch |
-| D2.2c Core validation wrapper retirement / retention decision package | D2.2c | Decision package prepared for whether to retain `app.core.validation_messages` long-term or approve a future deletion batch | Evidence-only: wrapper exists; active source import consumers excluding wrapper=`0`; docs/API legacy references=`0`; compatibility test `2 passed`; boundary test `1 passed`; canonical and wrapper exports remain identity-equivalent; no backend source, tests, OpenSpec, route, PM2, or frontend files changed | `docs/reports/quality/backend-core-validation-wrapper-retirement-decision-package-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human decision: retain wrapper or approve a separate D2.2d deletion implementation batch; wrapper deletion remains locked |
+| D2.2c Core validation wrapper retirement / retention decision package | D2.2c | Decision package prepared for whether to retain `app.core.validation_messages` long-term or approve a future deletion batch; D2.2 is formally closed as a decision lane | Evidence-only: wrapper exists; active source import consumers excluding wrapper=`0`; docs/API legacy references=`0`; compatibility test `2 passed`; boundary test `1 passed`; canonical and wrapper exports remain identity-equivalent; no backend source, tests, OpenSpec, route, PM2, or frontend files changed | `docs/reports/quality/backend-core-validation-wrapper-retirement-decision-package-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Move to D2.3; wrapper deletion remains locked unless a separate D2.2d deletion implementation batch is approved |
+| D2.3 Trading route/OpenAPI governance planning package | D2.3 | Trading route ownership is folded into unified route/OpenAPI governance, not a standalone implementation lane | Planning/evidence only: current smoke at HEAD `c24f43016` reports routes=`548`, OpenAPI paths=`500`, trading candidate routes=`41`, schema-exposed=`41`, schema paths=`32`, duplicate trading operationIds=`0`; consumer scan records backend, frontend, test, script, docs/governance, and other tracked-file references; no route, OpenAPI, source, frontend, test, PM2, or OpenSpec mutation is authorized | `docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate route/OpenAPI governance proposal or implementation issue before route mutation |
 
 ## OpenSpec Branch Register
 

--- a/docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md
+++ b/docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md
@@ -1,0 +1,189 @@
+# Backend Trading Route OpenAPI Governance Planning Package
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以
+> `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、
+> 当前代码与最近一次实际验证结果为准。
+
+- Date: 2026-05-21
+- Status: D2.3 planning package prepared; no route implementation authorized
+- Parent issue: <https://github.com/chengjon/mystocks/issues/92>
+- Track: D2.3 trading route ownership under unified route/OpenAPI governance
+- Base HEAD: `c24f430167bbfc9cf573121f30d817b2c2db875b`
+- Prepared at: `2026-05-21T03:21:58Z`
+
+## Boundary
+
+This package is planning and evidence only.
+
+It does not modify backend route modules, does not change route registration,
+does not change OpenAPI schema exposure, does not edit frontend consumers, does
+not edit tests, does not create or modify OpenSpec change/spec files, does not
+run PM2, and does not move issue `#92` or any downstream child to
+`ready-for-agent`.
+
+## Decision Question
+
+Should trading route ownership be handled by the unified route/OpenAPI
+governance lane instead of a standalone trading-only implementation lane?
+
+Recommended answer for this package: yes, keep trading under unified
+route/OpenAPI governance and require a separate approved proposal or
+implementation issue before any route mutation.
+
+## Why This Exists
+
+Issue `#92` downstream splitting accepted three decisions:
+
+- `TechnicalPatternDetectionService` is the first DI design pilot.
+- trading route ownership folds into unified route/OpenAPI governance.
+- backup route ownership remains a dedicated proposal candidate.
+
+D2.3 records the trading decision as a planning package. It converts the
+decision into a concrete route/OpenAPI evidence shape without approving route
+edits.
+
+## Current Route Evidence Snapshot
+
+The 2026-05-18 domain-router reconciliation report counted `trading` as
+`31` runtime routes and `31` schema-exposed routes. The refreshed D2.3 smoke
+uses a broader trading candidate heuristic and should be treated as the current
+planning snapshot for this package.
+
+| Evidence | Result |
+|---|---|
+| Current HEAD | `c24f430167bbfc9cf573121f30d817b2c2db875b` |
+| App import smoke | `app.main` imported with placeholder local env |
+| Runtime routes | `548` |
+| OpenAPI paths | `500` |
+| Trading candidate routes | `41` |
+| Trading schema-exposed routes | `41` |
+| Trading schema path count | `32` |
+| Trading duplicate operationIds | `0` |
+
+The `31` to `41` difference is not evidence of a route deletion or route
+creation by D2.3. It reflects a refreshed candidate scope that includes trade
+execution tracking, runtime/status routes, v1 position/session surfaces, and one
+trading-adjacent advanced-analysis route that still needs ownership
+classification.
+
+## Candidate Ownership Classes
+
+| Class | Current endpoint modules | Planning treatment |
+|---|---|---|
+| Core trade package | `app.api.trade.routes`, `app.api.trade.execution_tracking_routes`, `app.api.trade.reconciliation_routes` | Candidate for canonical trading route ownership review |
+| Runtime trading API | `app.api.trading_runtime` | Needs route/OpenAPI taxonomy before route mutation |
+| Chart and widget API | `app.api.tradingview` | Fold into unified route/OpenAPI governance; do not handle as isolated trading cleanup |
+| v1 trading API | `app.api.v1.trading.session`, `app.api.v1.trading.positions` | Needs path and consumer parity review |
+| Trading-adjacent candidate | `app.api.advanced_analysis_api` | Needs explicit classification before being treated as trading-owned |
+
+## Current Module And Prefix Snapshot
+
+| Endpoint module | Routes | Schema exposed |
+|---|---:|---:|
+| `app.api.trade.routes` | 7 | 7 |
+| `app.api.trade.execution_tracking_routes` | 3 | 3 |
+| `app.api.trade.reconciliation_routes` | 5 | 5 |
+| `app.api.trading_runtime` | 8 | 8 |
+| `app.api.tradingview` | 6 | 6 |
+| `app.api.v1.trading.session` | 5 | 5 |
+| `app.api.v1.trading.positions` | 6 | 6 |
+| `app.api.advanced_analysis_api` | 1 | 1 |
+
+| Path group | Routes | Schema exposed |
+|---|---:|---:|
+| `/api/v1/trade` | 15 | 15 |
+| `/api/trading/status` | 1 | 1 |
+| `/api/trading/start` | 1 | 1 |
+| `/api/trading/stop` | 1 | 1 |
+| `/api/trading/strategies` | 3 | 3 |
+| `/api/trading/market` | 1 | 1 |
+| `/api/trading/risk` | 1 | 1 |
+| `/api/tradingview/chart` | 1 | 1 |
+| `/api/tradingview/mini-chart` | 1 | 1 |
+| `/api/tradingview/ticker-tape` | 1 | 1 |
+| `/api/tradingview/market-overview` | 1 | 1 |
+| `/api/tradingview/screener` | 1 | 1 |
+| `/api/tradingview/symbol` | 1 | 1 |
+| `/api/v1/trading` | 5 | 5 |
+| `/api/v1/positions` | 6 | 6 |
+| `/api/v1/advanced-analysis` | 1 | 1 |
+
+## Consumer Matrix Snapshot
+
+Tracked-file string scans for `/api/v1/trade`, `/api/trading`,
+`/api/tradingview`, `/api/v1/trading`, and `/api/v1/positions` found the
+following planning surface.
+
+| Consumer class | Hit files | Hits | Planning impact |
+|---|---:|---:|---|
+| Backend source | 4 | 12 | `router_registry`, `VERSION_MAPPING`, and contract route references must be reviewed before route mutation |
+| Frontend source | 15 | 66 | Frontend consumer contract parity is a hard future gate |
+| Tests | 24 | 150 | Existing test expectations must be classified before route edits |
+| Scripts | 4 | 24 | Operational and generated tooling references must be included in the consumer matrix |
+| Docs and governance | 77 | 431 | Historical references must be separated from active consumers |
+| Other tracked files | 14 | 19 | Needs review before implementation planning |
+
+This matrix is intentionally a planning snapshot. It is not enough to authorize
+route edits because it has not yet classified active runtime callers, historical
+references, generated artifacts, or stale snapshots.
+
+## Required Future Evidence Before Any Route Mutation
+
+A future trading route implementation proposal or issue must include:
+
+- current FastAPI route table with endpoint module, method, path, and
+  `include_in_schema`;
+- current `app.openapi()` snapshot with path count, operation count, warnings,
+  and duplicate operationId check;
+- path-prefix taxonomy for `/api/v1/trade`, `/api/trading`,
+  `/api/tradingview`, `/api/v1/trading`, and `/api/v1/positions`;
+- `router_registry`, `VERSION_MAPPING`, and `docs/FUNCTION_TREE.md` status;
+- frontend, backend, test, script, PM2, Docker, CI, and docs consumer matrix;
+- contract parity matrix covering path, query parameters, response shape,
+  caller parser expectations, OpenAPI examples, and minimal regression tests;
+- explicit treatment for trading-adjacent routes such as
+  `/api/v1/advanced-analysis/trading-signals`;
+- include-in-schema exposure policy and compatibility route policy;
+- rollback and compatibility strategy for any renamed, hidden, or retired route.
+
+## Governance Recommendation
+
+Trading route ownership should stay under the unified route/OpenAPI governance
+parent, currently referred to by the candidate branch name
+`refresh-backend-route-openapi-governance`.
+
+D2.3 should not create a trading-only implementation lane. The next approved
+unit should be either:
+
+- an evidence-only OpenSpec proposal that formalizes route/OpenAPI governance
+  requirements; or
+- a separate implementation issue after route/OpenAPI evidence and consumer
+  parity are accepted by a human reviewer.
+
+Backup route ownership remains outside D2.3 and should continue as its own D2.4
+candidate because backup routes have different ownership, security, and
+operational boundaries.
+
+## Explicit Non-Authorizations
+
+D2.3 does not authorize:
+
+- moving any route module;
+- renaming or retiring any path;
+- changing `include_in_schema`;
+- changing operationIds;
+- editing `web/backend/app/api/**`;
+- editing `web/frontend/**`;
+- editing tests or fixtures;
+- opening a broad route implementation issue;
+- moving issue `#92` or any downstream item to `ready-for-agent`.
+
+## Next Gate
+
+Human review of this D2.3 package.
+
+If accepted, the maintainer should decide whether to create a separate
+route/OpenAPI governance OpenSpec proposal or a narrower implementation issue.
+Until that decision exists, route behavior remains locked.

--- a/governance/mainline/task-cards/pr-102.yaml
+++ b/governance/mainline/task-cards/pr-102.yaml
@@ -1,0 +1,107 @@
+version: "v0.2"
+
+task:
+  id: "pr-102"
+  title: "prepare trading route openapi governance planning package"
+  owner: "main"
+  created_at: "2026-05-21"
+
+mainline:
+  id: "L1-issue92-d2-3-trading-route-governance-planning"
+  objective: "prepare an evidence-only planning package for folding trading routes into unified route/OpenAPI governance"
+  milestone_id: "L2-architecture-governance-closeout"
+  slice_id: "L3-trading-route-openapi-governance-planning"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-d2-3-planning-package"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "api"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Evidence-only trading route/OpenAPI governance planning package; no backend source, frontend, tests, docs/api, OpenSpec, PM2, or route behavior changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md"
+    - "governance/mainline/task-cards/pr-102.yaml"
+  forbidden_paths:
+    - "web/backend/app/**"
+    - "web/frontend/**"
+    - "tests/**"
+    - "src/**"
+    - "docs/api/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend route module modification"
+  - "No route registration change"
+  - "No OpenAPI schema exposure or operationId change"
+  - "No frontend consumer modification"
+  - "No test or fixture modification"
+  - "No docs/api modification"
+  - "No OpenSpec change/spec creation or modification"
+  - "No PM2 or runtime stateful gate execution"
+  - "No movement of issue #92 or any downstream item to ready-for-agent"
+
+acceptance:
+  checks:
+    - id: "trading-route-evidence-recorded"
+      command: "report records current route/OpenAPI smoke totals and trading candidate module/prefix snapshot"
+      required: true
+    - id: "consumer-matrix-recorded"
+      command: "report records tracked-file consumer matrix for trading path prefixes"
+      required: true
+    - id: "no-source-mutation"
+      command: "git diff --name-only origin/wip/root-dirty-20260403...HEAD must be limited to the allowed governance paths"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-102.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "A planning package could be misread as permission to move or rename trading routes"
+    - "Trading-adjacent routes could be incorrectly classified as trading-owned before consumer parity review"
+  rollback_plan: "revert the D2.3 planning report, task-tree update, and this task card"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "prepare trading route/OpenAPI governance planning package"
+    modified_scope: "one evidence report, steward task tree, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "no route behavior changes; trading route ownership remains planning-only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "decision-only rollback by reverting this PR"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-21T03:21:58Z"
+    approval_note: "human maintainer formally closed D2.2 and approved immediate D2.3 trading route/OpenAPI governance planning package with evidence-only and no-route-mutation boundaries"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- close D2.2 as a decision/planning lane while keeping wrapper deletion locked behind a separate D2.2d approval
- add the D2.3 trading route/OpenAPI governance planning package
- update the CODEBASE-MAP task tree and add the PR #102 mainline task card

## Boundary

This PR is governance and evidence only. It does not modify backend routes, frontend consumers, tests, docs/api, OpenSpec change/spec files, PM2 state, or route/OpenAPI runtime behavior.

## Verification

- `python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md` -> `errors=0`, `checked_files=2`
- `git diff --cached --check` before commit -> no output
- `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-102.yaml` after commit -> `pass=True`
- `gitnexus_detect_changes(scope=staged)` before commit -> low risk, 3 files, 0 changed symbols, 0 affected processes

Parent issue: #92