### PR TITLE
docs(openspec): plan d2.1a technical pattern di pilot

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -132,8 +132,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   ├── Current fact: GitNexus impact is LOW with 0 affected symbols/processes;
 │   │                 route consumer is `_technical_patterns_router.py`;
 │   │                 implementation remains locked
-│   └── Next gate: Human review of the design packet before creating any
-│                  implementation issue or moving any issue to `ready-for-agent`
+│   └── Next gate: Human review of D2.1a implementation authorization package
+│                  before creating any implementation issue or moving any issue
+│                  to `ready-for-agent`
+│
+├── D2.1a. TechnicalPatternDetectionService DI Pilot Implementation Authorization
+│   ├── Source evidence:
+│   │   `docs/superpowers/plans/2026-05-21-d2-1a-technical-pattern-detection-di-pilot-implementation-authorization.md`
+│   ├── State: implementation-authorization-plan-prepared
+│   ├── Role: Concrete implementation package for the first DI lifecycle pilot
+│   ├── Current fact: planned write scope is limited to
+│   │                 `web/backend/app/api/_technical_patterns_router.py` and
+│   │                 `web/backend/tests/test_technical_patterns_router_regressions.py`;
+│   │                 `TechnicalPatternDetectionService` internals remain
+│   │                 unchanged; GitNexus impact is LOW for both the service
+│   │                 class and `_detect_patterns_for_symbol`
+│   └── Next gate: Human approval to create a separate D2.1a implementation
+│                  issue or OpenSpec branch; only that child item may later be
+│                  moved to `ready-for-agent`
 │
 ├── D2.2. Core Validation Wrapper Retirement Readiness
 │   ├── Source evidence:
@@ -364,6 +380,7 @@ review, PR review, or OpenSpec archive review.
 | Issue `#92` downstream decision split draft | D2 | Draft split prepared for human review: D2.1 DI pilot candidate, D2.2 Core validation wrapper-retirement readiness, D2.3 route governance, D2.4 backup route ownership, D2.5 control-plane OpenAPI docs, and D2.6 PM2 stateful gate approval | Review-ready draft only: issue `#92` remains `OPEN`; `ready-for-agent` remains absent; no backend, OpenSpec change, route, or test mutation is authorized by the draft | `docs/reports/quality/backend-openspec-issue92-downstream-decision-split-2026-05-21.md` | Human review and explicit acceptance or revision of the split before any child issue/proposal is created |
 | Issue `#92` downstream split accepted | D2 | Human maintainer accepted the split in full: `TechnicalPatternDetectionService` is the first DI design pilot; trading route ownership folds into unified route/OpenAPI governance; backup route ownership becomes a dedicated proposal candidate with `cleanup_old_backups.py` owned by that lane | Reviewed/pass in current thread: acceptance remains decision/proposal-only and does not authorize backend implementation, route mutation, Core file movement, PM2 execution, or any `ready-for-agent` movement | `docs/reports/quality/backend-openspec-issue92-downstream-split-acceptance-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Draft D2.1 design packet for `TechnicalPatternDetectionService`; keep implementation locked behind separate approval |
 | D2.1 `TechnicalPatternDetectionService` DI design packet | D2.1 | First DI design pilot packet prepared with provider shape, dependency override strategy, teardown artifact, rollback path, and implementation verification gates | Review-ready design only: GitNexus impact for `TechnicalPatternDetectionService` is LOW with 0 affected symbols/processes; no source, route, test, PM2, or OpenSpec mutation is authorized | `docs/reports/quality/backend-di-pilot-technical-pattern-detection-design-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate implementation issue or OpenSpec branch before source edits |
+| D2.1a `TechnicalPatternDetectionService` DI pilot implementation authorization | D2.1a | Concrete implementation authorization plan prepared for the first DI pilot | Plan-only: future write scope is limited to `_technical_patterns_router.py` and `test_technical_patterns_router_regressions.py`; service internals, route path, response contract, OpenAPI schema, PM2, frontend, docs/API, and OpenSpec remain locked until separate implementation approval | `docs/superpowers/plans/2026-05-21-d2-1a-technical-pattern-detection-di-pilot-implementation-authorization.md`; `https://github.com/chengjon/mystocks/issues/92` | Human approval to create a separate D2.1a implementation issue or OpenSpec branch; do not move issue `#92` to `ready-for-agent` |
 | D2.2 Core validation wrapper retirement readiness | D2.2 | Readiness packet prepared for `app.core.validation_messages` retirement; deletion remains locked pending a separate wrapper-retirement decision | Review-ready readiness only: compatibility test passed `2 passed`; placeholder-env import smoke passed; active source blockers were later closed by D2.2a and docs/API examples were later closed by D2.2b | `docs/reports/quality/backend-core-validation-wrapper-retirement-readiness-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | D2.2c wrapper-retirement decision or explicit long-term retention; no wrapper deletion before that approval |
 | D2.2a Core validation active source migration | D2.2a | Active source imports in `validators.py` and `error_codes.py` migrated from `app.core.validation_messages` to `app.core.validation`; wrapper retained | TDD red/green completed; boundary test `1 passed`; compatibility test `2 passed`; import smoke passed; app import smoke routes=`548`; collect-only smoke `112 tests collected`; ruff passed; active source legacy imports excluding wrapper=`0` | `docs/reports/quality/backend-core-validation-active-source-migration-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Completed by D2.2b docs/API examples canonicalization; wrapper deletion remains a separate decision |
 | D2.2b Core validation docs/API example canonicalization | D2.2b | `docs/api/` examples now point to canonical `app.core.validation`; wrapper retained | Docs-only batch: pre-change `docs/api/` legacy reference count was `10`; post-change count is `0`; no backend source, tests, OpenSpec, route, PM2, or frontend files changed | `docs/reports/quality/backend-core-validation-docs-api-canonicalization-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | D2.2c wrapper-retirement decision or explicit retention; do not delete `app.core.validation_messages` from this batch |

--- a/docs/superpowers/plans/2026-05-21-d2-1a-technical-pattern-detection-di-pilot-implementation-authorization.md
+++ b/docs/superpowers/plans/2026-05-21-d2-1a-technical-pattern-detection-di-pilot-implementation-authorization.md
@@ -1,0 +1,351 @@
+# D2.1a Technical Pattern Detection DI Pilot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Date: 2026-05-21
+Parent issue: `#92`
+Track: D2.1a `TechnicalPatternDetectionService` DI pilot
+Base HEAD: `5ffc9fdfe845b511fe39294b06b063dd469c71df`
+Status: implementation authorization plan prepared; implementation remains locked until separately approved
+
+## Authorization Boundary
+
+This plan is a concrete implementation package, not implementation approval by
+itself. It may be executed only after a human maintainer explicitly approves a
+separate D2.1a implementation issue or OpenSpec branch and marks that child item
+ready for agent work.
+
+This plan does not authorize:
+
+- editing backend source from issue `#92` directly;
+- moving issue `#92` to `ready-for-agent`;
+- creating or editing OpenSpec changes/specs in this PR;
+- expanding beyond `TechnicalPatternDetectionService` route-level dependency injection;
+- modifying PM2, scripts, frontend, `docs/api`, route paths, response models, schemas, or pattern-detection algorithms.
+
+## Current Evidence
+
+| Item | Current fact |
+|---|---|
+| Service class | `web/backend/app/services/technical_pattern_detection_service.py::TechnicalPatternDetectionService` |
+| Route consumer | `web/backend/app/api/_technical_patterns_router.py` |
+| Current route seam | `_detect_patterns_for_symbol()` directly constructs `TechnicalPatternDetectionService()` |
+| Public route | `detect_patterns()` calls `_detect_patterns_for_symbol()` and returns `UnifiedResponse[PatternDetectionData]` |
+| Focused service tests | `web/backend/tests/test_technical_pattern_detection_service.py` |
+| Focused route tests | `web/backend/tests/test_technical_patterns_router_regressions.py` |
+| GitNexus service impact | `LOW`, `impactedCount=0`, `processes_affected=0` |
+| GitNexus helper impact | `_detect_patterns_for_symbol` is `LOW`, direct caller is `detect_patterns()` only |
+
+## Future Write Scope
+
+Allowed implementation files after approval:
+
+- `web/backend/app/api/_technical_patterns_router.py`
+- `web/backend/tests/test_technical_patterns_router_regressions.py`
+
+Read-only or verification-only files:
+
+- `web/backend/app/services/technical_pattern_detection_service.py`
+- `web/backend/tests/test_technical_pattern_detection_service.py`
+- `docs/reports/quality/backend-di-pilot-technical-pattern-detection-design-2026-05-21.md`
+
+Do not modify these in D2.1a unless a new approval explicitly expands scope:
+
+- `web/backend/app/services/technical_pattern_detection_service.py`
+- `web/backend/app/api/_technical_patterns_models.py`
+- `web/backend/app/core/responses.py`
+- `web/backend/app/core/exceptions.py`
+- PM2, scripts, config, frontend, `docs/api`, and OpenSpec files
+
+## Target Shape
+
+The implementation should add a route-local provider:
+
+```python
+def get_technical_pattern_detection_service() -> TechnicalPatternDetectionService:
+    return TechnicalPatternDetectionService()
+```
+
+It should pass the service into the private helper:
+
+```python
+async def _detect_patterns_for_symbol(
+    symbol: str,
+    period: str,
+    service: TechnicalPatternDetectionService,
+) -> list[PatternDetection]:
+    return await service.detect_for_symbol(symbol=symbol, period=period)
+```
+
+The public route should receive the service through FastAPI dependency injection:
+
+```python
+service: TechnicalPatternDetectionService = Depends(get_technical_pattern_detection_service)
+```
+
+This pilot is route-level DI only. It must not refactor the internals of
+`TechnicalPatternDetectionService`, `DataSourceFactory`, or the chart pattern
+detector loader.
+
+## Task 0: Implementation Gate
+
+- [ ] Confirm a separate D2.1a implementation issue or OpenSpec branch exists.
+- [ ] Confirm that child item, not issue `#92`, is approved for implementation.
+- [ ] Confirm the child item names this plan and the exact allowed write scope.
+- [ ] Confirm the child item includes rollback criteria and verification commands.
+- [ ] Stop if any of the above is missing.
+
+## Task 1: Pre-Edit Impact And Baseline
+
+- [ ] Run GitNexus impact before editing:
+
+```bash
+gitnexus impact --target TechnicalPatternDetectionService --direction upstream
+gitnexus impact --target _detect_patterns_for_symbol --direction upstream
+```
+
+- [ ] Expected current result:
+  - `TechnicalPatternDetectionService`: LOW, 0 affected symbols/processes.
+  - `_detect_patterns_for_symbol`: LOW, direct caller `detect_patterns()`.
+
+- [ ] Run baseline import smoke:
+
+```bash
+PYTHONPATH=web/backend python -c "from app.api._technical_patterns_router import router; from app.services.technical_pattern_detection_service import TechnicalPatternDetectionService; print(router is not None, TechnicalPatternDetectionService.__name__)"
+```
+
+- [ ] Run focused baseline tests:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_technical_pattern_detection_service.py -q --no-cov
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_technical_patterns_router_regressions.py -q --no-cov
+```
+
+## Task 2: Add A Failing Route-Level DI Test
+
+- [ ] Edit `web/backend/tests/test_technical_patterns_router_regressions.py`.
+- [ ] Add a small async service double near the top of the file:
+
+```python
+class _PatternServiceDouble:
+    def __init__(self, detections=None, error: Exception | None = None):
+        self.detections = [] if detections is None else detections
+        self.error = error
+        self.calls = []
+
+    async def detect_for_symbol(self, symbol: str, period: str):
+        self.calls.append((symbol, period))
+        if self.error is not None:
+            raise self.error
+        return self.detections
+```
+
+- [ ] Add a helper fixture or helper function that installs the dependency override and clears it after use:
+
+```python
+def _build_client_with_pattern_service(module, service):
+    app = FastAPI()
+    app.include_router(module.router)
+    app.dependency_overrides[module.get_technical_pattern_detection_service] = lambda: service
+    return app, TestClient(app)
+```
+
+- [ ] Any test that calls this helper must clear `app.dependency_overrides` in `finally`.
+
+- [ ] Add a failing test proving the public route uses the dependency override:
+
+```python
+def test_detect_patterns_uses_dependency_override_service():
+    module = _import_patterns_router_module()
+    service = _PatternServiceDouble()
+    app, client = _build_client_with_pattern_service(module, service)
+
+    try:
+        response = client.get("/patterns/600519.SH", params={"period": "weekly"})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert service.calls == [("600519.SH", "weekly")]
+    payload = response.json()["data"]
+    assert payload["symbol"] == "600519.SH"
+    assert payload["period"] == "weekly"
+    assert payload["status"] == "empty"
+```
+
+- [ ] Run only the new test and confirm it fails because `get_technical_pattern_detection_service` is not present yet:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_technical_patterns_router_regressions.py::test_detect_patterns_uses_dependency_override_service -q --no-cov
+```
+
+## Task 3: Implement Route-Level Provider Injection
+
+- [ ] Edit `web/backend/app/api/_technical_patterns_router.py`.
+- [ ] Add `Depends` to the FastAPI import:
+
+```python
+from fastapi import APIRouter, Depends, Path, Query, status
+```
+
+- [ ] Add the provider after constants and before helper functions:
+
+```python
+def get_technical_pattern_detection_service() -> TechnicalPatternDetectionService:
+    return TechnicalPatternDetectionService()
+```
+
+- [ ] Change `_detect_patterns_for_symbol()` to accept the service:
+
+```python
+async def _detect_patterns_for_symbol(
+    symbol: str,
+    period: str,
+    service: TechnicalPatternDetectionService,
+) -> list[PatternDetection]:
+    try:
+        return await service.detect_for_symbol(symbol=symbol, period=period)
+    except BusinessException:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "technical_pattern_detection_failed",
+            extra={"symbol": symbol, "period": period, "error": str(exc)},
+        )
+        raise BusinessException(
+            message="Pattern analysis unavailable",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        ) from exc
+```
+
+- [ ] Change the public route signature to receive the dependency:
+
+```python
+async def detect_patterns(
+    symbol: str = Path(..., description="Stock symbol, e.g. 600519.SH"),
+    period: str = Query("daily", description="K-line period", enum=SUPPORTED_PATTERN_PERIODS),
+    service: TechnicalPatternDetectionService = Depends(get_technical_pattern_detection_service),
+) -> UnifiedResponse[PatternDetectionData]:
+```
+
+- [ ] Pass the service into the helper:
+
+```python
+detections = await _detect_patterns_for_symbol(
+    symbol=normalized_symbol,
+    period=normalized_period,
+    service=service,
+)
+```
+
+- [ ] Keep route path, response model, response shape, error message, and OpenAPI period enum unchanged.
+
+## Task 4: Convert Focused Route Tests To Dependency Overrides
+
+- [ ] Update direct route-function tests to pass an explicit service double:
+
+```python
+service = _PatternServiceDouble()
+response = asyncio.run(module.detect_patterns(symbol="600519.SH", period="weekly", service=service))
+```
+
+- [ ] Replace public-route monkeypatching with dependency overrides for route tests.
+
+- [ ] In failure test, replace class monkeypatching with a failing service double:
+
+```python
+service = _PatternServiceDouble(error=RuntimeError("synthetic detector outage"))
+app, client = _build_client_with_pattern_service(module, service)
+```
+
+- [ ] Keep helper-level monkeypatching only where the test intentionally exercises helper behavior, not public route dependency behavior.
+
+- [ ] Ensure every `app.dependency_overrides` write is cleared in teardown or `finally`.
+
+## Task 5: Run Focused Verification
+
+- [ ] Run import smoke:
+
+```bash
+PYTHONPATH=web/backend python -c "from app.api._technical_patterns_router import router; from app.services.technical_pattern_detection_service import TechnicalPatternDetectionService; print(router is not None, TechnicalPatternDetectionService.__name__)"
+```
+
+- [ ] Run focused service tests:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_technical_pattern_detection_service.py -q --no-cov
+```
+
+- [ ] Run focused route tests:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_technical_patterns_router_regressions.py -q --no-cov
+```
+
+- [ ] Run lint on touched files:
+
+```bash
+ruff check web/backend/app/api/_technical_patterns_router.py web/backend/tests/test_technical_patterns_router_regressions.py
+```
+
+- [ ] If the service file remains untouched, do not include it in the staged implementation diff. It may still be linted as a read-only verification target if desired.
+
+## Task 6: Pre-Commit Scope Gate
+
+- [ ] Stage only the implementation files:
+
+```bash
+git add web/backend/app/api/_technical_patterns_router.py web/backend/tests/test_technical_patterns_router_regressions.py
+```
+
+- [ ] Run whitespace check:
+
+```bash
+git diff --cached --check
+```
+
+- [ ] Run GitNexus staged scope check:
+
+```bash
+gitnexus detect-changes --scope staged
+```
+
+- [ ] Stop if staged scope includes unrelated files.
+
+## Rollback
+
+Rollback is intentionally narrow:
+
+1. Restore `_detect_patterns_for_symbol()` to direct `TechnicalPatternDetectionService()` construction.
+2. Remove `Depends` import and `get_technical_pattern_detection_service()`.
+3. Restore route tests to their pre-DI helper/class monkeypatch style.
+4. Do not modify `TechnicalPatternDetectionService` internals during rollback.
+
+## Acceptance Criteria
+
+Implementation is complete only when:
+
+- public route behavior remains unchanged;
+- `UnifiedResponse[PatternDetectionData]` contract remains unchanged;
+- OpenAPI period enum remains `daily`, `weekly`, `monthly`;
+- route tests use `app.dependency_overrides` for the public-route service seam;
+- dependency overrides are cleared after tests;
+- focused service tests pass;
+- focused route tests pass;
+- lint passes for touched files;
+- GitNexus staged detect reports only the intended implementation scope.
+
+## Explicit Non-Goals
+
+- Do not migrate DB/session-backed services.
+- Do not introduce a global container or service registry.
+- Do not use `app.state` for this first pilot unless a new approval expands scope.
+- Do not refactor `DataSourceFactory`.
+- Do not change pattern detection algorithms.
+- Do not change route paths, response models, schemas, status codes, or docs/API examples.
+- Do not run PM2 gates from this implementation issue unless a separate D2.6 approval exists.
+- Do not treat this plan as approval to move issue `#92` to `ready-for-agent`.

--- a/governance/mainline/task-cards/pr-109.yaml
+++ b/governance/mainline/task-cards/pr-109.yaml
@@ -1,0 +1,111 @@
+version: "v0.2"
+
+task:
+  id: "pr-109"
+  title: "prepare D2.1a technical pattern DI pilot implementation authorization"
+  owner: "main"
+  created_at: "2026-05-21"
+
+mainline:
+  id: "L1-issue92-d2-1a-di-pilot-implementation-authorization"
+  objective: "prepare a concrete implementation authorization plan for the TechnicalPatternDetectionService DI pilot"
+  milestone_id: "L2-architecture-governance-closeout"
+  slice_id: "L3-d2-1a-di-pilot-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-d2-1a-implementation-authorization-plan"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "api"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Plan-only D2.1a implementation authorization package; no runtime source, frontend, tests, docs/api, OpenSpec, PM2, route, script, config, or service behavior changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "docs/superpowers/plans/2026-05-21-d2-1a-technical-pattern-detection-di-pilot-implementation-authorization.md"
+    - "governance/mainline/task-cards/pr-109.yaml"
+  forbidden_paths:
+    - "web/backend/app/**"
+    - "web/frontend/**"
+    - "tests/**"
+    - "src/**"
+    - "docs/api/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+    - "scripts/**"
+    - "config/**"
+
+non_goals:
+  - "No backend runtime code modification"
+  - "No test or fixture modification"
+  - "No route registration change"
+  - "No OpenAPI schema exposure or operationId change"
+  - "No frontend consumer modification"
+  - "No docs/api modification"
+  - "No scripts or config modification"
+  - "No PM2 workflow execution"
+  - "No OpenSpec change/spec creation or modification"
+  - "No GitHub issue creation"
+  - "No movement of issue #92 or any downstream item to ready-for-agent"
+
+acceptance:
+  checks:
+    - id: "implementation-scope-recorded"
+      command: "plan records future write scope and locked files for D2.1a"
+      required: true
+    - id: "tdd-plan-recorded"
+      command: "plan records failing-test, implementation, focused verification, and rollback steps"
+      required: true
+    - id: "implementation-boundary-preserved"
+      command: "plan and task tree state that this PR does not authorize implementation or ready-for-agent movement"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/superpowers/plans/2026-05-21-d2-1a-technical-pattern-detection-di-pilot-implementation-authorization.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-109.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "A concrete implementation plan could be misread as implementation approval"
+    - "A future worker could edit service internals instead of the narrow route-level provider seam"
+  rollback_plan: "revert the D2.1a implementation authorization plan, task-tree update, and this task card"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "prepare D2.1a TechnicalPatternDetectionService DI pilot implementation authorization plan"
+    modified_scope: "one implementation plan, steward task tree, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "no runtime, route, docs/api, PM2, or service behavior changes"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "decision-only rollback by reverting this PR"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-21T09:55:00Z"
+    approval_note: "human maintainer asked to continue after issue #92 downstream rollup review alignment; this task prepares a D2.1a implementation authorization plan without implementation authorization"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Add the D2.1a TechnicalPatternDetectionService DI pilot implementation authorization plan.
- Record future write scope, TDD sequence, rollback path, dependency override strategy, GitNexus pre-edit gate, and focused verification commands.
- Update the codebase-map steward tree and add the PR-scoped mainline governance task card.

## Boundary
- Governance / planning only.
- No backend source, test, route, OpenAPI, docs/api, script, config, frontend, PM2, OpenSpec change, GitHub issue publication, or ready-for-agent movement.
- #92 remains the parent decision rollup; any future implementation must happen through a separately approved D2.1a child issue or OpenSpec branch.

## Verification
- Path scope: exactly 3 governance files.
- Markdown governance gate: 2 checked files, 0 errors.
- YAML task card parse: ok.
- git diff --check and git diff --cached --check: ok.
- GitNexus staged detect: low risk, 3 changed files, 0 changed symbols, 0 affected processes.
- Mainline scope gate: pass=true, no violations, no warnings.

Parent: #92
