### PR TITLE
docs(route): plan D2.4 backup route ownership

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -198,6 +198,20 @@ CODEBASE-MAP Architecture Remediation Program
 │                  separate OpenSpec proposal or implementation issue under
 │                  unified route/OpenAPI governance before any route mutation
 │
+├── D2.4. Backup Route Ownership Planning Package
+│   ├── Source evidence:
+│   │   `backend-backup-route-ownership-planning-package-2026-05-21.md`
+│   ├── State: planning-package-prepared
+│   ├── Role: Keep backup routes as a dedicated ownership proposal candidate
+│   ├── Current fact: current smoke at HEAD `553e71a90` reports routes=`548`,
+│   │                 OpenAPI paths=`500`, backup candidate routes=`13`,
+│   │                 backup schema-exposed routes=`13`, backup OpenAPI
+│   │                 operations=`13`, duplicate backup operationIds=`0`, and
+│   │                 `cleanup_old_backups.py` owning cleanup plus health routes
+│   └── Next gate: Human review; if accepted, decide whether to create a
+│                  separate backup route ownership OpenSpec proposal or
+│                  implementation issue before any backup route mutation
+│
 ├── E. Candidate Branch: close-backend-schema-dual-directory
 │   ├── Source evidence: backend-schema-dual-directory-closure-2026-05-19.md
 │   ├── State: blocked
@@ -309,6 +323,7 @@ review, PR review, or OpenSpec archive review.
 | D2.2b Core validation docs/API example canonicalization | D2.2b | `docs/api/` examples now point to canonical `app.core.validation`; wrapper retained | Docs-only batch: pre-change `docs/api/` legacy reference count was `10`; post-change count is `0`; no backend source, tests, OpenSpec, route, PM2, or frontend files changed | `docs/reports/quality/backend-core-validation-docs-api-canonicalization-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | D2.2c wrapper-retirement decision or explicit retention; do not delete `app.core.validation_messages` from this batch |
 | D2.2c Core validation wrapper retirement / retention decision package | D2.2c | Decision package prepared for whether to retain `app.core.validation_messages` long-term or approve a future deletion batch; D2.2 is formally closed as a decision lane | Evidence-only: wrapper exists; active source import consumers excluding wrapper=`0`; docs/API legacy references=`0`; compatibility test `2 passed`; boundary test `1 passed`; canonical and wrapper exports remain identity-equivalent; no backend source, tests, OpenSpec, route, PM2, or frontend files changed | `docs/reports/quality/backend-core-validation-wrapper-retirement-decision-package-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Move to D2.3; wrapper deletion remains locked unless a separate D2.2d deletion implementation batch is approved |
 | D2.3 Trading route/OpenAPI governance planning package | D2.3 | Trading route ownership is folded into unified route/OpenAPI governance, not a standalone implementation lane | Planning/evidence only: current smoke at HEAD `c24f43016` reports routes=`548`, OpenAPI paths=`500`, trading candidate routes=`41` (`40` trading-route candidates plus `1` unclassified trading-adjacent route), schema-exposed=`41`, schema paths=`32`, duplicate trading operationIds=`0`; classification heuristic and consumer scan scope are recorded; no route, OpenAPI, source, frontend, test, PM2, or OpenSpec mutation is authorized | `docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate route/OpenAPI governance proposal or implementation issue before route mutation |
+| D2.4 Backup route ownership planning package | D2.4 | Backup route ownership remains a dedicated proposal candidate, not a trading or generic route cleanup lane | Planning/evidence only: current smoke at HEAD `553e71a90` reports routes=`548`, OpenAPI paths=`500`, backup candidate routes=`13`, schema-exposed=`13`, backup OpenAPI paths=`13`, backup operations=`13`, duplicate backup operationIds=`0`; `cleanup_old_backups.py` owns cleanup plus health routes; no route, OpenAPI, source, frontend, test, docs/API, PM2, or OpenSpec mutation is authorized | `docs/reports/quality/backend-backup-route-ownership-planning-package-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate backup route ownership proposal or implementation issue before backup route mutation |
 
 ## OpenSpec Branch Register
 
@@ -320,6 +335,7 @@ review, PR review, or OpenSpec archive review.
 | `github-issue-92-backend-openspec-issue15` | `downstream-split-accepted` | Current review-thread approval, issue `#83` acceptance, downstream split draft, and human split acceptance | Post-approval implementation decision boundary | Decision/design issue only; no implementation work | Draft D2.1 `TechnicalPatternDetectionService` DI design packet; keep implementation locked behind separate approval |
 | `select-backend-technical-pattern-di-pilot` | `design-packet-prepared` | Issue `#92` downstream split acceptance | First DI lifecycle pilot design packet | Provider shape, dependency override strategy, teardown, rollback, and verification gates for `TechnicalPatternDetectionService` | Human review before creating any implementation issue or OpenSpec branch |
 | `decide-backend-core-validation-wrapper-retirement` | `active-source-migration-complete` | Issue `#92` downstream split acceptance and validation helper split archive | Core validation compatibility wrapper retirement readiness and staged migration | D2.2a active source migration is complete; docs/API examples and compatibility-test conversion remain separate gates | D2.2b docs/API examples canonicalization or explicit waiver; wrapper deletion remains blocked |
+| `define-backend-backup-route-ownership` | `candidate-track-no-git-branch` | Issue `#92` downstream split acceptance and D2.4 planning package | Backup route ownership planning, `cleanup_old_backups.py`, and backup route/OpenAPI evidence | Backup, recovery, scheduler, integrity, cleanup, and health route ownership | Create an explicit OpenSpec change-id, issue, and git branch only after D2.4 planning is accepted |
 | `close-backend-schema-dual-directory` | `candidate` | Master execution plan | Schema dual-directory closure | Schema exports, consumer migration, shim retirement decision | Create only after `sequence-backend-architecture-unblocks` schema tasks are accepted |
 | `refresh-backend-route-openapi-governance` | `candidate-track-no-git-branch` | Master execution plan and D2.3 planning package | API flat/package closure records plus trading route/OpenAPI governance planning | Route table, OpenAPI, operationId, probe matrix, trading route ownership classification | Create an explicit OpenSpec change-id, issue, and git branch only after D2.3 planning is accepted |
 | `define-backend-service-seams-and-singleton-pilots` | `candidate` | Master execution plan | Singleton lifecycle routing matrix | Service seam definition, interface/test-double pilot strategy | Create as a design proposal after complete classification |

--- a/docs/reports/quality/backend-backup-route-ownership-planning-package-2026-05-21.md
+++ b/docs/reports/quality/backend-backup-route-ownership-planning-package-2026-05-21.md
@@ -1,0 +1,198 @@
+# Backend Backup Route Ownership Planning Package
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以
+> `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、
+> 当前代码与最近一次实际验证结果为准。
+
+- Date: 2026-05-21
+- Status: D2.4 planning package prepared; no route implementation authorized
+- Parent issue: <https://github.com/chengjon/mystocks/issues/92>
+- Track: D2.4 backup route ownership dedicated proposal candidate
+- Base HEAD: `553e71a90c833a3f9a2ffbec2342d67816baa2ad`
+- Prepared at: `2026-05-21T04:18:21Z`
+
+## Boundary
+
+This package is planning and evidence only.
+
+It does not modify backend route modules, does not change route registration,
+does not change OpenAPI schema exposure, does not edit frontend consumers, does
+not edit tests, does not create or modify OpenSpec change/spec files, does not
+run PM2, and does not move issue `#92` or any downstream child to
+`ready-for-agent`.
+
+## Decision Question
+
+Should backup route ownership be handled as a dedicated proposal candidate
+instead of being folded into the general trading or route cleanup lanes?
+
+Recommended answer for this package: yes. Backup routes should remain a
+dedicated proposal candidate because they combine destructive operations,
+restore workflows, scheduler control, security logging, integrity checks, and
+health/status semantics.
+
+## Why This Exists
+
+Issue `#92` downstream splitting accepted that backup route ownership becomes a
+dedicated proposal candidate and that `cleanup_old_backups.py` is owned by that
+lane.
+
+D2.4 records the backup decision as a planning package. It converts the decision
+into a concrete route/OpenAPI evidence shape without approving route edits.
+
+## Current Route Evidence Snapshot
+
+The current FastAPI route table and `app.openapi()` snapshot were collected by
+importing `app.main` with local placeholder environment variables.
+
+| Evidence | Result |
+|---|---|
+| Current HEAD | `553e71a90c833a3f9a2ffbec2342d67816baa2ad` |
+| App import smoke | `app.main` imported with placeholder local env |
+| Runtime routes | `548` |
+| OpenAPI paths | `500` |
+| Backup candidate routes | `13` |
+| Backup schema-exposed routes | `13` |
+| Backup OpenAPI paths | `13` |
+| Backup OpenAPI operations | `13` |
+| Backup duplicate operationIds | `0` |
+
+## Classification Heuristic
+
+The D2.4 backup candidate count is reproducible from the loaded FastAPI route
+table by including route rows whose endpoint module contains
+`app.api.backup_recovery_secure` or whose path contains `/api/backup-recovery`.
+
+The current matching modules are:
+
+- `app.api.backup_recovery_secure.log_security_event`: `11` routes
+- `app.api.backup_recovery_secure.cleanup_old_backups`: `2` routes
+
+Do not treat every repository file with `backup` in its name as backup-route
+ownership. Historical `.backup` files, archived reports, infrastructure backup
+managers, and operational scripts need separate classification before any
+implementation proposal uses them as active route consumers.
+
+## Candidate Ownership Classes
+
+| Class | Current path group | Routes | Planning treatment |
+|---|---|---:|---|
+| Backup execution | `/api/backup-recovery/backup/*` | 3 | High-risk stateful operations; require permission, rate-limit, logging, and rollback review |
+| Backup listing | `/api/backup-recovery/backups` | 1 | Consumer contract and pagination/filter semantics need review |
+| Recovery execution | `/api/backup-recovery/recovery/*` | 4 | Destructive restore surface; keep separate from ordinary route cleanup |
+| Scheduler control | `/api/backup-recovery/scheduler/*` | 2 | Operational control-plane surface; requires run-state and permission gates |
+| Integrity verification | `/api/backup-recovery/integrity/verify/{backup_id}` | 1 | Verification surface tied to backup identity and audit history |
+| Cleanup and health | `/api/backup-recovery/cleanup/old-backups`, `/api/backup-recovery/health` | 2 | Owned by `cleanup_old_backups.py`; needs dedicated security/ops classification |
+
+## Current Route Snapshot
+
+| Method | Path | Endpoint module | Endpoint name |
+|---|---|---|---|
+| `POST` | `/api/backup-recovery/backup/tdengine/full` | `app.api.backup_recovery_secure.log_security_event` | `backup_tdengine_full` |
+| `POST` | `/api/backup-recovery/backup/tdengine/incremental` | `app.api.backup_recovery_secure.log_security_event` | `backup_tdengine_incremental` |
+| `POST` | `/api/backup-recovery/backup/postgresql/full` | `app.api.backup_recovery_secure.log_security_event` | `backup_postgresql_full` |
+| `GET` | `/api/backup-recovery/backups` | `app.api.backup_recovery_secure.log_security_event` | `list_backups` |
+| `POST` | `/api/backup-recovery/recovery/tdengine/full` | `app.api.backup_recovery_secure.log_security_event` | `restore_tdengine_full` |
+| `POST` | `/api/backup-recovery/recovery/tdengine/pitr` | `app.api.backup_recovery_secure.log_security_event` | `restore_tdengine_pitr` |
+| `POST` | `/api/backup-recovery/recovery/postgresql/full` | `app.api.backup_recovery_secure.log_security_event` | `restore_postgresql_full` |
+| `GET` | `/api/backup-recovery/recovery/objectives` | `app.api.backup_recovery_secure.log_security_event` | `get_recovery_objectives` |
+| `POST` | `/api/backup-recovery/scheduler/control` | `app.api.backup_recovery_secure.log_security_event` | `scheduler_control` |
+| `GET` | `/api/backup-recovery/scheduler/jobs` | `app.api.backup_recovery_secure.log_security_event` | `get_scheduled_jobs` |
+| `GET` | `/api/backup-recovery/integrity/verify/{backup_id}` | `app.api.backup_recovery_secure.log_security_event` | `verify_backup_integrity` |
+| `POST` | `/api/backup-recovery/cleanup/old-backups` | `app.api.backup_recovery_secure.cleanup_old_backups` | `cleanup_old_backups` |
+| `GET` | `/api/backup-recovery/health` | `app.api.backup_recovery_secure.cleanup_old_backups` | `backup_service_health` |
+
+All `13` routes are currently schema-exposed.
+
+## `cleanup_old_backups.py` Ownership Note
+
+`web/backend/app/api/backup_recovery_secure/cleanup_old_backups.py` owns two
+runtime routes:
+
+- `POST /api/backup-recovery/cleanup/old-backups`
+- `GET /api/backup-recovery/health`
+
+The cleanup route depends on `get_current_user`, calls `verify_admin_permission`,
+logs security events, and delegates to `backup_manager.cleanup_old_backups()`.
+That makes it a state-changing operations endpoint, not a generic route cleanup
+candidate.
+
+Any future implementation proposal must keep this file inside the dedicated
+backup route ownership lane unless a human reviewer explicitly approves a
+different ownership split.
+
+## Consumer Matrix Snapshot
+
+Tracked-file string scans found the following planning surface.
+
+| Pattern | Backend source | Frontend source | Tests | Scripts | Docs/governance | Other | Planning impact |
+|---|---:|---:|---:|---:|---:|---:|---|
+| `/api/backup-recovery` | 3 files / 23 hits | 0 / 0 | 2 / 25 | 0 / 0 | 13 / 44 | 0 / 0 | Active path consumers appear concentrated in backend source, tests, and docs |
+| `backup_recovery_secure` | 6 / 9 | 0 / 0 | 2 / 4 | 1 / 1 | 50 / 137 | 3 / 123 | Includes module-level, historical, and generated references; needs classification |
+| `cleanup_old_backups` | 2 / 11 | 0 / 0 | 2 / 2 | 1 / 2 | 23 / 54 | 4 / 20 | Dedicated cleanup ownership evidence; not deletion authorization |
+| `backup_service_health` | 2 / 3 | 0 / 0 | 0 / 0 | 0 / 0 | 2 / 3 | 0 / 0 | Health/status semantics need separate treatment from destructive cleanup |
+
+This matrix is a planning snapshot. It is not enough to authorize route edits
+because it has not yet classified active runtime callers, historical references,
+generated artifacts, stale snapshots, or operational scripts.
+
+## Required Future Evidence Before Any Backup Route Mutation
+
+A future backup route implementation proposal or issue must include:
+
+- current FastAPI route table with endpoint module, method, path, and
+  `include_in_schema`;
+- current `app.openapi()` snapshot with path count, operation count, warnings,
+  and duplicate operationId check;
+- backup ownership taxonomy for backup, recovery, scheduler, integrity,
+  cleanup, and health routes;
+- explicit ownership of `cleanup_old_backups.py` and its `backup_service_health`
+  endpoint;
+- `router_registry`, `VERSION_MAPPING`, and `docs/FUNCTION_TREE.md` status;
+- frontend, backend, test, script, PM2, Docker, CI, and docs consumer matrix;
+- security matrix covering auth dependency, admin permission, backup/recovery
+  permission, rate limit, and security audit logging;
+- contract parity matrix covering path, query/body parameters, response shape,
+  caller parser expectations, OpenAPI examples, and minimal regression tests;
+- rollback and compatibility strategy for any renamed, hidden, or retired route;
+- explicit decision on whether `/api/backup-recovery/health` remains a service
+  health endpoint, a backup route endpoint, or a control-plane endpoint.
+
+## Governance Recommendation
+
+Backup route ownership should remain a dedicated proposal candidate, currently
+referred to by the future candidate name `define-backend-backup-route-ownership`.
+
+No git branch, GitHub issue, or OpenSpec change with that name exists or is
+required by this D2.4 package. If future implementation begins, the actual git
+branch, OpenSpec change-id, and issue identifier must be created and recorded at
+that time.
+
+D2.4 should not be folded into the D2.3 trading route planning package and
+should not be treated as a generic route cleanup batch.
+
+## Explicit Non-Authorizations
+
+D2.4 does not authorize:
+
+- moving any backup route module;
+- renaming or retiring any backup path;
+- changing `include_in_schema`;
+- changing operationIds;
+- editing `web/backend/app/api/**`;
+- editing `src/infrastructure/backup_recovery/**`;
+- editing `web/frontend/**`;
+- editing tests or fixtures;
+- editing `docs/api/**`;
+- opening a broad backup implementation issue;
+- moving issue `#92` or any downstream item to `ready-for-agent`.
+
+## Next Gate
+
+Human review of this D2.4 package.
+
+If accepted, the maintainer should decide whether to create a separate backup
+route ownership OpenSpec proposal or a narrower implementation issue. Until that
+decision exists, backup route behavior remains locked.

--- a/governance/mainline/task-cards/pr-104.yaml
+++ b/governance/mainline/task-cards/pr-104.yaml
@@ -1,0 +1,111 @@
+version: "v0.2"
+
+task:
+  id: "pr-104"
+  title: "prepare backup route ownership planning package"
+  owner: "main"
+  created_at: "2026-05-21"
+
+mainline:
+  id: "L1-issue92-d2-4-backup-route-ownership-planning"
+  objective: "prepare an evidence-only planning package for dedicated backup route ownership"
+  milestone_id: "L2-architecture-governance-closeout"
+  slice_id: "L3-backup-route-ownership-planning"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-d2-4-planning-package"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "api"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Evidence-only backup route ownership planning package; no backend source, frontend, tests, docs/api, OpenSpec, PM2, or route behavior changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "docs/reports/quality/backend-backup-route-ownership-planning-package-2026-05-21.md"
+    - "governance/mainline/task-cards/pr-104.yaml"
+  forbidden_paths:
+    - "web/backend/app/**"
+    - "web/frontend/**"
+    - "tests/**"
+    - "src/**"
+    - "docs/api/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend route module modification"
+  - "No route registration change"
+  - "No OpenAPI schema exposure or operationId change"
+  - "No frontend consumer modification"
+  - "No test or fixture modification"
+  - "No docs/api modification"
+  - "No OpenSpec change/spec creation or modification"
+  - "No PM2 or runtime stateful gate execution"
+  - "No creation of define-backend-backup-route-ownership as a git branch"
+  - "No movement of issue #92 or any downstream item to ready-for-agent"
+
+acceptance:
+  checks:
+    - id: "backup-route-evidence-recorded"
+      command: "report records current route/OpenAPI smoke totals and backup candidate module/path snapshot"
+      required: true
+    - id: "cleanup-ownership-recorded"
+      command: "report records cleanup_old_backups.py ownership of cleanup and health routes"
+      required: true
+    - id: "consumer-matrix-recorded"
+      command: "report records tracked-file consumer matrix for backup path/module patterns"
+      required: true
+    - id: "candidate-track-not-branch"
+      command: "report and task tree state that define-backend-backup-route-ownership is a candidate track or future change-id placeholder, not an existing git branch"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-backup-route-ownership-planning-package-2026-05-21.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-104.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "A planning package could be misread as permission to move or rename backup routes"
+    - "cleanup_old_backups.py could be mistaken for a deletion candidate instead of a stateful operations endpoint owner"
+  rollback_plan: "revert the D2.4 planning report, task-tree update, and this task card"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "prepare backup route ownership planning package"
+    modified_scope: "one evidence report, steward task tree, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "no backup route behavior changes; ownership remains planning-only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "decision-only rollback by reverting this PR"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-21T04:18:21Z"
+    approval_note: "human maintainer asked to continue after D2.3; D2.4 prepares backup route ownership planning with evidence-only and no-route-mutation boundaries"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- add the D2.4 backup route ownership planning package
- record the current backup route/OpenAPI snapshot: 13 backup candidate routes, 13 schema-exposed routes, 13 backup OpenAPI operations, duplicate operationIds 0
- classify backup route ownership into backup, recovery, scheduler, integrity, cleanup, and health surfaces
- mark `cleanup_old_backups.py` as dedicated backup ownership evidence, not a deletion candidate
- update the CODEBASE-MAP task tree and add the PR #104 mainline task card

## Boundary

This PR is governance and evidence only. It does not modify backend routes, frontend consumers, tests, docs/api, OpenSpec change/spec files, PM2 state, or route/OpenAPI runtime behavior.

## Verification

- `python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-backup-route-ownership-planning-package-2026-05-21.md` -> `errors=0`, `checked_files=2`
- `git diff --cached --check` before commit -> no output
- `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-104.yaml` after commit -> `pass=True`
- `gitnexus_detect_changes(scope=staged)` before commit -> low risk, 3 files, 0 changed symbols, 0 affected processes

Parent issue: #92