### PR TITLE
docs(route): clarify D2.3 review notes

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -188,9 +188,12 @@ CODEBASE-MAP Architecture Remediation Program
 │   ├── State: planning-package-prepared
 │   ├── Role: Fold trading route ownership into unified route/OpenAPI governance
 │   ├── Current fact: current smoke at HEAD `c24f43016` reports routes=`548`,
-│   │                 OpenAPI paths=`500`, trading candidate routes=`41`,
+│   │                 OpenAPI paths=`500`, trading candidate routes=`41`
+│   │                 (`40` trading-route candidates plus `1` unclassified
+│   │                 trading-adjacent route),
 │   │                 trading schema-exposed routes=`41`, trading schema paths=`32`,
-│   │                 and duplicate trading operationIds=`0`
+│   │                 and duplicate trading operationIds=`0`; classification
+│   │                 heuristic and consumer scan scope are now recorded
 │   └── Next gate: Human review; if accepted, decide whether to create a
 │                  separate OpenSpec proposal or implementation issue under
 │                  unified route/OpenAPI governance before any route mutation
@@ -201,11 +204,12 @@ CODEBASE-MAP Architecture Remediation Program
 │   ├── Role: Migrate legacy app.schema consumers and decide shim retirement
 │   └── Next gate: Prove canonical app.schemas exports and compatibility tests
 │
-├── F. Candidate Branch: refresh-backend-route-openapi-governance
+├── F. Candidate Governance Track: refresh-backend-route-openapi-governance
 │   ├── Source evidence: backend-api-flat-package-closure-records-2026-05-19.md
 │   ├── State: ready-after-sequence-refresh
 │   ├── Role: Rebuild route table, OpenAPI, operationId, and probe consumer evidence
-│   └── Next gate: Use Task 2.x runtime evidence, then run route/OpenAPI/probe refresh
+│   └── Next gate: Create an explicit OpenSpec change-id, issue, and git branch
+│                  only after the D2.3 planning package is accepted
 │
 ├── G. Candidate Branch: define-backend-service-seams-and-singleton-pilots
 │   ├── Source evidence: backend-singleton-lifecycle-routing-matrix-2026-05-19.md
@@ -304,7 +308,7 @@ review, PR review, or OpenSpec archive review.
 | D2.2a Core validation active source migration | D2.2a | Active source imports in `validators.py` and `error_codes.py` migrated from `app.core.validation_messages` to `app.core.validation`; wrapper retained | TDD red/green completed; boundary test `1 passed`; compatibility test `2 passed`; import smoke passed; app import smoke routes=`548`; collect-only smoke `112 tests collected`; ruff passed; active source legacy imports excluding wrapper=`0` | `docs/reports/quality/backend-core-validation-active-source-migration-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Completed by D2.2b docs/API examples canonicalization; wrapper deletion remains a separate decision |
 | D2.2b Core validation docs/API example canonicalization | D2.2b | `docs/api/` examples now point to canonical `app.core.validation`; wrapper retained | Docs-only batch: pre-change `docs/api/` legacy reference count was `10`; post-change count is `0`; no backend source, tests, OpenSpec, route, PM2, or frontend files changed | `docs/reports/quality/backend-core-validation-docs-api-canonicalization-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | D2.2c wrapper-retirement decision or explicit retention; do not delete `app.core.validation_messages` from this batch |
 | D2.2c Core validation wrapper retirement / retention decision package | D2.2c | Decision package prepared for whether to retain `app.core.validation_messages` long-term or approve a future deletion batch; D2.2 is formally closed as a decision lane | Evidence-only: wrapper exists; active source import consumers excluding wrapper=`0`; docs/API legacy references=`0`; compatibility test `2 passed`; boundary test `1 passed`; canonical and wrapper exports remain identity-equivalent; no backend source, tests, OpenSpec, route, PM2, or frontend files changed | `docs/reports/quality/backend-core-validation-wrapper-retirement-decision-package-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Move to D2.3; wrapper deletion remains locked unless a separate D2.2d deletion implementation batch is approved |
-| D2.3 Trading route/OpenAPI governance planning package | D2.3 | Trading route ownership is folded into unified route/OpenAPI governance, not a standalone implementation lane | Planning/evidence only: current smoke at HEAD `c24f43016` reports routes=`548`, OpenAPI paths=`500`, trading candidate routes=`41`, schema-exposed=`41`, schema paths=`32`, duplicate trading operationIds=`0`; consumer scan records backend, frontend, test, script, docs/governance, and other tracked-file references; no route, OpenAPI, source, frontend, test, PM2, or OpenSpec mutation is authorized | `docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate route/OpenAPI governance proposal or implementation issue before route mutation |
+| D2.3 Trading route/OpenAPI governance planning package | D2.3 | Trading route ownership is folded into unified route/OpenAPI governance, not a standalone implementation lane | Planning/evidence only: current smoke at HEAD `c24f43016` reports routes=`548`, OpenAPI paths=`500`, trading candidate routes=`41` (`40` trading-route candidates plus `1` unclassified trading-adjacent route), schema-exposed=`41`, schema paths=`32`, duplicate trading operationIds=`0`; classification heuristic and consumer scan scope are recorded; no route, OpenAPI, source, frontend, test, PM2, or OpenSpec mutation is authorized | `docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate route/OpenAPI governance proposal or implementation issue before route mutation |
 
 ## OpenSpec Branch Register
 
@@ -317,7 +321,7 @@ review, PR review, or OpenSpec archive review.
 | `select-backend-technical-pattern-di-pilot` | `design-packet-prepared` | Issue `#92` downstream split acceptance | First DI lifecycle pilot design packet | Provider shape, dependency override strategy, teardown, rollback, and verification gates for `TechnicalPatternDetectionService` | Human review before creating any implementation issue or OpenSpec branch |
 | `decide-backend-core-validation-wrapper-retirement` | `active-source-migration-complete` | Issue `#92` downstream split acceptance and validation helper split archive | Core validation compatibility wrapper retirement readiness and staged migration | D2.2a active source migration is complete; docs/API examples and compatibility-test conversion remain separate gates | D2.2b docs/API examples canonicalization or explicit waiver; wrapper deletion remains blocked |
 | `close-backend-schema-dual-directory` | `candidate` | Master execution plan | Schema dual-directory closure | Schema exports, consumer migration, shim retirement decision | Create only after `sequence-backend-architecture-unblocks` schema tasks are accepted |
-| `refresh-backend-route-openapi-governance` | `candidate-unblocked` | Master execution plan | API flat/package closure records | Route table, OpenAPI, operationId, probe matrix | Can be prepared after Task 5.x route/OpenAPI refresh evidence is recorded |
+| `refresh-backend-route-openapi-governance` | `candidate-track-no-git-branch` | Master execution plan and D2.3 planning package | API flat/package closure records plus trading route/OpenAPI governance planning | Route table, OpenAPI, operationId, probe matrix, trading route ownership classification | Create an explicit OpenSpec change-id, issue, and git branch only after D2.3 planning is accepted |
 | `define-backend-service-seams-and-singleton-pilots` | `candidate` | Master execution plan | Singleton lifecycle routing matrix | Service seam definition, interface/test-double pilot strategy | Create as a design proposal after complete classification |
 
 ## Dependency and Freshness Matrix

--- a/docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md
+++ b/docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md
@@ -8,6 +8,7 @@
 
 - Date: 2026-05-21
 - Status: D2.3 planning package prepared; no route implementation authorized
+- Review note status: reproducibility notes absorbed; scope remains planning-only
 - Parent issue: <https://github.com/chengjon/mystocks/issues/92>
 - Track: D2.3 trading route ownership under unified route/OpenAPI governance
 - Base HEAD: `c24f430167bbfc9cf573121f30d817b2c2db875b`
@@ -57,7 +58,7 @@ planning snapshot for this package.
 | App import smoke | `app.main` imported with placeholder local env |
 | Runtime routes | `548` |
 | OpenAPI paths | `500` |
-| Trading candidate routes | `41` |
+| Trading candidate routes | `41` total: `40` trading-route candidates plus `1` unclassified trading-adjacent route |
 | Trading schema-exposed routes | `41` |
 | Trading schema path count | `32` |
 | Trading duplicate operationIds | `0` |
@@ -68,6 +69,28 @@ execution tracking, runtime/status routes, v1 position/session surfaces, and one
 trading-adjacent advanced-analysis route that still needs ownership
 classification.
 
+## Classification Heuristic
+
+The D2.3 trading candidate count is reproducible from the loaded FastAPI route
+table by including route rows whose endpoint module is one of the following:
+
+- `app.api.trade.routes`
+- `app.api.trade.execution_tracking_routes`
+- `app.api.trade.reconciliation_routes`
+- `app.api.trading_runtime`
+- `app.api.tradingview`
+- `app.api.v1.trading.session`
+- `app.api.v1.trading.positions`
+
+One additional trading-adjacent route is included only because its path is
+`/api/v1/advanced-analysis/trading-signals` and its endpoint module is
+`app.api.advanced_analysis_api`.
+
+Do not treat the whole `app.api.advanced_analysis_api` module as trading-owned.
+Only the `trading-signals` route is included in this D2.3 count, and it remains
+unclassified until a future route/OpenAPI governance proposal decides whether it
+belongs to trading ownership or advanced-analysis ownership.
+
 ## Candidate Ownership Classes
 
 | Class | Current endpoint modules | Planning treatment |
@@ -76,7 +99,7 @@ classification.
 | Runtime trading API | `app.api.trading_runtime` | Needs route/OpenAPI taxonomy before route mutation |
 | Chart and widget API | `app.api.tradingview` | Fold into unified route/OpenAPI governance; do not handle as isolated trading cleanup |
 | v1 trading API | `app.api.v1.trading.session`, `app.api.v1.trading.positions` | Needs path and consumer parity review |
-| Trading-adjacent candidate | `app.api.advanced_analysis_api` | Needs explicit classification before being treated as trading-owned |
+| Trading-adjacent candidate | `app.api.advanced_analysis_api` path `/api/v1/advanced-analysis/trading-signals` only | Needs explicit classification before being treated as trading-owned |
 
 ## Current Module And Prefix Snapshot
 
@@ -110,6 +133,11 @@ classification.
 | `/api/v1/positions` | 6 | 6 |
 | `/api/v1/advanced-analysis` | 1 | 1 |
 
+The `/api/v1/advanced-analysis` row above refers only to
+`/api/v1/advanced-analysis/trading-signals`. It is counted in the `41` planning
+total as one unclassified trading-adjacent route, not as settled trading route
+ownership.
+
 ## Consumer Matrix Snapshot
 
 Tracked-file string scans for `/api/v1/trade`, `/api/trading`,
@@ -128,6 +156,20 @@ following planning surface.
 This matrix is intentionally a planning snapshot. It is not enough to authorize
 route edits because it has not yet classified active runtime callers, historical
 references, generated artifacts, or stale snapshots.
+
+The scan scope was tracked files from the checkout at the recorded base HEAD.
+The scan matched literal path-prefix strings only:
+
+- `/api/v1/trade`
+- `/api/trading`
+- `/api/tradingview`
+- `/api/v1/trading`
+- `/api/v1/positions`
+
+The counts are file/hit counts, not active-consumer counts. A future execution
+proposal must rerun the scan, record the command or generated artifact path, and
+split results into active consumers, tests, generated snapshots, historical
+governance references, and stale artifacts before route mutation is considered.
 
 ## Required Future Evidence Before Any Route Mutation
 
@@ -151,8 +193,13 @@ A future trading route implementation proposal or issue must include:
 ## Governance Recommendation
 
 Trading route ownership should stay under the unified route/OpenAPI governance
-parent, currently referred to by the candidate branch name
+parent, currently referred to by the candidate governance track or future
+OpenSpec change-id placeholder
 `refresh-backend-route-openapi-governance`.
+
+No git branch with that name exists or is required by this D2.3 package. If a
+future implementation lane begins, the actual git branch, OpenSpec change-id,
+and issue identifier must be created and recorded at that time.
 
 D2.3 should not create a trading-only implementation lane. The next approved
 unit should be either:

--- a/governance/mainline/task-cards/pr-103.yaml
+++ b/governance/mainline/task-cards/pr-103.yaml
@@ -1,0 +1,111 @@
+version: "v0.2"
+
+task:
+  id: "pr-103"
+  title: "absorb D2.3 trading governance review notes"
+  owner: "main"
+  created_at: "2026-05-21"
+
+mainline:
+  id: "L1-issue92-d2-3-trading-route-governance-review-notes"
+  objective: "absorb review notes into the D2.3 trading route/OpenAPI governance planning package without changing route behavior"
+  milestone_id: "L2-architecture-governance-closeout"
+  slice_id: "L3-trading-route-openapi-governance-review-notes"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-d2-3-review-note-absorption"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "api"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Evidence-only review note absorption for D2.3 trading route/OpenAPI governance planning; no backend source, frontend, tests, docs/api, OpenSpec, PM2, or route behavior changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md"
+    - "governance/mainline/task-cards/pr-103.yaml"
+  forbidden_paths:
+    - "web/backend/app/**"
+    - "web/frontend/**"
+    - "tests/**"
+    - "src/**"
+    - "docs/api/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend route module modification"
+  - "No route registration change"
+  - "No OpenAPI schema exposure or operationId change"
+  - "No frontend consumer modification"
+  - "No test or fixture modification"
+  - "No docs/api modification"
+  - "No OpenSpec change/spec creation or modification"
+  - "No PM2 or runtime stateful gate execution"
+  - "No creation of refresh-backend-route-openapi-governance as a git branch"
+  - "No movement of issue #92 or any downstream item to ready-for-agent"
+
+acceptance:
+  checks:
+    - id: "classification-heuristic-recorded"
+      command: "report records exact module/path heuristic for the 41 trading candidate routes"
+      required: true
+    - id: "candidate-track-not-branch"
+      command: "report and task tree state that refresh-backend-route-openapi-governance is a candidate track or future change-id placeholder, not an existing git branch"
+      required: true
+    - id: "advanced-analysis-footnote"
+      command: "report states 41 includes 40 trading-route candidates plus 1 unclassified trading-adjacent route"
+      required: true
+    - id: "consumer-scan-scope-recorded"
+      command: "report records literal path prefixes and tracked-file scan scope for the consumer matrix"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-103.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "A reproducibility note could be misread as approval to start route mutation"
+    - "The candidate governance track could still be mistaken for a created OpenSpec change or git branch"
+  rollback_plan: "revert the D2.3 review-note report edits, task-tree updates, and this task card"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "absorb D2.3 trading route/OpenAPI governance review notes"
+    modified_scope: "one evidence report, steward task tree, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "no route behavior changes; planning package remains evidence-only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "decision-only rollback by reverting this PR"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-21T04:08:36Z"
+    approval_note: "human maintainer asked to review the D2.3 planning-package review; this batch absorbs reproducibility notes only and preserves no-route-mutation boundaries"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- absorb D2.3 planning-package review notes about reproducibility
- document the exact module/path heuristic for the 41 trading candidate routes
- clarify that `refresh-backend-route-openapi-governance` is a candidate governance track / future change-id placeholder, not an existing git branch
- record consumer scan scope and the advanced-analysis trading-adjacent count footnote

## Boundary

This PR is governance and evidence only. It does not modify backend routes, frontend consumers, tests, docs/api, OpenSpec change/spec files, PM2 state, or route/OpenAPI runtime behavior.

## Verification

- `python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md` -> `errors=0`, `checked_files=2`
- `git diff --cached --check` -> no output
- `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-103.yaml` -> `pass=True`
- `gitnexus_detect_changes(scope=staged)` -> low risk, 3 files, 0 changed symbols, 0 affected processes

Parent issue: #92