### PR TITLE
docs: add D2.3 route OpenAPI governance decision package

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -227,25 +227,26 @@ CODEBASE-MAP Architecture Remediation Program
 ├── D2.3. Trading Route/OpenAPI Governance Planning Package
 │   ├── Source evidence:
 │   │   `backend-trading-route-openapi-governance-planning-package-2026-05-21.md`
-│   ├── State: openspec-approved-for-governance-execution
+│   ├── State: decision-package-prepared-for-review
 │   ├── Role: Fold trading route ownership into unified route/OpenAPI governance
 │   ├── Current fact: current smoke at HEAD `c24f43016` reports routes=`548`,
 │   │                 OpenAPI paths=`500`, trading candidate routes=`41`
 │   │                 (`40` trading-route candidates plus `1` unclassified
 │   │                 trading-adjacent route),
-│   │                 trading schema-exposed routes=`41`, trading schema paths=`32`,
-│   │                 and duplicate trading operationIds=`0`; classification
-│   │                 heuristic and consumer scan scope are now recorded
-│   └── Next gate: Execute `refresh-backend-route-openapi-governance`
-│                  governance/evidence tasks with current-head freshness; no
-│                  route mutation, OpenAPI schema/exposure change, docs/API
-│                  edit, implementation issue, PM2 action, source edit, or
-│                  test edit is authorized
+│   │                 trading schema-exposed routes=`41`, trading schema paths=`35`,
+│   │                 duplicate trading operationIds=`0`, and `/metrics` as the
+│   │                 only duplicate runtime path/method; classification and
+│   │                 consumer contract evidence are now prepared for review
+│   └── Next gate: Review
+│                  `backend-route-openapi-governance-decision-package-2026-05-22.md`;
+│                  no route mutation, OpenAPI schema/exposure change, docs/API
+│                  edit, implementation issue, PM2 action, source edit, or test
+│                  edit is authorized
 │
 ├── D2.4. Backup Route Ownership Planning Package
 │   ├── Source evidence:
 │   │   `backend-backup-route-ownership-planning-package-2026-05-21.md`
-│   ├── State: approved-for-governance-execution
+│   ├── State: decision-package-prepared-for-review
 │   ├── Role: Keep backup routes as a dedicated ownership proposal candidate
 │   │         with explicit safety, security, consumer, OpenAPI, and rollback
 │   │         evidence before backup route mutation
@@ -326,9 +327,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   ├── Role: Classify route table, OpenAPI, operationId, probe consumer,
 │   │         trading ownership, control-plane, backup, compatibility-route,
 │   │         and schema-exposure evidence before route mutation
-│   └── Next gate: Execute `refresh-backend-route-openapi-governance`
-│                  governance/evidence tasks with current-head freshness; no
-│                  backend source, route, OpenAPI, probe, docs/API, or test
+│   └── Next gate: Review
+│                  `backend-route-openapi-governance-decision-package-2026-05-22.md`;
+│                  no backend source, route, OpenAPI, probe, docs/API, or test
 │                  mutation is authorized
 │
 ├── G. Candidate Branch: define-backend-service-seams-and-singleton-pilots
@@ -434,6 +435,7 @@ review, PR review, or OpenSpec archive review.
 | D2.2c Core validation wrapper retirement / retention decision package | D2.2c | Decision package prepared for whether to retain `app.core.validation_messages` long-term or approve a future deletion batch; D2.2 is formally closed as a decision lane | Evidence-only: wrapper exists; active source import consumers excluding wrapper=`0`; docs/API legacy references=`0`; compatibility test `2 passed`; boundary test `1 passed`; canonical and wrapper exports remain identity-equivalent; no backend source, tests, OpenSpec, route, PM2, or frontend files changed | `docs/reports/quality/backend-core-validation-wrapper-retirement-decision-package-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Move to D2.3; wrapper deletion remains locked unless a separate D2.2d deletion implementation batch is approved |
 | D2.3 Trading route/OpenAPI governance planning package | D2.3 | Trading route ownership is folded into unified route/OpenAPI governance, not a standalone implementation lane | Planning/evidence only: current smoke at HEAD `c24f43016` reports routes=`548`, OpenAPI paths=`500`, trading candidate routes=`41` (`40` trading-route candidates plus `1` unclassified trading-adjacent route), schema-exposed=`41`, schema paths=`32`, duplicate trading operationIds=`0`; classification heuristic and consumer scan scope are recorded; no route, OpenAPI, source, frontend, test, PM2, or OpenSpec mutation is authorized | `docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate route/OpenAPI governance proposal or implementation issue before route mutation |
 | D2.3 Route/OpenAPI governance OpenSpec proposal | D2.3/F | Explicit proposal created for unified backend route/OpenAPI governance after D2.3 planning acceptance | Proposal-only: `refresh-backend-route-openapi-governance` adds an architecture-governance gate requiring current-head route/OpenAPI/probe evidence, route ownership classification, runtime-vs-schema exposure classification, and separate D2.4/D2.5/D2.6 lane handling before mutation; no backend source, frontend source, tests, generated client, docs/API, route behavior, OpenAPI schema, probe URL, or PM2 changes are authorized | `openspec/changes/refresh-backend-route-openapi-governance/`; `docs/reports/quality/backend-route-openapi-governance-openspec-proposal-2026-05-21.md`; `governance/mainline/task-cards/pr-116.yaml` | Approved for governance/evidence task-list execution; no implementation or runtime mutation authorized |
+| D2.3 Route/OpenAPI governance decision package | D2.3/F | Governance/evidence task list executed and decision package prepared for review | Evidence-only: current HEAD `c173bbc8d` reports routes=`548`, schema-visible routes=`536`, hidden runtime routes=`12`, endpoint modules=`99`, OpenAPI paths=`500`, operations=`536`, schemas=`301`, duplicate operationIds=`0`, OpenAPI warnings=`0`, D2.3 trading candidate routes=`41`, and `/metrics` as the only duplicate runtime path/method; no backend source, frontend source, tests, generated client, docs/API, route behavior, OpenAPI schema, probe URL, PM2, or implementation issue is authorized | `docs/reports/quality/backend-route-openapi-governance-decision-package-2026-05-22.md`; `.planning/codebase/generated/backend-route-table-2026-05-22.json`; `.planning/codebase/generated/route-openapi-snapshot-2026-05-22.json`; `.planning/codebase/generated/probe-consumer-matrix-2026-05-22.json`; `.planning/codebase/generated/route-consumer-contract-matrix-2026-05-22.json` | Human review; after acceptance, update steward tree review status and decide whether any separate child lane is needed |
 | D2.4 Backup route ownership planning package | D2.4 | Backup route ownership remains a dedicated proposal candidate, not a trading or generic route cleanup lane | Planning/evidence only: current smoke at HEAD `553e71a90` reports routes=`548`, OpenAPI paths=`500`, backup candidate routes=`13`, schema-exposed=`13`, backup OpenAPI paths=`13`, backup operations=`13`, duplicate backup operationIds=`0`; `cleanup_old_backups.py` owns cleanup plus health routes; no route, OpenAPI, source, frontend, test, docs/API, PM2, or OpenSpec mutation is authorized | `docs/reports/quality/backend-backup-route-ownership-planning-package-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate backup route ownership proposal or implementation issue before backup route mutation |
 | D2.4 Backup route ownership OpenSpec proposal | D2.4/F | Explicit proposal created for dedicated backup route ownership after D2.4 planning acceptance | Proposal-only: `define-backend-backup-route-ownership` adds an architecture-governance gate requiring current-head backup route/OpenAPI evidence, backup ownership class taxonomy, explicit `cleanup_old_backups.py` and `backup_service_health` ownership, security/permission/audit/rollback evidence, and separate D2.3/D2.5/D2.6 lane handling before mutation; no backend source, frontend source, tests, generated client, docs/API, route behavior, OpenAPI schema, infrastructure backup code, probe URL, or PM2 changes are authorized | `openspec/changes/define-backend-backup-route-ownership/`; `docs/reports/quality/backend-backup-route-ownership-openspec-proposal-2026-05-21.md`; `governance/mainline/task-cards/pr-118.yaml` | Approved for governance/evidence task-list execution; no implementation or runtime mutation authorized |
 | D2.5 Control-plane OpenAPI docs planning package | D2.5 | Control-plane OpenAPI docs stabilization remains a dedicated documentation/probe governance lane | Planning/evidence only: current smoke at HEAD `b39b7b3ee` reports routes=`548`, OpenAPI paths=`500`, broad control/status candidate routes=`128`, focused duplicate operationIds=`0`, `/health/readiness` absent, `/api/strategy-mgmt/{path:path}` runtime-only hidden, and `/metrics` as the focused duplicate runtime path/method; no route, OpenAPI, docs/API, source, frontend, test, PM2, or OpenSpec mutation is authorized | `docs/reports/quality/backend-control-plane-openapi-docs-planning-package-2026-05-21.md`; `https://github.com/chengjon/mystocks/issues/92` | Human review; if accepted, create a separate control-plane OpenAPI docs proposal or documentation issue before docs/API or route mutation |
@@ -460,7 +462,7 @@ review, PR review, or OpenSpec archive review.
 | `stabilize-backend-control-plane-openapi-docs` | `approved-for-governance-execution` | Issue `#92` downstream split acceptance, D2.5 planning package, route/OpenAPI/probe refresh, and D2.3 route governance proposal | Explicit OpenSpec proposal plus control-plane docs/probe planning, health/readiness taxonomy, OpenAPI docs UI/schema routes, metrics/status probes, and runtime-only compat redirects | Documentation/probe governance for liveness, readiness, service health, detailed health, status, metrics, docs UI, OpenAPI schema, runtime-only compat redirects, and intentionally absent aliases | Review and approve the OpenSpec change before executing docs/probe governance tasks or opening implementation lanes |
 | `approve-backend-pm2-stateful-gate` | `approved-for-governance-execution` | Issue `#92` downstream split acceptance, D2.6 approval-governance package, and historical health/status PM2 evidence | Explicit OpenSpec proposal for PM2 stateful workflow approval strategy and named-equivalent rules | Approval records for `run_pm2_integration_workflow.sh` modes, stateful service mutation, rollback, evidence artifact routing, read-only sampling, and named equivalents | Review and approve the policy proposal; create a small approval issue or approved runbook only when a future workline needs a fresh PM2 run |
 | `close-backend-schema-dual-directory` | `candidate` | Master execution plan | Schema dual-directory closure | Schema exports, consumer migration, shim retirement decision | Create only after `sequence-backend-architecture-unblocks` schema tasks are accepted |
-| `refresh-backend-route-openapi-governance` | `approved-for-governance-execution` | Master execution plan, route/OpenAPI/probe refresh, D2.3 planning package, and next child-lane selection | Explicit OpenSpec proposal plus API flat/package closure records, trading route/OpenAPI governance planning, and probe consumer evidence | Route table, OpenAPI, operationId, probe matrix, trading ownership, control-plane, backup, compatibility, and schema-exposure classification | Review and approve the OpenSpec change before executing governance tasks or opening implementation lanes |
+| `refresh-backend-route-openapi-governance` | `decision-package-prepared-for-review` | Master execution plan, route/OpenAPI/probe refresh, D2.3 planning package, and proposal approval record | Decision package prepared with current-head route table, OpenAPI, probe matrix, trading ownership, runtime-vs-schema, and consumer contract evidence | Route table, OpenAPI, operationId, probe matrix, trading ownership, control-plane, backup, compatibility, and schema-exposure classification; no route/OpenAPI/source/docs/API/PM2 mutation | Review `backend-route-openapi-governance-decision-package-2026-05-22.md`; do not open implementation lanes before acceptance |
 | `define-backend-service-seams-and-singleton-pilots` | `candidate` | Master execution plan | Singleton lifecycle routing matrix | Service seam definition, interface/test-double pilot strategy | Create as a design proposal after complete classification |
 
 ## Dependency and Freshness Matrix
@@ -472,7 +474,7 @@ review, PR review, or OpenSpec archive review.
 | C. `sequence-backend-architecture-unblocks` | Human approval, current runtime blocker verification | `7b097fffd` | Tasks 1.x through 8.x complete; runtime blocker closed, schema shim closure implemented, route/OpenAPI/probe evidence refreshed, service seam proposal path recorded |
 | D. Core split continuation | Task 3.2 disposition, #83 evidence acceptance, runtime evidence refresh | `7b097fffd` | Batch 2 remains blocked |
 | E. Schema dual-directory closure | `app.schema` consumer scan and `app.schemas` export proof | `7b097fffd` | Task 3.x complete; root checkout now has 0 legacy `app.schema` consumers and canonical exports are live |
-| F. Route/OpenAPI governance | Healthy `app.main` import chain | `1f3298209` | D2.3 route/OpenAPI, D2.4 backup ownership, D2.5 control-plane docs, and D2.6 PM2 approval policy proposals are merged and approved for governance/evidence task-list execution; next execution must refresh current-head evidence before using artifacts for backup, docs/API, route mutation, or PM2 approval decisions |
+| F. Route/OpenAPI governance | Healthy `app.main` import chain and current-head evidence refresh | `c173bbc8d` | D2.3 route/OpenAPI decision package is prepared for review with current-head route/OpenAPI/probe/consumer artifacts; D2.4 backup, D2.5 control-plane docs, and D2.6 PM2 lanes remain separate; no backup, docs/API, route mutation, OpenAPI exposure change, or PM2 approval decision is authorized until review acceptance |
 | G. Service seams and singleton pilots | Full service classification plus interface/test-double strategy | `7b097fffd` | Task 6.x proposal path complete; service directory is dirty, no implementation batch is scheduled, and future work needs a clean candidate packet plus approved proposal |
 
 ## Update Protocol

--- a/.planning/codebase/generated/backend-route-table-2026-05-22.json
+++ b/.planning/codebase/generated/backend-route-table-2026-05-22.json
@@ -1,0 +1,6580 @@
+{
+  "generated_at": "2026-05-21T17:02:48.078861Z",
+  "git_head": "c173bbc8d48d5e20ed5905d698ca39001237198a",
+  "git_head_short": "c173bbc8d",
+  "stale_if_head_mismatch": true,
+  "app_import_error": null,
+  "env_mode": "placeholder env for import/openapi governance; no service startup",
+  "summary": {
+    "total_routes": 548,
+    "schema_visible_routes": 536,
+    "hidden_runtime_routes": 12,
+    "endpoint_module_count": 99,
+    "duplicate_path_method_count_excluding_head_options": 1,
+    "trading_candidate_routes": 41,
+    "trading_schema_exposed_routes": 41,
+    "trading_schema_hidden_routes": 0
+  },
+  "duplicate_path_methods": [
+    {
+      "path": "/metrics",
+      "method": "GET",
+      "count": 2,
+      "routes": [
+        {
+          "index": 6,
+          "path": "/metrics",
+          "name": "prometheus_metrics",
+          "methods": [
+            "GET"
+          ],
+          "include_in_schema": false,
+          "endpoint_module": "app.main",
+          "endpoint_name": "prometheus_metrics"
+        },
+        {
+          "index": 518,
+          "path": "/metrics",
+          "name": "metrics",
+          "methods": [
+            "GET"
+          ],
+          "include_in_schema": true,
+          "endpoint_module": "app.api.prometheus_exporter",
+          "endpoint_name": "metrics"
+        }
+      ]
+    }
+  ],
+  "trading_candidate_module_counts": {
+    "app.api.advanced_analysis_api": 1,
+    "app.api.trade.execution_tracking_routes": 3,
+    "app.api.trade.reconciliation_routes": 5,
+    "app.api.trade.routes": 7,
+    "app.api.trading_runtime": 8,
+    "app.api.tradingview": 6,
+    "app.api.v1.trading.positions": 6,
+    "app.api.v1.trading.session": 5
+  },
+  "trading_candidate_path_group_counts": {
+    "/api/trading": 14,
+    "/api/v1/advanced-analysis/trading-signals": 1,
+    "/api/v1/positions": 6,
+    "/api/v1/trade": 15,
+    "/api/v1/trading": 5
+  },
+  "trading_candidates": [
+    {
+      "index": 65,
+      "path": "/api/v1/trade/health",
+      "name": "health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.routes",
+      "endpoint_name": "health_check",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 66,
+      "path": "/api/v1/trade/portfolio",
+      "name": "get_portfolio",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.routes",
+      "endpoint_name": "get_portfolio",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 67,
+      "path": "/api/v1/trade/positions",
+      "name": "get_positions",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.routes",
+      "endpoint_name": "get_positions",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 68,
+      "path": "/api/v1/trade/signals",
+      "name": "get_signals",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.routes",
+      "endpoint_name": "get_signals",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 69,
+      "path": "/api/v1/trade/trades",
+      "name": "get_trades",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.routes",
+      "endpoint_name": "get_trades",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 70,
+      "path": "/api/v1/trade/statistics",
+      "name": "get_statistics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.routes",
+      "endpoint_name": "get_statistics",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 71,
+      "path": "/api/v1/trade/execute",
+      "name": "execute_trade",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.routes",
+      "endpoint_name": "execute_trade",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 72,
+      "path": "/api/v1/trade/execution-tracking",
+      "name": "get_execution_tracking",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.execution_tracking_routes",
+      "endpoint_name": "get_execution_tracking",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 73,
+      "path": "/api/v1/trade/execution-tracking/trigger",
+      "name": "trigger_external_execution",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.execution_tracking_routes",
+      "endpoint_name": "trigger_external_execution",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 74,
+      "path": "/api/v1/trade/execution-tracking/{tracking_id}",
+      "name": "get_execution_tracking_detail",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.execution_tracking_routes",
+      "endpoint_name": "get_execution_tracking_detail",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 75,
+      "path": "/api/v1/trade/reconciliation/accounts",
+      "name": "get_reconciliation_accounts",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.reconciliation_routes",
+      "endpoint_name": "get_reconciliation_accounts",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 76,
+      "path": "/api/v1/trade/reconciliation/statements",
+      "name": "get_reconciliation_statements",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.reconciliation_routes",
+      "endpoint_name": "get_reconciliation_statements",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 77,
+      "path": "/api/v1/trade/reconciliation/results",
+      "name": "get_reconciliation_results",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.reconciliation_routes",
+      "endpoint_name": "get_reconciliation_results",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 78,
+      "path": "/api/v1/trade/reconciliation/export",
+      "name": "export_reconciliation_results",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.reconciliation_routes",
+      "endpoint_name": "export_reconciliation_results",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 79,
+      "path": "/api/v1/trade/reconciliation/import",
+      "name": "import_reconciliation_csv",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.reconciliation_routes",
+      "endpoint_name": "import_reconciliation_csv",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 80,
+      "path": "/api/trading/status",
+      "name": "get_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "get_status",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 81,
+      "path": "/api/trading/start",
+      "name": "start_session",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "start_session",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 82,
+      "path": "/api/trading/stop",
+      "name": "stop_session",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "stop_session",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 83,
+      "path": "/api/trading/strategies/performance",
+      "name": "get_strategies_performance",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "get_strategies_performance",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 84,
+      "path": "/api/trading/strategies/add",
+      "name": "add_strategy",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "add_strategy",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 85,
+      "path": "/api/trading/strategies/{strategy_name}",
+      "name": "remove_strategy",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "remove_strategy",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 86,
+      "path": "/api/trading/market/snapshot",
+      "name": "get_market_snapshot",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "get_market_snapshot",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 87,
+      "path": "/api/trading/risk/metrics",
+      "name": "get_risk_metrics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "get_risk_metrics",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 315,
+      "path": "/api/tradingview/chart/config",
+      "name": "get_chart_config",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tradingview",
+      "endpoint_name": "get_chart_config",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 316,
+      "path": "/api/tradingview/mini-chart/config",
+      "name": "get_mini_chart_config",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tradingview",
+      "endpoint_name": "get_mini_chart_config",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 317,
+      "path": "/api/tradingview/ticker-tape/config",
+      "name": "get_ticker_tape_config",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tradingview",
+      "endpoint_name": "get_ticker_tape_config",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 318,
+      "path": "/api/tradingview/market-overview/config",
+      "name": "get_market_overview_config",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tradingview",
+      "endpoint_name": "get_market_overview_config",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 319,
+      "path": "/api/tradingview/screener/config",
+      "name": "get_screener_config",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tradingview",
+      "endpoint_name": "get_screener_config",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 320,
+      "path": "/api/tradingview/symbol/convert",
+      "name": "convert_symbol",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tradingview",
+      "endpoint_name": "convert_symbol",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 439,
+      "path": "/api/v1/trading/sessions",
+      "name": "list_trading_sessions",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.session",
+      "endpoint_name": "list_trading_sessions",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 440,
+      "path": "/api/v1/trading/sessions/{session_id}",
+      "name": "get_trading_session",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.session",
+      "endpoint_name": "get_trading_session",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 441,
+      "path": "/api/v1/trading/sessions",
+      "name": "create_trading_session",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.session",
+      "endpoint_name": "create_trading_session",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 442,
+      "path": "/api/v1/trading/sessions/{session_id}",
+      "name": "update_trading_session",
+      "methods": [
+        "PATCH"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.session",
+      "endpoint_name": "update_trading_session",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 443,
+      "path": "/api/v1/trading/sessions/{session_id}",
+      "name": "delete_trading_session",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.session",
+      "endpoint_name": "delete_trading_session",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 444,
+      "path": "/api/v1/positions",
+      "name": "list_positions",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.positions",
+      "endpoint_name": "list_positions",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 445,
+      "path": "/api/v1/positions/attribution",
+      "name": "get_position_attribution",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.positions",
+      "endpoint_name": "get_position_attribution",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 446,
+      "path": "/api/v1/positions/{position_id}",
+      "name": "get_position",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.positions",
+      "endpoint_name": "get_position",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 447,
+      "path": "/api/v1/positions",
+      "name": "create_position",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.positions",
+      "endpoint_name": "create_position",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 448,
+      "path": "/api/v1/positions/{position_id}",
+      "name": "update_position",
+      "methods": [
+        "PATCH"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.positions",
+      "endpoint_name": "update_position",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 449,
+      "path": "/api/v1/positions/{position_id}",
+      "name": "delete_position",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.positions",
+      "endpoint_name": "delete_position",
+      "ownership_class": "trading-owned"
+    },
+    {
+      "index": 536,
+      "path": "/api/v1/advanced-analysis/trading-signals",
+      "name": "analyze_trading_signals",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "analyze_trading_signals",
+      "ownership_class": "trading-adjacent-unclassified"
+    }
+  ],
+  "routes": [
+    {
+      "index": 0,
+      "path": "/openapi.json",
+      "name": "openapi",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": false,
+      "endpoint_module": "fastapi.applications",
+      "endpoint_name": "openapi"
+    },
+    {
+      "index": 1,
+      "path": "/swagger-ui-static",
+      "name": "swagger-ui-static",
+      "methods": [],
+      "include_in_schema": false,
+      "endpoint_module": null,
+      "endpoint_name": null
+    },
+    {
+      "index": 2,
+      "path": "/static",
+      "name": "static",
+      "methods": [],
+      "include_in_schema": false,
+      "endpoint_module": null,
+      "endpoint_name": null
+    },
+    {
+      "index": 3,
+      "path": "/health",
+      "name": "health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.main",
+      "endpoint_name": "health_check"
+    },
+    {
+      "index": 4,
+      "path": "/api/health/ready",
+      "name": "readiness_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.main",
+      "endpoint_name": "readiness_check"
+    },
+    {
+      "index": 5,
+      "path": "/health/ready",
+      "name": "readiness_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.main",
+      "endpoint_name": "readiness_check"
+    },
+    {
+      "index": 6,
+      "path": "/metrics",
+      "name": "prometheus_metrics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": false,
+      "endpoint_module": "app.main",
+      "endpoint_name": "prometheus_metrics"
+    },
+    {
+      "index": 7,
+      "path": "/api/socketio-status",
+      "name": "socketio_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.main",
+      "endpoint_name": "socketio_status"
+    },
+    {
+      "index": 8,
+      "path": "/api/csrf-token",
+      "name": "get_csrf_token",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.main",
+      "endpoint_name": "get_csrf_token"
+    },
+    {
+      "index": 9,
+      "path": "/",
+      "name": "root",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.main",
+      "endpoint_name": "root"
+    },
+    {
+      "index": 10,
+      "path": "/api/docs",
+      "name": "custom_swagger_ui_html",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": false,
+      "endpoint_module": "app.main",
+      "endpoint_name": "custom_swagger_ui_html"
+    },
+    {
+      "index": 11,
+      "path": "/api/redoc",
+      "name": "custom_redoc_html",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": false,
+      "endpoint_module": "app.main",
+      "endpoint_name": "custom_redoc_html"
+    },
+    {
+      "index": 12,
+      "path": "/api/v1/auth/login",
+      "name": "login_for_access_token",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.auth",
+      "endpoint_name": "login_for_access_token"
+    },
+    {
+      "index": 13,
+      "path": "/api/v1/auth/logout",
+      "name": "logout",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.auth",
+      "endpoint_name": "logout"
+    },
+    {
+      "index": 14,
+      "path": "/api/v1/auth/me",
+      "name": "read_users_me",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.auth",
+      "endpoint_name": "read_users_me"
+    },
+    {
+      "index": 15,
+      "path": "/api/v1/auth/refresh",
+      "name": "refresh_token",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.auth",
+      "endpoint_name": "refresh_token"
+    },
+    {
+      "index": 16,
+      "path": "/api/v1/auth/users",
+      "name": "get_users",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.auth",
+      "endpoint_name": "get_users"
+    },
+    {
+      "index": 17,
+      "path": "/api/v1/auth/csrf/token",
+      "name": "get_csrf_token",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.auth",
+      "endpoint_name": "get_csrf_token"
+    },
+    {
+      "index": 18,
+      "path": "/api/v1/auth/register",
+      "name": "register_user",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.auth",
+      "endpoint_name": "register_user"
+    },
+    {
+      "index": 19,
+      "path": "/api/v1/auth/reset-password/request",
+      "name": "request_password_reset",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.auth",
+      "endpoint_name": "request_password_reset"
+    },
+    {
+      "index": 20,
+      "path": "/api/v1/auth/reset-password/confirm",
+      "name": "confirm_password_reset",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.auth",
+      "endpoint_name": "confirm_password_reset"
+    },
+    {
+      "index": 21,
+      "path": "/api/v1/market/heatmap",
+      "name": "get_market_heatmap",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market._market_heatmap_router",
+      "endpoint_name": "get_market_heatmap"
+    },
+    {
+      "index": 22,
+      "path": "/api/v1/market/health",
+      "name": "health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market.health_check",
+      "endpoint_name": "health_check"
+    },
+    {
+      "index": 23,
+      "path": "/api/v1/market/fund-flow",
+      "name": "get_fund_flow",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market.market_data_request",
+      "endpoint_name": "get_fund_flow"
+    },
+    {
+      "index": 24,
+      "path": "/api/v1/market/fund-flow/refresh",
+      "name": "refresh_fund_flow",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market.market_data_request",
+      "endpoint_name": "refresh_fund_flow"
+    },
+    {
+      "index": 25,
+      "path": "/api/v1/market/etf/list",
+      "name": "get_etf_list",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market.market_data_request",
+      "endpoint_name": "get_etf_list"
+    },
+    {
+      "index": 26,
+      "path": "/api/v1/market/etf/refresh",
+      "name": "refresh_etf_data",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market.market_data_request",
+      "endpoint_name": "refresh_etf_data"
+    },
+    {
+      "index": 27,
+      "path": "/api/v1/market/chip-race",
+      "name": "get_chip_race",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market.market_data_request",
+      "endpoint_name": "get_chip_race"
+    },
+    {
+      "index": 28,
+      "path": "/api/v1/market/chip-race/refresh",
+      "name": "refresh_chip_race",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market.market_data_request",
+      "endpoint_name": "refresh_chip_race"
+    },
+    {
+      "index": 29,
+      "path": "/api/v1/market/lhb",
+      "name": "get_lhb_detail",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market.market_data_request",
+      "endpoint_name": "get_lhb_detail"
+    },
+    {
+      "index": 30,
+      "path": "/api/v1/market/lhb/refresh",
+      "name": "refresh_lhb_detail",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market.market_data_request",
+      "endpoint_name": "refresh_lhb_detail"
+    },
+    {
+      "index": 31,
+      "path": "/api/v1/market/quotes",
+      "name": "get_market_quotes",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market.market_data_request",
+      "endpoint_name": "get_market_quotes"
+    },
+    {
+      "index": 32,
+      "path": "/api/v1/market/stocks",
+      "name": "get_stock_list",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market.market_data_request",
+      "endpoint_name": "get_stock_list"
+    },
+    {
+      "index": 33,
+      "path": "/api/v1/market/kline",
+      "name": "get_kline_data",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market.market_data_request",
+      "endpoint_name": "get_kline_data"
+    },
+    {
+      "index": 34,
+      "path": "/api/v2/market/fund-flow",
+      "name": "get_fund_flow",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market_v2",
+      "endpoint_name": "get_fund_flow"
+    },
+    {
+      "index": 35,
+      "path": "/api/v2/market/fund-flow/refresh",
+      "name": "refresh_fund_flow",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market_v2",
+      "endpoint_name": "refresh_fund_flow"
+    },
+    {
+      "index": 36,
+      "path": "/api/v2/market/etf/list",
+      "name": "get_etf_list",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market_v2",
+      "endpoint_name": "get_etf_list"
+    },
+    {
+      "index": 37,
+      "path": "/api/v2/market/etf/refresh",
+      "name": "refresh_etf_spot",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market_v2",
+      "endpoint_name": "refresh_etf_spot"
+    },
+    {
+      "index": 38,
+      "path": "/api/v2/market/lhb",
+      "name": "get_lhb_detail",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market_v2",
+      "endpoint_name": "get_lhb_detail"
+    },
+    {
+      "index": 39,
+      "path": "/api/v2/market/lhb/refresh",
+      "name": "refresh_lhb_detail",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market_v2",
+      "endpoint_name": "refresh_lhb_detail"
+    },
+    {
+      "index": 40,
+      "path": "/api/v2/market/sector/fund-flow",
+      "name": "get_sector_fund_flow",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market_v2",
+      "endpoint_name": "get_sector_fund_flow"
+    },
+    {
+      "index": 41,
+      "path": "/api/v2/market/sector/fund-flow/refresh",
+      "name": "refresh_sector_fund_flow",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market_v2",
+      "endpoint_name": "refresh_sector_fund_flow"
+    },
+    {
+      "index": 42,
+      "path": "/api/v2/market/dividend",
+      "name": "get_stock_dividend",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market_v2",
+      "endpoint_name": "get_stock_dividend"
+    },
+    {
+      "index": 43,
+      "path": "/api/v2/market/dividend/refresh",
+      "name": "refresh_stock_dividend",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market_v2",
+      "endpoint_name": "refresh_stock_dividend"
+    },
+    {
+      "index": 44,
+      "path": "/api/v2/market/blocktrade",
+      "name": "get_stock_blocktrade",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market_v2",
+      "endpoint_name": "get_stock_blocktrade"
+    },
+    {
+      "index": 45,
+      "path": "/api/v2/market/blocktrade/refresh",
+      "name": "refresh_stock_blocktrade",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market_v2",
+      "endpoint_name": "refresh_stock_blocktrade"
+    },
+    {
+      "index": 46,
+      "path": "/api/v2/market/refresh-all",
+      "name": "refresh_all_market_data",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.market_v2",
+      "endpoint_name": "refresh_all_market_data"
+    },
+    {
+      "index": 47,
+      "path": "/api/v1/monitoring/realtime/{symbol}",
+      "name": "get_realtime_monitoring",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_market_routes",
+      "endpoint_name": "get_realtime_monitoring"
+    },
+    {
+      "index": 48,
+      "path": "/api/v1/monitoring/realtime",
+      "name": "get_realtime_monitoring_list",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_market_routes",
+      "endpoint_name": "get_realtime_monitoring_list"
+    },
+    {
+      "index": 49,
+      "path": "/api/v1/monitoring/realtime/fetch",
+      "name": "fetch_realtime_data",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_market_routes",
+      "endpoint_name": "fetch_realtime_data"
+    },
+    {
+      "index": 50,
+      "path": "/api/v1/monitoring/dragon-tiger",
+      "name": "get_dragon_tiger_list",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_market_routes",
+      "endpoint_name": "get_dragon_tiger_list"
+    },
+    {
+      "index": 51,
+      "path": "/api/v1/monitoring/dragon-tiger/fetch",
+      "name": "fetch_dragon_tiger_data",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_market_routes",
+      "endpoint_name": "fetch_dragon_tiger_data"
+    },
+    {
+      "index": 52,
+      "path": "/api/v1/monitoring/alert-rules",
+      "name": "get_alert_rules",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring",
+      "endpoint_name": "get_alert_rules"
+    },
+    {
+      "index": 53,
+      "path": "/api/v1/monitoring/alert-rules",
+      "name": "create_alert_rule",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring",
+      "endpoint_name": "create_alert_rule"
+    },
+    {
+      "index": 54,
+      "path": "/api/v1/monitoring/alert-rules/{rule_id}",
+      "name": "update_alert_rule",
+      "methods": [
+        "PUT"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring",
+      "endpoint_name": "update_alert_rule"
+    },
+    {
+      "index": 55,
+      "path": "/api/v1/monitoring/alert-rules/{rule_id}",
+      "name": "delete_alert_rule",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring",
+      "endpoint_name": "delete_alert_rule"
+    },
+    {
+      "index": 56,
+      "path": "/api/v1/monitoring/alerts",
+      "name": "get_alert_records",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring",
+      "endpoint_name": "get_alert_records"
+    },
+    {
+      "index": 57,
+      "path": "/api/v1/monitoring/alerts/{alert_id}/mark-read",
+      "name": "mark_alert_read",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring",
+      "endpoint_name": "mark_alert_read"
+    },
+    {
+      "index": 58,
+      "path": "/api/v1/monitoring/alerts/mark-all-read",
+      "name": "mark_all_alerts_read",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring",
+      "endpoint_name": "mark_all_alerts_read"
+    },
+    {
+      "index": 59,
+      "path": "/api/v1/monitoring/analyze",
+      "name": "analyze_monitoring",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring",
+      "endpoint_name": "analyze_monitoring"
+    },
+    {
+      "index": 60,
+      "path": "/api/v1/monitoring/summary",
+      "name": "get_monitoring_summary",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring",
+      "endpoint_name": "get_monitoring_summary"
+    },
+    {
+      "index": 61,
+      "path": "/api/v1/monitoring/stats/today",
+      "name": "get_today_statistics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring",
+      "endpoint_name": "get_today_statistics"
+    },
+    {
+      "index": 62,
+      "path": "/api/v1/monitoring/control/start",
+      "name": "start_monitoring",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring",
+      "endpoint_name": "start_monitoring"
+    },
+    {
+      "index": 63,
+      "path": "/api/v1/monitoring/control/stop",
+      "name": "stop_monitoring",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring",
+      "endpoint_name": "stop_monitoring"
+    },
+    {
+      "index": 64,
+      "path": "/api/v1/monitoring/control/status",
+      "name": "get_monitoring_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring",
+      "endpoint_name": "get_monitoring_status"
+    },
+    {
+      "index": 65,
+      "path": "/api/v1/trade/health",
+      "name": "health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.routes",
+      "endpoint_name": "health_check"
+    },
+    {
+      "index": 66,
+      "path": "/api/v1/trade/portfolio",
+      "name": "get_portfolio",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.routes",
+      "endpoint_name": "get_portfolio"
+    },
+    {
+      "index": 67,
+      "path": "/api/v1/trade/positions",
+      "name": "get_positions",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.routes",
+      "endpoint_name": "get_positions"
+    },
+    {
+      "index": 68,
+      "path": "/api/v1/trade/signals",
+      "name": "get_signals",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.routes",
+      "endpoint_name": "get_signals"
+    },
+    {
+      "index": 69,
+      "path": "/api/v1/trade/trades",
+      "name": "get_trades",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.routes",
+      "endpoint_name": "get_trades"
+    },
+    {
+      "index": 70,
+      "path": "/api/v1/trade/statistics",
+      "name": "get_statistics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.routes",
+      "endpoint_name": "get_statistics"
+    },
+    {
+      "index": 71,
+      "path": "/api/v1/trade/execute",
+      "name": "execute_trade",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.routes",
+      "endpoint_name": "execute_trade"
+    },
+    {
+      "index": 72,
+      "path": "/api/v1/trade/execution-tracking",
+      "name": "get_execution_tracking",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.execution_tracking_routes",
+      "endpoint_name": "get_execution_tracking"
+    },
+    {
+      "index": 73,
+      "path": "/api/v1/trade/execution-tracking/trigger",
+      "name": "trigger_external_execution",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.execution_tracking_routes",
+      "endpoint_name": "trigger_external_execution"
+    },
+    {
+      "index": 74,
+      "path": "/api/v1/trade/execution-tracking/{tracking_id}",
+      "name": "get_execution_tracking_detail",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.execution_tracking_routes",
+      "endpoint_name": "get_execution_tracking_detail"
+    },
+    {
+      "index": 75,
+      "path": "/api/v1/trade/reconciliation/accounts",
+      "name": "get_reconciliation_accounts",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.reconciliation_routes",
+      "endpoint_name": "get_reconciliation_accounts"
+    },
+    {
+      "index": 76,
+      "path": "/api/v1/trade/reconciliation/statements",
+      "name": "get_reconciliation_statements",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.reconciliation_routes",
+      "endpoint_name": "get_reconciliation_statements"
+    },
+    {
+      "index": 77,
+      "path": "/api/v1/trade/reconciliation/results",
+      "name": "get_reconciliation_results",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.reconciliation_routes",
+      "endpoint_name": "get_reconciliation_results"
+    },
+    {
+      "index": 78,
+      "path": "/api/v1/trade/reconciliation/export",
+      "name": "export_reconciliation_results",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.reconciliation_routes",
+      "endpoint_name": "export_reconciliation_results"
+    },
+    {
+      "index": 79,
+      "path": "/api/v1/trade/reconciliation/import",
+      "name": "import_reconciliation_csv",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trade.reconciliation_routes",
+      "endpoint_name": "import_reconciliation_csv"
+    },
+    {
+      "index": 80,
+      "path": "/api/trading/status",
+      "name": "get_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "get_status"
+    },
+    {
+      "index": 81,
+      "path": "/api/trading/start",
+      "name": "start_session",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "start_session"
+    },
+    {
+      "index": 82,
+      "path": "/api/trading/stop",
+      "name": "stop_session",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "stop_session"
+    },
+    {
+      "index": 83,
+      "path": "/api/trading/strategies/performance",
+      "name": "get_strategies_performance",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "get_strategies_performance"
+    },
+    {
+      "index": 84,
+      "path": "/api/trading/strategies/add",
+      "name": "add_strategy",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "add_strategy"
+    },
+    {
+      "index": 85,
+      "path": "/api/trading/strategies/{strategy_name}",
+      "name": "remove_strategy",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "remove_strategy"
+    },
+    {
+      "index": 86,
+      "path": "/api/trading/market/snapshot",
+      "name": "get_market_snapshot",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "get_market_snapshot"
+    },
+    {
+      "index": 87,
+      "path": "/api/trading/risk/metrics",
+      "name": "get_risk_metrics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.trading_runtime",
+      "endpoint_name": "get_risk_metrics"
+    },
+    {
+      "index": 88,
+      "path": "/api/v1/technical/patterns/{symbol}",
+      "name": "detect_patterns",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._technical_patterns_router",
+      "endpoint_name": "detect_patterns"
+    },
+    {
+      "index": 89,
+      "path": "/api/v1/technical/{symbol}/indicators",
+      "name": "get_all_indicators",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.technical_analysis",
+      "endpoint_name": "get_all_indicators"
+    },
+    {
+      "index": 90,
+      "path": "/api/v1/technical/{symbol}/trend",
+      "name": "get_trend_indicators",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.technical_analysis",
+      "endpoint_name": "get_trend_indicators"
+    },
+    {
+      "index": 91,
+      "path": "/api/v1/technical/{symbol}/momentum",
+      "name": "get_momentum_indicators",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.technical_analysis",
+      "endpoint_name": "get_momentum_indicators"
+    },
+    {
+      "index": 92,
+      "path": "/api/v1/technical/{symbol}/volatility",
+      "name": "get_volatility_indicators",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.technical_analysis",
+      "endpoint_name": "get_volatility_indicators"
+    },
+    {
+      "index": 93,
+      "path": "/api/v1/technical/{symbol}/volume",
+      "name": "get_volume_indicators",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.technical_analysis",
+      "endpoint_name": "get_volume_indicators"
+    },
+    {
+      "index": 94,
+      "path": "/api/v1/technical/{symbol}/signals",
+      "name": "get_trading_signals",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.technical_analysis",
+      "endpoint_name": "get_trading_signals"
+    },
+    {
+      "index": 95,
+      "path": "/api/v1/technical/{symbol}/history",
+      "name": "get_stock_history",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.technical_analysis",
+      "endpoint_name": "get_stock_history"
+    },
+    {
+      "index": 96,
+      "path": "/api/v1/technical/batch/indicators",
+      "name": "get_batch_indicators",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.technical_analysis",
+      "endpoint_name": "get_batch_indicators"
+    },
+    {
+      "index": 97,
+      "path": "/api/v1/data/stocks/basic",
+      "name": "get_stocks_basic",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.stocks",
+      "endpoint_name": "get_stocks_basic"
+    },
+    {
+      "index": 98,
+      "path": "/api/v1/data/stocks/industries",
+      "name": "get_stocks_industries",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.stocks",
+      "endpoint_name": "get_stocks_industries"
+    },
+    {
+      "index": 99,
+      "path": "/api/v1/data/stocks/concepts",
+      "name": "get_stocks_concepts",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.stocks",
+      "endpoint_name": "get_stocks_concepts"
+    },
+    {
+      "index": 100,
+      "path": "/api/v1/data/stocks/search",
+      "name": "search_stocks",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.stocks",
+      "endpoint_name": "search_stocks"
+    },
+    {
+      "index": 101,
+      "path": "/api/v1/data/stocks/{symbol}/detail",
+      "name": "get_stock_detail",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.stocks",
+      "endpoint_name": "get_stock_detail"
+    },
+    {
+      "index": 102,
+      "path": "/api/v1/data/markets/overview",
+      "name": "get_market_overview",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.market",
+      "endpoint_name": "get_market_overview"
+    },
+    {
+      "index": 103,
+      "path": "/api/v1/data/markets/price-distribution",
+      "name": "get_price_distribution",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.market",
+      "endpoint_name": "get_price_distribution"
+    },
+    {
+      "index": 104,
+      "path": "/api/v1/data/markets/hot-industries",
+      "name": "get_hot_industries",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.market",
+      "endpoint_name": "get_hot_industries"
+    },
+    {
+      "index": 105,
+      "path": "/api/v1/data/markets/hot-concepts",
+      "name": "get_hot_concepts",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.market",
+      "endpoint_name": "get_hot_concepts"
+    },
+    {
+      "index": 106,
+      "path": "/api/v1/data/stocks/daily",
+      "name": "get_daily_kline",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.kline",
+      "endpoint_name": "get_daily_kline"
+    },
+    {
+      "index": 107,
+      "path": "/api/v1/data/kline",
+      "name": "get_kline",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.kline",
+      "endpoint_name": "get_kline"
+    },
+    {
+      "index": 108,
+      "path": "/api/v1/data/stocks/kline",
+      "name": "get_kline_data",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.kline",
+      "endpoint_name": "get_kline_data"
+    },
+    {
+      "index": 109,
+      "path": "/api/v1/data/stocks/intraday",
+      "name": "get_intraday_data",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.kline",
+      "endpoint_name": "get_intraday_data"
+    },
+    {
+      "index": 110,
+      "path": "/api/v1/data/margin/account-info",
+      "name": "get_margin_account_info",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.margin",
+      "endpoint_name": "get_margin_account_info"
+    },
+    {
+      "index": 111,
+      "path": "/api/v1/data/margin/detail/sse",
+      "name": "get_margin_detail_sse",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.margin",
+      "endpoint_name": "get_margin_detail_sse"
+    },
+    {
+      "index": 112,
+      "path": "/api/v1/data/margin/detail/szse",
+      "name": "get_margin_detail_szse",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.margin",
+      "endpoint_name": "get_margin_detail_szse"
+    },
+    {
+      "index": 113,
+      "path": "/api/v1/data/dragon-tiger/detail",
+      "name": "get_dragon_tiger_detail",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.lhb",
+      "endpoint_name": "get_dragon_tiger_detail"
+    },
+    {
+      "index": 114,
+      "path": "/api/v1/data/dragon-tiger/institution-stats",
+      "name": "get_dragon_tiger_institution_stats",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.lhb",
+      "endpoint_name": "get_dragon_tiger_institution_stats"
+    },
+    {
+      "index": 115,
+      "path": "/api/v1/data/futures/index/daily",
+      "name": "get_futures_index_daily",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.futures",
+      "endpoint_name": "get_futures_index_daily"
+    },
+    {
+      "index": 116,
+      "path": "/api/v1/data/futures/index/realtime",
+      "name": "get_futures_index_realtime",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.futures",
+      "endpoint_name": "get_futures_index_realtime"
+    },
+    {
+      "index": 117,
+      "path": "/api/v1/data/financial",
+      "name": "get_financial_data",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data.financial",
+      "endpoint_name": "get_financial_data"
+    },
+    {
+      "index": 118,
+      "path": "/api/v1/system/health",
+      "name": "system_health",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.system.system_health",
+      "endpoint_name": "system_health"
+    },
+    {
+      "index": 119,
+      "path": "/api/v1/system/adapters/health",
+      "name": "get_adapters_health",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.system.system_health",
+      "endpoint_name": "get_adapters_health"
+    },
+    {
+      "index": 120,
+      "path": "/api/v1/system/datasources",
+      "name": "get_datasources",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.system.system_health",
+      "endpoint_name": "get_datasources"
+    },
+    {
+      "index": 121,
+      "path": "/api/v1/system/test-connection",
+      "name": "test_database_connection",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.system.system_health",
+      "endpoint_name": "test_database_connection"
+    },
+    {
+      "index": 122,
+      "path": "/api/v1/system/logs",
+      "name": "get_system_logs",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.system.system_health",
+      "endpoint_name": "get_system_logs"
+    },
+    {
+      "index": 123,
+      "path": "/api/v1/system/logs/summary",
+      "name": "get_logs_summary",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.system.system_health",
+      "endpoint_name": "get_logs_summary"
+    },
+    {
+      "index": 124,
+      "path": "/api/v1/indicators/registry",
+      "name": "get_indicator_registry_endpoint",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.indicators.indicator_cache",
+      "endpoint_name": "get_indicator_registry_endpoint"
+    },
+    {
+      "index": 125,
+      "path": "/api/v1/indicators/registry/{category}",
+      "name": "get_indicators_by_category",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.indicators.indicator_cache",
+      "endpoint_name": "get_indicators_by_category"
+    },
+    {
+      "index": 126,
+      "path": "/api/v1/indicators/calculate",
+      "name": "calculate_indicators",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.indicators.indicator_cache",
+      "endpoint_name": "calculate_indicators"
+    },
+    {
+      "index": 127,
+      "path": "/api/v1/indicators/calculate/batch",
+      "name": "calculate_indicators_batch",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.indicators.indicator_cache",
+      "endpoint_name": "calculate_indicators_batch"
+    },
+    {
+      "index": 128,
+      "path": "/api/v1/indicators/cache/stats",
+      "name": "get_cache_statistics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.indicators.indicator_cache",
+      "endpoint_name": "get_cache_statistics"
+    },
+    {
+      "index": 129,
+      "path": "/api/v1/indicators/cache/clear",
+      "name": "clear_cache",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.indicators.indicator_cache",
+      "endpoint_name": "clear_cache"
+    },
+    {
+      "index": 130,
+      "path": "/api/v1/tdx/quote/{symbol}",
+      "name": "get_stock_quote",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tdx",
+      "endpoint_name": "get_stock_quote"
+    },
+    {
+      "index": 131,
+      "path": "/api/v1/tdx/kline",
+      "name": "get_stock_kline",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tdx",
+      "endpoint_name": "get_stock_kline"
+    },
+    {
+      "index": 132,
+      "path": "/api/v1/tdx/index/quote/{symbol}",
+      "name": "get_index_quote",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tdx",
+      "endpoint_name": "get_index_quote"
+    },
+    {
+      "index": 133,
+      "path": "/api/v1/tdx/index/kline",
+      "name": "get_index_kline",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tdx",
+      "endpoint_name": "get_index_kline"
+    },
+    {
+      "index": 134,
+      "path": "/api/v1/tdx/health",
+      "name": "health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tdx",
+      "endpoint_name": "health_check"
+    },
+    {
+      "index": 135,
+      "path": "/api/auth/login",
+      "name": "compat_login",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.auth_compat",
+      "endpoint_name": "compat_login"
+    },
+    {
+      "index": 136,
+      "path": "/api/akshare/market/sse/overview",
+      "name": "get_sse_market_overview",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.sse",
+      "endpoint_name": "get_sse_market_overview"
+    },
+    {
+      "index": 137,
+      "path": "/api/akshare/market/sse/daily-deal",
+      "name": "get_sse_daily_deal",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.sse",
+      "endpoint_name": "get_sse_daily_deal"
+    },
+    {
+      "index": 138,
+      "path": "/api/akshare/market/szse/overview",
+      "name": "get_szse_market_overview",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.szse",
+      "endpoint_name": "get_szse_market_overview"
+    },
+    {
+      "index": 139,
+      "path": "/api/akshare/market/szse/area-trading",
+      "name": "get_szse_area_trading",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.szse",
+      "endpoint_name": "get_szse_area_trading"
+    },
+    {
+      "index": 140,
+      "path": "/api/akshare/market/szse/sector-trading",
+      "name": "get_szse_sector_trading",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.szse",
+      "endpoint_name": "get_szse_sector_trading"
+    },
+    {
+      "index": 141,
+      "path": "/api/akshare/market/stock/individual-info/em",
+      "name": "get_stock_individual_info_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.stock_info",
+      "endpoint_name": "get_stock_individual_info_em"
+    },
+    {
+      "index": 142,
+      "path": "/api/akshare/market/stock/individual-info/xq",
+      "name": "get_stock_individual_info_xq",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.stock_info",
+      "endpoint_name": "get_stock_individual_info_xq"
+    },
+    {
+      "index": 143,
+      "path": "/api/akshare/market/stock/business-intro/ths",
+      "name": "get_stock_business_intro_ths",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.stock_info",
+      "endpoint_name": "get_stock_business_intro_ths"
+    },
+    {
+      "index": 144,
+      "path": "/api/akshare/market/stock/business-composition/em",
+      "name": "get_stock_business_composition_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.stock_info",
+      "endpoint_name": "get_stock_business_composition_em"
+    },
+    {
+      "index": 145,
+      "path": "/api/akshare/market/stock/comment/em",
+      "name": "get_stock_comment_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.stock_info",
+      "endpoint_name": "get_stock_comment_em"
+    },
+    {
+      "index": 146,
+      "path": "/api/akshare/market/stock/comment-detail/em",
+      "name": "get_stock_comment_detail_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.stock_info",
+      "endpoint_name": "get_stock_comment_detail_em"
+    },
+    {
+      "index": 147,
+      "path": "/api/akshare/market/stock/news/em",
+      "name": "get_stock_news_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.stock_info",
+      "endpoint_name": "get_stock_news_em"
+    },
+    {
+      "index": 148,
+      "path": "/api/akshare/market/stock/bid-ask/em",
+      "name": "get_stock_bid_ask_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.stock_info",
+      "endpoint_name": "get_stock_bid_ask_em"
+    },
+    {
+      "index": 149,
+      "path": "/api/akshare/market/fund-flow/hsgt-summary",
+      "name": "get_hsgt_fund_flow_summary",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.fund_flow",
+      "endpoint_name": "get_hsgt_fund_flow_summary"
+    },
+    {
+      "index": 150,
+      "path": "/api/akshare/market/fund-flow/hsgt-detail",
+      "name": "get_hsgt_fund_flow_detail",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.fund_flow",
+      "endpoint_name": "get_hsgt_fund_flow_detail"
+    },
+    {
+      "index": 151,
+      "path": "/api/akshare/market/fund-flow/north-daily",
+      "name": "get_north_fund_daily",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.fund_flow",
+      "endpoint_name": "get_north_fund_daily"
+    },
+    {
+      "index": 152,
+      "path": "/api/akshare/market/fund-flow/south-daily",
+      "name": "get_south_fund_daily",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.fund_flow",
+      "endpoint_name": "get_south_fund_daily"
+    },
+    {
+      "index": 153,
+      "path": "/api/akshare/market/fund-flow/north-stock/{symbol}",
+      "name": "get_north_fund_stock",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.fund_flow",
+      "endpoint_name": "get_north_fund_stock"
+    },
+    {
+      "index": 154,
+      "path": "/api/akshare/market/fund-flow/south-stock/{symbol}",
+      "name": "get_south_fund_stock",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.fund_flow",
+      "endpoint_name": "get_south_fund_stock"
+    },
+    {
+      "index": 155,
+      "path": "/api/akshare/market/fund-flow/hsgt-holdings/{symbol}",
+      "name": "get_hsgt_holdings",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.fund_flow",
+      "endpoint_name": "get_hsgt_holdings"
+    },
+    {
+      "index": 156,
+      "path": "/api/akshare/market/fund-flow/big-deal",
+      "name": "get_fund_flow_big_deal",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.fund_flow",
+      "endpoint_name": "get_fund_flow_big_deal"
+    },
+    {
+      "index": 157,
+      "path": "/api/akshare/market/board/concept/cons/{symbol}",
+      "name": "get_concept_board_constituents",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.boards",
+      "endpoint_name": "get_concept_board_constituents"
+    },
+    {
+      "index": 158,
+      "path": "/api/akshare/market/board/concept/history/{symbol}",
+      "name": "get_concept_board_history",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.boards",
+      "endpoint_name": "get_concept_board_history"
+    },
+    {
+      "index": 159,
+      "path": "/api/akshare/market/board/concept/minute/{symbol}",
+      "name": "get_concept_board_minute",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.boards",
+      "endpoint_name": "get_concept_board_minute"
+    },
+    {
+      "index": 160,
+      "path": "/api/akshare/market/board/industry/cons/{symbol}",
+      "name": "get_industry_board_constituents",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.boards",
+      "endpoint_name": "get_industry_board_constituents"
+    },
+    {
+      "index": 161,
+      "path": "/api/akshare/market/board/industry/history/{symbol}",
+      "name": "get_industry_board_history",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.boards",
+      "endpoint_name": "get_industry_board_history"
+    },
+    {
+      "index": 162,
+      "path": "/api/akshare/market/board/industry/minute/{symbol}",
+      "name": "get_industry_board_minute",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.boards",
+      "endpoint_name": "get_industry_board_minute"
+    },
+    {
+      "index": 163,
+      "path": "/api/akshare/market/sector/hot-ranking",
+      "name": "get_sector_hot_ranking",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.boards",
+      "endpoint_name": "get_sector_hot_ranking"
+    },
+    {
+      "index": 164,
+      "path": "/api/akshare/market/sector/fund-flow-ranking",
+      "name": "get_sector_fund_flow_ranking",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.boards",
+      "endpoint_name": "get_sector_fund_flow_ranking"
+    },
+    {
+      "index": 165,
+      "path": "/api/akshare/market/chip-distribution/{symbol}",
+      "name": "get_chip_distribution",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.analysis",
+      "endpoint_name": "get_chip_distribution"
+    },
+    {
+      "index": 166,
+      "path": "/api/akshare/market/forecast/profit/em/{symbol}",
+      "name": "get_profit_forecast_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.analysis",
+      "endpoint_name": "get_profit_forecast_em"
+    },
+    {
+      "index": 167,
+      "path": "/api/akshare/market/forecast/profit/ths/{symbol}",
+      "name": "get_profit_forecast_ths",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.analysis",
+      "endpoint_name": "get_profit_forecast_ths"
+    },
+    {
+      "index": 168,
+      "path": "/api/akshare/market/technical/indicators/em/{symbol}",
+      "name": "get_technical_indicators_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.analysis",
+      "endpoint_name": "get_technical_indicators_em"
+    },
+    {
+      "index": 169,
+      "path": "/api/akshare/market/market/account-statistics",
+      "name": "get_account_statistics_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.analysis",
+      "endpoint_name": "get_account_statistics_em"
+    },
+    {
+      "index": 170,
+      "path": "/api/akshare/market/stock/hot-follow/xq",
+      "name": "get_stock_hot_follow_xq",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.sentiment_monitor",
+      "endpoint_name": "get_stock_hot_follow_xq"
+    },
+    {
+      "index": 171,
+      "path": "/api/akshare/market/stock/zt-pool/em",
+      "name": "get_stock_zt_pool_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.sentiment_monitor",
+      "endpoint_name": "get_stock_zt_pool_em"
+    },
+    {
+      "index": 172,
+      "path": "/api/akshare/market/stock/dt-pool/em",
+      "name": "get_stock_dt_pool_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.sentiment_monitor",
+      "endpoint_name": "get_stock_dt_pool_em"
+    },
+    {
+      "index": 173,
+      "path": "/api/akshare/market/stock/strong-pool/em",
+      "name": "get_stock_strong_pool_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.sentiment_monitor",
+      "endpoint_name": "get_stock_strong_pool_em"
+    },
+    {
+      "index": 174,
+      "path": "/api/akshare/market/stock/new/em",
+      "name": "get_stock_new_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.sentiment_monitor",
+      "endpoint_name": "get_stock_new_em"
+    },
+    {
+      "index": 175,
+      "path": "/api/akshare/market/stock/changes/em",
+      "name": "get_stock_changes_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.sentiment_monitor",
+      "endpoint_name": "get_stock_changes_em"
+    },
+    {
+      "index": 176,
+      "path": "/api/akshare/market/board/change/em",
+      "name": "get_board_change_em",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.akshare_market.sentiment_monitor",
+      "endpoint_name": "get_board_change_em"
+    },
+    {
+      "index": 177,
+      "path": "/api/data-quality/health",
+      "name": "get_sources_health",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_quality",
+      "endpoint_name": "get_sources_health"
+    },
+    {
+      "index": 178,
+      "path": "/api/data-quality/metrics",
+      "name": "get_data_quality_metrics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_quality",
+      "endpoint_name": "get_data_quality_metrics"
+    },
+    {
+      "index": 179,
+      "path": "/api/data-quality/alerts",
+      "name": "get_active_alerts",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_quality",
+      "endpoint_name": "get_active_alerts"
+    },
+    {
+      "index": 180,
+      "path": "/api/data-quality/alerts/{alert_id}/acknowledge",
+      "name": "acknowledge_alert",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_quality",
+      "endpoint_name": "acknowledge_alert"
+    },
+    {
+      "index": 181,
+      "path": "/api/data-quality/alerts/{alert_id}/resolve",
+      "name": "resolve_alert",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_quality",
+      "endpoint_name": "resolve_alert"
+    },
+    {
+      "index": 182,
+      "path": "/api/data-quality/config/mode",
+      "name": "get_data_source_mode",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_quality",
+      "endpoint_name": "get_data_source_mode"
+    },
+    {
+      "index": 183,
+      "path": "/api/data-quality/status/overview",
+      "name": "get_system_status_overview",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_quality",
+      "endpoint_name": "get_system_status_overview"
+    },
+    {
+      "index": 184,
+      "path": "/api/data-quality/test/quality",
+      "name": "test_data_quality",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_quality",
+      "endpoint_name": "test_data_quality"
+    },
+    {
+      "index": 185,
+      "path": "/api/data-quality/metrics/trends",
+      "name": "get_quality_trends",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_quality",
+      "endpoint_name": "get_quality_trends"
+    },
+    {
+      "index": 186,
+      "path": "/api/health",
+      "name": "health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.metrics",
+      "endpoint_name": "health_check"
+    },
+    {
+      "index": 187,
+      "path": "/api/metrics/health",
+      "name": "health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.metrics",
+      "endpoint_name": "health_check"
+    },
+    {
+      "index": 188,
+      "path": "/api/status",
+      "name": "basic_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.metrics",
+      "endpoint_name": "basic_status"
+    },
+    {
+      "index": 189,
+      "path": "/api/basic",
+      "name": "basic_metrics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.metrics",
+      "endpoint_name": "basic_metrics"
+    },
+    {
+      "index": 190,
+      "path": "/api/performance",
+      "name": "performance_metrics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.metrics",
+      "endpoint_name": "performance_metrics"
+    },
+    {
+      "index": 191,
+      "path": "/api/metrics",
+      "name": "prometheus_metrics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.metrics",
+      "endpoint_name": "prometheus_metrics"
+    },
+    {
+      "index": 192,
+      "path": "/api/detailed",
+      "name": "detailed_metrics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.metrics",
+      "endpoint_name": "detailed_metrics"
+    },
+    {
+      "index": 193,
+      "path": "/api/reset",
+      "name": "reset_metrics",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.metrics",
+      "endpoint_name": "reset_metrics"
+    },
+    {
+      "index": 194,
+      "path": "/api/pool-monitoring/postgresql/stats",
+      "name": "get_postgresql_pool_stats",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.pool_monitoring",
+      "endpoint_name": "get_postgresql_pool_stats"
+    },
+    {
+      "index": 195,
+      "path": "/api/pool-monitoring/tdengine/stats",
+      "name": "get_tdengine_pool_stats",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.pool_monitoring",
+      "endpoint_name": "get_tdengine_pool_stats"
+    },
+    {
+      "index": 196,
+      "path": "/api/pool-monitoring/health",
+      "name": "connection_pools_health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.pool_monitoring",
+      "endpoint_name": "connection_pools_health_check"
+    },
+    {
+      "index": 197,
+      "path": "/api/pool-monitoring/alerts",
+      "name": "check_connection_pool_alerts",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.pool_monitoring",
+      "endpoint_name": "check_connection_pool_alerts"
+    },
+    {
+      "index": 198,
+      "path": "/api/cache",
+      "name": "clear_all_cache",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.cache",
+      "endpoint_name": "clear_all_cache"
+    },
+    {
+      "index": 199,
+      "path": "/api/cache/status",
+      "name": "get_cache_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._cache_basic_routes",
+      "endpoint_name": "get_cache_status"
+    },
+    {
+      "index": 200,
+      "path": "/api/cache/{symbol}/{data_type}",
+      "name": "get_cached_data",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._cache_basic_routes",
+      "endpoint_name": "get_cached_data"
+    },
+    {
+      "index": 201,
+      "path": "/api/cache/{symbol}/{data_type}",
+      "name": "write_cache_data",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._cache_basic_routes",
+      "endpoint_name": "write_cache_data"
+    },
+    {
+      "index": 202,
+      "path": "/api/cache/{symbol}",
+      "name": "invalidate_symbol_cache",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._cache_basic_routes",
+      "endpoint_name": "invalidate_symbol_cache"
+    },
+    {
+      "index": 203,
+      "path": "/api/cache/{symbol}/{data_type}/fresh",
+      "name": "check_cache_freshness",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._cache_basic_routes",
+      "endpoint_name": "check_cache_freshness"
+    },
+    {
+      "index": 204,
+      "path": "/api/cache/evict/manual",
+      "name": "manual_cache_eviction",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._cache_eviction_routes",
+      "endpoint_name": "manual_cache_eviction"
+    },
+    {
+      "index": 205,
+      "path": "/api/cache/eviction/stats",
+      "name": "get_eviction_statistics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._cache_eviction_routes",
+      "endpoint_name": "get_eviction_statistics"
+    },
+    {
+      "index": 206,
+      "path": "/api/cache/prewarming/trigger",
+      "name": "trigger_cache_prewarming",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._cache_prewarming_routes",
+      "endpoint_name": "trigger_cache_prewarming"
+    },
+    {
+      "index": 207,
+      "path": "/api/cache/prewarming/status",
+      "name": "get_prewarming_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._cache_prewarming_routes",
+      "endpoint_name": "get_prewarming_status"
+    },
+    {
+      "index": 208,
+      "path": "/api/cache/monitoring/metrics",
+      "name": "get_cache_monitoring_metrics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._cache_prewarming_routes",
+      "endpoint_name": "get_cache_monitoring_metrics"
+    },
+    {
+      "index": 209,
+      "path": "/api/cache/monitoring/health",
+      "name": "get_cache_health_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._cache_prewarming_routes",
+      "endpoint_name": "get_cache_health_status"
+    },
+    {
+      "index": 210,
+      "path": "/api/ml/tdx/data",
+      "name": "get_tdx_data",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.ml",
+      "endpoint_name": "get_tdx_data"
+    },
+    {
+      "index": 211,
+      "path": "/api/ml/tdx/stocks/{market}",
+      "name": "list_tdx_stocks",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.ml",
+      "endpoint_name": "list_tdx_stocks"
+    },
+    {
+      "index": 212,
+      "path": "/api/ml/features/generate",
+      "name": "generate_features",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.ml",
+      "endpoint_name": "generate_features"
+    },
+    {
+      "index": 213,
+      "path": "/api/ml/models/train",
+      "name": "train_model",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.ml",
+      "endpoint_name": "train_model"
+    },
+    {
+      "index": 214,
+      "path": "/api/ml/models/predict",
+      "name": "predict_with_model",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.ml",
+      "endpoint_name": "predict_with_model"
+    },
+    {
+      "index": 215,
+      "path": "/api/ml/models",
+      "name": "list_models",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.ml",
+      "endpoint_name": "list_models"
+    },
+    {
+      "index": 216,
+      "path": "/api/ml/models/{model_name}",
+      "name": "get_model_detail",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.ml",
+      "endpoint_name": "get_model_detail"
+    },
+    {
+      "index": 217,
+      "path": "/api/ml/models/hyperparameter-search",
+      "name": "hyperparameter_search",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.ml",
+      "endpoint_name": "hyperparameter_search"
+    },
+    {
+      "index": 218,
+      "path": "/api/ml/models/evaluate",
+      "name": "evaluate_model",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.ml",
+      "endpoint_name": "evaluate_model"
+    },
+    {
+      "index": 219,
+      "path": "/api/ws/market",
+      "name": "websocket_market",
+      "methods": [],
+      "include_in_schema": false,
+      "endpoint_module": "app.api.realtime_market",
+      "endpoint_name": "websocket_market"
+    },
+    {
+      "index": 220,
+      "path": "/api/ws/portfolio",
+      "name": "websocket_portfolio",
+      "methods": [],
+      "include_in_schema": false,
+      "endpoint_module": "app.api.realtime_market",
+      "endpoint_name": "websocket_portfolio"
+    },
+    {
+      "index": 221,
+      "path": "/api/api/realtime/quote/{symbol}",
+      "name": "get_realtime_quote",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.realtime_market",
+      "endpoint_name": "get_realtime_quote"
+    },
+    {
+      "index": 222,
+      "path": "/api/api/realtime/quotes",
+      "name": "get_realtime_quotes",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.realtime_market",
+      "endpoint_name": "get_realtime_quotes"
+    },
+    {
+      "index": 223,
+      "path": "/api/api/mtm/portfolio/{portfolio_id}",
+      "name": "get_portfolio_mtm",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.realtime_market",
+      "endpoint_name": "get_portfolio_mtm"
+    },
+    {
+      "index": 224,
+      "path": "/api/api/mtm/position/{position_id}",
+      "name": "get_position_mtm",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.realtime_market",
+      "endpoint_name": "get_position_mtm"
+    },
+    {
+      "index": 225,
+      "path": "/api/api/mtm/stats",
+      "name": "get_mtm_stats",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.realtime_market",
+      "endpoint_name": "get_mtm_stats"
+    },
+    {
+      "index": 226,
+      "path": "/api/signals/history",
+      "name": "get_signal_history",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.signal_monitoring.signal_history_response",
+      "endpoint_name": "get_signal_history"
+    },
+    {
+      "index": 227,
+      "path": "/api/signals/quality-report",
+      "name": "get_signal_quality_report",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.signal_monitoring.signal_history_response",
+      "endpoint_name": "get_signal_quality_report"
+    },
+    {
+      "index": 228,
+      "path": "/api/strategies/{strategy_id}/realtime",
+      "name": "get_strategy_realtime_monitoring",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.signal_monitoring.signal_history_response",
+      "endpoint_name": "get_strategy_realtime_monitoring"
+    },
+    {
+      "index": 229,
+      "path": "/api/signals/health",
+      "name": "health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.signal_monitoring.signal_history_response",
+      "endpoint_name": "health_check"
+    },
+    {
+      "index": 230,
+      "path": "/api/announcement/health",
+      "name": "health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.announcement.routes",
+      "endpoint_name": "health_check"
+    },
+    {
+      "index": 231,
+      "path": "/api/announcement/status",
+      "name": "get_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.announcement.routes",
+      "endpoint_name": "get_status"
+    },
+    {
+      "index": 232,
+      "path": "/api/announcement/analyze",
+      "name": "analyze_data",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.announcement.routes",
+      "endpoint_name": "analyze_data"
+    },
+    {
+      "index": 233,
+      "path": "/api/announcement/fetch",
+      "name": "fetch_announcements",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.announcement.routes",
+      "endpoint_name": "fetch_announcements"
+    },
+    {
+      "index": 234,
+      "path": "/api/announcement/list",
+      "name": "get_announcements",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.announcement.routes",
+      "endpoint_name": "get_announcements"
+    },
+    {
+      "index": 235,
+      "path": "/api/announcement/today",
+      "name": "get_today_announcements",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.announcement.routes",
+      "endpoint_name": "get_today_announcements"
+    },
+    {
+      "index": 236,
+      "path": "/api/announcement/important",
+      "name": "get_important_announcements",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.announcement.routes",
+      "endpoint_name": "get_important_announcements"
+    },
+    {
+      "index": 237,
+      "path": "/api/announcement/stats",
+      "name": "get_announcement_stats",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.announcement.routes",
+      "endpoint_name": "get_announcement_stats"
+    },
+    {
+      "index": 238,
+      "path": "/api/announcement/monitor-rules",
+      "name": "get_monitor_rules",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.announcement.routes",
+      "endpoint_name": "get_monitor_rules"
+    },
+    {
+      "index": 239,
+      "path": "/api/announcement/monitor-rules",
+      "name": "create_monitor_rule",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.announcement.routes",
+      "endpoint_name": "create_monitor_rule"
+    },
+    {
+      "index": 240,
+      "path": "/api/announcement/monitor-rules/{rule_id}",
+      "name": "update_monitor_rule",
+      "methods": [
+        "PUT"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.announcement.routes",
+      "endpoint_name": "update_monitor_rule"
+    },
+    {
+      "index": 241,
+      "path": "/api/announcement/monitor-rules/{rule_id}",
+      "name": "delete_monitor_rule",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.announcement.routes",
+      "endpoint_name": "delete_monitor_rule"
+    },
+    {
+      "index": 242,
+      "path": "/api/announcement/triggered-records",
+      "name": "get_triggered_records",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.announcement.routes",
+      "endpoint_name": "get_triggered_records"
+    },
+    {
+      "index": 243,
+      "path": "/api/announcement/monitor/evaluate",
+      "name": "evaluate_monitor_rules",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.announcement.routes",
+      "endpoint_name": "evaluate_monitor_rules"
+    },
+    {
+      "index": 244,
+      "path": "/api/health/services",
+      "name": "check_system_health",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.health",
+      "endpoint_name": "check_system_health"
+    },
+    {
+      "index": 245,
+      "path": "/api/health/detailed",
+      "name": "detailed_health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.health",
+      "endpoint_name": "detailed_health_check"
+    },
+    {
+      "index": 246,
+      "path": "/api/reports/health/{timestamp}",
+      "name": "get_health_report",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.health",
+      "endpoint_name": "get_health_report"
+    },
+    {
+      "index": 247,
+      "path": "/ws/events",
+      "name": "websocket_events",
+      "methods": [],
+      "include_in_schema": false,
+      "endpoint_module": "app.api.websocket",
+      "endpoint_name": "websocket_events"
+    },
+    {
+      "index": 248,
+      "path": "/ws/stats",
+      "name": "get_websocket_stats",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.websocket",
+      "endpoint_name": "get_websocket_stats"
+    },
+    {
+      "index": 249,
+      "path": "/ws/channels",
+      "name": "list_channels",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.websocket",
+      "endpoint_name": "list_channels"
+    },
+    {
+      "index": 250,
+      "path": "/api/tasks/register",
+      "name": "register_task",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "register_task"
+    },
+    {
+      "index": 251,
+      "path": "/api/tasks/{task_id}",
+      "name": "unregister_task",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "unregister_task"
+    },
+    {
+      "index": 252,
+      "path": "/api/tasks/",
+      "name": "list_tasks",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "list_tasks"
+    },
+    {
+      "index": 253,
+      "path": "/api/tasks/{task_id}",
+      "name": "get_task",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "get_task"
+    },
+    {
+      "index": 254,
+      "path": "/api/tasks/{task_id}/start",
+      "name": "start_task",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "start_task"
+    },
+    {
+      "index": 255,
+      "path": "/api/tasks/{task_id}/stop",
+      "name": "stop_task",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "stop_task"
+    },
+    {
+      "index": 256,
+      "path": "/api/tasks/executions/",
+      "name": "list_task_executions",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "list_task_executions"
+    },
+    {
+      "index": 257,
+      "path": "/api/tasks/executions/{execution_id}",
+      "name": "get_execution",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "get_execution"
+    },
+    {
+      "index": 258,
+      "path": "/api/tasks/statistics/",
+      "name": "get_task_statistics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "get_task_statistics"
+    },
+    {
+      "index": 259,
+      "path": "/api/tasks/import",
+      "name": "import_config",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "import_config"
+    },
+    {
+      "index": 260,
+      "path": "/api/tasks/export",
+      "name": "export_config",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "export_config"
+    },
+    {
+      "index": 261,
+      "path": "/api/tasks/executions/cleanup",
+      "name": "cleanup_executions",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "cleanup_executions"
+    },
+    {
+      "index": 262,
+      "path": "/api/tasks/health",
+      "name": "tasks_health",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "tasks_health"
+    },
+    {
+      "index": 263,
+      "path": "/api/tasks/audit/logs",
+      "name": "get_audit_logs",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "get_audit_logs"
+    },
+    {
+      "index": 264,
+      "path": "/api/tasks/cleanup/audit",
+      "name": "cleanup_audit_logs",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tasks",
+      "endpoint_name": "cleanup_audit_logs"
+    },
+    {
+      "index": 265,
+      "path": "/api/market/wencai/queries",
+      "name": "get_all_queries",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.wencai",
+      "endpoint_name": "get_all_queries"
+    },
+    {
+      "index": 266,
+      "path": "/api/market/wencai/queries/{query_name}",
+      "name": "get_query_by_name",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.wencai",
+      "endpoint_name": "get_query_by_name"
+    },
+    {
+      "index": 267,
+      "path": "/api/market/wencai/query",
+      "name": "execute_query",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.wencai",
+      "endpoint_name": "execute_query"
+    },
+    {
+      "index": 268,
+      "path": "/api/market/wencai/results/{query_name}",
+      "name": "get_query_results",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.wencai",
+      "endpoint_name": "get_query_results"
+    },
+    {
+      "index": 269,
+      "path": "/api/market/wencai/refresh/{query_name}",
+      "name": "refresh_query",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.wencai",
+      "endpoint_name": "refresh_query"
+    },
+    {
+      "index": 270,
+      "path": "/api/market/wencai/history/{query_name}",
+      "name": "get_query_history",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.wencai",
+      "endpoint_name": "get_query_history"
+    },
+    {
+      "index": 271,
+      "path": "/api/market/wencai/custom-query",
+      "name": "execute_custom_query",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.wencai",
+      "endpoint_name": "execute_custom_query"
+    },
+    {
+      "index": 272,
+      "path": "/api/market/wencai/health",
+      "name": "health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.wencai",
+      "endpoint_name": "health_check"
+    },
+    {
+      "index": 273,
+      "path": "/api/dashboard/summary",
+      "name": "get_dashboard_summary",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.dashboard",
+      "endpoint_name": "get_dashboard_summary"
+    },
+    {
+      "index": 274,
+      "path": "/api/dashboard/market-overview",
+      "name": "get_market_overview",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.dashboard",
+      "endpoint_name": "get_market_overview"
+    },
+    {
+      "index": 275,
+      "path": "/api/dashboard/health",
+      "name": "health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.dashboard",
+      "endpoint_name": "health_check"
+    },
+    {
+      "index": 276,
+      "path": "/api/strategy-mgmt/strategies",
+      "name": "create_strategy",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_mgmt",
+      "endpoint_name": "create_strategy"
+    },
+    {
+      "index": 277,
+      "path": "/api/strategy-mgmt/strategies",
+      "name": "list_strategies",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_mgmt",
+      "endpoint_name": "list_strategies"
+    },
+    {
+      "index": 278,
+      "path": "/api/strategy-mgmt/strategies/{strategy_id}",
+      "name": "get_strategy",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_mgmt",
+      "endpoint_name": "get_strategy"
+    },
+    {
+      "index": 279,
+      "path": "/api/strategy-mgmt/strategies/{strategy_id}",
+      "name": "update_strategy",
+      "methods": [
+        "PUT"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_mgmt",
+      "endpoint_name": "update_strategy"
+    },
+    {
+      "index": 280,
+      "path": "/api/strategy-mgmt/strategies/{strategy_id}",
+      "name": "delete_strategy",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_mgmt",
+      "endpoint_name": "delete_strategy"
+    },
+    {
+      "index": 281,
+      "path": "/api/strategy-mgmt/backtest/execute",
+      "name": "execute_backtest",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_mgmt",
+      "endpoint_name": "execute_backtest"
+    },
+    {
+      "index": 282,
+      "path": "/api/strategy-mgmt/backtest/results/{backtest_id}",
+      "name": "get_backtest_result",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_mgmt",
+      "endpoint_name": "get_backtest_result"
+    },
+    {
+      "index": 283,
+      "path": "/api/strategy-mgmt/backtest/results",
+      "name": "list_backtests",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_mgmt",
+      "endpoint_name": "list_backtests"
+    },
+    {
+      "index": 284,
+      "path": "/api/strategy-mgmt/health",
+      "name": "health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_mgmt",
+      "endpoint_name": "health_check"
+    },
+    {
+      "index": 285,
+      "path": "/api/strategy-mgmt/backtest/status/{backtest_id}",
+      "name": "get_backtest_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_mgmt",
+      "endpoint_name": "get_backtest_status"
+    },
+    {
+      "index": 286,
+      "path": "/api/strategy-mgmt/{path:path}",
+      "name": "redirect_to_canonical",
+      "methods": [
+        "DELETE",
+        "GET",
+        "PATCH",
+        "POST",
+        "PUT"
+      ],
+      "include_in_schema": false,
+      "endpoint_module": "app.api._strategy_mgmt_compat",
+      "endpoint_name": "redirect_to_canonical"
+    },
+    {
+      "index": 287,
+      "path": "/api/multi-source/health",
+      "name": "health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.multi_source.routes",
+      "endpoint_name": "health_check"
+    },
+    {
+      "index": 288,
+      "path": "/api/multi-source/status",
+      "name": "get_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.multi_source.routes",
+      "endpoint_name": "get_status"
+    },
+    {
+      "index": 289,
+      "path": "/api/multi-source/analyze",
+      "name": "analyze_data",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.multi_source.routes",
+      "endpoint_name": "analyze_data"
+    },
+    {
+      "index": 290,
+      "path": "/api/stock-search/search",
+      "name": "search_stocks",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.stock_search.stock_search_result",
+      "endpoint_name": "search_stocks"
+    },
+    {
+      "index": 291,
+      "path": "/api/stock-search/quote/{symbol}",
+      "name": "get_stock_quote",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.stock_search.stock_search_result",
+      "endpoint_name": "get_stock_quote"
+    },
+    {
+      "index": 292,
+      "path": "/api/stock-search/profile/{symbol}",
+      "name": "get_company_profile",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.stock_search.stock_search_result",
+      "endpoint_name": "get_company_profile"
+    },
+    {
+      "index": 293,
+      "path": "/api/stock-search/news/{symbol}",
+      "name": "get_stock_news",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.stock_search.stock_search_result",
+      "endpoint_name": "get_stock_news"
+    },
+    {
+      "index": 294,
+      "path": "/api/stock-search/news/market/{category}",
+      "name": "get_market_news",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.stock_search.stock_search_result",
+      "endpoint_name": "get_market_news"
+    },
+    {
+      "index": 295,
+      "path": "/api/stock-search/recommendation/{symbol}",
+      "name": "get_recommendation_trends",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.stock_search.stock_search_result",
+      "endpoint_name": "get_recommendation_trends"
+    },
+    {
+      "index": 296,
+      "path": "/api/stock-search/cache/clear",
+      "name": "clear_search_cache",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.stock_search.stock_search_result",
+      "endpoint_name": "clear_search_cache"
+    },
+    {
+      "index": 297,
+      "path": "/api/stock-search/analytics/searches",
+      "name": "get_search_analytics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.stock_search.stock_search_result",
+      "endpoint_name": "get_search_analytics"
+    },
+    {
+      "index": 298,
+      "path": "/api/stock-search/analytics/cleanup",
+      "name": "cleanup_search_analytics",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.stock_search.stock_search_result",
+      "endpoint_name": "cleanup_search_analytics"
+    },
+    {
+      "index": 299,
+      "path": "/api/stock-search/rate-limits/status",
+      "name": "get_rate_limits_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.stock_search.get_rate_limits_status",
+      "endpoint_name": "get_rate_limits_status"
+    },
+    {
+      "index": 300,
+      "path": "/api/watchlist/",
+      "name": "get_my_watchlist",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "get_my_watchlist"
+    },
+    {
+      "index": 301,
+      "path": "/api/watchlist/symbols",
+      "name": "get_my_watchlist_symbols",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "get_my_watchlist_symbols"
+    },
+    {
+      "index": 302,
+      "path": "/api/watchlist/add",
+      "name": "add_to_watchlist",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "add_to_watchlist"
+    },
+    {
+      "index": 303,
+      "path": "/api/watchlist/remove/{symbol}",
+      "name": "remove_from_watchlist",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "remove_from_watchlist"
+    },
+    {
+      "index": 304,
+      "path": "/api/watchlist/check/{symbol}",
+      "name": "check_in_watchlist",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "check_in_watchlist"
+    },
+    {
+      "index": 305,
+      "path": "/api/watchlist/notes/{symbol}",
+      "name": "update_watchlist_notes",
+      "methods": [
+        "PUT"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "update_watchlist_notes"
+    },
+    {
+      "index": 306,
+      "path": "/api/watchlist/count",
+      "name": "get_watchlist_count",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "get_watchlist_count"
+    },
+    {
+      "index": 307,
+      "path": "/api/watchlist/clear",
+      "name": "clear_watchlist",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "clear_watchlist"
+    },
+    {
+      "index": 308,
+      "path": "/api/watchlist/groups",
+      "name": "get_user_groups",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "get_user_groups"
+    },
+    {
+      "index": 309,
+      "path": "/api/watchlist/groups",
+      "name": "create_group",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "create_group"
+    },
+    {
+      "index": 310,
+      "path": "/api/watchlist/groups/{group_id}",
+      "name": "update_group",
+      "methods": [
+        "PUT"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "update_group"
+    },
+    {
+      "index": 311,
+      "path": "/api/watchlist/groups/{group_id}",
+      "name": "delete_group",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "delete_group"
+    },
+    {
+      "index": 312,
+      "path": "/api/watchlist/group/{group_id}",
+      "name": "get_watchlist_by_group",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "get_watchlist_by_group"
+    },
+    {
+      "index": 313,
+      "path": "/api/watchlist/move",
+      "name": "move_stock_to_group",
+      "methods": [
+        "PUT"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "move_stock_to_group"
+    },
+    {
+      "index": 314,
+      "path": "/api/watchlist/with-groups",
+      "name": "get_watchlist_with_groups",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.watchlist",
+      "endpoint_name": "get_watchlist_with_groups"
+    },
+    {
+      "index": 315,
+      "path": "/api/tradingview/chart/config",
+      "name": "get_chart_config",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tradingview",
+      "endpoint_name": "get_chart_config"
+    },
+    {
+      "index": 316,
+      "path": "/api/tradingview/mini-chart/config",
+      "name": "get_mini_chart_config",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tradingview",
+      "endpoint_name": "get_mini_chart_config"
+    },
+    {
+      "index": 317,
+      "path": "/api/tradingview/ticker-tape/config",
+      "name": "get_ticker_tape_config",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tradingview",
+      "endpoint_name": "get_ticker_tape_config"
+    },
+    {
+      "index": 318,
+      "path": "/api/tradingview/market-overview/config",
+      "name": "get_market_overview_config",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tradingview",
+      "endpoint_name": "get_market_overview_config"
+    },
+    {
+      "index": 319,
+      "path": "/api/tradingview/screener/config",
+      "name": "get_screener_config",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tradingview",
+      "endpoint_name": "get_screener_config"
+    },
+    {
+      "index": 320,
+      "path": "/api/tradingview/symbol/convert",
+      "name": "convert_symbol",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.tradingview",
+      "endpoint_name": "convert_symbol"
+    },
+    {
+      "index": 321,
+      "path": "/api/notification/status",
+      "name": "get_email_service_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.notification",
+      "endpoint_name": "get_email_service_status"
+    },
+    {
+      "index": 322,
+      "path": "/api/notification/email/send",
+      "name": "send_email",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.notification",
+      "endpoint_name": "send_email"
+    },
+    {
+      "index": 323,
+      "path": "/api/notification/ws/notifications",
+      "name": "websocket_notifications",
+      "methods": [],
+      "include_in_schema": false,
+      "endpoint_module": "app.api.notification",
+      "endpoint_name": "websocket_notifications"
+    },
+    {
+      "index": 324,
+      "path": "/api/notification/email/welcome",
+      "name": "send_welcome_email",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.notification",
+      "endpoint_name": "send_welcome_email"
+    },
+    {
+      "index": 325,
+      "path": "/api/notification/email/newsletter",
+      "name": "send_daily_newsletter",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.notification",
+      "endpoint_name": "send_daily_newsletter"
+    },
+    {
+      "index": 326,
+      "path": "/api/notification/email/price-alert",
+      "name": "send_price_alert",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.notification",
+      "endpoint_name": "send_price_alert"
+    },
+    {
+      "index": 327,
+      "path": "/api/notification/test-email",
+      "name": "send_test_email",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.notification",
+      "endpoint_name": "send_test_email"
+    },
+    {
+      "index": 328,
+      "path": "/api/notification/preferences",
+      "name": "get_notification_preferences",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.notification",
+      "endpoint_name": "get_notification_preferences"
+    },
+    {
+      "index": 329,
+      "path": "/api/notification/preferences",
+      "name": "update_notification_preferences",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.notification",
+      "endpoint_name": "update_notification_preferences"
+    },
+    {
+      "index": 330,
+      "path": "/api/v1/monitoring/watchlists",
+      "name": "create_watchlist",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_watchlists",
+      "endpoint_name": "create_watchlist"
+    },
+    {
+      "index": 331,
+      "path": "/api/v1/monitoring/watchlists",
+      "name": "list_watchlists",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_watchlists",
+      "endpoint_name": "list_watchlists"
+    },
+    {
+      "index": 332,
+      "path": "/api/v1/monitoring/watchlists/{watchlist_id}",
+      "name": "get_watchlist",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_watchlists",
+      "endpoint_name": "get_watchlist"
+    },
+    {
+      "index": 333,
+      "path": "/api/v1/monitoring/watchlists/{watchlist_id}",
+      "name": "update_watchlist",
+      "methods": [
+        "PUT"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_watchlists",
+      "endpoint_name": "update_watchlist"
+    },
+    {
+      "index": 334,
+      "path": "/api/v1/monitoring/watchlists/{watchlist_id}",
+      "name": "delete_watchlist",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_watchlists",
+      "endpoint_name": "delete_watchlist"
+    },
+    {
+      "index": 335,
+      "path": "/api/v1/monitoring/watchlists/{watchlist_id}/stocks",
+      "name": "add_stock_to_watchlist",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_watchlists",
+      "endpoint_name": "add_stock_to_watchlist"
+    },
+    {
+      "index": 336,
+      "path": "/api/v1/monitoring/watchlists/{watchlist_id}/stocks",
+      "name": "list_watchlist_stocks",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_watchlists",
+      "endpoint_name": "list_watchlist_stocks"
+    },
+    {
+      "index": 337,
+      "path": "/api/v1/monitoring/watchlists/{watchlist_id}/stocks/{stock_code}",
+      "name": "remove_stock_from_watchlist",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_watchlists",
+      "endpoint_name": "remove_stock_from_watchlist"
+    },
+    {
+      "index": 338,
+      "path": "/api/v1/monitoring/analysis/portfolio/{watchlist_id}/summary",
+      "name": "get_portfolio_summary",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._monitoring_portfolio_router",
+      "endpoint_name": "get_portfolio_summary"
+    },
+    {
+      "index": 339,
+      "path": "/api/v1/monitoring/analysis/portfolio/{watchlist_id}/alerts",
+      "name": "get_portfolio_alerts",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._monitoring_portfolio_router",
+      "endpoint_name": "get_portfolio_alerts"
+    },
+    {
+      "index": 340,
+      "path": "/api/v1/monitoring/analysis/portfolio/{watchlist_id}/rebalance",
+      "name": "get_rebalance_suggestions",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api._monitoring_portfolio_router",
+      "endpoint_name": "get_rebalance_suggestions"
+    },
+    {
+      "index": 341,
+      "path": "/api/v1/monitoring/analysis/calculate",
+      "name": "calculate_health_score",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_analysis",
+      "endpoint_name": "calculate_health_score"
+    },
+    {
+      "index": 342,
+      "path": "/api/v1/monitoring/analysis/calculate/batch",
+      "name": "batch_calculate_health_scores",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_analysis",
+      "endpoint_name": "batch_calculate_health_scores"
+    },
+    {
+      "index": 343,
+      "path": "/api/v1/monitoring/analysis/results/{stock_code}",
+      "name": "get_health_score_history",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_analysis",
+      "endpoint_name": "get_health_score_history"
+    },
+    {
+      "index": 344,
+      "path": "/api/v1/monitoring/analysis/portfolio/{watchlist_id}",
+      "name": "analyze_portfolio",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_analysis",
+      "endpoint_name": "analyze_portfolio"
+    },
+    {
+      "index": 345,
+      "path": "/api/v1/monitoring/analysis/market-regime",
+      "name": "identify_market_regime",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_analysis",
+      "endpoint_name": "identify_market_regime"
+    },
+    {
+      "index": 346,
+      "path": "/api/v1/monitoring/analysis/engine/status",
+      "name": "get_engine_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.monitoring_analysis",
+      "endpoint_name": "get_engine_status"
+    },
+    {
+      "index": 347,
+      "path": "/api/v1/strategy/strategies",
+      "name": "list_strategies",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_crud_router",
+      "endpoint_name": "list_strategies"
+    },
+    {
+      "index": 348,
+      "path": "/api/v1/strategy/strategies",
+      "name": "create_strategy",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_crud_router",
+      "endpoint_name": "create_strategy"
+    },
+    {
+      "index": 349,
+      "path": "/api/v1/strategy/strategies/{strategy_id}",
+      "name": "get_strategy",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_crud_router",
+      "endpoint_name": "get_strategy"
+    },
+    {
+      "index": 350,
+      "path": "/api/v1/strategy/strategies/{strategy_id}",
+      "name": "update_strategy",
+      "methods": [
+        "PUT"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_crud_router",
+      "endpoint_name": "update_strategy"
+    },
+    {
+      "index": 351,
+      "path": "/api/v1/strategy/strategies/{strategy_id}",
+      "name": "delete_strategy",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_crud_router",
+      "endpoint_name": "delete_strategy"
+    },
+    {
+      "index": 352,
+      "path": "/api/v1/strategy/{strategy_id}/start",
+      "name": "start_strategy",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_crud_router",
+      "endpoint_name": "start_strategy"
+    },
+    {
+      "index": 353,
+      "path": "/api/v1/strategy/{strategy_id}/pause",
+      "name": "pause_strategy",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_crud_router",
+      "endpoint_name": "pause_strategy"
+    },
+    {
+      "index": 354,
+      "path": "/api/v1/strategy/{strategy_id}/resume",
+      "name": "resume_strategy",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_crud_router",
+      "endpoint_name": "resume_strategy"
+    },
+    {
+      "index": 355,
+      "path": "/api/v1/strategy/{strategy_id}/stop",
+      "name": "stop_strategy",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_crud_router",
+      "endpoint_name": "stop_strategy"
+    },
+    {
+      "index": 356,
+      "path": "/api/v1/strategy/models/train",
+      "name": "train_model",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._model_backtest_router",
+      "endpoint_name": "train_model"
+    },
+    {
+      "index": 357,
+      "path": "/api/v1/strategy/models/training/{task_id}/status",
+      "name": "get_training_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._model_backtest_router",
+      "endpoint_name": "get_training_status"
+    },
+    {
+      "index": 358,
+      "path": "/api/v1/strategy/models",
+      "name": "list_models",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._model_backtest_router",
+      "endpoint_name": "list_models"
+    },
+    {
+      "index": 359,
+      "path": "/api/v1/strategy/backtest/run",
+      "name": "run_backtest",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._model_backtest_router",
+      "endpoint_name": "run_backtest"
+    },
+    {
+      "index": 360,
+      "path": "/api/v1/strategy/backtest/results",
+      "name": "list_backtest_results",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._model_backtest_router",
+      "endpoint_name": "list_backtest_results"
+    },
+    {
+      "index": 361,
+      "path": "/api/v1/strategy/backtest/results/{backtest_id}",
+      "name": "get_backtest_result",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._model_backtest_router",
+      "endpoint_name": "get_backtest_result"
+    },
+    {
+      "index": 362,
+      "path": "/api/v1/strategy/backtest/status/{backtest_id}",
+      "name": "get_backtest_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._model_backtest_router",
+      "endpoint_name": "get_backtest_status"
+    },
+    {
+      "index": 363,
+      "path": "/api/v1/strategy/definitions",
+      "name": "get_strategy_definitions",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_execution_router",
+      "endpoint_name": "get_strategy_definitions"
+    },
+    {
+      "index": 364,
+      "path": "/api/v1/strategy/run/single",
+      "name": "run_strategy_single",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_execution_router",
+      "endpoint_name": "run_strategy_single"
+    },
+    {
+      "index": 365,
+      "path": "/api/v1/strategy/run/batch",
+      "name": "run_strategy_batch",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_execution_router",
+      "endpoint_name": "run_strategy_batch"
+    },
+    {
+      "index": 366,
+      "path": "/api/v1/strategy/results",
+      "name": "query_strategy_results",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_execution_router",
+      "endpoint_name": "query_strategy_results"
+    },
+    {
+      "index": 367,
+      "path": "/api/v1/strategy/matched-stocks",
+      "name": "get_matched_stocks",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_execution_router",
+      "endpoint_name": "get_matched_stocks"
+    },
+    {
+      "index": 368,
+      "path": "/api/v1/strategy/stats/summary",
+      "name": "get_strategy_summary",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._strategy_execution_router",
+      "endpoint_name": "get_strategy_summary"
+    },
+    {
+      "index": 369,
+      "path": "/api/v1/strategy/backtest/results/{backtest_id}/chart-data",
+      "name": "get_backtest_chart_data",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.strategy_management._chart_data_router",
+      "endpoint_name": "get_backtest_chart_data"
+    },
+    {
+      "index": 370,
+      "path": "/api/v1/risk/var-cvar",
+      "name": "calculate_var_cvar",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.metrics",
+      "endpoint_name": "calculate_var_cvar"
+    },
+    {
+      "index": 371,
+      "path": "/api/v1/risk/beta",
+      "name": "calculate_beta",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.metrics",
+      "endpoint_name": "calculate_beta"
+    },
+    {
+      "index": 372,
+      "path": "/api/v1/risk/dashboard",
+      "name": "get_risk_dashboard",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.metrics",
+      "endpoint_name": "get_risk_dashboard"
+    },
+    {
+      "index": 373,
+      "path": "/api/v1/risk/metrics/history",
+      "name": "get_risk_metrics_history",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.metrics",
+      "endpoint_name": "get_risk_metrics_history"
+    },
+    {
+      "index": 374,
+      "path": "/api/v1/risk/metrics/calculate",
+      "name": "calculate_risk_metrics",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.metrics",
+      "endpoint_name": "calculate_risk_metrics"
+    },
+    {
+      "index": 375,
+      "path": "/api/v1/risk/position/assess",
+      "name": "assess_position_risk",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.metrics",
+      "endpoint_name": "assess_position_risk"
+    },
+    {
+      "index": 376,
+      "path": "/api/v1/risk/v31/stop-loss/add-position",
+      "name": "add_stop_loss_position",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.stop_loss",
+      "endpoint_name": "add_stop_loss_position"
+    },
+    {
+      "index": 377,
+      "path": "/api/v1/risk/v31/stop-loss/update-price",
+      "name": "update_stop_loss_price",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.stop_loss",
+      "endpoint_name": "update_stop_loss_price"
+    },
+    {
+      "index": 378,
+      "path": "/api/v1/risk/v31/stop-loss/remove-position/{position_id}",
+      "name": "remove_stop_loss_position",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.stop_loss",
+      "endpoint_name": "remove_stop_loss_position"
+    },
+    {
+      "index": 379,
+      "path": "/api/v1/risk/v31/stop-loss/status/{position_id}",
+      "name": "get_stop_loss_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.stop_loss",
+      "endpoint_name": "get_stop_loss_status"
+    },
+    {
+      "index": 380,
+      "path": "/api/v1/risk/v31/stop-loss/overview",
+      "name": "get_stop_loss_overview",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.stop_loss",
+      "endpoint_name": "get_stop_loss_overview"
+    },
+    {
+      "index": 381,
+      "path": "/api/v1/risk/v31/stop-loss/batch-update",
+      "name": "batch_update_stop_loss_prices",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.stop_loss",
+      "endpoint_name": "batch_update_stop_loss_prices"
+    },
+    {
+      "index": 382,
+      "path": "/api/v1/risk/v31/stop-loss/history/performance",
+      "name": "get_stop_loss_performance",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.stop_loss",
+      "endpoint_name": "get_stop_loss_performance"
+    },
+    {
+      "index": 383,
+      "path": "/api/v1/risk/v31/stop-loss/history/recommendations",
+      "name": "get_stop_loss_recommendations",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.stop_loss",
+      "endpoint_name": "get_stop_loss_recommendations"
+    },
+    {
+      "index": 384,
+      "path": "/api/v1/risk/v31/stop-loss/calculate",
+      "name": "calculate_stop_loss_v31",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.stop_loss",
+      "endpoint_name": "calculate_stop_loss_v31"
+    },
+    {
+      "index": 385,
+      "path": "/api/v1/risk/v31/stop-loss/trigger",
+      "name": "trigger_stop_loss_v31",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.stop_loss",
+      "endpoint_name": "trigger_stop_loss_v31"
+    },
+    {
+      "index": 386,
+      "path": "/api/v1/risk/v31/alert/send",
+      "name": "send_risk_alert",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "send_risk_alert"
+    },
+    {
+      "index": 387,
+      "path": "/api/v1/risk/v31/alert/statistics",
+      "name": "get_alert_statistics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "get_alert_statistics"
+    },
+    {
+      "index": 388,
+      "path": "/api/v1/risk/v31/rules/evaluate",
+      "name": "evaluate_alert_rules",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "evaluate_alert_rules"
+    },
+    {
+      "index": 389,
+      "path": "/api/v1/risk/v31/rules/add",
+      "name": "add_alert_rule",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "add_alert_rule"
+    },
+    {
+      "index": 390,
+      "path": "/api/v1/risk/v31/rules/remove/{rule_id}",
+      "name": "remove_alert_rule",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "remove_alert_rule"
+    },
+    {
+      "index": 391,
+      "path": "/api/v1/risk/v31/rules/statistics",
+      "name": "get_rule_statistics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "get_rule_statistics"
+    },
+    {
+      "index": 392,
+      "path": "/api/v1/risk/v31/risk/realtime/{symbol}",
+      "name": "get_realtime_risk_metrics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "get_realtime_risk_metrics"
+    },
+    {
+      "index": 393,
+      "path": "/api/v1/risk/alerts",
+      "name": "list_risk_alerts",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "list_risk_alerts"
+    },
+    {
+      "index": 394,
+      "path": "/api/v1/risk/alerts",
+      "name": "create_risk_alert",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "create_risk_alert"
+    },
+    {
+      "index": 395,
+      "path": "/api/v1/risk/alerts/{alert_id}",
+      "name": "update_risk_alert",
+      "methods": [
+        "PUT"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "update_risk_alert"
+    },
+    {
+      "index": 396,
+      "path": "/api/v1/risk/alerts/{alert_id}",
+      "name": "delete_risk_alert",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "delete_risk_alert"
+    },
+    {
+      "index": 397,
+      "path": "/api/v1/risk/notifications/test",
+      "name": "test_notification",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "test_notification"
+    },
+    {
+      "index": 398,
+      "path": "/api/v1/risk/alerts/generate",
+      "name": "generate_risk_alerts",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "generate_risk_alerts"
+    },
+    {
+      "index": 399,
+      "path": "/api/v1/risk/v31/alerts/active",
+      "name": "get_active_alerts_v31",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "get_active_alerts_v31"
+    },
+    {
+      "index": 400,
+      "path": "/api/v1/risk/v31/alerts/{alert_id}/acknowledge",
+      "name": "acknowledge_alert_v31",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.alerts",
+      "endpoint_name": "acknowledge_alert_v31"
+    },
+    {
+      "index": 401,
+      "path": "/api/v1/risk/v31/stock/{symbol}",
+      "name": "get_stock_risk_v31",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.v31",
+      "endpoint_name": "get_stock_risk_v31"
+    },
+    {
+      "index": 402,
+      "path": "/api/v1/risk/v31/portfolio/{portfolio_id}",
+      "name": "get_portfolio_risk_v31",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.v31",
+      "endpoint_name": "get_portfolio_risk_v31"
+    },
+    {
+      "index": 403,
+      "path": "/api/v1/risk/v31/health",
+      "name": "get_risk_management_health",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.v31",
+      "endpoint_name": "get_risk_management_health"
+    },
+    {
+      "index": 404,
+      "path": "/api/v1/risk/v31/ws/risk-updates",
+      "name": "websocket_risk_updates",
+      "methods": [],
+      "include_in_schema": false,
+      "endpoint_module": "app.api.risk.v31",
+      "endpoint_name": "websocket_risk_updates"
+    },
+    {
+      "index": 405,
+      "path": "/api/v1/risk/v31/ws/broadcast/{topic}",
+      "name": "broadcast_risk_update",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.v31",
+      "endpoint_name": "broadcast_risk_update"
+    },
+    {
+      "index": 406,
+      "path": "/api/v1/risk/v31/ws/connections",
+      "name": "get_websocket_connections",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.risk.v31",
+      "endpoint_name": "get_websocket_connections"
+    },
+    {
+      "index": 407,
+      "path": "/api/v1/sse/training",
+      "name": "sse_training_stream",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.sse_endpoints",
+      "endpoint_name": "sse_training_stream"
+    },
+    {
+      "index": 408,
+      "path": "/api/v1/sse/backtest",
+      "name": "sse_backtest_stream",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.sse_endpoints",
+      "endpoint_name": "sse_backtest_stream"
+    },
+    {
+      "index": 409,
+      "path": "/api/v1/sse/alerts",
+      "name": "sse_alerts_stream",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.sse_endpoints",
+      "endpoint_name": "sse_alerts_stream"
+    },
+    {
+      "index": 410,
+      "path": "/api/v1/sse/dashboard",
+      "name": "sse_dashboard_stream",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.sse_endpoints",
+      "endpoint_name": "sse_dashboard_stream"
+    },
+    {
+      "index": 411,
+      "path": "/api/v1/sse/status",
+      "name": "sse_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.sse_endpoints",
+      "endpoint_name": "sse_status"
+    },
+    {
+      "index": 412,
+      "path": "/api/analysis/industry/list",
+      "name": "get_industry_list",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.industry_concept_analysis",
+      "endpoint_name": "get_industry_list"
+    },
+    {
+      "index": 413,
+      "path": "/api/analysis/concept/list",
+      "name": "get_concept_list",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.industry_concept_analysis",
+      "endpoint_name": "get_concept_list"
+    },
+    {
+      "index": 414,
+      "path": "/api/analysis/industry/stocks",
+      "name": "get_industry_stocks",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.industry_concept_analysis",
+      "endpoint_name": "get_industry_stocks"
+    },
+    {
+      "index": 415,
+      "path": "/api/analysis/concept/stocks",
+      "name": "get_concept_stocks",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.industry_concept_analysis",
+      "endpoint_name": "get_concept_stocks"
+    },
+    {
+      "index": 416,
+      "path": "/api/analysis/industry/performance",
+      "name": "get_industry_performance",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.industry_concept_analysis",
+      "endpoint_name": "get_industry_performance"
+    },
+    {
+      "index": 417,
+      "path": "/api/v1/health/database",
+      "name": "get_database_health",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.system.health",
+      "endpoint_name": "get_database_health"
+    },
+    {
+      "index": 418,
+      "path": "/api/v1/health/classification/stats",
+      "name": "get_data_classification_stats",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.system.health",
+      "endpoint_name": "get_data_classification_stats"
+    },
+    {
+      "index": 419,
+      "path": "/api/v1/system/resources",
+      "name": "get_system_resource_metrics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.system.resources",
+      "endpoint_name": "get_system_resource_metrics"
+    },
+    {
+      "index": 420,
+      "path": "/api/v1/data/route",
+      "name": "get_data_route",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.system.routing",
+      "endpoint_name": "get_data_route"
+    },
+    {
+      "index": 421,
+      "path": "/api/v1/system/settings/general",
+      "name": "get_general_settings",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.system.settings",
+      "endpoint_name": "get_general_settings"
+    },
+    {
+      "index": 422,
+      "path": "/api/v1/system/settings/general",
+      "name": "update_general_settings",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.system.settings",
+      "endpoint_name": "update_general_settings"
+    },
+    {
+      "index": 423,
+      "path": "/api/v1/system/settings/security",
+      "name": "get_security_settings",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.system.settings",
+      "endpoint_name": "get_security_settings"
+    },
+    {
+      "index": 424,
+      "path": "/api/v1/system/settings/security",
+      "name": "update_security_settings",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.system.settings",
+      "endpoint_name": "update_security_settings"
+    },
+    {
+      "index": 425,
+      "path": "/api/v1/strategies/batch-analysis/runtime-status",
+      "name": "get_batch_analysis_runtime_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.strategy.batch_analysis",
+      "endpoint_name": "get_batch_analysis_runtime_status"
+    },
+    {
+      "index": 426,
+      "path": "/api/v1/strategies/batch-analysis/submit",
+      "name": "submit_batch_analysis_task",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.strategy.batch_analysis",
+      "endpoint_name": "submit_batch_analysis_task"
+    },
+    {
+      "index": 427,
+      "path": "/api/v1/strategies/batch-analysis/tasks",
+      "name": "list_batch_analysis_tasks",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.strategy.batch_analysis",
+      "endpoint_name": "list_batch_analysis_tasks"
+    },
+    {
+      "index": 428,
+      "path": "/api/v1/strategies/batch-analysis/tasks/{task_id}",
+      "name": "get_batch_analysis_task_detail",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.strategy.batch_analysis",
+      "endpoint_name": "get_batch_analysis_task_detail"
+    },
+    {
+      "index": 429,
+      "path": "/api/v1/strategies/ml/runtime-status",
+      "name": "get_ml_runtime_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.strategy.ml_workbench",
+      "endpoint_name": "get_ml_runtime_status"
+    },
+    {
+      "index": 430,
+      "path": "/api/v1/strategies/ml/train",
+      "name": "train_ml_workbench_model",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.strategy.ml_workbench",
+      "endpoint_name": "train_ml_workbench_model"
+    },
+    {
+      "index": 431,
+      "path": "/api/v1/strategies/ml/predict",
+      "name": "predict_ml_workbench_model",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.strategy.ml_workbench",
+      "endpoint_name": "predict_ml_workbench_model"
+    },
+    {
+      "index": 432,
+      "path": "/api/v1/strategies/ml/models",
+      "name": "list_ml_workbench_models",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.strategy.ml_workbench",
+      "endpoint_name": "list_ml_workbench_models"
+    },
+    {
+      "index": 433,
+      "path": "/api/v1/strategies/ml/models/{model_id}",
+      "name": "get_ml_workbench_model_detail",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.strategy.ml_workbench",
+      "endpoint_name": "get_ml_workbench_model_detail"
+    },
+    {
+      "index": 434,
+      "path": "/api/v1/strategies/train",
+      "name": "train_ml_strategy",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.strategy.machine_learning",
+      "endpoint_name": "train_ml_strategy"
+    },
+    {
+      "index": 435,
+      "path": "/api/v1/strategies/predict",
+      "name": "generate_strategy_prediction",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.strategy.machine_learning",
+      "endpoint_name": "generate_strategy_prediction"
+    },
+    {
+      "index": 436,
+      "path": "/api/v1/strategies/backtest",
+      "name": "backtest_ml_strategy",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.strategy.machine_learning",
+      "endpoint_name": "backtest_ml_strategy"
+    },
+    {
+      "index": 437,
+      "path": "/api/v1/strategies",
+      "name": "list_strategies",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.strategy.machine_learning",
+      "endpoint_name": "list_strategies"
+    },
+    {
+      "index": 438,
+      "path": "/api/v1/technical-indicators",
+      "name": "get_technical_indicators",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.strategy.indicators",
+      "endpoint_name": "get_technical_indicators"
+    },
+    {
+      "index": 439,
+      "path": "/api/v1/trading/sessions",
+      "name": "list_trading_sessions",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.session",
+      "endpoint_name": "list_trading_sessions"
+    },
+    {
+      "index": 440,
+      "path": "/api/v1/trading/sessions/{session_id}",
+      "name": "get_trading_session",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.session",
+      "endpoint_name": "get_trading_session"
+    },
+    {
+      "index": 441,
+      "path": "/api/v1/trading/sessions",
+      "name": "create_trading_session",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.session",
+      "endpoint_name": "create_trading_session"
+    },
+    {
+      "index": 442,
+      "path": "/api/v1/trading/sessions/{session_id}",
+      "name": "update_trading_session",
+      "methods": [
+        "PATCH"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.session",
+      "endpoint_name": "update_trading_session"
+    },
+    {
+      "index": 443,
+      "path": "/api/v1/trading/sessions/{session_id}",
+      "name": "delete_trading_session",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.session",
+      "endpoint_name": "delete_trading_session"
+    },
+    {
+      "index": 444,
+      "path": "/api/v1/positions",
+      "name": "list_positions",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.positions",
+      "endpoint_name": "list_positions"
+    },
+    {
+      "index": 445,
+      "path": "/api/v1/positions/attribution",
+      "name": "get_position_attribution",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.positions",
+      "endpoint_name": "get_position_attribution"
+    },
+    {
+      "index": 446,
+      "path": "/api/v1/positions/{position_id}",
+      "name": "get_position",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.positions",
+      "endpoint_name": "get_position"
+    },
+    {
+      "index": 447,
+      "path": "/api/v1/positions",
+      "name": "create_position",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.positions",
+      "endpoint_name": "create_position"
+    },
+    {
+      "index": 448,
+      "path": "/api/v1/positions/{position_id}",
+      "name": "update_position",
+      "methods": [
+        "PATCH"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.positions",
+      "endpoint_name": "update_position"
+    },
+    {
+      "index": 449,
+      "path": "/api/v1/positions/{position_id}",
+      "name": "delete_position",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.trading.positions",
+      "endpoint_name": "delete_position"
+    },
+    {
+      "index": 450,
+      "path": "/api/v1/audit/logs",
+      "name": "list_audit_logs",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.admin.audit",
+      "endpoint_name": "list_audit_logs"
+    },
+    {
+      "index": 451,
+      "path": "/api/v1/audit/logs/{log_id}",
+      "name": "get_audit_log",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.admin.audit",
+      "endpoint_name": "get_audit_log"
+    },
+    {
+      "index": 452,
+      "path": "/api/v1/audit/statistics",
+      "name": "get_audit_statistics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.admin.audit",
+      "endpoint_name": "get_audit_statistics"
+    },
+    {
+      "index": 453,
+      "path": "/api/v1/optimization/vacuum",
+      "name": "vacuum_database",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.admin.optimization",
+      "endpoint_name": "vacuum_database"
+    },
+    {
+      "index": 454,
+      "path": "/api/v1/optimization/analyze",
+      "name": "analyze_database",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.admin.optimization",
+      "endpoint_name": "analyze_database"
+    },
+    {
+      "index": 455,
+      "path": "/api/v1/optimization/reindex",
+      "name": "reindex_database",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.admin.optimization",
+      "endpoint_name": "reindex_database"
+    },
+    {
+      "index": 456,
+      "path": "/api/v1/optimization/status",
+      "name": "get_database_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.admin.optimization",
+      "endpoint_name": "get_database_status"
+    },
+    {
+      "index": 457,
+      "path": "/api/v1/optimization/slow-queries",
+      "name": "get_slow_queries",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.admin.optimization",
+      "endpoint_name": "get_slow_queries"
+    },
+    {
+      "index": 458,
+      "path": "/api/v1/sentiment/analyze",
+      "name": "analyze_sentiment",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.analysis.sentiment",
+      "endpoint_name": "analyze_sentiment"
+    },
+    {
+      "index": 459,
+      "path": "/api/v1/sentiment/stock/{symbol}",
+      "name": "get_stock_sentiment",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.analysis.sentiment",
+      "endpoint_name": "get_stock_sentiment"
+    },
+    {
+      "index": 460,
+      "path": "/api/v1/sentiment/market",
+      "name": "get_market_sentiment",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.analysis.sentiment",
+      "endpoint_name": "get_market_sentiment"
+    },
+    {
+      "index": 461,
+      "path": "/api/v1/backtest/monte-carlo",
+      "name": "run_monte_carlo_backtest",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.analysis.backtest",
+      "endpoint_name": "run_monte_carlo_backtest"
+    },
+    {
+      "index": 462,
+      "path": "/api/v1/backtest/stress-test",
+      "name": "run_stress_test",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.analysis.backtest",
+      "endpoint_name": "run_stress_test"
+    },
+    {
+      "index": 463,
+      "path": "/api/v1/backtest/equity-curve/{strategy_id}",
+      "name": "get_equity_curve",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.analysis.backtest",
+      "endpoint_name": "get_equity_curve"
+    },
+    {
+      "index": 464,
+      "path": "/api/v1/backtest/{backtest_id}/attribution",
+      "name": "get_backtest_attribution",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.analysis.backtest",
+      "endpoint_name": "get_backtest_attribution"
+    },
+    {
+      "index": 465,
+      "path": "/api/v1/stress-test/run",
+      "name": "run_custom_stress_test",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.analysis.stress_test",
+      "endpoint_name": "run_custom_stress_test"
+    },
+    {
+      "index": 466,
+      "path": "/api/v1/stress-test/scenarios",
+      "name": "get_predefined_scenarios",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.analysis.stress_test",
+      "endpoint_name": "get_predefined_scenarios"
+    },
+    {
+      "index": 467,
+      "path": "/api/v1/stress-test/history",
+      "name": "get_stress_test_history",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.analysis.stress_test",
+      "endpoint_name": "get_stress_test_history"
+    },
+    {
+      "index": 468,
+      "path": "/api/v1/kronos/predict",
+      "name": "predict_with_kronos",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.analysis.kronos",
+      "endpoint_name": "predict_with_kronos"
+    },
+    {
+      "index": 469,
+      "path": "/api/v1/kronos/encode",
+      "name": "encode_with_kronos",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.analysis.kronos",
+      "endpoint_name": "encode_with_kronos"
+    },
+    {
+      "index": 470,
+      "path": "/api/v1/kronos/status",
+      "name": "get_kronos_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.v1.analysis.kronos",
+      "endpoint_name": "get_kronos_status"
+    },
+    {
+      "index": 471,
+      "path": "/api/contracts/versions",
+      "name": "create_version",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.contract.routes",
+      "endpoint_name": "create_version"
+    },
+    {
+      "index": 472,
+      "path": "/api/contracts/versions/{version_id}",
+      "name": "get_version",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.contract.routes",
+      "endpoint_name": "get_version"
+    },
+    {
+      "index": 473,
+      "path": "/api/contracts/versions/{name}/active",
+      "name": "get_active_version",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.contract.routes",
+      "endpoint_name": "get_active_version"
+    },
+    {
+      "index": 474,
+      "path": "/api/contracts/versions",
+      "name": "list_versions",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.contract.routes",
+      "endpoint_name": "list_versions"
+    },
+    {
+      "index": 475,
+      "path": "/api/contracts/versions/{version_id}",
+      "name": "update_version",
+      "methods": [
+        "PUT"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.contract.routes",
+      "endpoint_name": "update_version"
+    },
+    {
+      "index": 476,
+      "path": "/api/contracts/versions/{version_id}/activate",
+      "name": "activate_version",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.contract.routes",
+      "endpoint_name": "activate_version"
+    },
+    {
+      "index": 477,
+      "path": "/api/contracts/versions/{version_id}",
+      "name": "delete_version",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.contract.routes",
+      "endpoint_name": "delete_version"
+    },
+    {
+      "index": 478,
+      "path": "/api/contracts/contracts",
+      "name": "list_contracts",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.contract.routes",
+      "endpoint_name": "list_contracts"
+    },
+    {
+      "index": 479,
+      "path": "/api/contracts/diff",
+      "name": "compare_versions",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.contract.routes",
+      "endpoint_name": "compare_versions"
+    },
+    {
+      "index": 480,
+      "path": "/api/contracts/validate",
+      "name": "validate_contract",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.contract.routes",
+      "endpoint_name": "validate_contract"
+    },
+    {
+      "index": 481,
+      "path": "/api/contracts/drift/incidents",
+      "name": "list_contract_drift_incidents",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.contract.routes",
+      "endpoint_name": "list_contract_drift_incidents"
+    },
+    {
+      "index": 482,
+      "path": "/api/contracts/sync",
+      "name": "sync_contract",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.contract.routes",
+      "endpoint_name": "sync_contract"
+    },
+    {
+      "index": 483,
+      "path": "/api/contracts/sync/report",
+      "name": "get_sync_report",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.contract.routes",
+      "endpoint_name": "get_sync_report"
+    },
+    {
+      "index": 484,
+      "path": "/api/contracts/impact",
+      "name": "analyze_contract_impact",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.contract.impact_routes",
+      "endpoint_name": "analyze_contract_impact"
+    },
+    {
+      "index": 485,
+      "path": "/api/v1/data-sources/",
+      "name": "search_data_sources",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_registry",
+      "endpoint_name": "search_data_sources"
+    },
+    {
+      "index": 486,
+      "path": "/api/v1/data-sources/categories",
+      "name": "get_category_stats",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_registry",
+      "endpoint_name": "get_category_stats"
+    },
+    {
+      "index": 487,
+      "path": "/api/v1/data-sources/{endpoint_name}",
+      "name": "get_data_source",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_registry",
+      "endpoint_name": "get_data_source"
+    },
+    {
+      "index": 488,
+      "path": "/api/v1/data-sources/{endpoint_name}",
+      "name": "update_data_source",
+      "methods": [
+        "PUT"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_registry",
+      "endpoint_name": "update_data_source"
+    },
+    {
+      "index": 489,
+      "path": "/api/v1/data-sources/{endpoint_name}/test",
+      "name": "test_data_source",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_registry",
+      "endpoint_name": "test_data_source"
+    },
+    {
+      "index": 490,
+      "path": "/api/v1/data-sources/{endpoint_name}/health-check",
+      "name": "health_check_data_source",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_registry",
+      "endpoint_name": "health_check_data_source"
+    },
+    {
+      "index": 491,
+      "path": "/api/v1/data-sources/health-check/all",
+      "name": "health_check_all_data_sources",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_registry",
+      "endpoint_name": "health_check_all_data_sources"
+    },
+    {
+      "index": 492,
+      "path": "/api/v1/data-sources/config/",
+      "name": "create_data_source",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_config",
+      "endpoint_name": "create_data_source"
+    },
+    {
+      "index": 493,
+      "path": "/api/v1/data-sources/config/{endpoint_name}",
+      "name": "update_data_source",
+      "methods": [
+        "PUT"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_config",
+      "endpoint_name": "update_data_source"
+    },
+    {
+      "index": 494,
+      "path": "/api/v1/data-sources/config/{endpoint_name}",
+      "name": "delete_data_source",
+      "methods": [
+        "DELETE"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_config",
+      "endpoint_name": "delete_data_source"
+    },
+    {
+      "index": 495,
+      "path": "/api/v1/data-sources/config/{endpoint_name}",
+      "name": "get_data_source",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_config",
+      "endpoint_name": "get_data_source"
+    },
+    {
+      "index": 496,
+      "path": "/api/v1/data-sources/config/",
+      "name": "list_data_sources",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_config",
+      "endpoint_name": "list_data_sources"
+    },
+    {
+      "index": 497,
+      "path": "/api/v1/data-sources/config/batch",
+      "name": "batch_operations",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_config",
+      "endpoint_name": "batch_operations"
+    },
+    {
+      "index": 498,
+      "path": "/api/v1/data-sources/config/{endpoint_name}/versions",
+      "name": "get_version_history",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_config",
+      "endpoint_name": "get_version_history"
+    },
+    {
+      "index": 499,
+      "path": "/api/v1/data-sources/config/{endpoint_name}/rollback/{version}",
+      "name": "rollback_to_version",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_config",
+      "endpoint_name": "rollback_to_version"
+    },
+    {
+      "index": 500,
+      "path": "/api/v1/data-sources/config/reload",
+      "name": "reload_config",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_source_config",
+      "endpoint_name": "reload_config"
+    },
+    {
+      "index": 501,
+      "path": "/api/v1/lineage/record",
+      "name": "record_lineage",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_lineage",
+      "endpoint_name": "record_lineage"
+    },
+    {
+      "index": 502,
+      "path": "/api/v1/lineage/{node_id}/upstream",
+      "name": "get_upstream_lineage",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_lineage",
+      "endpoint_name": "get_upstream_lineage"
+    },
+    {
+      "index": 503,
+      "path": "/api/v1/lineage/{node_id}/downstream",
+      "name": "get_downstream_lineage",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_lineage",
+      "endpoint_name": "get_downstream_lineage"
+    },
+    {
+      "index": 504,
+      "path": "/api/v1/lineage/graph",
+      "name": "get_lineage_graph",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_lineage",
+      "endpoint_name": "get_lineage_graph"
+    },
+    {
+      "index": 505,
+      "path": "/api/v1/lineage/impact",
+      "name": "analyze_impact",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.data_lineage",
+      "endpoint_name": "analyze_impact"
+    },
+    {
+      "index": 506,
+      "path": "/api/v1/governance/quality/overview",
+      "name": "get_quality_overview",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.governance_dashboard",
+      "endpoint_name": "get_quality_overview"
+    },
+    {
+      "index": 507,
+      "path": "/api/v1/governance/lineage/stats",
+      "name": "get_lineage_stats",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.governance_dashboard",
+      "endpoint_name": "get_lineage_stats"
+    },
+    {
+      "index": 508,
+      "path": "/api/v1/governance/assets/catalog",
+      "name": "get_assets_catalog",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.governance_dashboard",
+      "endpoint_name": "get_assets_catalog"
+    },
+    {
+      "index": 509,
+      "path": "/api/v1/governance/compliance/metrics",
+      "name": "get_compliance_metrics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.governance_dashboard",
+      "endpoint_name": "get_compliance_metrics"
+    },
+    {
+      "index": 510,
+      "path": "/api/v1/governance/dashboard/summary",
+      "name": "get_dashboard_summary",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.governance_dashboard",
+      "endpoint_name": "get_dashboard_summary"
+    },
+    {
+      "index": 511,
+      "path": "/api/indicator-registry/indicators",
+      "name": "list_indicators",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.indicator_registry",
+      "endpoint_name": "list_indicators"
+    },
+    {
+      "index": 512,
+      "path": "/api/indicator-registry/indicators/{indicator_id}",
+      "name": "get_indicator_details",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.indicator_registry",
+      "endpoint_name": "get_indicator_details"
+    },
+    {
+      "index": 513,
+      "path": "/api/indicator-registry/calculate",
+      "name": "calculate_indicator",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.indicator_registry",
+      "endpoint_name": "calculate_indicator"
+    },
+    {
+      "index": 514,
+      "path": "/api/gpu/status",
+      "name": "get_gpu_status",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.gpu_monitoring",
+      "endpoint_name": "get_gpu_status"
+    },
+    {
+      "index": 515,
+      "path": "/api/gpu/performance",
+      "name": "get_gpu_performance",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.gpu_monitoring",
+      "endpoint_name": "get_gpu_performance"
+    },
+    {
+      "index": 516,
+      "path": "/api/gpu/metrics",
+      "name": "get_prometheus_metrics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.gpu_monitoring",
+      "endpoint_name": "get_prometheus_metrics"
+    },
+    {
+      "index": 517,
+      "path": "/api/gpu/history",
+      "name": "get_gpu_history",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.gpu_monitoring",
+      "endpoint_name": "get_gpu_history"
+    },
+    {
+      "index": 518,
+      "path": "/metrics",
+      "name": "metrics",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.prometheus_exporter",
+      "endpoint_name": "metrics"
+    },
+    {
+      "index": 519,
+      "path": "/metrics/health",
+      "name": "metrics_health",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.prometheus_exporter",
+      "endpoint_name": "metrics_health"
+    },
+    {
+      "index": 520,
+      "path": "/metrics/list",
+      "name": "metrics_list",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.prometheus_exporter",
+      "endpoint_name": "metrics_list"
+    },
+    {
+      "index": 521,
+      "path": "/api/backup-recovery/backup/tdengine/full",
+      "name": "backup_tdengine_full",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.backup_recovery_secure.log_security_event",
+      "endpoint_name": "backup_tdengine_full"
+    },
+    {
+      "index": 522,
+      "path": "/api/backup-recovery/backup/tdengine/incremental",
+      "name": "backup_tdengine_incremental",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.backup_recovery_secure.log_security_event",
+      "endpoint_name": "backup_tdengine_incremental"
+    },
+    {
+      "index": 523,
+      "path": "/api/backup-recovery/backup/postgresql/full",
+      "name": "backup_postgresql_full",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.backup_recovery_secure.log_security_event",
+      "endpoint_name": "backup_postgresql_full"
+    },
+    {
+      "index": 524,
+      "path": "/api/backup-recovery/backups",
+      "name": "list_backups",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.backup_recovery_secure.log_security_event",
+      "endpoint_name": "list_backups"
+    },
+    {
+      "index": 525,
+      "path": "/api/backup-recovery/recovery/tdengine/full",
+      "name": "restore_tdengine_full",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.backup_recovery_secure.log_security_event",
+      "endpoint_name": "restore_tdengine_full"
+    },
+    {
+      "index": 526,
+      "path": "/api/backup-recovery/recovery/tdengine/pitr",
+      "name": "restore_tdengine_pitr",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.backup_recovery_secure.log_security_event",
+      "endpoint_name": "restore_tdengine_pitr"
+    },
+    {
+      "index": 527,
+      "path": "/api/backup-recovery/recovery/postgresql/full",
+      "name": "restore_postgresql_full",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.backup_recovery_secure.log_security_event",
+      "endpoint_name": "restore_postgresql_full"
+    },
+    {
+      "index": 528,
+      "path": "/api/backup-recovery/recovery/objectives",
+      "name": "get_recovery_objectives",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.backup_recovery_secure.log_security_event",
+      "endpoint_name": "get_recovery_objectives"
+    },
+    {
+      "index": 529,
+      "path": "/api/backup-recovery/scheduler/control",
+      "name": "scheduler_control",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.backup_recovery_secure.log_security_event",
+      "endpoint_name": "scheduler_control"
+    },
+    {
+      "index": 530,
+      "path": "/api/backup-recovery/scheduler/jobs",
+      "name": "get_scheduled_jobs",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.backup_recovery_secure.log_security_event",
+      "endpoint_name": "get_scheduled_jobs"
+    },
+    {
+      "index": 531,
+      "path": "/api/backup-recovery/integrity/verify/{backup_id}",
+      "name": "verify_backup_integrity",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.backup_recovery_secure.log_security_event",
+      "endpoint_name": "verify_backup_integrity"
+    },
+    {
+      "index": 532,
+      "path": "/api/backup-recovery/cleanup/old-backups",
+      "name": "cleanup_old_backups",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.backup_recovery_secure.cleanup_old_backups",
+      "endpoint_name": "cleanup_old_backups"
+    },
+    {
+      "index": 533,
+      "path": "/api/backup-recovery/health",
+      "name": "backup_service_health",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.backup_recovery_secure.cleanup_old_backups",
+      "endpoint_name": "backup_service_health"
+    },
+    {
+      "index": 534,
+      "path": "/api/v1/advanced-analysis/fundamental",
+      "name": "analyze_fundamental",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "analyze_fundamental"
+    },
+    {
+      "index": 535,
+      "path": "/api/v1/advanced-analysis/technical",
+      "name": "analyze_technical",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "analyze_technical"
+    },
+    {
+      "index": 536,
+      "path": "/api/v1/advanced-analysis/trading-signals",
+      "name": "analyze_trading_signals",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "analyze_trading_signals"
+    },
+    {
+      "index": 537,
+      "path": "/api/v1/advanced-analysis/time-series",
+      "name": "analyze_time_series",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "analyze_time_series"
+    },
+    {
+      "index": 538,
+      "path": "/api/v1/advanced-analysis/market-panorama",
+      "name": "analyze_market_panorama",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "analyze_market_panorama"
+    },
+    {
+      "index": 539,
+      "path": "/api/v1/advanced-analysis/capital-flow",
+      "name": "analyze_capital_flow",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "analyze_capital_flow"
+    },
+    {
+      "index": 540,
+      "path": "/api/v1/advanced-analysis/chip-distribution",
+      "name": "analyze_chip_distribution",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "analyze_chip_distribution"
+    },
+    {
+      "index": 541,
+      "path": "/api/v1/advanced-analysis/anomaly-tracking",
+      "name": "analyze_anomaly_tracking",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "analyze_anomaly_tracking"
+    },
+    {
+      "index": 542,
+      "path": "/api/v1/advanced-analysis/financial-valuation",
+      "name": "analyze_financial_valuation",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "analyze_financial_valuation"
+    },
+    {
+      "index": 543,
+      "path": "/api/v1/advanced-analysis/sentiment",
+      "name": "analyze_sentiment",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "analyze_sentiment"
+    },
+    {
+      "index": 544,
+      "path": "/api/v1/advanced-analysis/decision-models",
+      "name": "analyze_decision_models",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "analyze_decision_models"
+    },
+    {
+      "index": 545,
+      "path": "/api/v1/advanced-analysis/multidimensional-radar",
+      "name": "analyze_multidimensional_radar",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "analyze_multidimensional_radar"
+    },
+    {
+      "index": 546,
+      "path": "/api/v1/advanced-analysis/batch",
+      "name": "analyze_batch",
+      "methods": [
+        "POST"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "analyze_batch"
+    },
+    {
+      "index": 547,
+      "path": "/api/v1/advanced-analysis/health",
+      "name": "health_check",
+      "methods": [
+        "GET"
+      ],
+      "include_in_schema": true,
+      "endpoint_module": "app.api.advanced_analysis_api",
+      "endpoint_name": "health_check"
+    }
+  ]
+}

--- a/.planning/codebase/generated/probe-consumer-matrix-2026-05-22.json
+++ b/.planning/codebase/generated/probe-consumer-matrix-2026-05-22.json
@@ -1,0 +1,4244 @@
+{
+  "generated_at": "2026-05-21T17:05:17.452Z",
+  "git_head": "c173bbc8d48d5e20ed5905d698ca39001237198a",
+  "git_head_short": "c173bbc8d",
+  "stale_if_head_mismatch": true,
+  "scan_roots": [
+    ".github/workflows",
+    "config",
+    "scripts",
+    "docker-compose.yml",
+    "docker-compose.override.yml",
+    "package.json",
+    "ecosystem.config.js",
+    "pm2.config.js"
+  ],
+  "patterns": {
+    "health": "/(?:\\/)(?:api\\/)?health(?:\\/[A-Za-z0-9_{}:-]+)?/g",
+    "status": "/(?:\\/)(?:api\\/)?(?:system\\/)?status(?:\\/[A-Za-z0-9_{}:-]+)?/g",
+    "openapi_docs": "/(?:\\/)(?:openapi\\.json|docs|redoc)\\b/g",
+    "strategy_compat": "/\\/api\\/strategy-mgmt(?:\\/[A-Za-z0-9_{}:-]+)?/g",
+    "trading": "/\\/api\\/(?:v1\\/)?(?:trade|trading|tradingview|positions)(?:\\/[A-Za-z0-9_{}:-]+)?/g",
+    "backup": "/\\/api\\/[A-Za-z0-9_{}:\\/-]*(?:backup|restore|recovery)[A-Za-z0-9_{}:\\/-]*/g",
+    "metrics": "/\\/metrics\\b/g"
+  },
+  "summary": {
+    "scanned_files": 1415,
+    "hit_files": 185,
+    "hit_lines": 600,
+    "category_counts": {
+      "health": 262,
+      "metrics": 140,
+      "openapi_docs": 144,
+      "status": 28,
+      "trading": 26
+    },
+    "consumer_class_counts": {
+      "config": 187,
+      "github_workflows": 40,
+      "scripts": 373
+    }
+  },
+  "hits": [
+    {
+      "path": ".github/workflows/deploy.yml",
+      "line": 119,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "timeout 300 bash -c 'until curl -f http://localhost:8001/health; do sleep 5; done' || {"
+    },
+    {
+      "path": ".github/workflows/deploy.yml",
+      "line": 125,
+      "category": "openapi_docs",
+      "consumer_class": "github_workflows",
+      "snippet": "curl -f http://localhost:8001/api/docs || {"
+    },
+    {
+      "path": ".github/workflows/deploy.yml",
+      "line": 277,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "timeout 300 bash -c 'until curl -f http://localhost/health; do sleep 5; done'"
+    },
+    {
+      "path": ".github/workflows/deploy.yml",
+      "line": 281,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "curl -f http://localhost/api/health || {"
+    },
+    {
+      "path": ".github/workflows/deploy.yml",
+      "line": 321,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "echo \"📊 API Health: https://mystocks.local/api/health\""
+    },
+    {
+      "path": ".github/workflows/deploy.yml",
+      "line": 328,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "curl -f https://mystocks.local/health || {"
+    },
+    {
+      "path": ".github/workflows/deploy.yml",
+      "line": 334,
+      "category": "openapi_docs",
+      "consumer_class": "github_workflows",
+      "snippet": "curl -f https://mystocks.local/api/docs || {"
+    },
+    {
+      "path": ".github/workflows/ai-test-optimization.yml",
+      "line": 496,
+      "category": "openapi_docs",
+      "consumer_class": "github_workflows",
+      "snippet": "comment += `🤖 [AI测试优化器文档](https://github.com/${{ github.repository }}/blob/main/docs/guides/AI_TEST_OPTIMIZER_USER_GUIDE.md)\\n`;"
+    },
+    {
+      "path": ".github/workflows/e2e-test.yml",
+      "line": 89,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "timeout 60 bash -c 'until curl -fsS http://localhost:${BACKEND_PORT}/api/announcement/health || curl -fsS http://localhost:${BACKEND_PORT}/health/ready; do sleep 2; done'"
+    },
+    {
+      "path": ".github/workflows/e2e-test.yml",
+      "line": 181,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "timeout 60 bash -c 'until curl -fsS http://localhost:${BACKEND_PORT}/api/announcement/health || curl -fsS http://localhost:${BACKEND_PORT}/health/ready; do sleep 2; done'"
+    },
+    {
+      "path": ".github/workflows/e2e-tests-enhanced.yml",
+      "line": 89,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "if curl -s http://localhost:8000/api/announcement/health > /dev/null || \\"
+    },
+    {
+      "path": ".github/workflows/e2e-tests-enhanced.yml",
+      "line": 90,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "curl -s http://localhost:8000/health/ready > /dev/null; then"
+    },
+    {
+      "path": ".github/workflows/e2e-tests-enhanced.yml",
+      "line": 120,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "curl -s http://localhost:8000/api/announcement/health || curl -s http://localhost:8000/health/ready || echo \"Backend health check failed\""
+    },
+    {
+      "path": ".github/workflows/e2e-tests.yml",
+      "line": 66,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "curl -f http://localhost:${BACKEND_PORT}/api/announcement/health || curl -f http://localhost:${BACKEND_PORT}/health/ready"
+    },
+    {
+      "path": ".github/workflows/e2e-testing.yml",
+      "line": 215,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "timeout 30 bash -c 'until curl -f http://localhost:8000/api/announcement/health || curl -f http://localhost:8000/health/ready; do sleep 1; done'"
+    },
+    {
+      "path": ".github/workflows/e2e-testing.yml",
+      "line": 220,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "curl -f http://localhost:8000/api/announcement/health || curl -f http://localhost:8000/health/ready"
+    },
+    {
+      "path": ".github/workflows/e2e-testing.yml",
+      "line": 365,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "timeout 60 bash -c 'until curl -f http://localhost:8000/api/announcement/health || curl -f http://localhost:8000/health/ready; do sleep 2; done'"
+    },
+    {
+      "path": ".github/workflows/e2e-testing.yml",
+      "line": 592,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "timeout 60 bash -c 'until curl -f http://localhost:8000/api/announcement/health || curl -f http://localhost:8000/health/ready; do sleep 2; done'"
+    },
+    {
+      "path": ".github/workflows/contract-testing.yml",
+      "line": 190,
+      "category": "openapi_docs",
+      "consumer_class": "github_workflows",
+      "snippet": "spec_file = Path('docs/api/openapi.json')"
+    },
+    {
+      "path": ".github/workflows/ci-cd.yml",
+      "line": 331,
+      "category": "metrics",
+      "consumer_class": "github_workflows",
+      "snippet": "jq -r '.[] | \"\\(.file):\\(.line):\\(.code):\\(.message)\"' ruff-results.json > optimization-data/metrics/code_quality_issues.txt || true"
+    },
+    {
+      "path": ".github/workflows/ci-cd.yml",
+      "line": 332,
+      "category": "metrics",
+      "consumer_class": "github_workflows",
+      "snippet": "echo \"${{ needs.code-quality.outputs.quality_score }}\" > optimization-data/metrics/quality_score.txt"
+    },
+    {
+      "path": ".github/workflows/ci-cd.yml",
+      "line": 336,
+      "category": "metrics",
+      "consumer_class": "github_workflows",
+      "snippet": "echo \"test_execution_time: $(date +%s)\" > optimization-data/metrics/test_performance.txt"
+    },
+    {
+      "path": ".github/workflows/ci-cd.yml",
+      "line": 337,
+      "category": "metrics",
+      "consumer_class": "github_workflows",
+      "snippet": "echo \"total_test_count: 3\" >> optimization-data/metrics/test_performance.txt  # basic-tests, frontend-tests, performance-validation"
+    },
+    {
+      "path": ".github/workflows/ci-cd.yml",
+      "line": 338,
+      "category": "metrics",
+      "consumer_class": "github_workflows",
+      "snippet": "echo \"success_rate: 100%\" >> optimization-data/metrics/test_performance.txt"
+    },
+    {
+      "path": ".github/workflows/ci-cd.yml",
+      "line": 342,
+      "category": "metrics",
+      "consumer_class": "github_workflows",
+      "snippet": "echo \"commit_count: $(git rev-list --count HEAD)\" > optimization-data/metrics/git_stats.txt"
+    },
+    {
+      "path": ".github/workflows/ci-cd.yml",
+      "line": 343,
+      "category": "metrics",
+      "consumer_class": "github_workflows",
+      "snippet": "echo \"branch_count: $(git branch -r | wc -l)\" >> optimization-data/metrics/git_stats.txt"
+    },
+    {
+      "path": ".github/workflows/ci-cd.yml",
+      "line": 344,
+      "category": "metrics",
+      "consumer_class": "github_workflows",
+      "snippet": "echo \"contributor_count: $(git shortlog -sn --no-merges | wc -l)\" >> optimization-data/metrics/git_stats.txt"
+    },
+    {
+      "path": ".github/workflows/ci-cd.yml",
+      "line": 348,
+      "category": "metrics",
+      "consumer_class": "github_workflows",
+      "snippet": "find . -name \"*.py\" -type f -exec wc -l {} \\; | awk '{sum += $1} END {print \"python_lines:\", sum}' > optimization-data/metrics/file_stats.txt"
+    },
+    {
+      "path": ".github/workflows/ci-cd.yml",
+      "line": 349,
+      "category": "metrics",
+      "consumer_class": "github_workflows",
+      "snippet": "find . -name \"*.js\" -o -name \"*.vue\" -o -name \"*.ts\" | wc -l | xargs echo \"frontend_files:\" >> optimization-data/metrics/file_stats.txt"
+    },
+    {
+      "path": ".github/workflows/ci-cd-with-type-checking.yml",
+      "line": 527,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "timeout 60 bash -c 'until curl -fsS http://localhost:${BACKEND_PORT}/api/announcement/health || curl -fsS http://localhost:${BACKEND_PORT}/health/ready; do sleep 2; done'"
+    },
+    {
+      "path": ".github/workflows/ci-cd-with-type-checking.yml",
+      "line": 655,
+      "category": "openapi_docs",
+      "consumer_class": "github_workflows",
+      "snippet": "lighthouse http://localhost:8000/docs \\"
+    },
+    {
+      "path": ".github/workflows/ci-cd-with-type-checking.yml",
+      "line": 744,
+      "category": "openapi_docs",
+      "consumer_class": "github_workflows",
+      "snippet": "if curl -f --max-time 10 http://localhost:8000/docs > /dev/null 2>&1; then"
+    },
+    {
+      "path": ".github/workflows/api-automation-discovery.yml",
+      "line": 101,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "if curl -fsS http://localhost:8000/api/announcement/health > /dev/null 2>&1 || \\"
+    },
+    {
+      "path": ".github/workflows/api-automation-discovery.yml",
+      "line": 102,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "curl -fsS http://localhost:8000/health/ready > /dev/null 2>&1; then"
+    },
+    {
+      "path": ".github/workflows/data-sync-testing.yml",
+      "line": 117,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "if curl -fsS http://localhost:8000/api/announcement/health >/dev/null 2>&1 || \\"
+    },
+    {
+      "path": ".github/workflows/data-sync-testing.yml",
+      "line": 118,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "curl -fsS http://localhost:8000/health/ready >/dev/null 2>&1; then"
+    },
+    {
+      "path": ".github/workflows/data-sync-testing.yml",
+      "line": 200,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "if curl -fsS http://localhost:${BACKEND_PORT}/api/announcement/health >/dev/null 2>&1 || \\"
+    },
+    {
+      "path": ".github/workflows/data-sync-testing.yml",
+      "line": 201,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "curl -fsS http://localhost:${BACKEND_PORT}/health/ready >/dev/null 2>&1; then"
+    },
+    {
+      "path": ".github/workflows/data-sync-testing.yml",
+      "line": 239,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "curl -fsS http://localhost:${BACKEND_PORT}/api/announcement/health >/dev/null 2>&1 || \\"
+    },
+    {
+      "path": ".github/workflows/data-sync-testing.yml",
+      "line": 240,
+      "category": "health",
+      "consumer_class": "github_workflows",
+      "snippet": "curl -fsS http://localhost:${BACKEND_PORT}/health/ready >/dev/null 2>&1"
+    },
+    {
+      "path": "config/monitoring-stack/DEPLOYMENT.md",
+      "line": 136,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "curl http://localhost:8000/health"
+    },
+    {
+      "path": "config/monitoring-stack/DEPLOYMENT.md",
+      "line": 138,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "curl http://localhost:8000/api/system/health"
+    },
+    {
+      "path": "config/monitoring-stack/config/prometheus.yml",
+      "line": 39,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "metrics_path: '/metrics'"
+    },
+    {
+      "path": "config/monitoring-stack/config/prometheus.yml",
+      "line": 46,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "# 历史上的 /health 与 /api/*/health 端点返回 JSON，不是 Prometheus exposition。"
+    },
+    {
+      "path": "config/monitoring-stack/config/prometheus.yml",
+      "line": 60,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "metrics_path: '/metrics'"
+    },
+    {
+      "path": "config/monitoring-stack/config/prometheus.yml",
+      "line": 89,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "metrics_path: '/metrics'"
+    },
+    {
+      "path": "config/monitoring-stack/verify_monitoring.sh",
+      "line": 74,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "test_service \"Grafana\" \"${GRAFANA_URL}/api/health\""
+    },
+    {
+      "path": "config/monitoring-stack/verify_monitoring.sh",
+      "line": 77,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "test_service \"Node Exporter\" \"${NODE_EXPORTER_URL}/metrics\""
+    },
+    {
+      "path": "config/monitoring-stack/MONITORING_VERIFICATION_COMPLETE_REPORT.md",
+      "line": 199,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "- 验证 `/metrics` 端点可访问"
+    },
+    {
+      "path": "config/monitoring-stack/MONITORING_VERIFICATION_COMPLETE_REPORT.md",
+      "line": 210,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "- 测试 `/api/gpu/metrics` 端点"
+    },
+    {
+      "path": "config/monitoring-stack/MONITORING_VERIFICATION_COMPLETE_REPORT.md",
+      "line": 254,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "- **后端Metrics**: http://localhost:8000/metrics"
+    },
+    {
+      "path": "config/monitoring-stack/MONITORING_VERIFICATION_COMPLETE_REPORT.md",
+      "line": 255,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "- **GPU监控Metrics**: http://localhost:8000/api/gpu/metrics"
+    },
+    {
+      "path": "config/monitoring-stack/MONITORING_VERIFICATION_COMPLETE_REPORT.md",
+      "line": 256,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "- **健康检查**: http://localhost:8000/health"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDABS3JQ66RBY3F00XKCX232/index",
+      "line": 2,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDABS3JQ66RBY3F00XKCX232/index",
+      "line": 2,
+      "category": "status",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDABS3JQ66RBY3F00XKCX232/index",
+      "line": 2,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDABS3JQ66RBY3F00XKCX232/index",
+      "line": 435,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "/-/healthy��\u0005\u0002\u0007handler\u0007/-/quit��\u0005\u0002\u0007handler\b/-/readyЇ\u0005\u0002\u0007handler\t/-/reload��\u0005\u0002\u0007handler\u0017/alertmanager-discovery��\u0005\u0002\u0007handler\u0007/alerts��\u0005\u0002\u0007handler\r/api/v1/*path��\u0005\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones��\u0005\u0002\u0007handler /api/"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDABS3JQ66RBY3F00XKCX232/index",
+      "line": 435,
+      "category": "status",
+      "consumer_class": "config",
+      "snippet": "/-/healthy��\u0005\u0002\u0007handler\u0007/-/quit��\u0005\u0002\u0007handler\b/-/readyЇ\u0005\u0002\u0007handler\t/-/reload��\u0005\u0002\u0007handler\u0017/alertmanager-discovery��\u0005\u0002\u0007handler\u0007/alerts��\u0005\u0002\u0007handler\r/api/v1/*path��\u0005\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones��\u0005\u0002\u0007handler /api/"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDABS3JQ66RBY3F00XKCX232/index",
+      "line": 435,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "/-/healthy��\u0005\u0002\u0007handler\u0007/-/quit��\u0005\u0002\u0007handler\b/-/readyЇ\u0005\u0002\u0007handler\t/-/reload��\u0005\u0002\u0007handler\u0017/alertmanager-discovery��\u0005\u0002\u0007handler\u0007/alerts��\u0005\u0002\u0007handler\r/api/v1/*path��\u0005\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones��\u0005\u0002\u0007handler /api/"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KD8MVEK6MB1Z1VA5MNWDR5YG/index",
+      "line": 2,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KD8MVEK6MB1Z1VA5MNWDR5YG/index",
+      "line": 2,
+      "category": "status",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KD8MVEK6MB1Z1VA5MNWDR5YG/index",
+      "line": 2,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KD8MVEK6MB1Z1VA5MNWDR5YG/index",
+      "line": 319,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "/-/healthy��\u0011\u0002\u0007handler\u0007/-/quit��\u0011\u0002\u0007handler\b/-/readyč\u0011\u0002\u0007handler\t/-/reloadԍ\u0011\u0002\u0007handler\u0017/alertmanager-discovery�\u0011\u0002\u0007handler\u0007/alerts�\u0011\u0002\u0007handler\r/api/v1/*path��\u0011\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones��\u0011\u0002\u0007handler /api/v1/"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KD8MVEK6MB1Z1VA5MNWDR5YG/index",
+      "line": 319,
+      "category": "status",
+      "consumer_class": "config",
+      "snippet": "/-/healthy��\u0011\u0002\u0007handler\u0007/-/quit��\u0011\u0002\u0007handler\b/-/readyč\u0011\u0002\u0007handler\t/-/reloadԍ\u0011\u0002\u0007handler\u0017/alertmanager-discovery�\u0011\u0002\u0007handler\u0007/alerts�\u0011\u0002\u0007handler\r/api/v1/*path��\u0011\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones��\u0011\u0002\u0007handler /api/v1/"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KD8MVEK6MB1Z1VA5MNWDR5YG/index",
+      "line": 319,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "/-/healthy��\u0011\u0002\u0007handler\u0007/-/quit��\u0011\u0002\u0007handler\b/-/readyč\u0011\u0002\u0007handler\t/-/reloadԍ\u0011\u0002\u0007handler\u0017/alertmanager-discovery�\u0011\u0002\u0007handler\u0007/alerts�\u0011\u0002\u0007handler\r/api/v1/*path��\u0011\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones��\u0011\u0002\u0007handler /api/v1/"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDAJMYREZXD3EAT81N8T5FHV/index",
+      "line": 2,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDAJMYREZXD3EAT81N8T5FHV/index",
+      "line": 2,
+      "category": "status",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDAJMYREZXD3EAT81N8T5FHV/index",
+      "line": 2,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDAJMYREZXD3EAT81N8T5FHV/index",
+      "line": 432,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "/-/healthy��\u0005\u0002\u0007handler\u0007/-/quit��\u0005\u0002\u0007handler\b/-/readyЇ\u0005\u0002\u0007handler\t/-/reload��\u0005\u0002\u0007handler\u0017/alertmanager-discovery��\u0005\u0002\u0007handler\u0007/alerts��\u0005\u0002\u0007handler\r/api/v1/*path��\u0005\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones��\u0005\u0002\u0007handler /api/"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDAJMYREZXD3EAT81N8T5FHV/index",
+      "line": 432,
+      "category": "status",
+      "consumer_class": "config",
+      "snippet": "/-/healthy��\u0005\u0002\u0007handler\u0007/-/quit��\u0005\u0002\u0007handler\b/-/readyЇ\u0005\u0002\u0007handler\t/-/reload��\u0005\u0002\u0007handler\u0017/alertmanager-discovery��\u0005\u0002\u0007handler\u0007/alerts��\u0005\u0002\u0007handler\r/api/v1/*path��\u0005\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones��\u0005\u0002\u0007handler /api/"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDAJMYREZXD3EAT81N8T5FHV/index",
+      "line": 432,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "/-/healthy��\u0005\u0002\u0007handler\u0007/-/quit��\u0005\u0002\u0007handler\b/-/readyЇ\u0005\u0002\u0007handler\t/-/reload��\u0005\u0002\u0007handler\u0017/alertmanager-discovery��\u0005\u0002\u0007handler\u0007/alerts��\u0005\u0002\u0007handler\r/api/v1/*path��\u0005\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones��\u0005\u0002\u0007handler /api/"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/wal/checkpoint.00000017/00000000",
+      "line": 58,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "monitoring\binstance\u0019host.docker.internal:8000\u0003job\u0013mystocks-m\u0015;\u0005d\b\u0000\u0003G\u0019e\\\u0017scrape_duration_seconds�z\u0000Zz\u0000\u0000H\u0019z\u0000\u0016\rz\u001csamples_\t\u000f\u0000d�y\u0000Zy\u0000\u0000I\u0019y\u0000%\tj\u0015yTpost_metric_relabeling��\u0000Z�\u0000\u0000J\u0019�\u0000\u0013\u0011� eries_add��\u0000F�\u0000\t\u0000۶�\u0011ǥ\u0004\u0004\u0001\u0000\u0005\u0001�O\u0003K\u0004\b__name__\u0002up"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDAJN171D943VTA4WG6S2K9M/index",
+      "line": 2,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDAJN171D943VTA4WG6S2K9M/index",
+      "line": 2,
+      "category": "status",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDAJN171D943VTA4WG6S2K9M/index",
+      "line": 2,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDAJN171D943VTA4WG6S2K9M/index",
+      "line": 321,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "/-/healthy��\u0011\u0002\u0007handler\u0007/-/quit��\u0011\u0002\u0007handler\b/-/ready��\u0011\u0002\u0007handler\t/-/reloadČ\u0011\u0002\u0007handler\u0017/alertmanager-discoveryԌ\u0011\u0002\u0007handler\u0007/alerts�\u0011\u0002\u0007handler\r/api/v1/*path�\u0011\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones��\u0011\u0002\u0007handler /api/v1/"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDAJN171D943VTA4WG6S2K9M/index",
+      "line": 321,
+      "category": "status",
+      "consumer_class": "config",
+      "snippet": "/-/healthy��\u0011\u0002\u0007handler\u0007/-/quit��\u0011\u0002\u0007handler\b/-/ready��\u0011\u0002\u0007handler\t/-/reloadČ\u0011\u0002\u0007handler\u0017/alertmanager-discoveryԌ\u0011\u0002\u0007handler\u0007/alerts�\u0011\u0002\u0007handler\r/api/v1/*path�\u0011\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones��\u0011\u0002\u0007handler /api/v1/"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KDAJN171D943VTA4WG6S2K9M/index",
+      "line": 321,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "/-/healthy��\u0011\u0002\u0007handler\u0007/-/quit��\u0011\u0002\u0007handler\b/-/ready��\u0011\u0002\u0007handler\t/-/reloadČ\u0011\u0002\u0007handler\u0017/alertmanager-discoveryԌ\u0011\u0002\u0007handler\u0007/alerts�\u0011\u0002\u0007handler\r/api/v1/*path�\u0011\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones��\u0011\u0002\u0007handler /api/v1/"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KD6FKYJTF5YEEJNWM57MVGTQ/index",
+      "line": 2,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KD6FKYJTF5YEEJNWM57MVGTQ/index",
+      "line": 2,
+      "category": "status",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KD6FKYJTF5YEEJNWM57MVGTQ/index",
+      "line": 2,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "/-/healthy\u0007/-/quit\b/-/ready\t/-/reload\u0017/alertmanager-discovery\u0007/alerts\r/api/v1/*path#/api/v1/admin/tsdb/clean_tombstones /api/v1/admin/tsdb/delete_series\u001b/api/v1/admin/tsdb/snapshot\u0015/api/v1/alertmanagers\u000e/api/v1/alerts\u0014/a"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KD6FKYJTF5YEEJNWM57MVGTQ/index",
+      "line": 543,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "/-/healthy�\u0004\u0002\u0007handler\u0007/-/quit��\u0004\u0002\u0007handler\b/-/ready��\u0004\u0002\u0007handler\t/-/reload��\u0004\u0002\u0007handler\u0017/alertmanager-discovery��\u0004\u0002\u0007handler\u0007/alerts��\u0004\u0002\u0007handler\r/api/v1/*path́\u0004\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones܁\u0004\u0002\u0007handler /api/v1"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KD6FKYJTF5YEEJNWM57MVGTQ/index",
+      "line": 543,
+      "category": "status",
+      "consumer_class": "config",
+      "snippet": "/-/healthy�\u0004\u0002\u0007handler\u0007/-/quit��\u0004\u0002\u0007handler\b/-/ready��\u0004\u0002\u0007handler\t/-/reload��\u0004\u0002\u0007handler\u0017/alertmanager-discovery��\u0004\u0002\u0007handler\u0007/alerts��\u0004\u0002\u0007handler\r/api/v1/*path́\u0004\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones܁\u0004\u0002\u0007handler /api/v1"
+    },
+    {
+      "path": "config/monitoring-stack/data/prometheus/01KD6FKYJTF5YEEJNWM57MVGTQ/index",
+      "line": 543,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "/-/healthy�\u0004\u0002\u0007handler\u0007/-/quit��\u0004\u0002\u0007handler\b/-/ready��\u0004\u0002\u0007handler\t/-/reload��\u0004\u0002\u0007handler\u0017/alertmanager-discovery��\u0004\u0002\u0007handler\u0007/alerts��\u0004\u0002\u0007handler\r/api/v1/*path́\u0004\u0002\u0007handler#/api/v1/admin/tsdb/clean_tombstones܁\u0004\u0002\u0007handler /api/v1"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-piechart-panel/README.md",
+      "line": 7,
+      "category": "status",
+      "consumer_class": "config",
+      "snippet": "[![Build Status](https://drone.grafana.net/api/badges/grafana/piechart-panel/status.svg)](https://drone.grafana.net/grafana/piechart-panel)"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-piechart-panel/README.md",
+      "line": 9,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "As of [Grafana 8.0](https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v8-0/#whats-new-in-grafana-v80) Pie chart panel is included with Grafana. Please refer to the [Pie chart panel](https://grafana.com/docs/g"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-piechart-panel/README.md",
+      "line": 21,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "More instructions on the Grafana CLI tool can be found in [Grafana CLI](https://grafana.com/docs/grafana/latest/administration/cli/)."
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-pyroscope-app/580.js",
+      "line": 90,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "`});function L(){const e=(0,l.useStyles2)(G),{data:t}=_();return u().createElement(\"div\",{\"data-testid\":\"onboarding-modal\"},u().createElement(\"div\",{className:e.hero,\"data-testid\":\"hero\"},u().createElement(\"div\",{classNa"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-pyroscope-app/580.js",
+      "line": 152,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "`});function Me({error:e}){var t;let n=\"Error while retrieving recording rules\";return 404===(null===(t=e.response)||void 0===t?void 0:t.status)?n=\"This feature requires Pyroscope with recording_rules flag enabled.\":e.me"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-pyroscope-app/167.js",
+      "line": 577,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "`});function vc({commit:e}){const t=(0,i.useStyles2)(bc);return m().createElement(\"div\",{className:t.container},m().createElement(\"span\",{className:t.sha},wc(e.sha)),m().createElement(\"div\",{className:t.message},m().crea"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-pyroscope-app/167.js",
+      "line": 757,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "`})},8629:(e,t,n)=>{n.d(t,{C:()=>k});var r=n(7781),o=n(9318),i=n(2007),a=n(5959),s=n.n(a),l=n(2673),c=n(7907),u=(n(8727),n(2249)),d=n.n(u),p=n(9090);function m(e,t,n,r,o,i,a){try{var s=e[i](a),l=s.value}catch(e){return v"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-pyroscope-app/README.md",
+      "line": 13,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "![Grafana Profiles Drilldown main screen](https://grafana.com/media/docs/explore-profiles/explore-profiles-homescreen-latest.png)"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-pyroscope-app/README.md",
+      "line": 20,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "- A Grafana stack in Grafana Cloud with a configured [Pyroscope data source](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/pyroscope/) receiving profiling data"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-pyroscope-app/README.md",
+      "line": 26,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "- A configured [Pyroscope data source](https://grafana.com/docs/grafana/latest/datasources/pyroscope/) receiving profiling data"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-pyroscope-app/README.md",
+      "line": 30,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "Refer to the [Grafana Profiles Drilldown](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/profiles/) documentation."
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-pyroscope-app/README.md",
+      "line": 31,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "For instructions installing, refer to the [access and installation instructions](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/profiles/)."
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-pyroscope-app/README.md",
+      "line": 35,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "- [Documentation](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/profiles/)"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-pyroscope-app/README.md",
+      "line": 49,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "For more information, refer to [Contributing to Grafana Profiles Drilldown](https://github.com/grafana/profiles-drilldown/blob/main/docs/CONTRIBUTING.md)"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-pyroscope-app/plugin.json",
+      "line": 2,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "\"$schema\": \"https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json\","
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-pyroscope-app/194.js",
+      "line": 2,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "(self.webpackChunkgrafana_pyroscope_app=self.webpackChunkgrafana_pyroscope_app||[]).push([[194],{219:(e,t,n)=>{(()=>{\"use strict\";var t={n:e=>{var n=e&&e.__esModule?()=>e.default:()=>e;return t.d(n,{a:n}),n},d:(e,n)=>{fo"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-pyroscope-app/194.js",
+      "line": 2,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "(self.webpackChunkgrafana_pyroscope_app=self.webpackChunkgrafana_pyroscope_app||[]).push([[194],{219:(e,t,n)=>{(()=>{\"use strict\";var t={n:e=>{var n=e&&e.__esModule?()=>e.default:()=>e;return t.d(n,{a:n}),n},d:(e,n)=>{fo"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-lokiexplore-app/README.md",
+      "line": 12,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "See the [getting started](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/get-started/) for more info using Grafana Logs Drilldown."
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-lokiexplore-app/README.md",
+      "line": 13,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "For instructions installing, see the [access and installation instructions](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/access/)"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-lokiexplore-app/README.md",
+      "line": 17,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "- [DOCS](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/)"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-lokiexplore-app/plugin.json",
+      "line": 2,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "\"$schema\": \"https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json\","
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-lokiexplore-app/328.js",
+      "line": 1,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "\"use strict\";(self.webpackChunkgrafana_lokiexplore_app=self.webpackChunkgrafana_lokiexplore_app||[]).push([[328],{7709:(e,t,n)=>{n.d(t,{F:()=>l});var r=n(5959),a=n.n(r),s=n(6089),i=n(2007),o=n(3571);const l=e=>{const{but"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-lokiexplore-app/826.js",
+      "line": 7,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "`,note:(0,i.css)({color:e.colors.text.secondary,marginBottom:e.spacing(1),marginTop:e.spacing(1)})}),y=(e,t)=>g(function*(){try{yield O(e,t),c.locationService.reload()}catch(e){u.v.error(e,{msg:\"Error while updating the "
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/module.js",
+      "line": 3,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "define([\"i18next\",\"react-router\",\"rxjs\",\"module\",\"@grafana/ui\",\"lodash\",\"react\",\"@emotion/css\",\"@grafana/data\",\"react-dom\",\"@grafana/runtime\"],(e,t,i,n,r,s,o,a,l,u,c)=>(()=>{var d,h,f,p,g={211:t=>{\"use strict\";t.exports="
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/MANIFEST.txt",
+      "line": 84,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "\"img/metrics-drilldown.png\": \"eef0ace68ed328773f9dddfd9f8b14c22c3e2f909aeab640263112251afca7f7\","
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/538.js",
+      "line": 49,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "`}}V(q,\"Component\",({model:e})=>{const{body:t,panelConfig:n}=e.useState(),r=(0,o.useStyles2)(U,n.height);return c().createElement(\"div\",{className:r.container,\"data-testid\":\"gmd-vizpanel\"},t&&c().createElement(t.Componen"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/538.js",
+      "line": 53,
+      "category": "status",
+      "consumer_class": "config",
+      "snippet": "`})},7014:(e,t,n)=>{n.d(t,{q:()=>a});var r=n(8162);const a=new Map([...[\"avg\",\"sum\",\"stddev\",\"quantile\",\"min\",\"max\",\"count\"].map(e=>[e,{name:e,fn:t=>r.GH[e](t)}]),[\"histogram_quantile\",{name:\"histogram_quantile\",fn:({exp"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/538.js",
+      "line": 131,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "`}),Se=ge.t,we=`https://github.com/grafana/metrics-drilldown/commit/${Se}`,{buildInfo:Oe}=r.config;function Ee(){const e=(0,u.useStyles2)(ke),{meta:{info:{version:t,updated:n}}}=(0,s.usePluginContext)()||{meta:{info:{ver"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/538.js",
+      "line": 131,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "`}),Se=ge.t,we=`https://github.com/grafana/metrics-drilldown/commit/${Se}`,{buildInfo:Oe}=r.config;function Ee(){const e=(0,u.useStyles2)(ke),{meta:{info:{version:t,updated:n}}}=(0,s.usePluginContext)()||{meta:{info:{ver"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/README.md",
+      "line": 11,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "See the [docs](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/metrics/) for more info using Grafana Metrics Drilldown."
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/README.md",
+      "line": 11,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See the [docs](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/metrics/) for more info using Grafana Metrics Drilldown."
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/README.md",
+      "line": 15,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "- [DOCS](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/metrics)"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/README.md",
+      "line": 15,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "- [DOCS](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/metrics)"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/README.md",
+      "line": 16,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "- [CHANGELOG](https://github.com/grafana/metrics-drilldown/releases)"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/README.md",
+      "line": 17,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "- [GITHUB](https://github.com/grafana/metrics-drilldown)"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/README.md",
+      "line": 25,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "If your issue is a bug, please open one [here](https://github.com/grafana/metrics-drilldown/issues/new)."
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/README.md",
+      "line": 29,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "We do not have a formal proposal process for changes or feature requests. If you have a change you would like to see in Grafana Metrics Drilldown, please [file an issue](https://github.com/grafana/metrics-drilldown/issue"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 109,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.20>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 113,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.19>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 117,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.18>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 121,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.17>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 125,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.16>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 129,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.15>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 133,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.14>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 137,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.13>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 141,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.12>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 145,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.11>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 149,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.10>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 153,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.9>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 157,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.8>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 161,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.7>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 165,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.6>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 169,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.5>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 173,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.4>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 177,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.3-corrected>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 181,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.2>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 185,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.2-0>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 189,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.1>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 193,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 197,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-9>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 201,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-8>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 205,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-7>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 209,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-6>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 213,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-5>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 217,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-4>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 221,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-3>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 225,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-2>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 229,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-1>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/CHANGELOG.md",
+      "line": 233,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "See <https://github.com/grafana/metrics-drilldown/releases/tag/v1.0.0-0>"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/plugin.json",
+      "line": 2,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "\"$schema\": \"https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json\","
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/plugin.json",
+      "line": 36,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "\"path\": \"img/metrics-drilldown.png\""
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/plugin.json",
+      "line": 48,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "\"url\": \"https://github.com/grafana/metrics-drilldown\""
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/plugin.json",
+      "line": 52,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "\"url\": \"https://github.com/grafana/metrics-drilldown/issues/new\""
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/plugin.json",
+      "line": 88,
+      "category": "status",
+      "consumer_class": "config",
+      "snippet": "\"grafana/datasources/config/status\""
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/509.js",
+      "line": 1,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "\"use strict\";(self.webpackChunkgrafana_metricsdrilldown_app=self.webpackChunkgrafana_metricsdrilldown_app||[]).push([[509],{2993:(e,t,a)=>{a.d(t,{E:()=>o});var r=a(6089),n=a(2007),l=a(5959),c=a.n(l),s=a(1159),i=a(6503);f"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-metricsdrilldown-app/509.js",
+      "line": 1,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "\"use strict\";(self.webpackChunkgrafana_metricsdrilldown_app=self.webpackChunkgrafana_metricsdrilldown_app||[]).push([[509],{2993:(e,t,a)=>{a.d(t,{E:()=>o});var r=a(6089),n=a(2007),l=a(5959),c=a.n(l),s=a(1159),i=a(6503);f"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-exploretraces-app/211.js",
+      "line": 1,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "(self.webpackChunkgrafana_exploretraces_app=self.webpackChunkgrafana_exploretraces_app||[]).push([[211],{775:(e,t,n)=>{\"use strict\";n.d(t,{v:()=>u});var a,r,i,s=n(118),o=n(5959),l=n.n(o),c=n(3733);class u extends s.Bs{}i"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-exploretraces-app/README.md",
+      "line": 19,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "![Root cause latency using Duration metrics](https://grafana.com/media/docs/explore-traces/explore-traces-rate-comparison.png)"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-exploretraces-app/README.md",
+      "line": 26,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "- A Grafana stack in Grafana Cloud with a configured [Tempo data source](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/tempo/configure-tempo-data-source/) receiving tracing data"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-exploretraces-app/README.md",
+      "line": 32,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "- A configured [Tempo data source](https://grafana.com/docs/grafana/latest/datasources/tempo/configure-tempo-data-source/) receiving tracing data"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-exploretraces-app/README.md",
+      "line": 36,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "Refer to the [Traces Drilldown](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/traces/) documentation."
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-exploretraces-app/README.md",
+      "line": 37,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "For instructions installing, refer to the [access and installation instructions](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/traces/)."
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-exploretraces-app/README.md",
+      "line": 41,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "- [Documentation](https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/traces/)"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-exploretraces-app/README.md",
+      "line": 103,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "If your project has dedicated documentation available for users, provide links here. For help in following Grafana's style recommendations for technical documentation, refer to our [Writer's Toolkit](https://grafana.com/"
+    },
+    {
+      "path": "config/monitoring-stack/data/grafana/plugins/grafana-exploretraces-app/plugin.json",
+      "line": 2,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "\"$schema\": \"https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json\","
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 23,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "│           │   Pull /metrics endpoint    │                   │"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 30,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "│   │  /api/metrics     - Prometheus 指标导出              │   │"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 31,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "│   │  /api/system/health    - 系统健康检查              │   │"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 32,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "│   │  /api/monitoring/health - 监控服务健康检查         │   │"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 33,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "│   │  /api/trade/health       - 交易服务健康检查         │   │"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 33,
+      "category": "trading",
+      "consumer_class": "config",
+      "snippet": "│   │  /api/trade/health       - 交易服务健康检查         │   │"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 34,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "│   │  /api/*/health           - 各组件健康检查            │   │"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 106,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "metrics_path: '/api/metrics'"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 113,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "| `/api/system/health` | 系统核心 | ✅ |"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 114,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "| `/api/monitoring/health` | 监控服务 | ✅ |"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 115,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "| `/api/trade/health` | 交易服务 | ✅ |"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 115,
+      "category": "trading",
+      "consumer_class": "config",
+      "snippet": "| `/api/trade/health` | 交易服务 | ✅ |"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 116,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "| `/api/technical/health` | 技术分析 | ✅ |"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 117,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "| `/api/announcement/health` | 公告监控 | ✅ |"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 118,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "| `/api/multi_source/health` | 多数据源 | ✅ |"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 119,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "| `/api/market/health` | 市场数据 | ✅ |"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 120,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "| `/api/wencai/health` | 问财API | ✅ |"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 121,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "| `/api/tasks/health` | 任务管理 | ✅ |"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 122,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "| `/metrics/health` | Prometheus导出器 | ✅ |"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 122,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "| `/metrics/health` | Prometheus导出器 | ✅ |"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 172,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "1. 检查后端是否运行：`curl http://localhost:8000/api/metrics`"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 179,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "1. 检查 Prometheus 是否运行：`curl http://localhost:9090/-/healthy`"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 195,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "- [Prometheus 文档](https://prometheus.io/docs/)"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 196,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "- [Grafana 文档](https://grafana.com/docs/)"
+    },
+    {
+      "path": "config/monitoring-stack/README.md",
+      "line": 197,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "- [Phase 2.4 实现文档](../docs/)"
+    },
+    {
+      "path": "config/monitoring-stack/MONITORING_STATUS.md",
+      "line": 79,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "curl http://localhost:9090/-/healthy"
+    },
+    {
+      "path": "config/monitoring-stack/MONITORING_STATUS.md",
+      "line": 100,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "curl http://localhost:9100/metrics"
+    },
+    {
+      "path": "config/ecosystem.production.config.js",
+      "line": 45,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "url: 'http://localhost:8000/api/monitoring/health',"
+    },
+    {
+      "path": "config/ecosystem.config.js",
+      "line": 53,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "url: 'http://localhost:8000/health',"
+    },
+    {
+      "path": "config/pm2/ecosystem.production.config.js",
+      "line": 46,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "url: 'http://localhost:8000/api/monitoring/health',"
+    },
+    {
+      "path": "config/pm2/ecosystem.config.js",
+      "line": 83,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "url: 'http://localhost:8000/api/health',"
+    },
+    {
+      "path": "config/pm2/pm2.config.js",
+      "line": 145,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "script: 'curl -f http://localhost:8000/health > /dev/null 2>&1',"
+    },
+    {
+      "path": "config/pm2/ecosystem.enhanced.config.js",
+      "line": 37,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "endpoint: '/api/health',"
+    },
+    {
+      "path": "config/pm2/ecosystem.enhanced.config.js",
+      "line": 85,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "health_endpoint: '/api/metrics',"
+    },
+    {
+      "path": "config/pm2/ecosystem.enhanced.config.js",
+      "line": 131,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "url: 'http://localhost:8000/api/health',"
+    },
+    {
+      "path": "config/pm2/ecosystem.enhanced.config.js",
+      "line": 144,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "{ path: '/api/health', method: 'GET', expected_status: 200 },"
+    },
+    {
+      "path": "config/pm2/ecosystem.enhanced.config.js",
+      "line": 171,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "health_endpoint: '/api/metrics',"
+    },
+    {
+      "path": "config/pm2/ecosystem.enhanced.config.js",
+      "line": 218,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "url: 'http://localhost:8000/api/monitoring/health',"
+    },
+    {
+      "path": "config/pm2/ecosystem.enhanced.config.js",
+      "line": 252,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "url: 'http://localhost:8001/health',"
+    },
+    {
+      "path": "config/pm2/ecosystem.enhanced.config.js",
+      "line": 370,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "metrics_endpoint: 'http://localhost:8000/api/metrics', // 后端指标端点"
+    },
+    {
+      "path": "config/prometheus.yml",
+      "line": 34,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "metrics_path: '/metrics'"
+    },
+    {
+      "path": "config/prometheus.yml",
+      "line": 58,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "metrics_path: '/api/prom/metrics'"
+    },
+    {
+      "path": "config/prometheus.yml",
+      "line": 131,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "#   metrics_path: '/metrics'"
+    },
+    {
+      "path": "config/.readthedocs.yaml",
+      "line": 2,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details"
+    },
+    {
+      "path": "config/.readthedocs.yaml",
+      "line": 19,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html"
+    },
+    {
+      "path": "config/pm2.config.js",
+      "line": 211,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "script: `curl -f http://localhost:${backendPort}/health > /dev/null 2>&1`,"
+    },
+    {
+      "path": "config/monitoring/prometheus.yml",
+      "line": 15,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "metrics_path: /metrics"
+    },
+    {
+      "path": "config/ai_automation_analysis_1763426351.json",
+      "line": 177,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "\"docs_path\": \"/opt/claude/mystocks_spec/docs\""
+    },
+    {
+      "path": "config/governance/documentation-taxonomy.yaml",
+      "line": 49,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "retired_docs: archive/docs/"
+    },
+    {
+      "path": "config/governance/documentation-taxonomy.yaml",
+      "line": 50,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "retired_api_docs: archive/docs/api/"
+    },
+    {
+      "path": "config/governance/documentation-taxonomy.yaml",
+      "line": 194,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "archive_target: archive/docs/architecture/"
+    },
+    {
+      "path": "config/governance/documentation-taxonomy.yaml",
+      "line": 371,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "archive_target: archive/docs/api/"
+    },
+    {
+      "path": "config/governance/documentation-taxonomy.yaml",
+      "line": 458,
+      "category": "openapi_docs",
+      "consumer_class": "config",
+      "snippet": "archive_target: archive/docs/testing/"
+    },
+    {
+      "path": "config/deployments/k8s-deployment.yaml",
+      "line": 139,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "prometheus.io/path: \"/metrics\""
+    },
+    {
+      "path": "config/deployments/k8s-deployment.yaml",
+      "line": 199,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "path: /health"
+    },
+    {
+      "path": "config/deployments/k8s-deployment.yaml",
+      "line": 207,
+      "category": "health",
+      "consumer_class": "config",
+      "snippet": "path: /health"
+    },
+    {
+      "path": "config/deployments/k8s-deployment.yaml",
+      "line": 403,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "path: /metrics"
+    },
+    {
+      "path": "config/deployments/k8s-deployment.yaml",
+      "line": 436,
+      "category": "metrics",
+      "consumer_class": "config",
+      "snippet": "- path: /metrics"
+    },
+    {
+      "path": "scripts/run_playwright_cli_tests.sh",
+      "line": 64,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if ! curl -sf \"http://localhost:${BACKEND_PORT}/health\" > /dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/run_monitoring_auth_performance_baseline.sh",
+      "line": 14,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "METRICS_BASELINE_RAW_PATH=\"${REPORT_DIR}/metrics.baseline.raw.txt\""
+    },
+    {
+      "path": "scripts/run_monitoring_auth_performance_baseline.sh",
+      "line": 15,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "METRICS_RAW_PATH=\"${REPORT_DIR}/metrics.raw.txt\""
+    },
+    {
+      "path": "scripts/run_monitoring_auth_performance_baseline.sh",
+      "line": 16,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "METRICS_HEALTH_PATH=\"${REPORT_DIR}/metrics-health.json\""
+    },
+    {
+      "path": "scripts/run_monitoring_auth_performance_baseline.sh",
+      "line": 17,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "METRICS_SUMMARY_PATH=\"${REPORT_DIR}/metrics-summary.json\""
+    },
+    {
+      "path": "scripts/run_monitoring_auth_performance_baseline.sh",
+      "line": 49,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "wait_for_url \"http://localhost:8020/health\" \"Backend\""
+    },
+    {
+      "path": "scripts/run_monitoring_auth_performance_baseline.sh",
+      "line": 50,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "wait_for_url \"http://localhost:8020/api/health/ready\" \"Backend readiness\""
+    },
+    {
+      "path": "scripts/run_monitoring_auth_performance_baseline.sh",
+      "line": 53,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent \"http://localhost:8020/metrics\" > \"${METRICS_BASELINE_RAW_PATH}\""
+    },
+    {
+      "path": "scripts/run_monitoring_auth_performance_baseline.sh",
+      "line": 94,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent \"http://localhost:8020/api/metrics/health\" > \"${METRICS_HEALTH_PATH}\""
+    },
+    {
+      "path": "scripts/run_monitoring_auth_performance_baseline.sh",
+      "line": 94,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent \"http://localhost:8020/api/metrics/health\" > \"${METRICS_HEALTH_PATH}\""
+    },
+    {
+      "path": "scripts/run_monitoring_auth_performance_baseline.sh",
+      "line": 95,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent \"http://localhost:8020/metrics\" > \"${METRICS_RAW_PATH}\""
+    },
+    {
+      "path": "scripts/run_monitoring_auth_performance_baseline.sh",
+      "line": 142,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "f\"- `/api/metrics/health`: `{metrics_snapshot['metrics_health'].get('status', 'unknown')}`\","
+    },
+    {
+      "path": "scripts/run_monitoring_auth_performance_baseline.sh",
+      "line": 142,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "f\"- `/api/metrics/health`: `{metrics_snapshot['metrics_health'].get('status', 'unknown')}`\","
+    },
+    {
+      "path": "scripts/run_runtime_delivery_summary_local.sh",
+      "line": 117,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "--declared-metrics-python-file \"${PROJECT_ROOT}/web/backend/app/api/metrics.py\""
+    },
+    {
+      "path": "scripts/run_runtime_delivery_summary_local.sh",
+      "line": 126,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "if [ -n \"${dir}\" ] && [ -f \"${dir}/metrics.raw.txt\" ]; then"
+    },
+    {
+      "path": "scripts/run_runtime_delivery_summary_local.sh",
+      "line": 127,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "reference_cmd+=(--metrics-file \"${dir}/metrics.raw.txt\")"
+    },
+    {
+      "path": "scripts/switch_data_mode.py",
+      "line": 160,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "(\"健康检查\", f\"{backend_base_url}/health\"),"
+    },
+    {
+      "path": "scripts/switch_data_mode.py",
+      "line": 161,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "(\"API状态\", f\"{backend_base_url}/api/status\"),"
+    },
+    {
+      "path": "scripts/switch_data_mode.py",
+      "line": 240,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "backend_response = requests.get(f\"{backend_base_url}/health\", timeout=3)"
+    },
+    {
+      "path": "scripts/switch_data_mode.py",
+      "line": 261,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "\"--mode\", choices=[\"mock\", \"real\", \"status\"], help=\"切换模式: mock/real/status\""
+    },
+    {
+      "path": "scripts/run_e2e_pm2.sh",
+      "line": 31,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl --noproxy '*' -s \"http://localhost:${TARGET_BACKEND_PORT}/health\" > /dev/null; then"
+    },
+    {
+      "path": "scripts/hooks/deny_list.py",
+      "line": 7,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- Block obviously wrong locations (e.g. duplicated nesting like `docs/docs/`)."
+    },
+    {
+      "path": "scripts/hooks/deny_list.py",
+      "line": 32,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "Rule(prefix=\"docs/docs/\", action=\"禁止创建\", reason=\"文档目录不应重复嵌套\"),"
+    },
+    {
+      "path": "scripts/hooks/check-documentation-placement.sh",
+      "line": 27,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "LOG_DIR=\"var/log/docs-audit\""
+    },
+    {
+      "path": "scripts/dev/task_assigner.py",
+      "line": 130,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "\"reason\": f\"{cli} CLI完成率{status['completed']/status['total_tasks']*100:.0f}%，可以继续分配\","
+    },
+    {
+      "path": "scripts/dev/probe_windows_qmt_service_readiness.py",
+      "line": 104,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "response = await client.get(f\"{base_url.rstrip('/')}/health\")"
+    },
+    {
+      "path": "scripts/dev/probe_windows_qmt_service_readiness.py",
+      "line": 108,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "raise ValueError(\"Windows qmt /health payload must be a JSON object\")"
+    },
+    {
+      "path": "scripts/dev/realtime_streaming_validation.py",
+      "line": 164,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "health_url = f\"{self.base_url}/api/market/health\""
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_quality_summary.py",
+      "line": 103,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "\"trading_status\": endpoint_map.get(\"/api/trading/status\"),"
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_quality_summary.py",
+      "line": 103,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "\"trading_status\": endpoint_map.get(\"/api/trading/status\"),"
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_quality_summary.py",
+      "line": 104,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "\"trading_market_snapshot\": endpoint_map.get(\"/api/trading/market/snapshot\"),"
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_quality_summary.py",
+      "line": 105,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "\"trading_risk_metrics\": endpoint_map.get(\"/api/trading/risk/metrics\"),"
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_quality_summary.py",
+      "line": 105,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "\"trading_risk_metrics\": endpoint_map.get(\"/api/trading/risk/metrics\"),"
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_quality_summary.py",
+      "line": 156,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"metrics_health\": _require_match(r\"- `/api/metrics/health`: `([^`]+)`\", summary_text, \"docker metrics health\"),"
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_quality_summary.py",
+      "line": 156,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "\"metrics_health\": _require_match(r\"- `/api/metrics/health`: `([^`]+)`\", summary_text, \"docker metrics health\"),"
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_quality_summary.py",
+      "line": 216,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "current_batch_issues.append(\"Monitoring rule metric references do not match runtime /metrics snapshots\")"
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_quality_summary.py",
+      "line": 288,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "f\"- `GET /api/trading/status`: `p95={trading_status.get('p95_ms', 'n/a')}ms error={trading_status.get('error_rate_percent', 'n/a')}%`\","
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_quality_summary.py",
+      "line": 288,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "f\"- `GET /api/trading/status`: `p95={trading_status.get('p95_ms', 'n/a')}ms error={trading_status.get('error_rate_percent', 'n/a')}%`\","
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_quality_summary.py",
+      "line": 289,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "f\"- `GET /api/trading/market/snapshot`: `p95={trading_market_snapshot.get('p95_ms', 'n/a')}ms error={trading_market_snapshot.get('error_rate_percent', 'n/a')}%`\","
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_quality_summary.py",
+      "line": 290,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "f\"- `GET /api/trading/risk/metrics`: `p95={trading_risk_metrics.get('p95_ms', 'n/a')}ms error={trading_risk_metrics.get('error_rate_percent', 'n/a')}%`\","
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_quality_summary.py",
+      "line": 290,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "f\"- `GET /api/trading/risk/metrics`: `p95={trading_risk_metrics.get('p95_ms', 'n/a')}ms error={trading_risk_metrics.get('error_rate_percent', 'n/a')}%`\","
+    },
+    {
+      "path": "scripts/dev/quality_gate/validate_monitoring_prometheus_references.py",
+      "line": 286,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "parser = argparse.ArgumentParser(description=\"Validate Prometheus rule metric references against runtime /metrics snapshots\")"
+    },
+    {
+      "path": "scripts/dev/quality_gate/summarize_metrics_snapshot.py",
+      "line": 175,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "parser.add_argument(\"--metrics-file\", required=True, help=\"Path to raw /metrics output\")"
+    },
+    {
+      "path": "scripts/dev/quality_gate/summarize_metrics_snapshot.py",
+      "line": 176,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "parser.add_argument(\"--baseline-metrics-file\", help=\"Optional path to raw /metrics output captured before the run\")"
+    },
+    {
+      "path": "scripts/dev/quality_gate/summarize_metrics_snapshot.py",
+      "line": 177,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "parser.add_argument(\"--health-file\", required=True, help=\"Path to /api/metrics/health JSON output\")"
+    },
+    {
+      "path": "scripts/dev/quality_gate/summarize_metrics_snapshot.py",
+      "line": 177,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "parser.add_argument(\"--health-file\", required=True, help=\"Path to /api/metrics/health JSON output\")"
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_ci_bundle.py",
+      "line": 369,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "f\"- Docker metrics health: `{_first_match(r'- `/api/metrics/health`: `([^`]+)`', docker_summary)}`\","
+    },
+    {
+      "path": "scripts/dev/quality_gate/build_runtime_ci_bundle.py",
+      "line": 369,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "f\"- Docker metrics health: `{_first_match(r'- `/api/metrics/health`: `([^`]+)`', docker_summary)}`\","
+    },
+    {
+      "path": "scripts/dev/check_api_health.py",
+      "line": 102,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"url\": \"/api/system/health\","
+    },
+    {
+      "path": "scripts/dev/check_api_health.py",
+      "line": 114,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "resp = requests.get(f\"{BASE_URL}/api/docs\", timeout=2)"
+    },
+    {
+      "path": "scripts/dev/ai_automation_improver.py",
+      "line": 106,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "routes_content = f'\"\"\"\\\\n{description}路由\\\\n\"\"\"\\\\n\\\\nfrom fastapi import APIRouter\\\\n\\\\nrouter = APIRouter(prefix=\"/{endpoint_name}\")\\\\n\\\\n\\\\n@router.get(\"/health\")\\\\nasync def health_check():\\\\n    \"\"\"健康检查\"\"\"\\\\n    retur"
+    },
+    {
+      "path": "scripts/dev/ai_automation_improver.py",
+      "line": 106,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "routes_content = f'\"\"\"\\\\n{description}路由\\\\n\"\"\"\\\\n\\\\nfrom fastapi import APIRouter\\\\n\\\\nrouter = APIRouter(prefix=\"/{endpoint_name}\")\\\\n\\\\n\\\\n@router.get(\"/health\")\\\\nasync def health_check():\\\\n    \"\"\"健康检查\"\"\"\\\\n    retur"
+    },
+    {
+      "path": "scripts/dev/tools/migrate_docs_structure.py",
+      "line": 133,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "docs_root = Path(\"/opt/claude/mystocks_spec/docs\")"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 50,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "'trading-signals': { apiEndpoint: '/api/trading/signals', wsChannel: 'trading:signals', description: '交易信号' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 51,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "'trading-history': { apiEndpoint: '/api/trading/history', wsChannel: 'trading:history', description: '历史订单' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 52,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "'trading-positions': { apiEndpoint: '/api/trading/positions', wsChannel: 'trading:positions', description: '持仓监控' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 53,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "'trading-attribution': { apiEndpoint: '/api/trading/attribution', wsChannel: 'trading:attribution', description: '绩效归因' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 59,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "'strategy-pos': { apiEndpoint: '/api/v1/trade/positions', description: '仓位管理' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 60,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "'trade-positions': { apiEndpoint: '/api/v1/trade/positions', wsChannel: 'trade:positions', description: '头寸管理' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 62,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "'trade-signals': { apiEndpoint: '/api/v1/trade/signals', wsChannel: 'trade:signals', description: '信号监控' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 63,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "'trade-portfolio': { apiEndpoint: '/api/v1/trade/positions', wsChannel: 'trade:portfolio', description: '持仓透视' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 64,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "'trade-history': { apiEndpoint: '/api/v1/trade/trades', wsChannel: 'trade:history', description: '历史对账' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 71,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "'system-settings': { apiEndpoint: '/health/detailed', description: '系统设置（本地持久化 + 健康监控）' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 72,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "'system-config': { apiEndpoint: '/health/detailed', description: '系统设置（本地持久化 + 健康监控）' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 73,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "'system-health': { apiEndpoint: '/health', description: '健康矩阵' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 74,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "'system-api': { apiEndpoint: '/health', description: 'API 终端' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 94,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "{ id: 'attribution', apiEndpoint: '/api/trading/attribution', wsChannel: 'trading:attribution' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 95,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "{ id: 'history', apiEndpoint: '/api/trading/history', wsChannel: 'trading:history' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 99,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "{ id: 'overview', apiEndpoint: '/api/trading/overview', wsChannel: 'trading:overview' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 100,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "{ id: 'signals', apiEndpoint: '/api/trading/signals', wsChannel: 'trading:signals' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 101,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "{ id: 'positions', apiEndpoint: '/api/trading/positions', wsChannel: 'trading:positions' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 102,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "{ id: 'history', apiEndpoint: '/api/trading/history', wsChannel: 'trading:history' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate-page-config.js",
+      "line": 103,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "{ id: 'attribution', apiEndpoint: '/api/trading/attribution', wsChannel: 'trading:attribution' },"
+    },
+    {
+      "path": "scripts/dev/tools/generate_large_file_splitting_inventory.sh",
+      "line": 44,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "-not -path \"*/.archive/*\" -not -path \"*/archived/*\" -not -path \"*/docs/*\" \\"
+    },
+    {
+      "path": "scripts/dev/tools/analyze_docs_suggestions.py",
+      "line": 30,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "def __init__(self, log_dir: str = \"var/log/docs-audit\"):"
+    },
+    {
+      "path": "scripts/dev/tools/performance_test_suite.py",
+      "line": 387,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "with self.client.get(\"/api/health\","
+    },
+    {
+      "path": "scripts/dev/tools/test-service-startup.sh",
+      "line": 39,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl -s --max-time 5 \"http://localhost:/api/health\" >/dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/dev/tools/verify-database-connections.sh",
+      "line": 208,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl -s --max-time 10 \"http://localhost:/api/health\" >/dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/dev/tools/verify-database-connections.sh",
+      "line": 296,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "- **后端API**: $(curl -s --max-time 5 \"http://localhost:/api/health\" >/dev/null 2>&1 && echo \"✅ 运行中\" || echo \"❌ 未运行\")"
+    },
+    {
+      "path": "scripts/dev/tools/pm2-integration.sh",
+      "line": 126,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "url: 'http://localhost:/api/health',"
+    },
+    {
+      "path": "scripts/dev/tools/pm2-integration.sh",
+      "line": 228,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl -s --max-time 10 \"http://localhost:/api/health\" >/dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/dev/tools/pm2-integration.sh",
+      "line": 278,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "$(curl -s -w \"HTTP状态: %{http_code}\\n响应时间: %{time_total}s\\n\" -o /dev/null \"http://localhost:/api/health\" 2>/dev/null || echo \"❌ 服务无响应\")"
+    },
+    {
+      "path": "scripts/dev/tools/pm2-integration.sh",
+      "line": 409,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl -f -s --max-time 30 \"http://localhost:/api/health\" >/dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/dev/frontend_optimization_audit.py",
+      "line": 440,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "default=\"docs/api/openapi.json\","
+    },
+    {
+      "path": "scripts/dev/verify_data_chain.sh",
+      "line": 16,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl -s -o /dev/null -w \"%{http_code}\" http://localhost:/health | grep -q \"200\"; then"
+    },
+    {
+      "path": "scripts/dev/verify_web_access.mjs",
+      "line": 139,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "'/system/health',"
+    },
+    {
+      "path": "scripts/dev/verify_web_access.mjs",
+      "line": 154,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "const response = await fetch(`${CONFIG.backendUrl}/health`, {"
+    },
+    {
+      "path": "scripts/dev/validate_documentation_consistency.py",
+      "line": 382,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "report_path = \"/opt/claude/mystocks_spec/docs/DOCUMENTATION_VALIDATION_REPORT.md\""
+    },
+    {
+      "path": "scripts/dev/检查系统状态.py",
+      "line": 48,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "f\"http://localhost:{port}/api/cache/status\", timeout=5"
+    },
+    {
+      "path": "scripts/dev/检查系统状态.py",
+      "line": 154,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "print(f\"   - API文档: {BACKEND_URL}/api/docs\")"
+    },
+    {
+      "path": "scripts/dev/检查系统状态.py",
+      "line": 156,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "print(f\"   - 系统监控: {BACKEND_URL}/api/cache/status\")"
+    },
+    {
+      "path": "scripts/dev/improved_realtime_validation.py",
+      "line": 149,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "health_url = f\"{self.base_url}/api/market/health\""
+    },
+    {
+      "path": "scripts/dev/health_check.py",
+      "line": 14,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "python scripts/dev/health_check.py --cli web"
+    },
+    {
+      "path": "scripts/dev/health_check.py",
+      "line": 17,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "python scripts/dev/health_check.py --all"
+    },
+    {
+      "path": "scripts/dev/health_check.py",
+      "line": 20,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "python scripts/dev/health_check.py --generate-report"
+    },
+    {
+      "path": "scripts/dev/health_check.py",
+      "line": 362,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "report_lines.append(\"**脚本**: `scripts/dev/health_check.py`\")"
+    },
+    {
+      "path": "scripts/dev/health_check.py",
+      "line": 375,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "python scripts/dev/health_check.py --all"
+    },
+    {
+      "path": "scripts/dev/health_check.py",
+      "line": 378,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "python scripts/dev/health_check.py --cli web"
+    },
+    {
+      "path": "scripts/dev/health_check.py",
+      "line": 381,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "python scripts/dev/health_check.py --generate-report"
+    },
+    {
+      "path": "scripts/dev/health_check.py",
+      "line": 384,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "python scripts/dev/health_check.py --all --verbose"
+    },
+    {
+      "path": "scripts/dev/analysis/utils/markdown_writer.py",
+      "line": 35,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "DEFAULT_OUTPUT_DIR = \"/opt/claude/mystocks_spec/docs/references/function-classification-manual\""
+    },
+    {
+      "path": "scripts/dev/test-artdeco-dashboard.js",
+      "line": 55,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "path: '/opt/claude/mystocks_spec/docs/reports/artdeco-dashboard-full-debug.png',"
+    },
+    {
+      "path": "scripts/dev/simplified_realtime_validation.py",
+      "line": 83,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "health_url = f\"{self.base_url}/api/market/health\""
+    },
+    {
+      "path": "scripts/dev/simple_auth_server.py",
+      "line": 89,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "@app.get(\"/health\")"
+    },
+    {
+      "path": "scripts/dev/simple_auth_server.py",
+      "line": 153,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "@app.get(\"/api/system/status\")"
+    },
+    {
+      "path": "scripts/dev/check_api_health_v2.py",
+      "line": 66,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "resp = requests.get(f\"{BASE_URL}/api/docs\", timeout=2)"
+    },
+    {
+      "path": "scripts/dev/check_api_health_v2.py",
+      "line": 211,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"url\": f\"{BASE_URL}/api/system/health\","
+    },
+    {
+      "path": "scripts/dev/automation/monitor_and_fix.py",
+      "line": 307,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"url\": f\"{backend_url}/api/health\","
+    },
+    {
+      "path": "scripts/dev/automation/regression_test.sh",
+      "line": 70,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if ! curl -s -f \"$API_BASE_URL/api/monitoring/health\" >/dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/dev/automation/regression_test.sh",
+      "line": 124,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"$API_BASE_URL/api/monitoring/health:健康检查\""
+    },
+    {
+      "path": "scripts/dev/automation/regression_test.sh",
+      "line": 266,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "measure_performance \"健康检查API\" \"$API_BASE_URL/api/monitoring/health\" \"0.5\" || ((failed_count++))"
+    },
+    {
+      "path": "scripts/dev/automation/health_check_simple.sh",
+      "line": 19,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "HEALTH_LOG=\"${LOG_DIR}/health_check.log\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check_simple.sh",
+      "line": 71,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "for api_endpoint in \"/api/health\" \"/api/docs\"; do"
+    },
+    {
+      "path": "scripts/dev/automation/health_check_simple.sh",
+      "line": 71,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "for api_endpoint in \"/api/health\" \"/api/docs\"; do"
+    },
+    {
+      "path": "scripts/dev/automation/health_check_simple.sh",
+      "line": 84,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "local report_file=\"${LOG_DIR}/health_report_$(date +%Y%m%d_%H%M%S).txt\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check_simple.sh",
+      "line": 95,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "echo \"API文档: $(curl -s -o /dev/null -w \"%{http_code}\" \"$API_BASE_URL/api/docs\" 2>/dev/null || echo '不可用')\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check_simple.sh",
+      "line": 96,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "echo \"API健康: $(curl -s -o /dev/null -w \"%{http_code}\" \"$API_BASE_URL/api/health\" 2>/dev/null || echo '不可用')\""
+    },
+    {
+      "path": "scripts/dev/automation/monitor.sh",
+      "line": 11,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "HEALTH_SCRIPT=\"${PROJECT_ROOT}/scripts/automation/health_check_simple.sh\""
+    },
+    {
+      "path": "scripts/dev/automation/deploy.sh",
+      "line": 248,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl -s -f http://localhost:/api/monitoring/health >/dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/dev/automation/deploy.sh",
+      "line": 458,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "log \"API文档地址: http://localhost:/api/docs\""
+    },
+    {
+      "path": "scripts/dev/automation/deploy.sh",
+      "line": 459,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "log \"API健康检查: http://localhost:/api/monitoring/health\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check_v2.sh",
+      "line": 10,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "exec 2>&1 | tee \"${LOG_DIR}/health_error.log\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check_v2.sh",
+      "line": 22,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "HEALTH_LOG=\"${LOG_DIR}/health_check.log\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check_v2.sh",
+      "line": 89,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"${API_BASE_URL}/api/health\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check_v2.sh",
+      "line": 90,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"${API_BASE_URL}/api/system/health\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check_v2.sh",
+      "line": 91,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"${API_BASE_URL}/api/monitoring/health\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check_v2.sh",
+      "line": 92,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "\"${API_BASE_URL}/api/docs\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check_v2.sh",
+      "line": 106,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if [[ \"$api_url\" == *\"/api/monitoring/health\"* ]]; then"
+    },
+    {
+      "path": "scripts/dev/automation/health_check_v2.sh",
+      "line": 256,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"${API_BASE_URL}/api/health\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check_v2.sh",
+      "line": 257,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"${API_BASE_URL}/api/system/health\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check_v2.sh",
+      "line": 258,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"${API_BASE_URL}/api/monitoring/health\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check_v2.sh",
+      "line": 259,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "\"${API_BASE_URL}/api/docs\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check_v2.sh",
+      "line": 286,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "local report_file=\"${LOG_DIR}/health_report_$(date +%Y%m%d_%H%M%S).txt\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check.sh",
+      "line": 21,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "HEALTH_LOG=\"${LOG_DIR}/health_check.log\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check.sh",
+      "line": 74,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "local api_url=\"${API_BASE_URL}/api/monitoring/health\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check.sh",
+      "line": 245,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"${API_BASE_URL}/api/monitoring/health\""
+    },
+    {
+      "path": "scripts/dev/automation/health_check.sh",
+      "line": 276,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "local report_file=\"${LOG_DIR}/health_report_$(date +%Y%m%d_%H%M%S).txt\""
+    },
+    {
+      "path": "scripts/dev/automation/monitor_config.json",
+      "line": 13,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"url\": \"http://localhost:8020/api/health\","
+    },
+    {
+      "path": "scripts/dev/automation/monitor_config.json",
+      "line": 23,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "{ \"path\": \"/api/health\", \"method\": \"GET\", \"expected_status\": 200 },"
+    },
+    {
+      "path": "scripts/dev/start_with_mock.sh",
+      "line": 148,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "if curl -s http://localhost:/api/cache/status > /dev/null; then"
+    },
+    {
+      "path": "scripts/dev/start_with_mock.sh",
+      "line": 177,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "echo -e \"  API文档: ${BLUE}http://localhost:/api/docs${NC}\""
+    },
+    {
+      "path": "scripts/dev/start_with_mock.sh",
+      "line": 179,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "echo -e \"  系统监控: ${BLUE}http://localhost:/api/cache/status${NC}\""
+    },
+    {
+      "path": "scripts/dev/tmux/mystocks-test.conf",
+      "line": 63,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "send-keys -t 3 'echo \"- PostgreSQL: curl -s http://localhost:${BACKEND_PORT:-8020}/api/system/database/health\"' C-m"
+    },
+    {
+      "path": "scripts/dev/tmux/mystocks-test.conf",
+      "line": 64,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "send-keys -t 3 'echo \"- TDengine: curl -s http://localhost:${BACKEND_PORT:-8020}/api/cache/monitoring/health\"' C-m"
+    },
+    {
+      "path": "scripts/dev/tmux/mystocks-test.conf",
+      "line": 65,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "send-keys -t 3 'echo \"- 缓存状态: curl -s http://localhost:${BACKEND_PORT:-8020}/api/cache/status\"' C-m"
+    },
+    {
+      "path": "scripts/dev/generate_market_api_openapi.sh",
+      "line": 7,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "OUTPUT_DIR=\"$PROJECT_ROOT/docs/api/openapi\""
+    },
+    {
+      "path": "scripts/dev/generate_market_api_openapi.sh",
+      "line": 32,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "output_path = Path(\"../../docs/api/openapi/market-data-api-full.json\")"
+    },
+    {
+      "path": "scripts/dev/verify_windows_qmt_agent_contract.py",
+      "line": 123,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "response = await client.get(f\"{base_url.rstrip('/')}/health\")"
+    },
+    {
+      "path": "scripts/dev/verify_windows_qmt_agent_contract.py",
+      "line": 127,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "raise ValueError(\"Windows qmt /health payload must be a JSON object\")"
+    },
+    {
+      "path": "scripts/dev/start-dev.sh",
+      "line": 184,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "echo \"  后端 API:  http://localhost:/api/docs\""
+    },
+    {
+      "path": "scripts/dev/start-dev.sh",
+      "line": 260,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "echo -e \"  后端 API: ${BLUE}http://localhost:/api/docs${NC}\""
+    },
+    {
+      "path": "scripts/dev/get-docker.sh",
+      "line": 9,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "# at https://docs.docker.com/engine/install/ for alternative installation methods."
+    },
+    {
+      "path": "scripts/dev/get-docker.sh",
+      "line": 304,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "echo \"Visit https://docs.docker.com/go/rootless/ to learn about rootless mode.\""
+    },
+    {
+      "path": "scripts/dev/get-docker.sh",
+      "line": 309,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "echo \"users access, refer to https://docs.docker.com/go/daemon-access/\""
+    },
+    {
+      "path": "scripts/dev/get-docker.sh",
+      "line": 313,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "echo \"         documentation for details: https://docs.docker.com/go/attack-surface/\""
+    },
+    {
+      "path": "scripts/verify_web_access.js",
+      "line": 136,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "const req = http.get(`http://localhost:${CONFIG.backendPort}/health`, (res) => {"
+    },
+    {
+      "path": "scripts/compliance/readiness_contract_gate.py",
+      "line": 15,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "'@app.get(\"/health/ready\")',"
+    },
+    {
+      "path": "scripts/compliance/readiness_contract_gate.py",
+      "line": 16,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"@app.get('/health/ready')\","
+    },
+    {
+      "path": "scripts/compliance/readiness_contract_gate.py",
+      "line": 17,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "'@router.get(\"/health/ready\")',"
+    },
+    {
+      "path": "scripts/compliance/readiness_contract_gate.py",
+      "line": 18,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"@router.get('/health/ready')\","
+    },
+    {
+      "path": "scripts/compliance/readiness_contract_gate.py",
+      "line": 37,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"/api/health/ready\","
+    },
+    {
+      "path": "scripts/compliance/readiness_contract_gate.py",
+      "line": 57,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"detail\": \"Detected /health/ready readiness probe\" if passed else \"Missing /health/ready readiness probe\","
+    },
+    {
+      "path": "scripts/deployment/INDEX.md",
+      "line": 15,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- [SETUP_GRAFANA](../../docs/operations/deployment/SETUP_GRAFANA.md)"
+    },
+    {
+      "path": "scripts/deployment/deploy/deploy.sh",
+      "line": 182,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "local health_url=\"http://localhost:8001/health\""
+    },
+    {
+      "path": "scripts/deployment/deploy/deploy.sh",
+      "line": 185,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "local health_url=\"http://localhost:/health\""
+    },
+    {
+      "path": "scripts/deployment/deploy/deploy.sh",
+      "line": 230,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl -f \"${api_base}/health\" || {"
+    },
+    {
+      "path": "scripts/deployment/deploy/deploy.sh",
+      "line": 236,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl -f \"${api_base}/system/health\" || {"
+    },
+    {
+      "path": "scripts/deployment/deploy/deploy.sh",
+      "line": 251,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl -f \"${api_base}/health\" || {"
+    },
+    {
+      "path": "scripts/deployment/deploy/deploy.sh",
+      "line": 257,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl -f \"${api_base}/system/health\" || {"
+    },
+    {
+      "path": "scripts/deployment/deploy/automation_test_deployment.py",
+      "line": 325,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "\"/api/monitoring/status\","
+    },
+    {
+      "path": "scripts/deployment/deploy/automation_test_deployment.py",
+      "line": 462,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"health_check\": f\"Health check script created at {scripts_dir}/health_check.sh\","
+    },
+    {
+      "path": "scripts/deployment/deploy/automation_test_deployment.py",
+      "line": 544,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"health_check_endpoint\": \"/health\","
+    },
+    {
+      "path": "scripts/deployment/deploy/automation_test_deployment.py",
+      "line": 562,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"api_health\": \"/api/health endpoint configured\","
+    },
+    {
+      "path": "scripts/deployment/deploy/automation_test_deployment.py",
+      "line": 594,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "./scripts/automation/health_check.sh"
+    },
+    {
+      "path": "scripts/deployment/deploy/automation_test_deployment.py",
+      "line": 598,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- 访问 http://localhost:{self.backend_port}/api/docs"
+    },
+    {
+      "path": "scripts/deployment/deploy/automation_test_deployment.py",
+      "line": 626,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "\"swagger_ui\": \"Swagger UI available at /api/docs\","
+    },
+    {
+      "path": "scripts/deployment/deploy/automation_test_deployment.py",
+      "line": 627,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "\"redoc\": \"ReDoc available at /api/redoc\","
+    },
+    {
+      "path": "scripts/deployment/setup-grafana.sh",
+      "line": 22,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if ! curl -s http://localhost:3000/api/health | grep -q '\"ok\"'; then"
+    },
+    {
+      "path": "scripts/deployment/k8s-deployment.yaml",
+      "line": 139,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "prometheus.io/path: \"/metrics\""
+    },
+    {
+      "path": "scripts/deployment/k8s-deployment.yaml",
+      "line": 199,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "path: /health"
+    },
+    {
+      "path": "scripts/deployment/k8s-deployment.yaml",
+      "line": 207,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "path: /health"
+    },
+    {
+      "path": "scripts/deployment/k8s-deployment.yaml",
+      "line": 403,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "path: /metrics"
+    },
+    {
+      "path": "scripts/deployment/k8s-deployment.yaml",
+      "line": 436,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "- path: /metrics"
+    },
+    {
+      "path": "scripts/deployment/automation_test_deployment.py",
+      "line": 325,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "\"/api/monitoring/status\","
+    },
+    {
+      "path": "scripts/deployment/automation_test_deployment.py",
+      "line": 462,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"health_check\": f\"Health check script created at {scripts_dir}/health_check.sh\","
+    },
+    {
+      "path": "scripts/deployment/automation_test_deployment.py",
+      "line": 544,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"health_check_endpoint\": \"/health\","
+    },
+    {
+      "path": "scripts/deployment/automation_test_deployment.py",
+      "line": 562,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"api_health\": \"/api/health endpoint configured\","
+    },
+    {
+      "path": "scripts/deployment/automation_test_deployment.py",
+      "line": 594,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "./scripts/automation/health_check.sh"
+    },
+    {
+      "path": "scripts/deployment/automation_test_deployment.py",
+      "line": 598,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- 访问 http://localhost:{self.backend_port}/api/docs"
+    },
+    {
+      "path": "scripts/deployment/automation_test_deployment.py",
+      "line": 626,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "\"swagger_ui\": \"Swagger UI available at /api/docs\","
+    },
+    {
+      "path": "scripts/deployment/automation_test_deployment.py",
+      "line": 627,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "\"redoc\": \"ReDoc available at /api/redoc\","
+    },
+    {
+      "path": "scripts/playwright_cli_routes.sh",
+      "line": 26,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"system/health|健康矩阵|P6\""
+    },
+    {
+      "path": "scripts/windows_qmt_agent/app.py",
+      "line": 18,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "@app.get(\"/health\", response_model=HealthResponse)"
+    },
+    {
+      "path": "scripts/port_status.py",
+      "line": 119,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "print(f\"   - API文档: http://localhost:{BACKEND_PORT}/docs\")"
+    },
+    {
+      "path": "scripts/port_status.py",
+      "line": 236,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "print(f\"   4. 查看API文档 http://localhost:{BACKEND_PORT}/docs\")"
+    },
+    {
+      "path": "scripts/run-e2e-tests.sh",
+      "line": 129,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if ! curl -s \"http://localhost:${BACKEND_PORT}/health\" > /dev/null; then"
+    },
+    {
+      "path": "scripts/cli/main/CHECKPOINTS.md",
+      "line": 51,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "- `scripts/dev/health_check.py`"
+    },
+    {
+      "path": "scripts/cli/main/CHECKPOINTS.md",
+      "line": 60,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "python scripts/dev/health_check.py --all"
+    },
+    {
+      "path": "scripts/cli/main/HEALTH.md",
+      "line": 105,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "**脚本**: `scripts/dev/health_check.py`"
+    },
+    {
+      "path": "scripts/cli/SHARED/KNOWLEDGE_BASE.md",
+      "line": 169,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "**健康检查**: `scripts/dev/health_check.py`"
+    },
+    {
+      "path": "scripts/cli/SHARED/KNOWLEDGE_BASE.md",
+      "line": 172,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "python scripts/dev/health_check.py --all"
+    },
+    {
+      "path": "scripts/cli/SHARED/KNOWLEDGE_BASE.md",
+      "line": 175,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "python scripts/dev/health_check.py --generate-report"
+    },
+    {
+      "path": "scripts/cli/SHARED/KNOWLEDGE_BASE.md",
+      "line": 294,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl -X GET http://localhost:8000/api/health"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 10,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "**完整文档**: [docs/guides/multi-cli-tasks/INDEX.md](../docs/guides/multi-cli-tasks/INDEX.md)"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 18,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "| **系统概览** | [系统初始化](#系统初始化) | [V2实施方案](../docs/architecture/MULTI_CLI_COLLABORATION_V2_IMPLEMENTATION.md) |"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 19,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "| **CLI报到** | [CLI报到流程](#cli报到流程) | [报到详细指南](../docs/guides/multi-cli-tasks/CLI_REGISTRATION_GUIDE.md) |"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 20,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "| **任务池** | [任务池使用](#任务池使用) | [任务池完整指南](../docs/guides/multi-cli-tasks/TASK_POOL_USAGE_GUIDE.md) |"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 21,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "| **实施报告** | - | [实施完成报告](../docs/06-项目管理与报告/MULTI_CLI_IMPLEMENTATION_COMPLETION_REPORT.md) |"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 108,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "**📖 详细文档**: [CLI报到完整指南](../docs/guides/multi-cli-tasks/CLI_REGISTRATION_GUIDE.md)"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 185,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "**📖 详细文档**: [任务池完整使用指南](../docs/guides/multi-cli-tasks/TASK_POOL_USAGE_GUIDE.md)"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 421,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- **[CLI报到详细指南](../docs/guides/multi-cli-tasks/CLI_REGISTRATION_GUIDE.md)** - 完整的报到流程、API文档、故障排查"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 422,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- **[任务池使用指南](../docs/guides/multi-cli-tasks/TASK_POOL_USAGE_GUIDE.md)** - 任务发布、认领、更新的完整说明"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 423,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- **[V2实施方案](../docs/architecture/MULTI_CLI_COLLABORATION_V2_IMPLEMENTATION.md)** - 架构设计、实现细节"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 424,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- **[实施完成报告](../docs/06-项目管理与报告/MULTI_CLI_IMPLEMENTATION_COMPLETION_REPORT.md)** - 实施总结、验证结果"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 425,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- **[V2.1修复总结](../docs/06-项目管理与报告/MULTI_CLI_V2_FIX_SUMMARY.md)** - 7个关键问题修复"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 446,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- **[FILE_ORGANIZATION_RULES.md](../docs/standards/FILE_ORGANIZATION_RULES.md)** - 文件组织规范"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 447,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- **[MULTI_CLI_COLLABORATION_METHOD.md](../docs/guides/multi-cli-tasks/MULTI_CLI_COLLABORATION_METHOD.md)** - V1方法文档（已归档）"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 457,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "ls ../docs/guides/"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 460,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "cat ../docs/guides/multi-cli-tasks/CLI_REGISTRATION_GUIDE.md"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 461,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "cat ../docs/guides/multi-cli-tasks/TASK_POOL_USAGE_GUIDE.md"
+    },
+    {
+      "path": "scripts/cli/README.md",
+      "line": 487,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "**详细问题**: 请参考 [docs/guides/multi-cli-tasks/INDEX.md](../docs/guides/multi-cli-tasks/INDEX.md) 下的完整文档"
+    },
+    {
+      "path": "scripts/test_api_fixes.sh",
+      "line": 149,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "test_api \"健康检查\" \"/api/monitoring/health\" \"GET\" \"200\""
+    },
+    {
+      "path": "scripts/test_api_fixes.sh",
+      "line": 151,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "test_api \"获取指标记录\" \"/api/monitoring/metrics?limit=10\" \"GET\" \"200\""
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 17,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "METRICS_BASELINE_RAW_PATH=\"${REPORT_DIR}/metrics.baseline.raw.txt\""
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 18,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "METRICS_RAW_PATH=\"${REPORT_DIR}/metrics.raw.txt\""
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 19,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "METRICS_HEALTH_PATH=\"${REPORT_DIR}/metrics-health.json\""
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 20,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "METRICS_SUMMARY_PATH=\"${REPORT_DIR}/metrics-summary.json\""
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 102,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "wait_for_url \"http://localhost:${BACKEND_PORT}/health\" \"Backend /health\""
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 103,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "wait_for_url \"http://localhost:${BACKEND_PORT}/api/health/ready\" \"Backend /api/health/ready\""
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 106,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent \"http://localhost:${BACKEND_PORT}/metrics\" > \"${METRICS_BASELINE_RAW_PATH}\""
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 107,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent --fail \"http://localhost:${BACKEND_PORT}/health\" > \"${BACKEND_HEALTH_PATH}\""
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 108,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent --fail \"http://localhost:${BACKEND_PORT}/api/health/ready\" > \"${BACKEND_READINESS_PATH}\""
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 110,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent --fail \"http://localhost:${BACKEND_PORT}/api/metrics/health\" > \"${METRICS_HEALTH_PATH}\""
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 110,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent --fail \"http://localhost:${BACKEND_PORT}/api/metrics/health\" > \"${METRICS_HEALTH_PATH}\""
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 111,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent --fail \"http://localhost:${BACKEND_PORT}/metrics\" > \"${METRICS_RAW_PATH}\""
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 168,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' http://localhost:${BACKEND_PORT}/health"
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 169,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' http://localhost:${BACKEND_PORT}/api/health/ready"
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 181,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "- \\`/api/metrics/health\\`: \\`${METRICS_HEALTH_STATUS}\\`"
+    },
+    {
+      "path": "scripts/run_containerized_runtime_smoke.sh",
+      "line": 181,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "- \\`/api/metrics/health\\`: \\`${METRICS_HEALTH_STATUS}\\`"
+    },
+    {
+      "path": "scripts/opencode/update_mydoc_opencode_guides.sh",
+      "line": 4,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "SRC_ROOT=\"/opt/claude/mystocks_spec/docs/guides\""
+    },
+    {
+      "path": "scripts/opencode/migrate_opencode_assets_to_mydoc.sh",
+      "line": 12,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "SRC_GUIDE=\"$SRC_ROOT/docs/guides/ai-tools/OMO_SETUP_GUIDE.md\""
+    },
+    {
+      "path": "scripts/run_test.sh",
+      "line": 199,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "local backend_status=$(curl -s -o /dev/null -w \"%{http_code}\" \"${BACKEND_URL}/health\" || echo \"000\")"
+    },
+    {
+      "path": "scripts/run_test.sh",
+      "line": 317,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "local frontend_health=$(curl -s \"${FRONTEND_URL}/health\" 2>/dev/null | head -c 100 || echo \"Unreachable\")"
+    },
+    {
+      "path": "scripts/run_test.sh",
+      "line": 318,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "local backend_health=$(curl -s \"${BACKEND_URL}/health\" 2>/dev/null || echo \"Unreachable\")"
+    },
+    {
+      "path": "scripts/run-api-tests.sh",
+      "line": 58,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if ! curl -fsS \"${BACKEND_BASE_URL}/api/announcement/health\" > /dev/null 2>&1 && \\"
+    },
+    {
+      "path": "scripts/run-api-tests.sh",
+      "line": 59,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "! curl -fsS \"${BACKEND_BASE_URL}/health/ready\" > /dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/test_data_consistency.py",
+      "line": 348,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "f\"{API_BASE_URL}/api/monitoring/health\", headers=HEADERS, timeout=10"
+    },
+    {
+      "path": "scripts/quick_validation.sh",
+      "line": 59,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "check_file \"/opt/claude/mystocks_spec/docs/api/API_FIXES_SUMMARY.md\" \"API修复文档\""
+    },
+    {
+      "path": "scripts/utils/frontend_status.py",
+      "line": 51,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "response = requests.get(f\"http://localhost:{port}/docs\", timeout=2)"
+    },
+    {
+      "path": "scripts/utils/frontend_status.py",
+      "line": 207,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "print(f\"   - API文档: http://localhost:{BACKEND_PORT}/docs\")"
+    },
+    {
+      "path": "scripts/utils/frontend_status.py",
+      "line": 209,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "print(f\"   - 健康检查: http://localhost:{BACKEND_PORT}/health\")"
+    },
+    {
+      "path": "scripts/runtime/start_metrics_server.py",
+      "line": 24,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "http://localhost:8001/metrics"
+    },
+    {
+      "path": "scripts/runtime/start_metrics_server.py",
+      "line": 146,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "logger.info(f\"  - Metrics端点: http://localhost:{metrics_port}/metrics\")"
+    },
+    {
+      "path": "scripts/runtime/start_metrics_server.py",
+      "line": 158,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "logger.info(f\"访问 http://localhost:{metrics_port}/metrics 查看指标\")"
+    },
+    {
+      "path": "scripts/runtime/import_to_apifox.py",
+      "line": 287,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "print(f\"   curl http://localhost:{backend_port}/openapi.json > {OPENAPI_FILE}\")"
+    },
+    {
+      "path": "scripts/runtime/run_platform.sh",
+      "line": 102,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "log_warn \"Installation guide: https://docs.tdengine.com/\""
+    },
+    {
+      "path": "scripts/runtime/run_platform.sh",
+      "line": 146,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "wait_for_service \"http://localhost:$BACKEND_PORT/health\" \"FastAPI backend\""
+    },
+    {
+      "path": "scripts/runtime/run_platform.sh",
+      "line": 283,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "- Backend: http://localhost:$BACKEND_PORT/health"
+    },
+    {
+      "path": "scripts/runtime/run_platform.sh",
+      "line": 376,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "log_info \"📖 API Docs: http://localhost:$BACKEND_PORT/docs\""
+    },
+    {
+      "path": "scripts/runtime/run_platform.sh",
+      "line": 379,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "log_info \"📖 API Docs: http://localhost:$BACKEND_PORT/docs\""
+    },
+    {
+      "path": "scripts/tests/run_e2e_tests.sh",
+      "line": 26,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl -s \"${BACKEND_URL}/api/health\" > /dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/tests/run_e2e_tests.sh",
+      "line": 50,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"/api/system/database/health\""
+    },
+    {
+      "path": "scripts/tests/run_e2e_tests.sh",
+      "line": 54,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "\"/api/system/performance/metrics\""
+    },
+    {
+      "path": "scripts/tests/load_test_scenarios.py",
+      "line": 66,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"/health\","
+    },
+    {
+      "path": "scripts/tests/test_phase3_integration.py",
+      "line": 65,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "(\"GET\", \"/api/v1/data-sources/config/health\", \"批量健康检查\"),"
+    },
+    {
+      "path": "scripts/tests/test_phase3_integration.py",
+      "line": 137,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "(\"GET\", \"/api/v1/governance/compliance/metrics\", \"治理合规指标\"),"
+    },
+    {
+      "path": "scripts/tests/cache_loadtest.py",
+      "line": 26,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "self.client.get(\"/health\")"
+    },
+    {
+      "path": "scripts/tests/cache_loadtest.py",
+      "line": 31,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "self.client.get(\"/metrics\")"
+    },
+    {
+      "path": "scripts/tests/LOAD_TESTING_GUIDE.md",
+      "line": 428,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "1. 检查API服务是否运行: `curl http://localhost:8000/health`"
+    },
+    {
+      "path": "scripts/tests/LOAD_TESTING_GUIDE.md",
+      "line": 435,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl -v http://localhost:8000/health"
+    },
+    {
+      "path": "scripts/tests/LOAD_TESTING_GUIDE.md",
+      "line": 501,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- **Locust官方文档**: https://docs.locust.io/"
+    },
+    {
+      "path": "scripts/tests/LOAD_TESTING_GUIDE.md",
+      "line": 503,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- **MyStocks API文档**: `/docs/api/README.md`"
+    },
+    {
+      "path": "scripts/tests/LOAD_TESTING_GUIDE.md",
+      "line": 504,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- **告警升级机制**: `/docs/api/TASK_15_COMPLETION_SUMMARY.md`"
+    },
+    {
+      "path": "scripts/tests/LOAD_TESTING_GUIDE.md",
+      "line": 561,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- 技术文档: `/docs/api/`"
+    },
+    {
+      "path": "scripts/tests/legacy/test_web_services.js",
+      "line": 44,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "testService('Backend API (port 8000)', 'http://localhost:8000/api/health'),"
+    },
+    {
+      "path": "scripts/tests/legacy/test_frontend_comprehensive.py",
+      "line": 280,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "'/api/health',"
+    },
+    {
+      "path": "scripts/tests/legacy/test_frontend_comprehensive.py",
+      "line": 617,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "const response = await fetch('/api/health');"
+    },
+    {
+      "path": "scripts/tests/legacy/test_frontend_deep.py",
+      "line": 220,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "endpoints = [\"/api/health\", \"/api/auth/login\"]"
+    },
+    {
+      "path": "scripts/tests/run_api_tests.sh",
+      "line": 27,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if ! curl -s http://localhost:/health > /dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/tests/run_api_tests.sh",
+      "line": 37,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl -s http://localhost:/health > /dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/tests/web-usability-runner.sh",
+      "line": 283,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if ! curl -s --max-time 10 \"$API_URL/health\" > /dev/null; then"
+    },
+    {
+      "path": "scripts/tests/verify_monitoring_integration.py",
+      "line": 163,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "\"\"\"测试/metrics端点是否可访问\"\"\""
+    },
+    {
+      "path": "scripts/tests/verify_monitoring_integration.py",
+      "line": 172,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "response = requests.get(\"http://localhost:8001/metrics\", timeout=5)"
+    },
+    {
+      "path": "scripts/tests/load_test_locustfile.py",
+      "line": 259,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "self.client.get(\"/health\", name=\"/health\")"
+    },
+    {
+      "path": "scripts/tests/LOAD_TEST_QUICK_REFERENCE.md",
+      "line": 138,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl -v http://localhost:8000/health"
+    },
+    {
+      "path": "scripts/tests/LOAD_TEST_QUICK_REFERENCE.md",
+      "line": 218,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl -s http://localhost:8000/health > /dev/null && echo \"OK\" || echo \"FAILED\""
+    },
+    {
+      "path": "scripts/tests/LOAD_TEST_QUICK_REFERENCE.md",
+      "line": 251,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- **Locust文档**: https://docs.locust.io/"
+    },
+    {
+      "path": "scripts/tests/LOAD_TEST_QUICK_REFERENCE.md",
+      "line": 252,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- **API文档**: `/docs/api/README.md`"
+    },
+    {
+      "path": "scripts/tests/LOAD_TEST_QUICK_REFERENCE.md",
+      "line": 253,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "- **Task 15**: `/docs/api/TASK_15_COMPLETION_SUMMARY.md`"
+    },
+    {
+      "path": "scripts/tests/test_check_api_health.py",
+      "line": 85,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "assert health_endpoint[\"url\"] == \"/api/system/health\""
+    },
+    {
+      "path": "scripts/tests/test_check_api_health.py",
+      "line": 103,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "mock_get.assert_called_once_with(f\"{BASE_URL}/api/docs\", timeout=2)"
+    },
+    {
+      "path": "scripts/tests/run-e2e-tests.sh",
+      "line": 181,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if ! curl -f \"$api_url/health\" &> /dev/null; then"
+    },
+    {
+      "path": "scripts/tests/test-env-checker.py",
+      "line": 238,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "response = requests.get(services[\"backend\"][\"url\"] + \"/docs\", timeout=5)"
+    },
+    {
+      "path": "scripts/tests/run-api-tests.sh",
+      "line": 25,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "REPORT_DIR=\"${PROJECT_ROOT}/docs/reports/test-results\""
+    },
+    {
+      "path": "scripts/tests/run-api-tests.sh",
+      "line": 66,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl -fsS \"${BASE_URL}/api/announcement/health\" > /dev/null 2>&1 || \\"
+    },
+    {
+      "path": "scripts/tests/run-api-tests.sh",
+      "line": 67,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl -fsS \"${BASE_URL}/health/ready\" > /dev/null 2>&1 || \\"
+    },
+    {
+      "path": "scripts/tests/run-api-tests.sh",
+      "line": 68,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl -fsS \"${BASE_URL}/health\" > /dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/tests/run-api-tests.sh",
+      "line": 72,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "print_message \"${RED}\" \"❌ 后端服务未响应或不可用 (${BASE_URL}/api/announcement/health or /health/ready)\""
+    },
+    {
+      "path": "scripts/tests/test-runner/run-schemathesis.sh",
+      "line": 60,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "if curl -s --max-time 5 \"${BACKEND_URL}/docs\" > /dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/tests/test-runner/run-schemathesis.sh",
+      "line": 85,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "log_info \"执行命令: schemathesis run ${BACKEND_URL}/openapi.json $SCHEMATHESIS_OPTIONS --report ${SCHEMATHESIS_REPORT}\""
+    },
+    {
+      "path": "scripts/tests/test-runner/run-schemathesis.sh",
+      "line": 89,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "\"${BACKEND_URL}/openapi.json\" \\"
+    },
+    {
+      "path": "scripts/tests/test-runner/run-performance-tests.sh",
+      "line": 49,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "if ! curl -s --max-time 5 \"http://localhost:/docs\" >/dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/tests/test-runner/run-performance-tests.sh",
+      "line": 103,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "self.client.get(\"/api/health\")"
+    },
+    {
+      "path": "scripts/tests/test-runner/start-environment.sh",
+      "line": 181,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl -s --max-time 5 \"http://localhost:$BACKEND_PORT/api/health\" >/dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/tests/test-runner/start-environment.sh",
+      "line": 236,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl -s --max-time 3 \"http://localhost:$BACKEND_PORT/api/health\" >/dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/tests/test-runner/start-environment.sh",
+      "line": 252,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "echo \"  1. 运行健康检查: ./scripts/test-runner/health-check.sh\""
+    },
+    {
+      "path": "scripts/tests/test-runner/esm-validation.sh",
+      "line": 64,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if ! check_service \"后端\" \"http://localhost:$BACKEND_PORT/api/health\" 10; then"
+    },
+    {
+      "path": "scripts/tests/test-runner/esm-validation.sh",
+      "line": 157,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if ! check_service \"后端\" \"http://localhost:$BACKEND_PORT/api/health\" 5 >/dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/tests/test-runner/health-check.sh",
+      "line": 10,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "BACKEND_URL=\"http://localhost:/api/health\""
+    },
+    {
+      "path": "scripts/tests/test_advanced_analysis_api_integration.py",
+      "line": 84,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "url = f\"{self.base_url}/health\""
+    },
+    {
+      "path": "scripts/tests/buger_integration_test.py",
+      "line": 4,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "按照 /opt/iflow/buger/docs/guides/B项目接入指南.md 执行"
+    },
+    {
+      "path": "scripts/tests/buger_integration_test.py",
+      "line": 64,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "response = requests.get(f\"{base_url}/health\", timeout=5)"
+    },
+    {
+      "path": "scripts/tests/test_security_owasp_top10.py",
+      "line": 185,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "f\"{self.base_url.replace('http', 'https')}/api/health\", timeout=5"
+    },
+    {
+      "path": "scripts/tests/test_security_owasp_top10.py",
+      "line": 325,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "response = self.session.get(f\"{self.base_url}{endpoint}/health\")"
+    },
+    {
+      "path": "scripts/tests/test_security_owasp_top10.py",
+      "line": 382,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "response = self.session.get(f\"{self.base_url}/api/health\")"
+    },
+    {
+      "path": "scripts/tests/test_security_owasp_top10.py",
+      "line": 503,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "response = self.session.get(f\"{self.base_url}/api/health\")"
+    },
+    {
+      "path": "scripts/tests/test_security_owasp_top10.py",
+      "line": 645,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "f\"{self.base_url}/api/trading/order\","
+    },
+    {
+      "path": "scripts/tests/test_check_api_health_v2.py",
+      "line": 137,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "mock_get.assert_called_with(f\"{EXPECTED_BASE_URL}/api/docs\", timeout=2)"
+    },
+    {
+      "path": "scripts/tests/test_tdx_api.py",
+      "line": 21,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "response = client.get(\"/api/tdx/health\")"
+    },
+    {
+      "path": "scripts/tests/manage-test-env.sh",
+      "line": 333,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl -f http://localhost:/health &> /dev/null; then"
+    },
+    {
+      "path": "scripts/tests/run-tests-no-docker.sh",
+      "line": 430,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "if curl -s http://localhost:/docs >/dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/tests/test_contract_testing.py",
+      "line": 410,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "\"/api/health\": {"
+    },
+    {
+      "path": "scripts/tests/test_contract_testing.py",
+      "line": 438,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "engine.register_test_handler(\"GET /api/health\", handler)"
+    },
+    {
+      "path": "scripts/tests/test_contract_testing.py",
+      "line": 440,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "assert \"GET /api/health\" in engine.test_handlers"
+    },
+    {
+      "path": "scripts/tests/test_contract_testing.py",
+      "line": 449,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "engine.register_test_handler(\"GET /api/health\", handler)"
+    },
+    {
+      "path": "scripts/tests/test-directory-org/check-structure.sh",
+      "line": 202,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "if [[ \"$basename_file\" =~ \\.md$ ]] && [[ \"$file\" != *\"/docs/\"* ]]; then"
+    },
+    {
+      "path": "scripts/tests/run-tests-no-docker.bat",
+      "line": 473,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "curl -s http://localhost:!BACKEND_PORT!/docs >nul 2>&1"
+    },
+    {
+      "path": "scripts/tests/verify_windows_bridge_connectivity.py",
+      "line": 24,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "resp = await client.get(f\"{url}/health\")"
+    },
+    {
+      "path": "scripts/tests/test_security_authentication/authentication_tester_methods/part1.py",
+      "line": 80,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "unprotected_endpoints = [\"/api/health\", \"/api/market/data\", \"/api/public/info\"]"
+    },
+    {
+      "path": "scripts/tests/web-usability/core/environment.js",
+      "line": 18,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "const backendResponse = await axios.get(`${this.config.apiUrl}/health`, { timeout: 5000 });"
+    },
+    {
+      "path": "scripts/tests/web-usability/core/environment.js",
+      "line": 38,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "const response = await axios.get(`${this.config.apiUrl}/api/system/health`, { timeout: 5000 });"
+    },
+    {
+      "path": "scripts/tests/web-usability/core/performance.js",
+      "line": 108,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "const endpoint = `${this.config.apiUrl}/health`;"
+    },
+    {
+      "path": "scripts/tests/test/run-comprehensive-tests.sh",
+      "line": 147,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl -s \"http://localhost:${BACKEND_PORT}/health\" > /dev/null 2>&1 || \\"
+    },
+    {
+      "path": "scripts/tests/test/run-comprehensive-tests.sh",
+      "line": 148,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl -s \"http://localhost:${BACKEND_PORT}/api/health\" > /dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/run_pm2_integration_workflow.sh",
+      "line": 189,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "wait_for_url \"http://localhost:8020/health\" \"Backend\""
+    },
+    {
+      "path": "scripts/run_pm2_integration_workflow.sh",
+      "line": 190,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "wait_for_url \"http://localhost:8020/api/health/ready\" \"Backend readiness\""
+    },
+    {
+      "path": "scripts/cicd_pipeline.sh",
+      "line": 253,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "lighthouse \"${BACKEND_BASE_URL}/api/docs\" --output json --output html --output-path ./reports/lighthouse-report.html || true"
+    },
+    {
+      "path": "scripts/cicd_pipeline.sh",
+      "line": 254,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "lighthouse \"${BACKEND_BASE_URL}/api/docs\" --output json --output-path ./reports/lighthouse-report.json || true"
+    },
+    {
+      "path": "scripts/verify_phase27_phase28.py",
+      "line": 397,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "report_path = \"/opt/claude/mystocks_spec/docs/reports/api_verification/PHASE_2.7_2.8_VERIFICATION_REPORT.md\""
+    },
+    {
+      "path": "scripts/find_large_files.py",
+      "line": 45,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "if \"/tests/\" in filepath or \"/docs/\" in filepath:"
+    },
+    {
+      "path": "scripts/ci_data_sync_tests.sh",
+      "line": 88,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "check_service_health \"后端\" \"http://localhost:$BACKEND_PORT/health\" 60"
+    },
+    {
+      "path": "scripts/verify_api_integration.py",
+      "line": 94,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "(\"健康检查\", \"/api/health\"),"
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 13,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "METRICS_HEAD_PATH=\"${REPORT_DIR}/metrics-head.txt\""
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 14,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "METRICS_BASELINE_RAW_PATH=\"${REPORT_DIR}/metrics.baseline.raw.txt\""
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 15,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "METRICS_RAW_PATH=\"${REPORT_DIR}/metrics.raw.txt\""
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 16,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "METRICS_HEALTH_PATH=\"${REPORT_DIR}/metrics-health.json\""
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 17,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "METRICS_SUMMARY_PATH=\"${REPORT_DIR}/metrics-summary.json\""
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 49,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "wait_for_url \"http://localhost:8020/health\" \"Backend\""
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 50,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "wait_for_url \"http://localhost:8020/api/health/ready\" \"Backend readiness\""
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 55,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent --fail --max-time 10 \"http://localhost:8020/health\" >/dev/null"
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 56,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent --fail --max-time 10 \"http://localhost:8020/api/health/ready\" >/dev/null"
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 61,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent \"http://localhost:8020/metrics\" > \"${METRICS_BASELINE_RAW_PATH}\""
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 72,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent \"http://localhost:8020/api/metrics/health\" > \"${METRICS_HEALTH_PATH}\""
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 72,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent \"http://localhost:8020/api/metrics/health\" > \"${METRICS_HEALTH_PATH}\""
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 73,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "curl --noproxy '*' --silent \"http://localhost:8020/metrics\" > \"${METRICS_RAW_PATH}\""
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 131,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "f\"- `/api/metrics/health`: `{metrics_health.get('status', 'unknown')}`\","
+    },
+    {
+      "path": "scripts/run_api_performance_baseline.sh",
+      "line": 131,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "f\"- `/api/metrics/health`: `{metrics_health.get('status', 'unknown')}`\","
+    },
+    {
+      "path": "scripts/verify_api_data.py",
+      "line": 214,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "report_file = \"/opt/claude/mystocks_spec/docs/reports/API_DATA_VERIFICATION_REPORT.json\""
+    },
+    {
+      "path": "scripts/stocks_spec.sh",
+      "line": 166,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if curl -sf http://localhost:$port/health >/dev/null 2>&1; then"
+    },
+    {
+      "path": "scripts/stocks_spec.sh",
+      "line": 173,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "print_info \"  Swagger文档: http://localhost:$port/docs\""
+    },
+    {
+      "path": "scripts/stocks_spec.sh",
+      "line": 174,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "print_info \"  ReDoc文档: http://localhost:$port/api/redoc\""
+    },
+    {
+      "path": "scripts/stocks_spec.sh",
+      "line": 330,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "print_info \"  Swagger文档: http://localhost:$DEFAULT_BACKEND_PORT/docs\""
+    },
+    {
+      "path": "scripts/stocks_spec.sh",
+      "line": 331,
+      "category": "openapi_docs",
+      "consumer_class": "scripts",
+      "snippet": "print_info \"  ReDoc文档: http://localhost:$DEFAULT_BACKEND_PORT/api/redoc\""
+    },
+    {
+      "path": "scripts/database/postgres_indexes.sql",
+      "line": 57,
+      "category": "trading",
+      "consumer_class": "scripts",
+      "snippet": "-- Used by: /api/v1/trade/history"
+    },
+    {
+      "path": "scripts/maintenance/organize-files.sh",
+      "line": 260,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "\"reports/metrics\""
+    },
+    {
+      "path": "scripts/maintenance/monitor_dashboard.py",
+      "line": 25,
+      "category": "status",
+      "consumer_class": "scripts",
+      "snippet": "@monitor_app.get(\"/status\")"
+    },
+    {
+      "path": "scripts/maintenance/monitor_dashboard.py",
+      "line": 56,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "response = requests.get(f\"http://localhost:{BACKEND_PORT}/health\", timeout=2)"
+    },
+    {
+      "path": "scripts/maintenance/monitor_dashboard.py",
+      "line": 64,
+      "category": "metrics",
+      "consumer_class": "scripts",
+      "snippet": "@monitor_app.get(\"/metrics\")"
+    },
+    {
+      "path": "scripts/run_three_level_tests.sh",
+      "line": 90,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if ! curl -s --connect-timeout 5 $PLAYWRIGHT_TEST_BASE_URL/api/stocks/health > /dev/null; then"
+    },
+    {
+      "path": "scripts/run_three_level_tests.sh",
+      "line": 102,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "if ! curl -s --connect-timeout 5 $PLAYWRIGHT_TEST_BASE_URL/api/stocks/health > /dev/null; then"
+    },
+    {
+      "path": "scripts/test_all_endpoints.sh",
+      "line": 77,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "test_endpoint \"System Health\" \"$BASE_URL/api/system/health\""
+    },
+    {
+      "path": "scripts/test_all_endpoints.sh",
+      "line": 78,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "test_endpoint \"Adapters Health\" \"$BASE_URL/api/system/adapters/health\""
+    },
+    {
+      "path": "scripts/test_all_endpoints.sh",
+      "line": 79,
+      "category": "health",
+      "consumer_class": "scripts",
+      "snippet": "test_endpoint \"Market Health\" \"$BASE_URL/api/market/health\""
+    }
+  ]
+}

--- a/.planning/codebase/generated/route-consumer-contract-matrix-2026-05-22.json
+++ b/.planning/codebase/generated/route-consumer-contract-matrix-2026-05-22.json
@@ -1,0 +1,453 @@
+{
+  "generated_at": "2026-05-21T17:04:36.089Z",
+  "git_head": "c173bbc8d48d5e20ed5905d698ca39001237198a",
+  "git_head_short": "c173bbc8d",
+  "stale_if_head_mismatch": true,
+  "groups": {
+    "/api/v1/trade": {
+      "ownership_class": "trading-owned",
+      "route_count": 15,
+      "schema_exposed_count": 15,
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoint_modules": [
+        "app.api.trade.execution_tracking_routes",
+        "app.api.trade.reconciliation_routes",
+        "app.api.trade.routes"
+      ],
+      "openapi_operation_count": 15,
+      "openapi_operation_ids": [
+        "execute_trade_api_v1_trade_execute_post",
+        "export_reconciliation_results_api_v1_trade_reconciliation_export_get",
+        "get_execution_tracking_api_v1_trade_execution_tracking_get",
+        "get_execution_tracking_detail_api_v1_trade_execution_tracking__tracking_id__get",
+        "get_portfolio_api_v1_trade_portfolio_get",
+        "get_positions_api_v1_trade_positions_get",
+        "get_reconciliation_accounts_api_v1_trade_reconciliation_accounts_get",
+        "get_reconciliation_results_api_v1_trade_reconciliation_results_get",
+        "get_reconciliation_statements_api_v1_trade_reconciliation_statements_get",
+        "get_signals_api_v1_trade_signals_get",
+        "get_statistics_api_v1_trade_statistics_get",
+        "get_trades_api_v1_trade_trades_get",
+        "health_check_api_v1_trade_health_get",
+        "import_reconciliation_csv_api_v1_trade_reconciliation_import_post",
+        "trigger_external_execution_api_v1_trade_execution_tracking_trigger_post"
+      ],
+      "openapi_examples_recorded": "not-proven-by-this-scan",
+      "caller_parser": "not-proven-by-string-scan; future implementation lane must inspect active frontend/test parsers before mutation",
+      "response_shape": "schema-visible operations present; exact response models require per-operation implementation-lane review before mutation",
+      "request_contract": "query/path/body details require per-operation OpenAPI diff review before mutation",
+      "consumers": {
+        "counts": {
+          "frontend": 4,
+          "tests": 4,
+          "scripts": 2,
+          "ops_config_ci": 0,
+          "docs_governance": 27,
+          "other": 0
+        },
+        "files": {
+          "frontend": [
+            "web/frontend/src/config/pageConfig.ts",
+            "web/frontend/src/router/index.ts",
+            "web/frontend/src/views/FreqtradeDemo.vue",
+            "web/frontend/src/views/artdeco-pages/system-tabs/__node_tests__/systemSettingsMonitorData.test.ts"
+          ],
+          "tests": [
+            "web/backend/tests/test_health_route_conflicts.py",
+            "web/backend/tests/test_trade_execution_tracking_routes.py",
+            "web/backend/tests/test_trade_reconciliation_routes.py",
+            "web/backend/tests/test_trading_runtime_routes.py"
+          ],
+          "scripts": [
+            "scripts/database/postgres_indexes.sql",
+            "scripts/dev/tools/generate-page-config.js"
+          ],
+          "ops_config_ci": [],
+          "docs_governance": [
+            "docs/FUNCTION_TREE.md",
+            "docs/api/API_ENDPOINTS_STATISTICS_REPORT.md",
+            "docs/api/API_INDEX.md",
+            "docs/api/MyStocks_API_Mapping_Document.md",
+            "docs/api/WEB_PAGES_API_MAPPING.md",
+            "docs/api/guides/integration/API_CONTRACT_VERIFICATION_PLAN.md",
+            "docs/api/openapi.json",
+            "docs/architecture/MENU_ARCHITECTURE_V3.2_ELITE.md",
+            "docs/design/new/07_trade_station.md",
+            "docs/guides/onboarding/USER_GUIDE.md",
+            "docs/plans/2026-03-04-runtime-log-fixes-handover.md",
+            "docs/plans/2026-03-12-api-availability-matrix-draft.md",
+            "docs/plans/2026-03-12-artdeco-p0-p1-batching-implementation-plan.md",
+            "docs/plans/2026-04-02-frontend-mainline-phase-1-execution-matrix.md",
+            "docs/plans/2026-04-03-frontend-mainline-phase-2-execution-matrix.md",
+            "docs/plans/2026-04-03-frontend-mainline-phase-3-execution-matrix.md",
+            "docs/plans/frontend-page-optimization-list.md",
+            "docs/references/artdeco-system-guide.md",
+            "docs/reports/FRONTEND_JS_SYNTAX_FIX_REPORT.md",
+            "docs/reports/api_verification/API_VERIFICATION_COMPREHENSIVE_REPORT.md"
+          ],
+          "other": []
+        }
+      },
+      "minimum_regression_checks": [
+        "app.main import",
+        "FastAPI route table diff",
+        "app.openapi() duplicate operationId check",
+        "targeted frontend/test consumer parser review",
+        "contract parity test for path/query/body/response before route mutation"
+      ]
+    },
+    "/api/trading": {
+      "ownership_class": "trading-owned",
+      "route_count": 8,
+      "schema_exposed_count": 8,
+      "methods": [
+        "DELETE",
+        "GET",
+        "POST"
+      ],
+      "endpoint_modules": [
+        "app.api.trading_runtime"
+      ],
+      "openapi_operation_count": 8,
+      "openapi_operation_ids": [
+        "add_strategy_api_trading_strategies_add_post",
+        "get_market_snapshot_api_trading_market_snapshot_get",
+        "get_risk_metrics_api_trading_risk_metrics_get",
+        "get_status_api_trading_status_get",
+        "get_strategies_performance_api_trading_strategies_performance_get",
+        "remove_strategy_api_trading_strategies__strategy_name__delete",
+        "start_session_api_trading_start_post",
+        "stop_session_api_trading_stop_post"
+      ],
+      "openapi_examples_recorded": "not-proven-by-this-scan",
+      "caller_parser": "not-proven-by-string-scan; future implementation lane must inspect active frontend/test parsers before mutation",
+      "response_shape": "schema-visible operations present; exact response models require per-operation implementation-lane review before mutation",
+      "request_contract": "query/path/body details require per-operation OpenAPI diff review before mutation",
+      "consumers": {
+        "counts": {
+          "frontend": 11,
+          "tests": 11,
+          "scripts": 3,
+          "ops_config_ci": 0,
+          "docs_governance": 40,
+          "other": 0
+        },
+        "files": {
+          "frontend": [
+            "web/frontend/src/config/pageConfigExtended.example.ts",
+            "web/frontend/src/layouts/archive/MenuConfig.ts",
+            "web/frontend/src/stores/__tests__/api-stores.spec.ts",
+            "web/frontend/src/stores/apiStores.ts",
+            "web/frontend/src/types/unified-api.ts",
+            "web/frontend/src/views/composables/__node_tests__/tradingDashboardActions.test.ts",
+            "web/frontend/src/views/composables/tradingDashboardActions.ts",
+            "web/frontend/src/views/composables/useTradingDashboard.ts",
+            "web/frontend/src/views/examples/TradingDashboard.migrated.vue",
+            "web/frontend/src/views/examples/composables/useTradingDashboard.migrated.ts",
+            "web/frontend/src/views/system/API.vue"
+          ],
+          "tests": [
+            "tests/002-arch-optimization/PHASE2_WEB_FOUNDATION_COMPLETION_REPORT.md",
+            "tests/config/api-config.ts",
+            "tests/helpers/api-helpers/functions-2.ts",
+            "tests/openapi.json",
+            "tests/performance/api_smoke_endpoints.json",
+            "tests/performance/test_api_smoke_endpoints_json.py",
+            "tests/performance/test_build_runtime_quality_summary.py",
+            "tests/performance/test_runtime_delivery_summary_local_script.py",
+            "tests/unit/governance/test_mainline_scope_gate_function_tree.py",
+            "web/backend/tests/test_health_route_conflicts.py",
+            "web/backend/tests/test_trading_runtime_routes.py"
+          ],
+          "scripts": [
+            "scripts/dev/quality_gate/build_runtime_quality_summary.py",
+            "scripts/dev/tools/generate-page-config.js",
+            "scripts/tests/test_security_owasp_top10.py"
+          ],
+          "ops_config_ci": [],
+          "docs_governance": [
+            "docs/FUNCTION_TREE.md",
+            "docs/api/API_ENDPOINTS_STATISTICS_REPORT.md",
+            "docs/api/openapi.json",
+            "docs/api/openapi/market-data-api-full.json",
+            "docs/api/reports/archives/merged_readmes/README_PLATFORM.md",
+            "docs/api/swagger.json",
+            "docs/architecture/FRONTEND_OPTIMIZATION_IMPLEMENTATION_PLAN_V2.md",
+            "docs/guides/features/TRADINGVIEW_TROUBLESHOOTING.md",
+            "docs/guides/frontend/frontend-data-capability-registry.md",
+            "docs/guides/frontend/frontend_optimization_next_steps.md",
+            "docs/guides/frontend/pinia-api-standardization-guide.md",
+            "docs/guides/pm2/PM2_INTEGRATION_TEST_WORKFLOW.md",
+            "docs/guides/quant-trading/broker-execution-truth-registry.md",
+            "docs/guides/web/ARTDECO_MENU_API_MAPPING.md",
+            "docs/plans/2026-03-04-runtime-log-fixes-handover.md",
+            "docs/plans/2026-03-12-api-availability-matrix-draft.md",
+            "docs/plans/2026-04-03-frontend-mainline-phase-3-execution-matrix.md",
+            "docs/plans/frontend-page-optimization-list.md",
+            "docs/reports/ARTDECO_MENU_FRONTEND_DESIGN_REVIEW.md",
+            "docs/reports/DAY5_PLUS_COMPLETION_REPORT.md"
+          ],
+          "other": []
+        }
+      },
+      "minimum_regression_checks": [
+        "app.main import",
+        "FastAPI route table diff",
+        "app.openapi() duplicate operationId check",
+        "targeted frontend/test consumer parser review",
+        "contract parity test for path/query/body/response before route mutation"
+      ]
+    },
+    "/api/tradingview": {
+      "ownership_class": "trading-owned",
+      "route_count": 6,
+      "schema_exposed_count": 6,
+      "methods": [
+        "GET",
+        "POST"
+      ],
+      "endpoint_modules": [
+        "app.api.tradingview"
+      ],
+      "openapi_operation_count": 6,
+      "openapi_operation_ids": [
+        "convert_symbol_api_tradingview_symbol_convert_get",
+        "get_chart_config_api_tradingview_chart_config_post",
+        "get_market_overview_config_api_tradingview_market_overview_config_get",
+        "get_mini_chart_config_api_tradingview_mini_chart_config_post",
+        "get_screener_config_api_tradingview_screener_config_get",
+        "get_ticker_tape_config_api_tradingview_ticker_tape_config_post"
+      ],
+      "openapi_examples_recorded": "not-proven-by-this-scan",
+      "caller_parser": "not-proven-by-string-scan; future implementation lane must inspect active frontend/test parsers before mutation",
+      "response_shape": "schema-visible operations present; exact response models require per-operation implementation-lane review before mutation",
+      "request_contract": "query/path/body details require per-operation OpenAPI diff review before mutation",
+      "consumers": {
+        "counts": {
+          "frontend": 0,
+          "tests": 3,
+          "scripts": 0,
+          "ops_config_ci": 0,
+          "docs_governance": 13,
+          "other": 0
+        },
+        "files": {
+          "frontend": [],
+          "tests": [
+            "tests/002-arch-optimization/PHASE2_WEB_FOUNDATION_COMPLETION_REPORT.md",
+            "tests/openapi.json",
+            "web/backend/tests/test_health_route_conflicts.py"
+          ],
+          "scripts": [],
+          "ops_config_ci": [],
+          "docs_governance": [
+            "docs/api/API_ENDPOINTS_STATISTICS_REPORT.md",
+            "docs/api/openapi.json",
+            "docs/api/openapi/market-data-api-full.json",
+            "docs/api/swagger.json",
+            "docs/guides/features/TRADINGVIEW_TROUBLESHOOTING.md",
+            "docs/reports/MENU_API_OPTIMIZATION_PLAN.md",
+            "docs/reports/pylint-errors-by-module.txt",
+            "docs/reports/quality/backend-lifecycle-di-inventory-2026-05-18.md",
+            "docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md",
+            "docs/reports/quality/generated/backend-getter-inventory.txt",
+            "docs/reports/quality/generated/backend-lifecycle-di-inventory-2026-05-18.json",
+            "docs/standards/MODULE_REGISTRY.md",
+            "docs/standards/PROJECT_MODULES.md"
+          ],
+          "other": []
+        }
+      },
+      "minimum_regression_checks": [
+        "app.main import",
+        "FastAPI route table diff",
+        "app.openapi() duplicate operationId check",
+        "targeted frontend/test consumer parser review",
+        "contract parity test for path/query/body/response before route mutation"
+      ]
+    },
+    "/api/v1/trading": {
+      "ownership_class": "trading-owned",
+      "route_count": 5,
+      "schema_exposed_count": 5,
+      "methods": [
+        "DELETE",
+        "GET",
+        "PATCH",
+        "POST"
+      ],
+      "endpoint_modules": [
+        "app.api.v1.trading.session"
+      ],
+      "openapi_operation_count": 5,
+      "openapi_operation_ids": [
+        "create_trading_session_api_v1_trading_sessions_post",
+        "delete_trading_session_api_v1_trading_sessions__session_id__delete",
+        "get_trading_session_api_v1_trading_sessions__session_id__get",
+        "list_trading_sessions_api_v1_trading_sessions_get",
+        "update_trading_session_api_v1_trading_sessions__session_id__patch"
+      ],
+      "openapi_examples_recorded": "not-proven-by-this-scan",
+      "caller_parser": "not-proven-by-string-scan; future implementation lane must inspect active frontend/test parsers before mutation",
+      "response_shape": "schema-visible operations present; exact response models require per-operation implementation-lane review before mutation",
+      "request_contract": "query/path/body details require per-operation OpenAPI diff review before mutation",
+      "consumers": {
+        "counts": {
+          "frontend": 0,
+          "tests": 1,
+          "scripts": 0,
+          "ops_config_ci": 0,
+          "docs_governance": 10,
+          "other": 0
+        },
+        "files": {
+          "frontend": [],
+          "tests": [
+            "web/backend/tests/test_health_route_conflicts.py"
+          ],
+          "scripts": [],
+          "ops_config_ci": [],
+          "docs_governance": [
+            "docs/api/WEB_PAGES_API_MAPPING.md",
+            "docs/api/openapi.json",
+            "docs/reports/API_AUTOMATION_TEST_GUIDE.md",
+            "docs/reports/ARTDECO_MENU_OPTIMIZATION_REVIEW.md",
+            "docs/reports/quality/backend-audit-phase3-decision-records.md",
+            "docs/reports/quality/backend-health-status-openapi-stabilization-2026-05-18.md",
+            "docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md",
+            "docs/reports/quality/generated/backend-getter-inventory.txt",
+            "docs/reports/quality/generated/backend-lifecycle-di-inventory-2026-05-18.json",
+            "docs/superpowers/specs/2026-05-08-attribution-analysis-design.md"
+          ],
+          "other": []
+        }
+      },
+      "minimum_regression_checks": [
+        "app.main import",
+        "FastAPI route table diff",
+        "app.openapi() duplicate operationId check",
+        "targeted frontend/test consumer parser review",
+        "contract parity test for path/query/body/response before route mutation"
+      ]
+    },
+    "/api/v1/positions": {
+      "ownership_class": "trading-owned",
+      "route_count": 6,
+      "schema_exposed_count": 6,
+      "methods": [
+        "DELETE",
+        "GET",
+        "PATCH",
+        "POST"
+      ],
+      "endpoint_modules": [
+        "app.api.v1.trading.positions"
+      ],
+      "openapi_operation_count": 6,
+      "openapi_operation_ids": [
+        "create_position_api_v1_positions_post",
+        "delete_position_api_v1_positions__position_id__delete",
+        "get_position_api_v1_positions__position_id__get",
+        "get_position_attribution_api_v1_positions_attribution_get",
+        "list_positions_api_v1_positions_get",
+        "update_position_api_v1_positions__position_id__patch"
+      ],
+      "openapi_examples_recorded": "not-proven-by-this-scan",
+      "caller_parser": "not-proven-by-string-scan; future implementation lane must inspect active frontend/test parsers before mutation",
+      "response_shape": "schema-visible operations present; exact response models require per-operation implementation-lane review before mutation",
+      "request_contract": "query/path/body details require per-operation OpenAPI diff review before mutation",
+      "consumers": {
+        "counts": {
+          "frontend": 0,
+          "tests": 3,
+          "scripts": 0,
+          "ops_config_ci": 0,
+          "docs_governance": 6,
+          "other": 0
+        },
+        "files": {
+          "frontend": [],
+          "tests": [
+            "tests/unit/test_legacy_attribution_compatibility.py",
+            "web/backend/tests/test_attribution_positions_route.py",
+            "web/backend/tests/test_health_route_conflicts.py"
+          ],
+          "scripts": [],
+          "ops_config_ci": [],
+          "docs_governance": [
+            "docs/FUNCTION_TREE.md",
+            "docs/api/WEB_PAGES_API_MAPPING.md",
+            "docs/api/openapi.json",
+            "docs/reports/quality/backend-health-status-openapi-stabilization-2026-05-18.md",
+            "docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md",
+            "docs/superpowers/specs/2026-05-08-attribution-analysis-design.md"
+          ],
+          "other": []
+        }
+      },
+      "minimum_regression_checks": [
+        "app.main import",
+        "FastAPI route table diff",
+        "app.openapi() duplicate operationId check",
+        "targeted frontend/test consumer parser review",
+        "contract parity test for path/query/body/response before route mutation"
+      ]
+    },
+    "/api/v1/advanced-analysis/trading-signals": {
+      "ownership_class": "trading-adjacent-unclassified",
+      "route_count": 1,
+      "schema_exposed_count": 1,
+      "methods": [
+        "GET"
+      ],
+      "endpoint_modules": [
+        "app.api.advanced_analysis_api"
+      ],
+      "openapi_operation_count": 1,
+      "openapi_operation_ids": [
+        "analyze_trading_signals_api_v1_advanced_analysis_trading_signals_get"
+      ],
+      "openapi_examples_recorded": "not-proven-by-this-scan",
+      "caller_parser": "not-proven-by-string-scan; future implementation lane must inspect active frontend/test parsers before mutation",
+      "response_shape": "schema-visible operations present; exact response models require per-operation implementation-lane review before mutation",
+      "request_contract": "query/path/body details require per-operation OpenAPI diff review before mutation",
+      "consumers": {
+        "counts": {
+          "frontend": 1,
+          "tests": 0,
+          "scripts": 1,
+          "ops_config_ci": 1,
+          "docs_governance": 2,
+          "other": 0
+        },
+        "files": {
+          "frontend": [
+            "web/frontend/src/api/advancedAnalysis.ts"
+          ],
+          "tests": [],
+          "scripts": [
+            "scripts/tests/test_advanced_analysis_api_integration.py"
+          ],
+          "ops_config_ci": [
+            "config/advanced_analysis_contract.json"
+          ],
+          "docs_governance": [
+            "docs/reports/quality/backend-route-openapi-governance-openspec-proposal-2026-05-21.md",
+            "docs/reports/quality/backend-trading-route-openapi-governance-planning-package-2026-05-21.md"
+          ],
+          "other": []
+        }
+      },
+      "minimum_regression_checks": [
+        "app.main import",
+        "FastAPI route table diff",
+        "app.openapi() duplicate operationId check",
+        "targeted frontend/test consumer parser review",
+        "contract parity test for path/query/body/response before route mutation"
+      ]
+    }
+  }
+}

--- a/.planning/codebase/generated/route-openapi-snapshot-2026-05-22.json
+++ b/.planning/codebase/generated/route-openapi-snapshot-2026-05-22.json
@@ -1,0 +1,2739 @@
+{
+  "generated_at": "2026-05-21T17:02:48.078861Z",
+  "git_head": "c173bbc8d48d5e20ed5905d698ca39001237198a",
+  "git_head_short": "c173bbc8d",
+  "stale_if_head_mismatch": true,
+  "app_import_error": null,
+  "openapi_error": null,
+  "env_mode": "placeholder env for import/openapi governance; no service startup",
+  "summary": {
+    "path_count": 500,
+    "operation_count": 536,
+    "schema_count": 301,
+    "duplicate_operation_id_count": 0,
+    "warning_count": 0,
+    "trading_schema_path_count": 35,
+    "trading_schema_operation_count": 41
+  },
+  "warnings": [],
+  "duplicate_operation_ids": [],
+  "trading_schema_paths": [
+    "/api/trading/market/snapshot",
+    "/api/trading/risk/metrics",
+    "/api/trading/start",
+    "/api/trading/status",
+    "/api/trading/stop",
+    "/api/trading/strategies/add",
+    "/api/trading/strategies/performance",
+    "/api/trading/strategies/{strategy_name}",
+    "/api/tradingview/chart/config",
+    "/api/tradingview/market-overview/config",
+    "/api/tradingview/mini-chart/config",
+    "/api/tradingview/screener/config",
+    "/api/tradingview/symbol/convert",
+    "/api/tradingview/ticker-tape/config",
+    "/api/v1/advanced-analysis/trading-signals",
+    "/api/v1/positions",
+    "/api/v1/positions/attribution",
+    "/api/v1/positions/{position_id}",
+    "/api/v1/trade/execute",
+    "/api/v1/trade/execution-tracking",
+    "/api/v1/trade/execution-tracking/trigger",
+    "/api/v1/trade/execution-tracking/{tracking_id}",
+    "/api/v1/trade/health",
+    "/api/v1/trade/portfolio",
+    "/api/v1/trade/positions",
+    "/api/v1/trade/reconciliation/accounts",
+    "/api/v1/trade/reconciliation/export",
+    "/api/v1/trade/reconciliation/import",
+    "/api/v1/trade/reconciliation/results",
+    "/api/v1/trade/reconciliation/statements",
+    "/api/v1/trade/signals",
+    "/api/v1/trade/statistics",
+    "/api/v1/trade/trades",
+    "/api/v1/trading/sessions",
+    "/api/v1/trading/sessions/{session_id}"
+  ],
+  "operations": [
+    {
+      "path": "/",
+      "method": "GET",
+      "operationId": "root__get"
+    },
+    {
+      "path": "/api/akshare/market/board/change/em",
+      "method": "GET",
+      "operationId": "get_board_change_em_api_akshare_market_board_change_em_get"
+    },
+    {
+      "path": "/api/akshare/market/board/concept/cons/{symbol}",
+      "method": "GET",
+      "operationId": "get_concept_board_constituents_api_akshare_market_board_concept_cons__symbol__get"
+    },
+    {
+      "path": "/api/akshare/market/board/concept/history/{symbol}",
+      "method": "GET",
+      "operationId": "get_concept_board_history_api_akshare_market_board_concept_history__symbol__get"
+    },
+    {
+      "path": "/api/akshare/market/board/concept/minute/{symbol}",
+      "method": "GET",
+      "operationId": "get_concept_board_minute_api_akshare_market_board_concept_minute__symbol__get"
+    },
+    {
+      "path": "/api/akshare/market/board/industry/cons/{symbol}",
+      "method": "GET",
+      "operationId": "get_industry_board_constituents_api_akshare_market_board_industry_cons__symbol__get"
+    },
+    {
+      "path": "/api/akshare/market/board/industry/history/{symbol}",
+      "method": "GET",
+      "operationId": "get_industry_board_history_api_akshare_market_board_industry_history__symbol__get"
+    },
+    {
+      "path": "/api/akshare/market/board/industry/minute/{symbol}",
+      "method": "GET",
+      "operationId": "get_industry_board_minute_api_akshare_market_board_industry_minute__symbol__get"
+    },
+    {
+      "path": "/api/akshare/market/chip-distribution/{symbol}",
+      "method": "GET",
+      "operationId": "get_chip_distribution_api_akshare_market_chip_distribution__symbol__get"
+    },
+    {
+      "path": "/api/akshare/market/forecast/profit/em/{symbol}",
+      "method": "GET",
+      "operationId": "get_profit_forecast_em_api_akshare_market_forecast_profit_em__symbol__get"
+    },
+    {
+      "path": "/api/akshare/market/forecast/profit/ths/{symbol}",
+      "method": "GET",
+      "operationId": "get_profit_forecast_ths_api_akshare_market_forecast_profit_ths__symbol__get"
+    },
+    {
+      "path": "/api/akshare/market/fund-flow/big-deal",
+      "method": "GET",
+      "operationId": "get_fund_flow_big_deal_api_akshare_market_fund_flow_big_deal_get"
+    },
+    {
+      "path": "/api/akshare/market/fund-flow/hsgt-detail",
+      "method": "GET",
+      "operationId": "get_hsgt_fund_flow_detail_api_akshare_market_fund_flow_hsgt_detail_get"
+    },
+    {
+      "path": "/api/akshare/market/fund-flow/hsgt-holdings/{symbol}",
+      "method": "GET",
+      "operationId": "get_hsgt_holdings_api_akshare_market_fund_flow_hsgt_holdings__symbol__get"
+    },
+    {
+      "path": "/api/akshare/market/fund-flow/hsgt-summary",
+      "method": "GET",
+      "operationId": "get_hsgt_fund_flow_summary_api_akshare_market_fund_flow_hsgt_summary_get"
+    },
+    {
+      "path": "/api/akshare/market/fund-flow/north-daily",
+      "method": "GET",
+      "operationId": "get_north_fund_daily_api_akshare_market_fund_flow_north_daily_get"
+    },
+    {
+      "path": "/api/akshare/market/fund-flow/north-stock/{symbol}",
+      "method": "GET",
+      "operationId": "get_north_fund_stock_api_akshare_market_fund_flow_north_stock__symbol__get"
+    },
+    {
+      "path": "/api/akshare/market/fund-flow/south-daily",
+      "method": "GET",
+      "operationId": "get_south_fund_daily_api_akshare_market_fund_flow_south_daily_get"
+    },
+    {
+      "path": "/api/akshare/market/fund-flow/south-stock/{symbol}",
+      "method": "GET",
+      "operationId": "get_south_fund_stock_api_akshare_market_fund_flow_south_stock__symbol__get"
+    },
+    {
+      "path": "/api/akshare/market/market/account-statistics",
+      "method": "GET",
+      "operationId": "get_account_statistics_em_api_akshare_market_market_account_statistics_get"
+    },
+    {
+      "path": "/api/akshare/market/sector/fund-flow-ranking",
+      "method": "GET",
+      "operationId": "get_sector_fund_flow_ranking_api_akshare_market_sector_fund_flow_ranking_get"
+    },
+    {
+      "path": "/api/akshare/market/sector/hot-ranking",
+      "method": "GET",
+      "operationId": "get_sector_hot_ranking_api_akshare_market_sector_hot_ranking_get"
+    },
+    {
+      "path": "/api/akshare/market/sse/daily-deal",
+      "method": "GET",
+      "operationId": "get_sse_daily_deal_api_akshare_market_sse_daily_deal_get"
+    },
+    {
+      "path": "/api/akshare/market/sse/overview",
+      "method": "GET",
+      "operationId": "get_sse_market_overview_api_akshare_market_sse_overview_get"
+    },
+    {
+      "path": "/api/akshare/market/stock/bid-ask/em",
+      "method": "GET",
+      "operationId": "get_stock_bid_ask_em_api_akshare_market_stock_bid_ask_em_get"
+    },
+    {
+      "path": "/api/akshare/market/stock/business-composition/em",
+      "method": "GET",
+      "operationId": "get_stock_business_composition_em_api_akshare_market_stock_business_composition_em_get"
+    },
+    {
+      "path": "/api/akshare/market/stock/business-intro/ths",
+      "method": "GET",
+      "operationId": "get_stock_business_intro_ths_api_akshare_market_stock_business_intro_ths_get"
+    },
+    {
+      "path": "/api/akshare/market/stock/changes/em",
+      "method": "GET",
+      "operationId": "get_stock_changes_em_api_akshare_market_stock_changes_em_get"
+    },
+    {
+      "path": "/api/akshare/market/stock/comment-detail/em",
+      "method": "GET",
+      "operationId": "get_stock_comment_detail_em_api_akshare_market_stock_comment_detail_em_get"
+    },
+    {
+      "path": "/api/akshare/market/stock/comment/em",
+      "method": "GET",
+      "operationId": "get_stock_comment_em_api_akshare_market_stock_comment_em_get"
+    },
+    {
+      "path": "/api/akshare/market/stock/dt-pool/em",
+      "method": "GET",
+      "operationId": "get_stock_dt_pool_em_api_akshare_market_stock_dt_pool_em_get"
+    },
+    {
+      "path": "/api/akshare/market/stock/hot-follow/xq",
+      "method": "GET",
+      "operationId": "get_stock_hot_follow_xq_api_akshare_market_stock_hot_follow_xq_get"
+    },
+    {
+      "path": "/api/akshare/market/stock/individual-info/em",
+      "method": "GET",
+      "operationId": "get_stock_individual_info_em_api_akshare_market_stock_individual_info_em_get"
+    },
+    {
+      "path": "/api/akshare/market/stock/individual-info/xq",
+      "method": "GET",
+      "operationId": "get_stock_individual_info_xq_api_akshare_market_stock_individual_info_xq_get"
+    },
+    {
+      "path": "/api/akshare/market/stock/new/em",
+      "method": "GET",
+      "operationId": "get_stock_new_em_api_akshare_market_stock_new_em_get"
+    },
+    {
+      "path": "/api/akshare/market/stock/news/em",
+      "method": "GET",
+      "operationId": "get_stock_news_em_api_akshare_market_stock_news_em_get"
+    },
+    {
+      "path": "/api/akshare/market/stock/strong-pool/em",
+      "method": "GET",
+      "operationId": "get_stock_strong_pool_em_api_akshare_market_stock_strong_pool_em_get"
+    },
+    {
+      "path": "/api/akshare/market/stock/zt-pool/em",
+      "method": "GET",
+      "operationId": "get_stock_zt_pool_em_api_akshare_market_stock_zt_pool_em_get"
+    },
+    {
+      "path": "/api/akshare/market/szse/area-trading",
+      "method": "GET",
+      "operationId": "get_szse_area_trading_api_akshare_market_szse_area_trading_get"
+    },
+    {
+      "path": "/api/akshare/market/szse/overview",
+      "method": "GET",
+      "operationId": "get_szse_market_overview_api_akshare_market_szse_overview_get"
+    },
+    {
+      "path": "/api/akshare/market/szse/sector-trading",
+      "method": "GET",
+      "operationId": "get_szse_sector_trading_api_akshare_market_szse_sector_trading_get"
+    },
+    {
+      "path": "/api/akshare/market/technical/indicators/em/{symbol}",
+      "method": "GET",
+      "operationId": "get_technical_indicators_em_api_akshare_market_technical_indicators_em__symbol__get"
+    },
+    {
+      "path": "/api/analysis/concept/list",
+      "method": "GET",
+      "operationId": "get_concept_list_api_analysis_concept_list_get"
+    },
+    {
+      "path": "/api/analysis/concept/stocks",
+      "method": "GET",
+      "operationId": "get_concept_stocks_api_analysis_concept_stocks_get"
+    },
+    {
+      "path": "/api/analysis/industry/list",
+      "method": "GET",
+      "operationId": "get_industry_list_api_analysis_industry_list_get"
+    },
+    {
+      "path": "/api/analysis/industry/performance",
+      "method": "GET",
+      "operationId": "get_industry_performance_api_analysis_industry_performance_get"
+    },
+    {
+      "path": "/api/analysis/industry/stocks",
+      "method": "GET",
+      "operationId": "get_industry_stocks_api_analysis_industry_stocks_get"
+    },
+    {
+      "path": "/api/announcement/analyze",
+      "method": "POST",
+      "operationId": "analyze_data_api_announcement_analyze_post"
+    },
+    {
+      "path": "/api/announcement/fetch",
+      "method": "POST",
+      "operationId": "fetch_announcements_api_announcement_fetch_post"
+    },
+    {
+      "path": "/api/announcement/health",
+      "method": "GET",
+      "operationId": "health_check_api_announcement_health_get"
+    },
+    {
+      "path": "/api/announcement/important",
+      "method": "GET",
+      "operationId": "get_important_announcements_api_announcement_important_get"
+    },
+    {
+      "path": "/api/announcement/list",
+      "method": "GET",
+      "operationId": "get_announcements_api_announcement_list_get"
+    },
+    {
+      "path": "/api/announcement/monitor-rules",
+      "method": "GET",
+      "operationId": "get_monitor_rules_api_announcement_monitor_rules_get"
+    },
+    {
+      "path": "/api/announcement/monitor-rules",
+      "method": "POST",
+      "operationId": "create_monitor_rule_api_announcement_monitor_rules_post"
+    },
+    {
+      "path": "/api/announcement/monitor-rules/{rule_id}",
+      "method": "DELETE",
+      "operationId": "delete_monitor_rule_api_announcement_monitor_rules__rule_id__delete"
+    },
+    {
+      "path": "/api/announcement/monitor-rules/{rule_id}",
+      "method": "PUT",
+      "operationId": "update_monitor_rule_api_announcement_monitor_rules__rule_id__put"
+    },
+    {
+      "path": "/api/announcement/monitor/evaluate",
+      "method": "POST",
+      "operationId": "evaluate_monitor_rules_api_announcement_monitor_evaluate_post"
+    },
+    {
+      "path": "/api/announcement/stats",
+      "method": "GET",
+      "operationId": "get_announcement_stats_api_announcement_stats_get"
+    },
+    {
+      "path": "/api/announcement/status",
+      "method": "GET",
+      "operationId": "get_status_api_announcement_status_get"
+    },
+    {
+      "path": "/api/announcement/today",
+      "method": "GET",
+      "operationId": "get_today_announcements_api_announcement_today_get"
+    },
+    {
+      "path": "/api/announcement/triggered-records",
+      "method": "GET",
+      "operationId": "get_triggered_records_api_announcement_triggered_records_get"
+    },
+    {
+      "path": "/api/api/mtm/portfolio/{portfolio_id}",
+      "method": "GET",
+      "operationId": "get_portfolio_mtm_api_api_mtm_portfolio__portfolio_id__get"
+    },
+    {
+      "path": "/api/api/mtm/position/{position_id}",
+      "method": "GET",
+      "operationId": "get_position_mtm_api_api_mtm_position__position_id__get"
+    },
+    {
+      "path": "/api/api/mtm/stats",
+      "method": "GET",
+      "operationId": "get_mtm_stats_api_api_mtm_stats_get"
+    },
+    {
+      "path": "/api/api/realtime/quote/{symbol}",
+      "method": "GET",
+      "operationId": "get_realtime_quote_api_api_realtime_quote__symbol__get"
+    },
+    {
+      "path": "/api/api/realtime/quotes",
+      "method": "GET",
+      "operationId": "get_realtime_quotes_api_api_realtime_quotes_get"
+    },
+    {
+      "path": "/api/auth/login",
+      "method": "POST",
+      "operationId": "compat_login_api_auth_login_post"
+    },
+    {
+      "path": "/api/backup-recovery/backup/postgresql/full",
+      "method": "POST",
+      "operationId": "backup_postgresql_full_api_backup_recovery_backup_postgresql_full_post"
+    },
+    {
+      "path": "/api/backup-recovery/backup/tdengine/full",
+      "method": "POST",
+      "operationId": "backup_tdengine_full_api_backup_recovery_backup_tdengine_full_post"
+    },
+    {
+      "path": "/api/backup-recovery/backup/tdengine/incremental",
+      "method": "POST",
+      "operationId": "backup_tdengine_incremental_api_backup_recovery_backup_tdengine_incremental_post"
+    },
+    {
+      "path": "/api/backup-recovery/backups",
+      "method": "GET",
+      "operationId": "list_backups_api_backup_recovery_backups_get"
+    },
+    {
+      "path": "/api/backup-recovery/cleanup/old-backups",
+      "method": "POST",
+      "operationId": "cleanup_old_backups_api_backup_recovery_cleanup_old_backups_post"
+    },
+    {
+      "path": "/api/backup-recovery/health",
+      "method": "GET",
+      "operationId": "backup_service_health_api_backup_recovery_health_get"
+    },
+    {
+      "path": "/api/backup-recovery/integrity/verify/{backup_id}",
+      "method": "GET",
+      "operationId": "verify_backup_integrity_api_backup_recovery_integrity_verify__backup_id__get"
+    },
+    {
+      "path": "/api/backup-recovery/recovery/objectives",
+      "method": "GET",
+      "operationId": "get_recovery_objectives_api_backup_recovery_recovery_objectives_get"
+    },
+    {
+      "path": "/api/backup-recovery/recovery/postgresql/full",
+      "method": "POST",
+      "operationId": "restore_postgresql_full_api_backup_recovery_recovery_postgresql_full_post"
+    },
+    {
+      "path": "/api/backup-recovery/recovery/tdengine/full",
+      "method": "POST",
+      "operationId": "restore_tdengine_full_api_backup_recovery_recovery_tdengine_full_post"
+    },
+    {
+      "path": "/api/backup-recovery/recovery/tdengine/pitr",
+      "method": "POST",
+      "operationId": "restore_tdengine_pitr_api_backup_recovery_recovery_tdengine_pitr_post"
+    },
+    {
+      "path": "/api/backup-recovery/scheduler/control",
+      "method": "POST",
+      "operationId": "scheduler_control_api_backup_recovery_scheduler_control_post"
+    },
+    {
+      "path": "/api/backup-recovery/scheduler/jobs",
+      "method": "GET",
+      "operationId": "get_scheduled_jobs_api_backup_recovery_scheduler_jobs_get"
+    },
+    {
+      "path": "/api/basic",
+      "method": "GET",
+      "operationId": "basic_metrics_api_basic_get"
+    },
+    {
+      "path": "/api/cache",
+      "method": "DELETE",
+      "operationId": "clear_all_cache_api_cache_delete"
+    },
+    {
+      "path": "/api/cache/evict/manual",
+      "method": "POST",
+      "operationId": "manual_cache_eviction_api_cache_evict_manual_post"
+    },
+    {
+      "path": "/api/cache/eviction/stats",
+      "method": "GET",
+      "operationId": "get_eviction_statistics_api_cache_eviction_stats_get"
+    },
+    {
+      "path": "/api/cache/monitoring/health",
+      "method": "GET",
+      "operationId": "get_cache_health_status_api_cache_monitoring_health_get"
+    },
+    {
+      "path": "/api/cache/monitoring/metrics",
+      "method": "GET",
+      "operationId": "get_cache_monitoring_metrics_api_cache_monitoring_metrics_get"
+    },
+    {
+      "path": "/api/cache/prewarming/status",
+      "method": "GET",
+      "operationId": "get_prewarming_status_api_cache_prewarming_status_get"
+    },
+    {
+      "path": "/api/cache/prewarming/trigger",
+      "method": "POST",
+      "operationId": "trigger_cache_prewarming_api_cache_prewarming_trigger_post"
+    },
+    {
+      "path": "/api/cache/status",
+      "method": "GET",
+      "operationId": "get_cache_status_api_cache_status_get"
+    },
+    {
+      "path": "/api/cache/{symbol}",
+      "method": "DELETE",
+      "operationId": "invalidate_symbol_cache_api_cache__symbol__delete"
+    },
+    {
+      "path": "/api/cache/{symbol}/{data_type}",
+      "method": "GET",
+      "operationId": "get_cached_data_api_cache__symbol___data_type__get"
+    },
+    {
+      "path": "/api/cache/{symbol}/{data_type}",
+      "method": "POST",
+      "operationId": "write_cache_data_api_cache__symbol___data_type__post"
+    },
+    {
+      "path": "/api/cache/{symbol}/{data_type}/fresh",
+      "method": "GET",
+      "operationId": "check_cache_freshness_api_cache__symbol___data_type__fresh_get"
+    },
+    {
+      "path": "/api/contracts/contracts",
+      "method": "GET",
+      "operationId": "list_contracts_api_contracts_contracts_get"
+    },
+    {
+      "path": "/api/contracts/diff",
+      "method": "POST",
+      "operationId": "compare_versions_api_contracts_diff_post"
+    },
+    {
+      "path": "/api/contracts/drift/incidents",
+      "method": "GET",
+      "operationId": "list_contract_drift_incidents_api_contracts_drift_incidents_get"
+    },
+    {
+      "path": "/api/contracts/impact",
+      "method": "POST",
+      "operationId": "analyze_contract_impact_api_contracts_impact_post"
+    },
+    {
+      "path": "/api/contracts/sync",
+      "method": "POST",
+      "operationId": "sync_contract_api_contracts_sync_post"
+    },
+    {
+      "path": "/api/contracts/sync/report",
+      "method": "GET",
+      "operationId": "get_sync_report_api_contracts_sync_report_get"
+    },
+    {
+      "path": "/api/contracts/validate",
+      "method": "POST",
+      "operationId": "validate_contract_api_contracts_validate_post"
+    },
+    {
+      "path": "/api/contracts/versions",
+      "method": "GET",
+      "operationId": "list_versions_api_contracts_versions_get"
+    },
+    {
+      "path": "/api/contracts/versions",
+      "method": "POST",
+      "operationId": "create_version_api_contracts_versions_post"
+    },
+    {
+      "path": "/api/contracts/versions/{name}/active",
+      "method": "GET",
+      "operationId": "get_active_version_api_contracts_versions__name__active_get"
+    },
+    {
+      "path": "/api/contracts/versions/{version_id}",
+      "method": "DELETE",
+      "operationId": "delete_version_api_contracts_versions__version_id__delete"
+    },
+    {
+      "path": "/api/contracts/versions/{version_id}",
+      "method": "GET",
+      "operationId": "get_version_api_contracts_versions__version_id__get"
+    },
+    {
+      "path": "/api/contracts/versions/{version_id}",
+      "method": "PUT",
+      "operationId": "update_version_api_contracts_versions__version_id__put"
+    },
+    {
+      "path": "/api/contracts/versions/{version_id}/activate",
+      "method": "POST",
+      "operationId": "activate_version_api_contracts_versions__version_id__activate_post"
+    },
+    {
+      "path": "/api/csrf-token",
+      "method": "GET",
+      "operationId": "get_csrf_token_api_csrf_token_get"
+    },
+    {
+      "path": "/api/dashboard/health",
+      "method": "GET",
+      "operationId": "health_check_api_dashboard_health_get"
+    },
+    {
+      "path": "/api/dashboard/market-overview",
+      "method": "GET",
+      "operationId": "get_market_overview_api_dashboard_market_overview_get"
+    },
+    {
+      "path": "/api/dashboard/summary",
+      "method": "GET",
+      "operationId": "get_dashboard_summary_api_dashboard_summary_get"
+    },
+    {
+      "path": "/api/data-quality/alerts",
+      "method": "GET",
+      "operationId": "get_active_alerts_api_data_quality_alerts_get"
+    },
+    {
+      "path": "/api/data-quality/alerts/{alert_id}/acknowledge",
+      "method": "POST",
+      "operationId": "acknowledge_alert_api_data_quality_alerts__alert_id__acknowledge_post"
+    },
+    {
+      "path": "/api/data-quality/alerts/{alert_id}/resolve",
+      "method": "POST",
+      "operationId": "resolve_alert_api_data_quality_alerts__alert_id__resolve_post"
+    },
+    {
+      "path": "/api/data-quality/config/mode",
+      "method": "GET",
+      "operationId": "get_data_source_mode_api_data_quality_config_mode_get"
+    },
+    {
+      "path": "/api/data-quality/health",
+      "method": "GET",
+      "operationId": "get_sources_health_api_data_quality_health_get"
+    },
+    {
+      "path": "/api/data-quality/metrics",
+      "method": "GET",
+      "operationId": "get_data_quality_metrics_api_data_quality_metrics_get"
+    },
+    {
+      "path": "/api/data-quality/metrics/trends",
+      "method": "GET",
+      "operationId": "get_quality_trends_api_data_quality_metrics_trends_get"
+    },
+    {
+      "path": "/api/data-quality/status/overview",
+      "method": "GET",
+      "operationId": "get_system_status_overview_api_data_quality_status_overview_get"
+    },
+    {
+      "path": "/api/data-quality/test/quality",
+      "method": "POST",
+      "operationId": "test_data_quality_api_data_quality_test_quality_post"
+    },
+    {
+      "path": "/api/detailed",
+      "method": "GET",
+      "operationId": "detailed_metrics_api_detailed_get"
+    },
+    {
+      "path": "/api/gpu/history",
+      "method": "GET",
+      "operationId": "get_gpu_history_api_gpu_history_get"
+    },
+    {
+      "path": "/api/gpu/metrics",
+      "method": "GET",
+      "operationId": "get_prometheus_metrics_api_gpu_metrics_get"
+    },
+    {
+      "path": "/api/gpu/performance",
+      "method": "GET",
+      "operationId": "get_gpu_performance_api_gpu_performance_get"
+    },
+    {
+      "path": "/api/gpu/status",
+      "method": "GET",
+      "operationId": "get_gpu_status_api_gpu_status_get"
+    },
+    {
+      "path": "/api/health",
+      "method": "GET",
+      "operationId": "health_check_api_health_get"
+    },
+    {
+      "path": "/api/health/detailed",
+      "method": "GET",
+      "operationId": "detailed_health_check_api_health_detailed_get"
+    },
+    {
+      "path": "/api/health/ready",
+      "method": "GET",
+      "operationId": "readiness_check_api_health_ready_get"
+    },
+    {
+      "path": "/api/health/services",
+      "method": "GET",
+      "operationId": "check_system_health_api_health_services_get"
+    },
+    {
+      "path": "/api/indicator-registry/calculate",
+      "method": "POST",
+      "operationId": "calculate_indicator_api_indicator_registry_calculate_post"
+    },
+    {
+      "path": "/api/indicator-registry/indicators",
+      "method": "GET",
+      "operationId": "list_indicators_api_indicator_registry_indicators_get"
+    },
+    {
+      "path": "/api/indicator-registry/indicators/{indicator_id}",
+      "method": "GET",
+      "operationId": "get_indicator_details_api_indicator_registry_indicators__indicator_id__get"
+    },
+    {
+      "path": "/api/market/wencai/custom-query",
+      "method": "POST",
+      "operationId": "execute_custom_query_api_market_wencai_custom_query_post"
+    },
+    {
+      "path": "/api/market/wencai/health",
+      "method": "GET",
+      "operationId": "health_check_api_market_wencai_health_get"
+    },
+    {
+      "path": "/api/market/wencai/history/{query_name}",
+      "method": "GET",
+      "operationId": "get_query_history_api_market_wencai_history__query_name__get"
+    },
+    {
+      "path": "/api/market/wencai/queries",
+      "method": "GET",
+      "operationId": "get_all_queries_api_market_wencai_queries_get"
+    },
+    {
+      "path": "/api/market/wencai/queries/{query_name}",
+      "method": "GET",
+      "operationId": "get_query_by_name_api_market_wencai_queries__query_name__get"
+    },
+    {
+      "path": "/api/market/wencai/query",
+      "method": "POST",
+      "operationId": "execute_query_api_market_wencai_query_post"
+    },
+    {
+      "path": "/api/market/wencai/refresh/{query_name}",
+      "method": "POST",
+      "operationId": "refresh_query_api_market_wencai_refresh__query_name__post"
+    },
+    {
+      "path": "/api/market/wencai/results/{query_name}",
+      "method": "GET",
+      "operationId": "get_query_results_api_market_wencai_results__query_name__get"
+    },
+    {
+      "path": "/api/metrics",
+      "method": "GET",
+      "operationId": "prometheus_metrics_api_metrics_get"
+    },
+    {
+      "path": "/api/metrics/health",
+      "method": "GET",
+      "operationId": "health_check_api_metrics_health_get"
+    },
+    {
+      "path": "/api/ml/features/generate",
+      "method": "POST",
+      "operationId": "generate_features_api_ml_features_generate_post"
+    },
+    {
+      "path": "/api/ml/models",
+      "method": "GET",
+      "operationId": "list_models_api_ml_models_get"
+    },
+    {
+      "path": "/api/ml/models/evaluate",
+      "method": "POST",
+      "operationId": "evaluate_model_api_ml_models_evaluate_post"
+    },
+    {
+      "path": "/api/ml/models/hyperparameter-search",
+      "method": "POST",
+      "operationId": "hyperparameter_search_api_ml_models_hyperparameter_search_post"
+    },
+    {
+      "path": "/api/ml/models/predict",
+      "method": "POST",
+      "operationId": "predict_with_model_api_ml_models_predict_post"
+    },
+    {
+      "path": "/api/ml/models/train",
+      "method": "POST",
+      "operationId": "train_model_api_ml_models_train_post"
+    },
+    {
+      "path": "/api/ml/models/{model_name}",
+      "method": "GET",
+      "operationId": "get_model_detail_api_ml_models__model_name__get"
+    },
+    {
+      "path": "/api/ml/tdx/data",
+      "method": "POST",
+      "operationId": "get_tdx_data_api_ml_tdx_data_post"
+    },
+    {
+      "path": "/api/ml/tdx/stocks/{market}",
+      "method": "GET",
+      "operationId": "list_tdx_stocks_api_ml_tdx_stocks__market__get"
+    },
+    {
+      "path": "/api/multi-source/analyze",
+      "method": "POST",
+      "operationId": "analyze_data_api_multi_source_analyze_post"
+    },
+    {
+      "path": "/api/multi-source/health",
+      "method": "GET",
+      "operationId": "health_check_api_multi_source_health_get"
+    },
+    {
+      "path": "/api/multi-source/status",
+      "method": "GET",
+      "operationId": "get_status_api_multi_source_status_get"
+    },
+    {
+      "path": "/api/notification/email/newsletter",
+      "method": "POST",
+      "operationId": "send_daily_newsletter_api_notification_email_newsletter_post"
+    },
+    {
+      "path": "/api/notification/email/price-alert",
+      "method": "POST",
+      "operationId": "send_price_alert_api_notification_email_price_alert_post"
+    },
+    {
+      "path": "/api/notification/email/send",
+      "method": "POST",
+      "operationId": "send_email_api_notification_email_send_post"
+    },
+    {
+      "path": "/api/notification/email/welcome",
+      "method": "POST",
+      "operationId": "send_welcome_email_api_notification_email_welcome_post"
+    },
+    {
+      "path": "/api/notification/preferences",
+      "method": "GET",
+      "operationId": "get_notification_preferences_api_notification_preferences_get"
+    },
+    {
+      "path": "/api/notification/preferences",
+      "method": "POST",
+      "operationId": "update_notification_preferences_api_notification_preferences_post"
+    },
+    {
+      "path": "/api/notification/status",
+      "method": "GET",
+      "operationId": "get_email_service_status_api_notification_status_get"
+    },
+    {
+      "path": "/api/notification/test-email",
+      "method": "POST",
+      "operationId": "send_test_email_api_notification_test_email_post"
+    },
+    {
+      "path": "/api/performance",
+      "method": "GET",
+      "operationId": "performance_metrics_api_performance_get"
+    },
+    {
+      "path": "/api/pool-monitoring/alerts",
+      "method": "GET",
+      "operationId": "check_connection_pool_alerts_api_pool_monitoring_alerts_get"
+    },
+    {
+      "path": "/api/pool-monitoring/health",
+      "method": "GET",
+      "operationId": "connection_pools_health_check_api_pool_monitoring_health_get"
+    },
+    {
+      "path": "/api/pool-monitoring/postgresql/stats",
+      "method": "GET",
+      "operationId": "get_postgresql_pool_stats_api_pool_monitoring_postgresql_stats_get"
+    },
+    {
+      "path": "/api/pool-monitoring/tdengine/stats",
+      "method": "GET",
+      "operationId": "get_tdengine_pool_stats_api_pool_monitoring_tdengine_stats_get"
+    },
+    {
+      "path": "/api/reports/health/{timestamp}",
+      "method": "GET",
+      "operationId": "get_health_report_api_reports_health__timestamp__get"
+    },
+    {
+      "path": "/api/reset",
+      "method": "POST",
+      "operationId": "reset_metrics_api_reset_post"
+    },
+    {
+      "path": "/api/signals/health",
+      "method": "GET",
+      "operationId": "health_check_api_signals_health_get"
+    },
+    {
+      "path": "/api/signals/history",
+      "method": "GET",
+      "operationId": "get_signal_history_api_signals_history_get"
+    },
+    {
+      "path": "/api/signals/quality-report",
+      "method": "GET",
+      "operationId": "get_signal_quality_report_api_signals_quality_report_get"
+    },
+    {
+      "path": "/api/socketio-status",
+      "method": "GET",
+      "operationId": "socketio_status_api_socketio_status_get"
+    },
+    {
+      "path": "/api/status",
+      "method": "GET",
+      "operationId": "basic_status_api_status_get"
+    },
+    {
+      "path": "/api/stock-search/analytics/cleanup",
+      "method": "POST",
+      "operationId": "cleanup_search_analytics_api_stock_search_analytics_cleanup_post"
+    },
+    {
+      "path": "/api/stock-search/analytics/searches",
+      "method": "GET",
+      "operationId": "get_search_analytics_api_stock_search_analytics_searches_get"
+    },
+    {
+      "path": "/api/stock-search/cache/clear",
+      "method": "POST",
+      "operationId": "clear_search_cache_api_stock_search_cache_clear_post"
+    },
+    {
+      "path": "/api/stock-search/news/market/{category}",
+      "method": "GET",
+      "operationId": "get_market_news_api_stock_search_news_market__category__get"
+    },
+    {
+      "path": "/api/stock-search/news/{symbol}",
+      "method": "GET",
+      "operationId": "get_stock_news_api_stock_search_news__symbol__get"
+    },
+    {
+      "path": "/api/stock-search/profile/{symbol}",
+      "method": "GET",
+      "operationId": "get_company_profile_api_stock_search_profile__symbol__get"
+    },
+    {
+      "path": "/api/stock-search/quote/{symbol}",
+      "method": "GET",
+      "operationId": "get_stock_quote_api_stock_search_quote__symbol__get"
+    },
+    {
+      "path": "/api/stock-search/rate-limits/status",
+      "method": "GET",
+      "operationId": "get_rate_limits_status_api_stock_search_rate_limits_status_get"
+    },
+    {
+      "path": "/api/stock-search/recommendation/{symbol}",
+      "method": "GET",
+      "operationId": "get_recommendation_trends_api_stock_search_recommendation__symbol__get"
+    },
+    {
+      "path": "/api/stock-search/search",
+      "method": "GET",
+      "operationId": "search_stocks_api_stock_search_search_get"
+    },
+    {
+      "path": "/api/strategies/{strategy_id}/realtime",
+      "method": "GET",
+      "operationId": "get_strategy_realtime_monitoring_api_strategies__strategy_id__realtime_get"
+    },
+    {
+      "path": "/api/strategy-mgmt/backtest/execute",
+      "method": "POST",
+      "operationId": "execute_backtest_api_strategy_mgmt_backtest_execute_post"
+    },
+    {
+      "path": "/api/strategy-mgmt/backtest/results",
+      "method": "GET",
+      "operationId": "list_backtests_api_strategy_mgmt_backtest_results_get"
+    },
+    {
+      "path": "/api/strategy-mgmt/backtest/results/{backtest_id}",
+      "method": "GET",
+      "operationId": "get_backtest_result_api_strategy_mgmt_backtest_results__backtest_id__get"
+    },
+    {
+      "path": "/api/strategy-mgmt/backtest/status/{backtest_id}",
+      "method": "GET",
+      "operationId": "get_backtest_status_api_strategy_mgmt_backtest_status__backtest_id__get"
+    },
+    {
+      "path": "/api/strategy-mgmt/health",
+      "method": "GET",
+      "operationId": "health_check_api_strategy_mgmt_health_get"
+    },
+    {
+      "path": "/api/strategy-mgmt/strategies",
+      "method": "GET",
+      "operationId": "list_strategies_api_strategy_mgmt_strategies_get"
+    },
+    {
+      "path": "/api/strategy-mgmt/strategies",
+      "method": "POST",
+      "operationId": "create_strategy_api_strategy_mgmt_strategies_post"
+    },
+    {
+      "path": "/api/strategy-mgmt/strategies/{strategy_id}",
+      "method": "DELETE",
+      "operationId": "delete_strategy_api_strategy_mgmt_strategies__strategy_id__delete"
+    },
+    {
+      "path": "/api/strategy-mgmt/strategies/{strategy_id}",
+      "method": "GET",
+      "operationId": "get_strategy_api_strategy_mgmt_strategies__strategy_id__get"
+    },
+    {
+      "path": "/api/strategy-mgmt/strategies/{strategy_id}",
+      "method": "PUT",
+      "operationId": "update_strategy_api_strategy_mgmt_strategies__strategy_id__put"
+    },
+    {
+      "path": "/api/tasks/",
+      "method": "GET",
+      "operationId": "list_tasks_api_tasks__get"
+    },
+    {
+      "path": "/api/tasks/audit/logs",
+      "method": "GET",
+      "operationId": "get_audit_logs_api_tasks_audit_logs_get"
+    },
+    {
+      "path": "/api/tasks/cleanup/audit",
+      "method": "POST",
+      "operationId": "cleanup_audit_logs_api_tasks_cleanup_audit_post"
+    },
+    {
+      "path": "/api/tasks/executions/",
+      "method": "GET",
+      "operationId": "list_task_executions_api_tasks_executions__get"
+    },
+    {
+      "path": "/api/tasks/executions/cleanup",
+      "method": "DELETE",
+      "operationId": "cleanup_executions_api_tasks_executions_cleanup_delete"
+    },
+    {
+      "path": "/api/tasks/executions/{execution_id}",
+      "method": "GET",
+      "operationId": "get_execution_api_tasks_executions__execution_id__get"
+    },
+    {
+      "path": "/api/tasks/export",
+      "method": "POST",
+      "operationId": "export_config_api_tasks_export_post"
+    },
+    {
+      "path": "/api/tasks/health",
+      "method": "GET",
+      "operationId": "tasks_health_api_tasks_health_get"
+    },
+    {
+      "path": "/api/tasks/import",
+      "method": "POST",
+      "operationId": "import_config_api_tasks_import_post"
+    },
+    {
+      "path": "/api/tasks/register",
+      "method": "POST",
+      "operationId": "register_task_api_tasks_register_post"
+    },
+    {
+      "path": "/api/tasks/statistics/",
+      "method": "GET",
+      "operationId": "get_task_statistics_api_tasks_statistics__get"
+    },
+    {
+      "path": "/api/tasks/{task_id}",
+      "method": "DELETE",
+      "operationId": "unregister_task_api_tasks__task_id__delete"
+    },
+    {
+      "path": "/api/tasks/{task_id}",
+      "method": "GET",
+      "operationId": "get_task_api_tasks__task_id__get"
+    },
+    {
+      "path": "/api/tasks/{task_id}/start",
+      "method": "POST",
+      "operationId": "start_task_api_tasks__task_id__start_post"
+    },
+    {
+      "path": "/api/tasks/{task_id}/stop",
+      "method": "POST",
+      "operationId": "stop_task_api_tasks__task_id__stop_post"
+    },
+    {
+      "path": "/api/trading/market/snapshot",
+      "method": "GET",
+      "operationId": "get_market_snapshot_api_trading_market_snapshot_get"
+    },
+    {
+      "path": "/api/trading/risk/metrics",
+      "method": "GET",
+      "operationId": "get_risk_metrics_api_trading_risk_metrics_get"
+    },
+    {
+      "path": "/api/trading/start",
+      "method": "POST",
+      "operationId": "start_session_api_trading_start_post"
+    },
+    {
+      "path": "/api/trading/status",
+      "method": "GET",
+      "operationId": "get_status_api_trading_status_get"
+    },
+    {
+      "path": "/api/trading/stop",
+      "method": "POST",
+      "operationId": "stop_session_api_trading_stop_post"
+    },
+    {
+      "path": "/api/trading/strategies/add",
+      "method": "POST",
+      "operationId": "add_strategy_api_trading_strategies_add_post"
+    },
+    {
+      "path": "/api/trading/strategies/performance",
+      "method": "GET",
+      "operationId": "get_strategies_performance_api_trading_strategies_performance_get"
+    },
+    {
+      "path": "/api/trading/strategies/{strategy_name}",
+      "method": "DELETE",
+      "operationId": "remove_strategy_api_trading_strategies__strategy_name__delete"
+    },
+    {
+      "path": "/api/tradingview/chart/config",
+      "method": "POST",
+      "operationId": "get_chart_config_api_tradingview_chart_config_post"
+    },
+    {
+      "path": "/api/tradingview/market-overview/config",
+      "method": "GET",
+      "operationId": "get_market_overview_config_api_tradingview_market_overview_config_get"
+    },
+    {
+      "path": "/api/tradingview/mini-chart/config",
+      "method": "POST",
+      "operationId": "get_mini_chart_config_api_tradingview_mini_chart_config_post"
+    },
+    {
+      "path": "/api/tradingview/screener/config",
+      "method": "GET",
+      "operationId": "get_screener_config_api_tradingview_screener_config_get"
+    },
+    {
+      "path": "/api/tradingview/symbol/convert",
+      "method": "GET",
+      "operationId": "convert_symbol_api_tradingview_symbol_convert_get"
+    },
+    {
+      "path": "/api/tradingview/ticker-tape/config",
+      "method": "POST",
+      "operationId": "get_ticker_tape_config_api_tradingview_ticker_tape_config_post"
+    },
+    {
+      "path": "/api/v1/advanced-analysis/anomaly-tracking",
+      "method": "GET",
+      "operationId": "analyze_anomaly_tracking_api_v1_advanced_analysis_anomaly_tracking_get"
+    },
+    {
+      "path": "/api/v1/advanced-analysis/batch",
+      "method": "POST",
+      "operationId": "analyze_batch_api_v1_advanced_analysis_batch_post"
+    },
+    {
+      "path": "/api/v1/advanced-analysis/capital-flow",
+      "method": "GET",
+      "operationId": "analyze_capital_flow_api_v1_advanced_analysis_capital_flow_get"
+    },
+    {
+      "path": "/api/v1/advanced-analysis/chip-distribution",
+      "method": "GET",
+      "operationId": "analyze_chip_distribution_api_v1_advanced_analysis_chip_distribution_get"
+    },
+    {
+      "path": "/api/v1/advanced-analysis/decision-models",
+      "method": "GET",
+      "operationId": "analyze_decision_models_api_v1_advanced_analysis_decision_models_get"
+    },
+    {
+      "path": "/api/v1/advanced-analysis/financial-valuation",
+      "method": "GET",
+      "operationId": "analyze_financial_valuation_api_v1_advanced_analysis_financial_valuation_get"
+    },
+    {
+      "path": "/api/v1/advanced-analysis/fundamental",
+      "method": "GET",
+      "operationId": "analyze_fundamental_api_v1_advanced_analysis_fundamental_get"
+    },
+    {
+      "path": "/api/v1/advanced-analysis/health",
+      "method": "GET",
+      "operationId": "health_check_api_v1_advanced_analysis_health_get"
+    },
+    {
+      "path": "/api/v1/advanced-analysis/market-panorama",
+      "method": "GET",
+      "operationId": "analyze_market_panorama_api_v1_advanced_analysis_market_panorama_get"
+    },
+    {
+      "path": "/api/v1/advanced-analysis/multidimensional-radar",
+      "method": "GET",
+      "operationId": "analyze_multidimensional_radar_api_v1_advanced_analysis_multidimensional_radar_get"
+    },
+    {
+      "path": "/api/v1/advanced-analysis/sentiment",
+      "method": "GET",
+      "operationId": "analyze_sentiment_api_v1_advanced_analysis_sentiment_get"
+    },
+    {
+      "path": "/api/v1/advanced-analysis/technical",
+      "method": "GET",
+      "operationId": "analyze_technical_api_v1_advanced_analysis_technical_get"
+    },
+    {
+      "path": "/api/v1/advanced-analysis/time-series",
+      "method": "GET",
+      "operationId": "analyze_time_series_api_v1_advanced_analysis_time_series_get"
+    },
+    {
+      "path": "/api/v1/advanced-analysis/trading-signals",
+      "method": "GET",
+      "operationId": "analyze_trading_signals_api_v1_advanced_analysis_trading_signals_get"
+    },
+    {
+      "path": "/api/v1/audit/logs",
+      "method": "GET",
+      "operationId": "list_audit_logs_api_v1_audit_logs_get"
+    },
+    {
+      "path": "/api/v1/audit/logs/{log_id}",
+      "method": "GET",
+      "operationId": "get_audit_log_api_v1_audit_logs__log_id__get"
+    },
+    {
+      "path": "/api/v1/audit/statistics",
+      "method": "GET",
+      "operationId": "get_audit_statistics_api_v1_audit_statistics_get"
+    },
+    {
+      "path": "/api/v1/auth/csrf/token",
+      "method": "GET",
+      "operationId": "get_csrf_token_api_v1_auth_csrf_token_get"
+    },
+    {
+      "path": "/api/v1/auth/login",
+      "method": "POST",
+      "operationId": "login_for_access_token_api_v1_auth_login_post"
+    },
+    {
+      "path": "/api/v1/auth/logout",
+      "method": "POST",
+      "operationId": "logout_api_v1_auth_logout_post"
+    },
+    {
+      "path": "/api/v1/auth/me",
+      "method": "GET",
+      "operationId": "read_users_me_api_v1_auth_me_get"
+    },
+    {
+      "path": "/api/v1/auth/refresh",
+      "method": "POST",
+      "operationId": "refresh_token_api_v1_auth_refresh_post"
+    },
+    {
+      "path": "/api/v1/auth/register",
+      "method": "POST",
+      "operationId": "register_user_api_v1_auth_register_post"
+    },
+    {
+      "path": "/api/v1/auth/reset-password/confirm",
+      "method": "POST",
+      "operationId": "confirm_password_reset_api_v1_auth_reset_password_confirm_post"
+    },
+    {
+      "path": "/api/v1/auth/reset-password/request",
+      "method": "POST",
+      "operationId": "request_password_reset_api_v1_auth_reset_password_request_post"
+    },
+    {
+      "path": "/api/v1/auth/users",
+      "method": "GET",
+      "operationId": "get_users_api_v1_auth_users_get"
+    },
+    {
+      "path": "/api/v1/backtest/equity-curve/{strategy_id}",
+      "method": "GET",
+      "operationId": "get_equity_curve_api_v1_backtest_equity_curve__strategy_id__get"
+    },
+    {
+      "path": "/api/v1/backtest/monte-carlo",
+      "method": "POST",
+      "operationId": "run_monte_carlo_backtest_api_v1_backtest_monte_carlo_post"
+    },
+    {
+      "path": "/api/v1/backtest/stress-test",
+      "method": "POST",
+      "operationId": "run_stress_test_api_v1_backtest_stress_test_post"
+    },
+    {
+      "path": "/api/v1/backtest/{backtest_id}/attribution",
+      "method": "GET",
+      "operationId": "get_backtest_attribution_api_v1_backtest__backtest_id__attribution_get"
+    },
+    {
+      "path": "/api/v1/data-sources/",
+      "method": "GET",
+      "operationId": "search_data_sources_api_v1_data_sources__get"
+    },
+    {
+      "path": "/api/v1/data-sources/categories",
+      "method": "GET",
+      "operationId": "get_category_stats_api_v1_data_sources_categories_get"
+    },
+    {
+      "path": "/api/v1/data-sources/config/",
+      "method": "GET",
+      "operationId": "list_data_sources_api_v1_data_sources_config__get"
+    },
+    {
+      "path": "/api/v1/data-sources/config/",
+      "method": "POST",
+      "operationId": "create_data_source_api_v1_data_sources_config__post"
+    },
+    {
+      "path": "/api/v1/data-sources/config/batch",
+      "method": "POST",
+      "operationId": "batch_operations_api_v1_data_sources_config_batch_post"
+    },
+    {
+      "path": "/api/v1/data-sources/config/reload",
+      "method": "POST",
+      "operationId": "reload_config_api_v1_data_sources_config_reload_post"
+    },
+    {
+      "path": "/api/v1/data-sources/config/{endpoint_name}",
+      "method": "DELETE",
+      "operationId": "delete_data_source_api_v1_data_sources_config__endpoint_name__delete"
+    },
+    {
+      "path": "/api/v1/data-sources/config/{endpoint_name}",
+      "method": "GET",
+      "operationId": "get_data_source_api_v1_data_sources_config__endpoint_name__get"
+    },
+    {
+      "path": "/api/v1/data-sources/config/{endpoint_name}",
+      "method": "PUT",
+      "operationId": "update_data_source_api_v1_data_sources_config__endpoint_name__put"
+    },
+    {
+      "path": "/api/v1/data-sources/config/{endpoint_name}/rollback/{version}",
+      "method": "POST",
+      "operationId": "rollback_to_version_api_v1_data_sources_config__endpoint_name__rollback__version__post"
+    },
+    {
+      "path": "/api/v1/data-sources/config/{endpoint_name}/versions",
+      "method": "GET",
+      "operationId": "get_version_history_api_v1_data_sources_config__endpoint_name__versions_get"
+    },
+    {
+      "path": "/api/v1/data-sources/health-check/all",
+      "method": "POST",
+      "operationId": "health_check_all_data_sources_api_v1_data_sources_health_check_all_post"
+    },
+    {
+      "path": "/api/v1/data-sources/{endpoint_name}",
+      "method": "GET",
+      "operationId": "get_data_source_api_v1_data_sources__endpoint_name__get"
+    },
+    {
+      "path": "/api/v1/data-sources/{endpoint_name}",
+      "method": "PUT",
+      "operationId": "update_data_source_api_v1_data_sources__endpoint_name__put"
+    },
+    {
+      "path": "/api/v1/data-sources/{endpoint_name}/health-check",
+      "method": "POST",
+      "operationId": "health_check_data_source_api_v1_data_sources__endpoint_name__health_check_post"
+    },
+    {
+      "path": "/api/v1/data-sources/{endpoint_name}/test",
+      "method": "POST",
+      "operationId": "test_data_source_api_v1_data_sources__endpoint_name__test_post"
+    },
+    {
+      "path": "/api/v1/data/dragon-tiger/detail",
+      "method": "GET",
+      "operationId": "get_dragon_tiger_detail_api_v1_data_dragon_tiger_detail_get"
+    },
+    {
+      "path": "/api/v1/data/dragon-tiger/institution-stats",
+      "method": "GET",
+      "operationId": "get_dragon_tiger_institution_stats_api_v1_data_dragon_tiger_institution_stats_get"
+    },
+    {
+      "path": "/api/v1/data/financial",
+      "method": "GET",
+      "operationId": "get_financial_data_api_v1_data_financial_get"
+    },
+    {
+      "path": "/api/v1/data/futures/index/daily",
+      "method": "GET",
+      "operationId": "get_futures_index_daily_api_v1_data_futures_index_daily_get"
+    },
+    {
+      "path": "/api/v1/data/futures/index/realtime",
+      "method": "GET",
+      "operationId": "get_futures_index_realtime_api_v1_data_futures_index_realtime_get"
+    },
+    {
+      "path": "/api/v1/data/kline",
+      "method": "GET",
+      "operationId": "get_kline_api_v1_data_kline_get"
+    },
+    {
+      "path": "/api/v1/data/margin/account-info",
+      "method": "GET",
+      "operationId": "get_margin_account_info_api_v1_data_margin_account_info_get"
+    },
+    {
+      "path": "/api/v1/data/margin/detail/sse",
+      "method": "GET",
+      "operationId": "get_margin_detail_sse_api_v1_data_margin_detail_sse_get"
+    },
+    {
+      "path": "/api/v1/data/margin/detail/szse",
+      "method": "GET",
+      "operationId": "get_margin_detail_szse_api_v1_data_margin_detail_szse_get"
+    },
+    {
+      "path": "/api/v1/data/markets/hot-concepts",
+      "method": "GET",
+      "operationId": "get_hot_concepts_api_v1_data_markets_hot_concepts_get"
+    },
+    {
+      "path": "/api/v1/data/markets/hot-industries",
+      "method": "GET",
+      "operationId": "get_hot_industries_api_v1_data_markets_hot_industries_get"
+    },
+    {
+      "path": "/api/v1/data/markets/overview",
+      "method": "GET",
+      "operationId": "get_market_overview_api_v1_data_markets_overview_get"
+    },
+    {
+      "path": "/api/v1/data/markets/price-distribution",
+      "method": "GET",
+      "operationId": "get_price_distribution_api_v1_data_markets_price_distribution_get"
+    },
+    {
+      "path": "/api/v1/data/route",
+      "method": "POST",
+      "operationId": "get_data_route_api_v1_data_route_post"
+    },
+    {
+      "path": "/api/v1/data/stocks/basic",
+      "method": "GET",
+      "operationId": "get_stocks_basic_api_v1_data_stocks_basic_get"
+    },
+    {
+      "path": "/api/v1/data/stocks/concepts",
+      "method": "GET",
+      "operationId": "get_stocks_concepts_api_v1_data_stocks_concepts_get"
+    },
+    {
+      "path": "/api/v1/data/stocks/daily",
+      "method": "GET",
+      "operationId": "get_daily_kline_api_v1_data_stocks_daily_get"
+    },
+    {
+      "path": "/api/v1/data/stocks/industries",
+      "method": "GET",
+      "operationId": "get_stocks_industries_api_v1_data_stocks_industries_get"
+    },
+    {
+      "path": "/api/v1/data/stocks/intraday",
+      "method": "GET",
+      "operationId": "get_intraday_data_api_v1_data_stocks_intraday_get"
+    },
+    {
+      "path": "/api/v1/data/stocks/kline",
+      "method": "GET",
+      "operationId": "get_kline_data_api_v1_data_stocks_kline_get"
+    },
+    {
+      "path": "/api/v1/data/stocks/search",
+      "method": "GET",
+      "operationId": "search_stocks_api_v1_data_stocks_search_get"
+    },
+    {
+      "path": "/api/v1/data/stocks/{symbol}/detail",
+      "method": "GET",
+      "operationId": "get_stock_detail_api_v1_data_stocks__symbol__detail_get"
+    },
+    {
+      "path": "/api/v1/governance/assets/catalog",
+      "method": "GET",
+      "operationId": "get_assets_catalog_api_v1_governance_assets_catalog_get"
+    },
+    {
+      "path": "/api/v1/governance/compliance/metrics",
+      "method": "GET",
+      "operationId": "get_compliance_metrics_api_v1_governance_compliance_metrics_get"
+    },
+    {
+      "path": "/api/v1/governance/dashboard/summary",
+      "method": "GET",
+      "operationId": "get_dashboard_summary_api_v1_governance_dashboard_summary_get"
+    },
+    {
+      "path": "/api/v1/governance/lineage/stats",
+      "method": "GET",
+      "operationId": "get_lineage_stats_api_v1_governance_lineage_stats_get"
+    },
+    {
+      "path": "/api/v1/governance/quality/overview",
+      "method": "GET",
+      "operationId": "get_quality_overview_api_v1_governance_quality_overview_get"
+    },
+    {
+      "path": "/api/v1/health/classification/stats",
+      "method": "GET",
+      "operationId": "get_data_classification_stats_api_v1_health_classification_stats_get"
+    },
+    {
+      "path": "/api/v1/health/database",
+      "method": "GET",
+      "operationId": "get_database_health_api_v1_health_database_get"
+    },
+    {
+      "path": "/api/v1/indicators/cache/clear",
+      "method": "POST",
+      "operationId": "clear_cache_api_v1_indicators_cache_clear_post"
+    },
+    {
+      "path": "/api/v1/indicators/cache/stats",
+      "method": "GET",
+      "operationId": "get_cache_statistics_api_v1_indicators_cache_stats_get"
+    },
+    {
+      "path": "/api/v1/indicators/calculate",
+      "method": "POST",
+      "operationId": "calculate_indicators_api_v1_indicators_calculate_post"
+    },
+    {
+      "path": "/api/v1/indicators/calculate/batch",
+      "method": "POST",
+      "operationId": "calculate_indicators_batch_api_v1_indicators_calculate_batch_post"
+    },
+    {
+      "path": "/api/v1/indicators/registry",
+      "method": "GET",
+      "operationId": "get_indicator_registry_endpoint_api_v1_indicators_registry_get"
+    },
+    {
+      "path": "/api/v1/indicators/registry/{category}",
+      "method": "GET",
+      "operationId": "get_indicators_by_category_api_v1_indicators_registry__category__get"
+    },
+    {
+      "path": "/api/v1/kronos/encode",
+      "method": "POST",
+      "operationId": "encode_with_kronos_api_v1_kronos_encode_post"
+    },
+    {
+      "path": "/api/v1/kronos/predict",
+      "method": "POST",
+      "operationId": "predict_with_kronos_api_v1_kronos_predict_post"
+    },
+    {
+      "path": "/api/v1/kronos/status",
+      "method": "GET",
+      "operationId": "get_kronos_status_api_v1_kronos_status_get"
+    },
+    {
+      "path": "/api/v1/lineage/graph",
+      "method": "POST",
+      "operationId": "get_lineage_graph_api_v1_lineage_graph_post"
+    },
+    {
+      "path": "/api/v1/lineage/impact",
+      "method": "POST",
+      "operationId": "analyze_impact_api_v1_lineage_impact_post"
+    },
+    {
+      "path": "/api/v1/lineage/record",
+      "method": "POST",
+      "operationId": "record_lineage_api_v1_lineage_record_post"
+    },
+    {
+      "path": "/api/v1/lineage/{node_id}/downstream",
+      "method": "GET",
+      "operationId": "get_downstream_lineage_api_v1_lineage__node_id__downstream_get"
+    },
+    {
+      "path": "/api/v1/lineage/{node_id}/upstream",
+      "method": "GET",
+      "operationId": "get_upstream_lineage_api_v1_lineage__node_id__upstream_get"
+    },
+    {
+      "path": "/api/v1/market/chip-race",
+      "method": "GET",
+      "operationId": "get_chip_race_api_v1_market_chip_race_get"
+    },
+    {
+      "path": "/api/v1/market/chip-race/refresh",
+      "method": "POST",
+      "operationId": "refresh_chip_race_api_v1_market_chip_race_refresh_post"
+    },
+    {
+      "path": "/api/v1/market/etf/list",
+      "method": "GET",
+      "operationId": "get_etf_list_api_v1_market_etf_list_get"
+    },
+    {
+      "path": "/api/v1/market/etf/refresh",
+      "method": "POST",
+      "operationId": "refresh_etf_data_api_v1_market_etf_refresh_post"
+    },
+    {
+      "path": "/api/v1/market/fund-flow",
+      "method": "GET",
+      "operationId": "get_fund_flow_api_v1_market_fund_flow_get"
+    },
+    {
+      "path": "/api/v1/market/fund-flow/refresh",
+      "method": "POST",
+      "operationId": "refresh_fund_flow_api_v1_market_fund_flow_refresh_post"
+    },
+    {
+      "path": "/api/v1/market/health",
+      "method": "GET",
+      "operationId": "health_check_api_v1_market_health_get"
+    },
+    {
+      "path": "/api/v1/market/heatmap",
+      "method": "GET",
+      "operationId": "get_market_heatmap_api_v1_market_heatmap_get"
+    },
+    {
+      "path": "/api/v1/market/kline",
+      "method": "GET",
+      "operationId": "get_kline_data_api_v1_market_kline_get"
+    },
+    {
+      "path": "/api/v1/market/lhb",
+      "method": "GET",
+      "operationId": "get_lhb_detail_api_v1_market_lhb_get"
+    },
+    {
+      "path": "/api/v1/market/lhb/refresh",
+      "method": "POST",
+      "operationId": "refresh_lhb_detail_api_v1_market_lhb_refresh_post"
+    },
+    {
+      "path": "/api/v1/market/quotes",
+      "method": "GET",
+      "operationId": "get_market_quotes_api_v1_market_quotes_get"
+    },
+    {
+      "path": "/api/v1/market/stocks",
+      "method": "GET",
+      "operationId": "get_stock_list_api_v1_market_stocks_get"
+    },
+    {
+      "path": "/api/v1/monitoring/alert-rules",
+      "method": "GET",
+      "operationId": "get_alert_rules_api_v1_monitoring_alert_rules_get"
+    },
+    {
+      "path": "/api/v1/monitoring/alert-rules",
+      "method": "POST",
+      "operationId": "create_alert_rule_api_v1_monitoring_alert_rules_post"
+    },
+    {
+      "path": "/api/v1/monitoring/alert-rules/{rule_id}",
+      "method": "DELETE",
+      "operationId": "delete_alert_rule_api_v1_monitoring_alert_rules__rule_id__delete"
+    },
+    {
+      "path": "/api/v1/monitoring/alert-rules/{rule_id}",
+      "method": "PUT",
+      "operationId": "update_alert_rule_api_v1_monitoring_alert_rules__rule_id__put"
+    },
+    {
+      "path": "/api/v1/monitoring/alerts",
+      "method": "GET",
+      "operationId": "get_alert_records_api_v1_monitoring_alerts_get"
+    },
+    {
+      "path": "/api/v1/monitoring/alerts/mark-all-read",
+      "method": "POST",
+      "operationId": "mark_all_alerts_read_api_v1_monitoring_alerts_mark_all_read_post"
+    },
+    {
+      "path": "/api/v1/monitoring/alerts/{alert_id}/mark-read",
+      "method": "POST",
+      "operationId": "mark_alert_read_api_v1_monitoring_alerts__alert_id__mark_read_post"
+    },
+    {
+      "path": "/api/v1/monitoring/analysis/calculate",
+      "method": "POST",
+      "operationId": "calculate_health_score_api_v1_monitoring_analysis_calculate_post"
+    },
+    {
+      "path": "/api/v1/monitoring/analysis/calculate/batch",
+      "method": "POST",
+      "operationId": "batch_calculate_health_scores_api_v1_monitoring_analysis_calculate_batch_post"
+    },
+    {
+      "path": "/api/v1/monitoring/analysis/engine/status",
+      "method": "GET",
+      "operationId": "get_engine_status_api_v1_monitoring_analysis_engine_status_get"
+    },
+    {
+      "path": "/api/v1/monitoring/analysis/market-regime",
+      "method": "GET",
+      "operationId": "identify_market_regime_api_v1_monitoring_analysis_market_regime_get"
+    },
+    {
+      "path": "/api/v1/monitoring/analysis/portfolio/{watchlist_id}",
+      "method": "GET",
+      "operationId": "analyze_portfolio_api_v1_monitoring_analysis_portfolio__watchlist_id__get"
+    },
+    {
+      "path": "/api/v1/monitoring/analysis/portfolio/{watchlist_id}/alerts",
+      "method": "GET",
+      "operationId": "get_portfolio_alerts_api_v1_monitoring_analysis_portfolio__watchlist_id__alerts_get"
+    },
+    {
+      "path": "/api/v1/monitoring/analysis/portfolio/{watchlist_id}/rebalance",
+      "method": "GET",
+      "operationId": "get_rebalance_suggestions_api_v1_monitoring_analysis_portfolio__watchlist_id__rebalance_get"
+    },
+    {
+      "path": "/api/v1/monitoring/analysis/portfolio/{watchlist_id}/summary",
+      "method": "GET",
+      "operationId": "get_portfolio_summary_api_v1_monitoring_analysis_portfolio__watchlist_id__summary_get"
+    },
+    {
+      "path": "/api/v1/monitoring/analysis/results/{stock_code}",
+      "method": "GET",
+      "operationId": "get_health_score_history_api_v1_monitoring_analysis_results__stock_code__get"
+    },
+    {
+      "path": "/api/v1/monitoring/analyze",
+      "method": "GET",
+      "operationId": "analyze_monitoring_api_v1_monitoring_analyze_get"
+    },
+    {
+      "path": "/api/v1/monitoring/control/start",
+      "method": "POST",
+      "operationId": "start_monitoring_api_v1_monitoring_control_start_post"
+    },
+    {
+      "path": "/api/v1/monitoring/control/status",
+      "method": "GET",
+      "operationId": "get_monitoring_status_api_v1_monitoring_control_status_get"
+    },
+    {
+      "path": "/api/v1/monitoring/control/stop",
+      "method": "POST",
+      "operationId": "stop_monitoring_api_v1_monitoring_control_stop_post"
+    },
+    {
+      "path": "/api/v1/monitoring/dragon-tiger",
+      "method": "GET",
+      "operationId": "get_dragon_tiger_list_api_v1_monitoring_dragon_tiger_get"
+    },
+    {
+      "path": "/api/v1/monitoring/dragon-tiger/fetch",
+      "method": "POST",
+      "operationId": "fetch_dragon_tiger_data_api_v1_monitoring_dragon_tiger_fetch_post"
+    },
+    {
+      "path": "/api/v1/monitoring/realtime",
+      "method": "GET",
+      "operationId": "get_realtime_monitoring_list_api_v1_monitoring_realtime_get"
+    },
+    {
+      "path": "/api/v1/monitoring/realtime/fetch",
+      "method": "POST",
+      "operationId": "fetch_realtime_data_api_v1_monitoring_realtime_fetch_post"
+    },
+    {
+      "path": "/api/v1/monitoring/realtime/{symbol}",
+      "method": "GET",
+      "operationId": "get_realtime_monitoring_api_v1_monitoring_realtime__symbol__get"
+    },
+    {
+      "path": "/api/v1/monitoring/stats/today",
+      "method": "GET",
+      "operationId": "get_today_statistics_api_v1_monitoring_stats_today_get"
+    },
+    {
+      "path": "/api/v1/monitoring/summary",
+      "method": "GET",
+      "operationId": "get_monitoring_summary_api_v1_monitoring_summary_get"
+    },
+    {
+      "path": "/api/v1/monitoring/watchlists",
+      "method": "GET",
+      "operationId": "list_watchlists_api_v1_monitoring_watchlists_get"
+    },
+    {
+      "path": "/api/v1/monitoring/watchlists",
+      "method": "POST",
+      "operationId": "create_watchlist_api_v1_monitoring_watchlists_post"
+    },
+    {
+      "path": "/api/v1/monitoring/watchlists/{watchlist_id}",
+      "method": "DELETE",
+      "operationId": "delete_watchlist_api_v1_monitoring_watchlists__watchlist_id__delete"
+    },
+    {
+      "path": "/api/v1/monitoring/watchlists/{watchlist_id}",
+      "method": "GET",
+      "operationId": "get_watchlist_api_v1_monitoring_watchlists__watchlist_id__get"
+    },
+    {
+      "path": "/api/v1/monitoring/watchlists/{watchlist_id}",
+      "method": "PUT",
+      "operationId": "update_watchlist_api_v1_monitoring_watchlists__watchlist_id__put"
+    },
+    {
+      "path": "/api/v1/monitoring/watchlists/{watchlist_id}/stocks",
+      "method": "GET",
+      "operationId": "list_watchlist_stocks_api_v1_monitoring_watchlists__watchlist_id__stocks_get"
+    },
+    {
+      "path": "/api/v1/monitoring/watchlists/{watchlist_id}/stocks",
+      "method": "POST",
+      "operationId": "add_stock_to_watchlist_api_v1_monitoring_watchlists__watchlist_id__stocks_post"
+    },
+    {
+      "path": "/api/v1/monitoring/watchlists/{watchlist_id}/stocks/{stock_code}",
+      "method": "DELETE",
+      "operationId": "remove_stock_from_watchlist_api_v1_monitoring_watchlists__watchlist_id__stocks__stock_code__delete"
+    },
+    {
+      "path": "/api/v1/optimization/analyze",
+      "method": "POST",
+      "operationId": "analyze_database_api_v1_optimization_analyze_post"
+    },
+    {
+      "path": "/api/v1/optimization/reindex",
+      "method": "POST",
+      "operationId": "reindex_database_api_v1_optimization_reindex_post"
+    },
+    {
+      "path": "/api/v1/optimization/slow-queries",
+      "method": "GET",
+      "operationId": "get_slow_queries_api_v1_optimization_slow_queries_get"
+    },
+    {
+      "path": "/api/v1/optimization/status",
+      "method": "GET",
+      "operationId": "get_database_status_api_v1_optimization_status_get"
+    },
+    {
+      "path": "/api/v1/optimization/vacuum",
+      "method": "POST",
+      "operationId": "vacuum_database_api_v1_optimization_vacuum_post"
+    },
+    {
+      "path": "/api/v1/positions",
+      "method": "GET",
+      "operationId": "list_positions_api_v1_positions_get"
+    },
+    {
+      "path": "/api/v1/positions",
+      "method": "POST",
+      "operationId": "create_position_api_v1_positions_post"
+    },
+    {
+      "path": "/api/v1/positions/attribution",
+      "method": "GET",
+      "operationId": "get_position_attribution_api_v1_positions_attribution_get"
+    },
+    {
+      "path": "/api/v1/positions/{position_id}",
+      "method": "DELETE",
+      "operationId": "delete_position_api_v1_positions__position_id__delete"
+    },
+    {
+      "path": "/api/v1/positions/{position_id}",
+      "method": "GET",
+      "operationId": "get_position_api_v1_positions__position_id__get"
+    },
+    {
+      "path": "/api/v1/positions/{position_id}",
+      "method": "PATCH",
+      "operationId": "update_position_api_v1_positions__position_id__patch"
+    },
+    {
+      "path": "/api/v1/risk/alerts",
+      "method": "GET",
+      "operationId": "list_risk_alerts_api_v1_risk_alerts_get"
+    },
+    {
+      "path": "/api/v1/risk/alerts",
+      "method": "POST",
+      "operationId": "create_risk_alert_api_v1_risk_alerts_post"
+    },
+    {
+      "path": "/api/v1/risk/alerts/generate",
+      "method": "POST",
+      "operationId": "generate_risk_alerts_api_v1_risk_alerts_generate_post"
+    },
+    {
+      "path": "/api/v1/risk/alerts/{alert_id}",
+      "method": "DELETE",
+      "operationId": "delete_risk_alert_api_v1_risk_alerts__alert_id__delete"
+    },
+    {
+      "path": "/api/v1/risk/alerts/{alert_id}",
+      "method": "PUT",
+      "operationId": "update_risk_alert_api_v1_risk_alerts__alert_id__put"
+    },
+    {
+      "path": "/api/v1/risk/beta",
+      "method": "POST",
+      "operationId": "calculate_beta_api_v1_risk_beta_post"
+    },
+    {
+      "path": "/api/v1/risk/dashboard",
+      "method": "GET",
+      "operationId": "get_risk_dashboard_api_v1_risk_dashboard_get"
+    },
+    {
+      "path": "/api/v1/risk/metrics/calculate",
+      "method": "POST",
+      "operationId": "calculate_risk_metrics_api_v1_risk_metrics_calculate_post"
+    },
+    {
+      "path": "/api/v1/risk/metrics/history",
+      "method": "GET",
+      "operationId": "get_risk_metrics_history_api_v1_risk_metrics_history_get"
+    },
+    {
+      "path": "/api/v1/risk/notifications/test",
+      "method": "POST",
+      "operationId": "test_notification_api_v1_risk_notifications_test_post"
+    },
+    {
+      "path": "/api/v1/risk/position/assess",
+      "method": "POST",
+      "operationId": "assess_position_risk_api_v1_risk_position_assess_post"
+    },
+    {
+      "path": "/api/v1/risk/v31/alert/send",
+      "method": "POST",
+      "operationId": "send_risk_alert_api_v1_risk_v31_alert_send_post"
+    },
+    {
+      "path": "/api/v1/risk/v31/alert/statistics",
+      "method": "GET",
+      "operationId": "get_alert_statistics_api_v1_risk_v31_alert_statistics_get"
+    },
+    {
+      "path": "/api/v1/risk/v31/alerts/active",
+      "method": "GET",
+      "operationId": "get_active_alerts_v31_api_v1_risk_v31_alerts_active_get"
+    },
+    {
+      "path": "/api/v1/risk/v31/alerts/{alert_id}/acknowledge",
+      "method": "POST",
+      "operationId": "acknowledge_alert_v31_api_v1_risk_v31_alerts__alert_id__acknowledge_post"
+    },
+    {
+      "path": "/api/v1/risk/v31/health",
+      "method": "GET",
+      "operationId": "get_risk_management_health_api_v1_risk_v31_health_get"
+    },
+    {
+      "path": "/api/v1/risk/v31/portfolio/{portfolio_id}",
+      "method": "GET",
+      "operationId": "get_portfolio_risk_v31_api_v1_risk_v31_portfolio__portfolio_id__get"
+    },
+    {
+      "path": "/api/v1/risk/v31/risk/realtime/{symbol}",
+      "method": "GET",
+      "operationId": "get_realtime_risk_metrics_api_v1_risk_v31_risk_realtime__symbol__get"
+    },
+    {
+      "path": "/api/v1/risk/v31/rules/add",
+      "method": "POST",
+      "operationId": "add_alert_rule_api_v1_risk_v31_rules_add_post"
+    },
+    {
+      "path": "/api/v1/risk/v31/rules/evaluate",
+      "method": "POST",
+      "operationId": "evaluate_alert_rules_api_v1_risk_v31_rules_evaluate_post"
+    },
+    {
+      "path": "/api/v1/risk/v31/rules/remove/{rule_id}",
+      "method": "DELETE",
+      "operationId": "remove_alert_rule_api_v1_risk_v31_rules_remove__rule_id__delete"
+    },
+    {
+      "path": "/api/v1/risk/v31/rules/statistics",
+      "method": "GET",
+      "operationId": "get_rule_statistics_api_v1_risk_v31_rules_statistics_get"
+    },
+    {
+      "path": "/api/v1/risk/v31/stock/{symbol}",
+      "method": "GET",
+      "operationId": "get_stock_risk_v31_api_v1_risk_v31_stock__symbol__get"
+    },
+    {
+      "path": "/api/v1/risk/v31/stop-loss/add-position",
+      "method": "POST",
+      "operationId": "add_stop_loss_position_api_v1_risk_v31_stop_loss_add_position_post"
+    },
+    {
+      "path": "/api/v1/risk/v31/stop-loss/batch-update",
+      "method": "POST",
+      "operationId": "batch_update_stop_loss_prices_api_v1_risk_v31_stop_loss_batch_update_post"
+    },
+    {
+      "path": "/api/v1/risk/v31/stop-loss/calculate",
+      "method": "POST",
+      "operationId": "calculate_stop_loss_v31_api_v1_risk_v31_stop_loss_calculate_post"
+    },
+    {
+      "path": "/api/v1/risk/v31/stop-loss/history/performance",
+      "method": "GET",
+      "operationId": "get_stop_loss_performance_api_v1_risk_v31_stop_loss_history_performance_get"
+    },
+    {
+      "path": "/api/v1/risk/v31/stop-loss/history/recommendations",
+      "method": "GET",
+      "operationId": "get_stop_loss_recommendations_api_v1_risk_v31_stop_loss_history_recommendations_get"
+    },
+    {
+      "path": "/api/v1/risk/v31/stop-loss/overview",
+      "method": "GET",
+      "operationId": "get_stop_loss_overview_api_v1_risk_v31_stop_loss_overview_get"
+    },
+    {
+      "path": "/api/v1/risk/v31/stop-loss/remove-position/{position_id}",
+      "method": "DELETE",
+      "operationId": "remove_stop_loss_position_api_v1_risk_v31_stop_loss_remove_position__position_id__delete"
+    },
+    {
+      "path": "/api/v1/risk/v31/stop-loss/status/{position_id}",
+      "method": "GET",
+      "operationId": "get_stop_loss_status_api_v1_risk_v31_stop_loss_status__position_id__get"
+    },
+    {
+      "path": "/api/v1/risk/v31/stop-loss/trigger",
+      "method": "POST",
+      "operationId": "trigger_stop_loss_v31_api_v1_risk_v31_stop_loss_trigger_post"
+    },
+    {
+      "path": "/api/v1/risk/v31/stop-loss/update-price",
+      "method": "POST",
+      "operationId": "update_stop_loss_price_api_v1_risk_v31_stop_loss_update_price_post"
+    },
+    {
+      "path": "/api/v1/risk/v31/ws/broadcast/{topic}",
+      "method": "POST",
+      "operationId": "broadcast_risk_update_api_v1_risk_v31_ws_broadcast__topic__post"
+    },
+    {
+      "path": "/api/v1/risk/v31/ws/connections",
+      "method": "GET",
+      "operationId": "get_websocket_connections_api_v1_risk_v31_ws_connections_get"
+    },
+    {
+      "path": "/api/v1/risk/var-cvar",
+      "method": "POST",
+      "operationId": "calculate_var_cvar_api_v1_risk_var_cvar_post"
+    },
+    {
+      "path": "/api/v1/sentiment/analyze",
+      "method": "POST",
+      "operationId": "analyze_sentiment_api_v1_sentiment_analyze_post"
+    },
+    {
+      "path": "/api/v1/sentiment/market",
+      "method": "GET",
+      "operationId": "get_market_sentiment_api_v1_sentiment_market_get"
+    },
+    {
+      "path": "/api/v1/sentiment/stock/{symbol}",
+      "method": "GET",
+      "operationId": "get_stock_sentiment_api_v1_sentiment_stock__symbol__get"
+    },
+    {
+      "path": "/api/v1/sse/alerts",
+      "method": "GET",
+      "operationId": "sse_alerts_stream_api_v1_sse_alerts_get"
+    },
+    {
+      "path": "/api/v1/sse/backtest",
+      "method": "GET",
+      "operationId": "sse_backtest_stream_api_v1_sse_backtest_get"
+    },
+    {
+      "path": "/api/v1/sse/dashboard",
+      "method": "GET",
+      "operationId": "sse_dashboard_stream_api_v1_sse_dashboard_get"
+    },
+    {
+      "path": "/api/v1/sse/status",
+      "method": "GET",
+      "operationId": "sse_status_api_v1_sse_status_get"
+    },
+    {
+      "path": "/api/v1/sse/training",
+      "method": "GET",
+      "operationId": "sse_training_stream_api_v1_sse_training_get"
+    },
+    {
+      "path": "/api/v1/strategies",
+      "method": "GET",
+      "operationId": "list_strategies_api_v1_strategies_get"
+    },
+    {
+      "path": "/api/v1/strategies/backtest",
+      "method": "POST",
+      "operationId": "backtest_ml_strategy_api_v1_strategies_backtest_post"
+    },
+    {
+      "path": "/api/v1/strategies/batch-analysis/runtime-status",
+      "method": "GET",
+      "operationId": "get_batch_analysis_runtime_status_api_v1_strategies_batch_analysis_runtime_status_get"
+    },
+    {
+      "path": "/api/v1/strategies/batch-analysis/submit",
+      "method": "POST",
+      "operationId": "submit_batch_analysis_task_api_v1_strategies_batch_analysis_submit_post"
+    },
+    {
+      "path": "/api/v1/strategies/batch-analysis/tasks",
+      "method": "GET",
+      "operationId": "list_batch_analysis_tasks_api_v1_strategies_batch_analysis_tasks_get"
+    },
+    {
+      "path": "/api/v1/strategies/batch-analysis/tasks/{task_id}",
+      "method": "GET",
+      "operationId": "get_batch_analysis_task_detail_api_v1_strategies_batch_analysis_tasks__task_id__get"
+    },
+    {
+      "path": "/api/v1/strategies/ml/models",
+      "method": "GET",
+      "operationId": "list_ml_workbench_models_api_v1_strategies_ml_models_get"
+    },
+    {
+      "path": "/api/v1/strategies/ml/models/{model_id}",
+      "method": "GET",
+      "operationId": "get_ml_workbench_model_detail_api_v1_strategies_ml_models__model_id__get"
+    },
+    {
+      "path": "/api/v1/strategies/ml/predict",
+      "method": "POST",
+      "operationId": "predict_ml_workbench_model_api_v1_strategies_ml_predict_post"
+    },
+    {
+      "path": "/api/v1/strategies/ml/runtime-status",
+      "method": "GET",
+      "operationId": "get_ml_runtime_status_api_v1_strategies_ml_runtime_status_get"
+    },
+    {
+      "path": "/api/v1/strategies/ml/train",
+      "method": "POST",
+      "operationId": "train_ml_workbench_model_api_v1_strategies_ml_train_post"
+    },
+    {
+      "path": "/api/v1/strategies/predict",
+      "method": "POST",
+      "operationId": "generate_strategy_prediction_api_v1_strategies_predict_post"
+    },
+    {
+      "path": "/api/v1/strategies/train",
+      "method": "POST",
+      "operationId": "train_ml_strategy_api_v1_strategies_train_post"
+    },
+    {
+      "path": "/api/v1/strategy/backtest/results",
+      "method": "GET",
+      "operationId": "list_backtest_results_api_v1_strategy_backtest_results_get"
+    },
+    {
+      "path": "/api/v1/strategy/backtest/results/{backtest_id}",
+      "method": "GET",
+      "operationId": "get_backtest_result_api_v1_strategy_backtest_results__backtest_id__get"
+    },
+    {
+      "path": "/api/v1/strategy/backtest/results/{backtest_id}/chart-data",
+      "method": "GET",
+      "operationId": "get_backtest_chart_data_api_v1_strategy_backtest_results__backtest_id__chart_data_get"
+    },
+    {
+      "path": "/api/v1/strategy/backtest/run",
+      "method": "POST",
+      "operationId": "run_backtest_api_v1_strategy_backtest_run_post"
+    },
+    {
+      "path": "/api/v1/strategy/backtest/status/{backtest_id}",
+      "method": "GET",
+      "operationId": "get_backtest_status_api_v1_strategy_backtest_status__backtest_id__get"
+    },
+    {
+      "path": "/api/v1/strategy/definitions",
+      "method": "GET",
+      "operationId": "get_strategy_definitions_api_v1_strategy_definitions_get"
+    },
+    {
+      "path": "/api/v1/strategy/matched-stocks",
+      "method": "GET",
+      "operationId": "get_matched_stocks_api_v1_strategy_matched_stocks_get"
+    },
+    {
+      "path": "/api/v1/strategy/models",
+      "method": "GET",
+      "operationId": "list_models_api_v1_strategy_models_get"
+    },
+    {
+      "path": "/api/v1/strategy/models/train",
+      "method": "POST",
+      "operationId": "train_model_api_v1_strategy_models_train_post"
+    },
+    {
+      "path": "/api/v1/strategy/models/training/{task_id}/status",
+      "method": "GET",
+      "operationId": "get_training_status_api_v1_strategy_models_training__task_id__status_get"
+    },
+    {
+      "path": "/api/v1/strategy/results",
+      "method": "GET",
+      "operationId": "query_strategy_results_api_v1_strategy_results_get"
+    },
+    {
+      "path": "/api/v1/strategy/run/batch",
+      "method": "POST",
+      "operationId": "run_strategy_batch_api_v1_strategy_run_batch_post"
+    },
+    {
+      "path": "/api/v1/strategy/run/single",
+      "method": "POST",
+      "operationId": "run_strategy_single_api_v1_strategy_run_single_post"
+    },
+    {
+      "path": "/api/v1/strategy/stats/summary",
+      "method": "GET",
+      "operationId": "get_strategy_summary_api_v1_strategy_stats_summary_get"
+    },
+    {
+      "path": "/api/v1/strategy/strategies",
+      "method": "GET",
+      "operationId": "list_strategies_api_v1_strategy_strategies_get"
+    },
+    {
+      "path": "/api/v1/strategy/strategies",
+      "method": "POST",
+      "operationId": "create_strategy_api_v1_strategy_strategies_post"
+    },
+    {
+      "path": "/api/v1/strategy/strategies/{strategy_id}",
+      "method": "DELETE",
+      "operationId": "delete_strategy_api_v1_strategy_strategies__strategy_id__delete"
+    },
+    {
+      "path": "/api/v1/strategy/strategies/{strategy_id}",
+      "method": "GET",
+      "operationId": "get_strategy_api_v1_strategy_strategies__strategy_id__get"
+    },
+    {
+      "path": "/api/v1/strategy/strategies/{strategy_id}",
+      "method": "PUT",
+      "operationId": "update_strategy_api_v1_strategy_strategies__strategy_id__put"
+    },
+    {
+      "path": "/api/v1/strategy/{strategy_id}/pause",
+      "method": "POST",
+      "operationId": "pause_strategy_api_v1_strategy__strategy_id__pause_post"
+    },
+    {
+      "path": "/api/v1/strategy/{strategy_id}/resume",
+      "method": "POST",
+      "operationId": "resume_strategy_api_v1_strategy__strategy_id__resume_post"
+    },
+    {
+      "path": "/api/v1/strategy/{strategy_id}/start",
+      "method": "POST",
+      "operationId": "start_strategy_api_v1_strategy__strategy_id__start_post"
+    },
+    {
+      "path": "/api/v1/strategy/{strategy_id}/stop",
+      "method": "POST",
+      "operationId": "stop_strategy_api_v1_strategy__strategy_id__stop_post"
+    },
+    {
+      "path": "/api/v1/stress-test/history",
+      "method": "GET",
+      "operationId": "get_stress_test_history_api_v1_stress_test_history_get"
+    },
+    {
+      "path": "/api/v1/stress-test/run",
+      "method": "POST",
+      "operationId": "run_custom_stress_test_api_v1_stress_test_run_post"
+    },
+    {
+      "path": "/api/v1/stress-test/scenarios",
+      "method": "GET",
+      "operationId": "get_predefined_scenarios_api_v1_stress_test_scenarios_get"
+    },
+    {
+      "path": "/api/v1/system/adapters/health",
+      "method": "GET",
+      "operationId": "get_adapters_health_api_v1_system_adapters_health_get"
+    },
+    {
+      "path": "/api/v1/system/datasources",
+      "method": "GET",
+      "operationId": "get_datasources_api_v1_system_datasources_get"
+    },
+    {
+      "path": "/api/v1/system/health",
+      "method": "GET",
+      "operationId": "system_health_api_v1_system_health_get"
+    },
+    {
+      "path": "/api/v1/system/logs",
+      "method": "GET",
+      "operationId": "get_system_logs_api_v1_system_logs_get"
+    },
+    {
+      "path": "/api/v1/system/logs/summary",
+      "method": "GET",
+      "operationId": "get_logs_summary_api_v1_system_logs_summary_get"
+    },
+    {
+      "path": "/api/v1/system/resources",
+      "method": "GET",
+      "operationId": "get_system_resource_metrics_api_v1_system_resources_get"
+    },
+    {
+      "path": "/api/v1/system/settings/general",
+      "method": "GET",
+      "operationId": "get_general_settings_api_v1_system_settings_general_get"
+    },
+    {
+      "path": "/api/v1/system/settings/general",
+      "method": "POST",
+      "operationId": "update_general_settings_api_v1_system_settings_general_post"
+    },
+    {
+      "path": "/api/v1/system/settings/security",
+      "method": "GET",
+      "operationId": "get_security_settings_api_v1_system_settings_security_get"
+    },
+    {
+      "path": "/api/v1/system/settings/security",
+      "method": "POST",
+      "operationId": "update_security_settings_api_v1_system_settings_security_post"
+    },
+    {
+      "path": "/api/v1/system/test-connection",
+      "method": "POST",
+      "operationId": "test_database_connection_api_v1_system_test_connection_post"
+    },
+    {
+      "path": "/api/v1/tdx/health",
+      "method": "GET",
+      "operationId": "health_check_api_v1_tdx_health_get"
+    },
+    {
+      "path": "/api/v1/tdx/index/kline",
+      "method": "GET",
+      "operationId": "get_index_kline_api_v1_tdx_index_kline_get"
+    },
+    {
+      "path": "/api/v1/tdx/index/quote/{symbol}",
+      "method": "GET",
+      "operationId": "get_index_quote_api_v1_tdx_index_quote__symbol__get"
+    },
+    {
+      "path": "/api/v1/tdx/kline",
+      "method": "GET",
+      "operationId": "get_stock_kline_api_v1_tdx_kline_get"
+    },
+    {
+      "path": "/api/v1/tdx/quote/{symbol}",
+      "method": "GET",
+      "operationId": "get_stock_quote_api_v1_tdx_quote__symbol__get"
+    },
+    {
+      "path": "/api/v1/technical-indicators",
+      "method": "GET",
+      "operationId": "get_technical_indicators_api_v1_technical_indicators_get"
+    },
+    {
+      "path": "/api/v1/technical/batch/indicators",
+      "method": "POST",
+      "operationId": "get_batch_indicators_api_v1_technical_batch_indicators_post"
+    },
+    {
+      "path": "/api/v1/technical/patterns/{symbol}",
+      "method": "GET",
+      "operationId": "detect_patterns_api_v1_technical_patterns__symbol__get"
+    },
+    {
+      "path": "/api/v1/technical/{symbol}/history",
+      "method": "GET",
+      "operationId": "get_stock_history_api_v1_technical__symbol__history_get"
+    },
+    {
+      "path": "/api/v1/technical/{symbol}/indicators",
+      "method": "GET",
+      "operationId": "get_all_indicators_api_v1_technical__symbol__indicators_get"
+    },
+    {
+      "path": "/api/v1/technical/{symbol}/momentum",
+      "method": "GET",
+      "operationId": "get_momentum_indicators_api_v1_technical__symbol__momentum_get"
+    },
+    {
+      "path": "/api/v1/technical/{symbol}/signals",
+      "method": "GET",
+      "operationId": "get_trading_signals_api_v1_technical__symbol__signals_get"
+    },
+    {
+      "path": "/api/v1/technical/{symbol}/trend",
+      "method": "GET",
+      "operationId": "get_trend_indicators_api_v1_technical__symbol__trend_get"
+    },
+    {
+      "path": "/api/v1/technical/{symbol}/volatility",
+      "method": "GET",
+      "operationId": "get_volatility_indicators_api_v1_technical__symbol__volatility_get"
+    },
+    {
+      "path": "/api/v1/technical/{symbol}/volume",
+      "method": "GET",
+      "operationId": "get_volume_indicators_api_v1_technical__symbol__volume_get"
+    },
+    {
+      "path": "/api/v1/trade/execute",
+      "method": "POST",
+      "operationId": "execute_trade_api_v1_trade_execute_post"
+    },
+    {
+      "path": "/api/v1/trade/execution-tracking",
+      "method": "GET",
+      "operationId": "get_execution_tracking_api_v1_trade_execution_tracking_get"
+    },
+    {
+      "path": "/api/v1/trade/execution-tracking/trigger",
+      "method": "POST",
+      "operationId": "trigger_external_execution_api_v1_trade_execution_tracking_trigger_post"
+    },
+    {
+      "path": "/api/v1/trade/execution-tracking/{tracking_id}",
+      "method": "GET",
+      "operationId": "get_execution_tracking_detail_api_v1_trade_execution_tracking__tracking_id__get"
+    },
+    {
+      "path": "/api/v1/trade/health",
+      "method": "GET",
+      "operationId": "health_check_api_v1_trade_health_get"
+    },
+    {
+      "path": "/api/v1/trade/portfolio",
+      "method": "GET",
+      "operationId": "get_portfolio_api_v1_trade_portfolio_get"
+    },
+    {
+      "path": "/api/v1/trade/positions",
+      "method": "GET",
+      "operationId": "get_positions_api_v1_trade_positions_get"
+    },
+    {
+      "path": "/api/v1/trade/reconciliation/accounts",
+      "method": "GET",
+      "operationId": "get_reconciliation_accounts_api_v1_trade_reconciliation_accounts_get"
+    },
+    {
+      "path": "/api/v1/trade/reconciliation/export",
+      "method": "GET",
+      "operationId": "export_reconciliation_results_api_v1_trade_reconciliation_export_get"
+    },
+    {
+      "path": "/api/v1/trade/reconciliation/import",
+      "method": "POST",
+      "operationId": "import_reconciliation_csv_api_v1_trade_reconciliation_import_post"
+    },
+    {
+      "path": "/api/v1/trade/reconciliation/results",
+      "method": "GET",
+      "operationId": "get_reconciliation_results_api_v1_trade_reconciliation_results_get"
+    },
+    {
+      "path": "/api/v1/trade/reconciliation/statements",
+      "method": "GET",
+      "operationId": "get_reconciliation_statements_api_v1_trade_reconciliation_statements_get"
+    },
+    {
+      "path": "/api/v1/trade/signals",
+      "method": "GET",
+      "operationId": "get_signals_api_v1_trade_signals_get"
+    },
+    {
+      "path": "/api/v1/trade/statistics",
+      "method": "GET",
+      "operationId": "get_statistics_api_v1_trade_statistics_get"
+    },
+    {
+      "path": "/api/v1/trade/trades",
+      "method": "GET",
+      "operationId": "get_trades_api_v1_trade_trades_get"
+    },
+    {
+      "path": "/api/v1/trading/sessions",
+      "method": "GET",
+      "operationId": "list_trading_sessions_api_v1_trading_sessions_get"
+    },
+    {
+      "path": "/api/v1/trading/sessions",
+      "method": "POST",
+      "operationId": "create_trading_session_api_v1_trading_sessions_post"
+    },
+    {
+      "path": "/api/v1/trading/sessions/{session_id}",
+      "method": "DELETE",
+      "operationId": "delete_trading_session_api_v1_trading_sessions__session_id__delete"
+    },
+    {
+      "path": "/api/v1/trading/sessions/{session_id}",
+      "method": "GET",
+      "operationId": "get_trading_session_api_v1_trading_sessions__session_id__get"
+    },
+    {
+      "path": "/api/v1/trading/sessions/{session_id}",
+      "method": "PATCH",
+      "operationId": "update_trading_session_api_v1_trading_sessions__session_id__patch"
+    },
+    {
+      "path": "/api/v2/market/blocktrade",
+      "method": "GET",
+      "operationId": "get_stock_blocktrade_api_v2_market_blocktrade_get"
+    },
+    {
+      "path": "/api/v2/market/blocktrade/refresh",
+      "method": "POST",
+      "operationId": "refresh_stock_blocktrade_api_v2_market_blocktrade_refresh_post"
+    },
+    {
+      "path": "/api/v2/market/dividend",
+      "method": "GET",
+      "operationId": "get_stock_dividend_api_v2_market_dividend_get"
+    },
+    {
+      "path": "/api/v2/market/dividend/refresh",
+      "method": "POST",
+      "operationId": "refresh_stock_dividend_api_v2_market_dividend_refresh_post"
+    },
+    {
+      "path": "/api/v2/market/etf/list",
+      "method": "GET",
+      "operationId": "get_etf_list_api_v2_market_etf_list_get"
+    },
+    {
+      "path": "/api/v2/market/etf/refresh",
+      "method": "POST",
+      "operationId": "refresh_etf_spot_api_v2_market_etf_refresh_post"
+    },
+    {
+      "path": "/api/v2/market/fund-flow",
+      "method": "GET",
+      "operationId": "get_fund_flow_api_v2_market_fund_flow_get"
+    },
+    {
+      "path": "/api/v2/market/fund-flow/refresh",
+      "method": "POST",
+      "operationId": "refresh_fund_flow_api_v2_market_fund_flow_refresh_post"
+    },
+    {
+      "path": "/api/v2/market/lhb",
+      "method": "GET",
+      "operationId": "get_lhb_detail_api_v2_market_lhb_get"
+    },
+    {
+      "path": "/api/v2/market/lhb/refresh",
+      "method": "POST",
+      "operationId": "refresh_lhb_detail_api_v2_market_lhb_refresh_post"
+    },
+    {
+      "path": "/api/v2/market/refresh-all",
+      "method": "POST",
+      "operationId": "refresh_all_market_data_api_v2_market_refresh_all_post"
+    },
+    {
+      "path": "/api/v2/market/sector/fund-flow",
+      "method": "GET",
+      "operationId": "get_sector_fund_flow_api_v2_market_sector_fund_flow_get"
+    },
+    {
+      "path": "/api/v2/market/sector/fund-flow/refresh",
+      "method": "POST",
+      "operationId": "refresh_sector_fund_flow_api_v2_market_sector_fund_flow_refresh_post"
+    },
+    {
+      "path": "/api/watchlist/",
+      "method": "GET",
+      "operationId": "get_my_watchlist_api_watchlist__get"
+    },
+    {
+      "path": "/api/watchlist/add",
+      "method": "POST",
+      "operationId": "add_to_watchlist_api_watchlist_add_post"
+    },
+    {
+      "path": "/api/watchlist/check/{symbol}",
+      "method": "GET",
+      "operationId": "check_in_watchlist_api_watchlist_check__symbol__get"
+    },
+    {
+      "path": "/api/watchlist/clear",
+      "method": "DELETE",
+      "operationId": "clear_watchlist_api_watchlist_clear_delete"
+    },
+    {
+      "path": "/api/watchlist/count",
+      "method": "GET",
+      "operationId": "get_watchlist_count_api_watchlist_count_get"
+    },
+    {
+      "path": "/api/watchlist/group/{group_id}",
+      "method": "GET",
+      "operationId": "get_watchlist_by_group_api_watchlist_group__group_id__get"
+    },
+    {
+      "path": "/api/watchlist/groups",
+      "method": "GET",
+      "operationId": "get_user_groups_api_watchlist_groups_get"
+    },
+    {
+      "path": "/api/watchlist/groups",
+      "method": "POST",
+      "operationId": "create_group_api_watchlist_groups_post"
+    },
+    {
+      "path": "/api/watchlist/groups/{group_id}",
+      "method": "DELETE",
+      "operationId": "delete_group_api_watchlist_groups__group_id__delete"
+    },
+    {
+      "path": "/api/watchlist/groups/{group_id}",
+      "method": "PUT",
+      "operationId": "update_group_api_watchlist_groups__group_id__put"
+    },
+    {
+      "path": "/api/watchlist/move",
+      "method": "PUT",
+      "operationId": "move_stock_to_group_api_watchlist_move_put"
+    },
+    {
+      "path": "/api/watchlist/notes/{symbol}",
+      "method": "PUT",
+      "operationId": "update_watchlist_notes_api_watchlist_notes__symbol__put"
+    },
+    {
+      "path": "/api/watchlist/remove/{symbol}",
+      "method": "DELETE",
+      "operationId": "remove_from_watchlist_api_watchlist_remove__symbol__delete"
+    },
+    {
+      "path": "/api/watchlist/symbols",
+      "method": "GET",
+      "operationId": "get_my_watchlist_symbols_api_watchlist_symbols_get"
+    },
+    {
+      "path": "/api/watchlist/with-groups",
+      "method": "GET",
+      "operationId": "get_watchlist_with_groups_api_watchlist_with_groups_get"
+    },
+    {
+      "path": "/health",
+      "method": "GET",
+      "operationId": "health_check_health_get"
+    },
+    {
+      "path": "/health/ready",
+      "method": "GET",
+      "operationId": "readiness_check_health_ready_get"
+    },
+    {
+      "path": "/metrics",
+      "method": "GET",
+      "operationId": "metrics_metrics_get"
+    },
+    {
+      "path": "/metrics/health",
+      "method": "GET",
+      "operationId": "metrics_health_metrics_health_get"
+    },
+    {
+      "path": "/metrics/list",
+      "method": "GET",
+      "operationId": "metrics_list_metrics_list_get"
+    },
+    {
+      "path": "/ws/channels",
+      "method": "GET",
+      "operationId": "list_channels_ws_channels_get"
+    },
+    {
+      "path": "/ws/stats",
+      "method": "GET",
+      "operationId": "get_websocket_stats_ws_stats_get"
+    }
+  ]
+}

--- a/docs/reports/quality/backend-route-openapi-governance-decision-package-2026-05-22.md
+++ b/docs/reports/quality/backend-route-openapi-governance-decision-package-2026-05-22.md
@@ -1,0 +1,206 @@
+# Backend Route/OpenAPI Governance Decision Package - 2026-05-22
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以
+> `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、
+> 当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: `decision-package-prepared-for-review`
+- OpenSpec change: `refresh-backend-route-openapi-governance`
+- Parent issue: <https://github.com/chengjon/mystocks/issues/92>
+- Current HEAD: `c173bbc8d48d5e20ed5905d698ca39001237198a`
+- Evidence generated at: `2026-05-21T17:02:48.078861Z`
+- Execution mode: governance/evidence only
+- Environment mode: placeholder env for `app.main` import and `app.openapi()`;
+  no backend service startup, no PM2 command, and no runtime route mutation
+
+## Authorization Boundary
+
+This package executes the approved D2.3 governance/evidence checklist. It does
+not authorize:
+
+- Backend source edits
+- Frontend source edits
+- Test edits
+- Generated client edits
+- `docs/api/` edits
+- Route path, method, router registration, or behavior changes
+- OpenAPI schema, operationId, response contract, or `include_in_schema` changes
+- Probe URL rewrites
+- PM2 command execution or service restart/recreation
+- Implementation issue creation
+- Moving issue `#92` to `ready-for-agent`
+
+## Evidence Artifacts
+
+| Evidence | Artifact | Current-HEAD Summary |
+|---|---|---|
+| Route table | `.planning/codebase/generated/backend-route-table-2026-05-22.json` | routes=`548`, schema-visible=`536`, hidden runtime=`12`, endpoint modules=`99`, duplicate path/method excluding HEAD/OPTIONS=`1` |
+| OpenAPI snapshot | `.planning/codebase/generated/route-openapi-snapshot-2026-05-22.json` | paths=`500`, operations=`536`, schemas=`301`, duplicate operationIds=`0`, warnings=`0` |
+| Probe consumer matrix | `.planning/codebase/generated/probe-consumer-matrix-2026-05-22.json` | scanned files=`1415`, hit files=`185`, hit lines=`600`; roots are workflows/config/scripts/root Docker/PM2/package config |
+| Route consumer contract matrix | `.planning/codebase/generated/route-consumer-contract-matrix-2026-05-22.json` | six D2.3 route groups summarized with consumers and future regression gates |
+
+All artifacts include `git_head`, `generated_at`, and
+`stale_if_head_mismatch=true`.
+
+## Freshness Gate
+
+| Gate | Result |
+|---|---|
+| `app.main` import | Passed under placeholder governance environment |
+| Route table generation | Passed |
+| `app.openapi()` generation | Passed |
+| OpenAPI duplicate operationId warnings | `0` |
+| Captured warning count | `0` |
+| Stop condition triggered | No |
+
+The app import printed informational startup logs and a GPU dependency fallback
+warning (`Numba needs NumPy 2.2 or less. Got NumPy 2.4.`). This package treats
+that warning as an environmental smoke note, not as D2.3 route governance
+authorization or a route/OpenAPI blocker.
+
+## Route/OpenAPI Snapshot
+
+| Metric | Value |
+|---|---:|
+| Runtime routes | `548` |
+| Schema-visible routes | `536` |
+| Hidden runtime routes | `12` |
+| Endpoint module count | `99` |
+| OpenAPI paths | `500` |
+| OpenAPI operations | `536` |
+| Component schemas | `301` |
+| Duplicate operationIds | `0` |
+| OpenAPI warnings | `0` |
+
+The only duplicate runtime path/method excluding `HEAD` and `OPTIONS` remains:
+
+| Path | Method | Routes | Classification |
+|---|---|---|---|
+| `/metrics` | `GET` | `app.main.prometheus_metrics` hidden from schema; `app.api.prometheus_exporter.metrics` schema-visible | D2.5 control-plane taxonomy item; no runtime or schema change is authorized here |
+
+## D2.3 Ownership Classification
+
+| Class | Routes | Schema Exposed | Decision |
+|---|---:|---:|---|
+| Trading-owned | `40` | `40` | Keep under unified route/OpenAPI governance; no trading-only implementation lane from this package |
+| Trading-adjacent unclassified | `1` | `1` | Keep `/api/v1/advanced-analysis/trading-signals` unclassified until a later accepted owner decision |
+| Backup/recovery | N/A | N/A | D2.4 lane, outside D2.3 mutation scope |
+| Health/status/docs/probe/control-plane | N/A | N/A | D2.5 lane, outside D2.3 mutation scope |
+| PM2/stateful gates | N/A | N/A | D2.6 policy lane, outside D2.3 mutation scope |
+
+### Module Counts
+
+| Endpoint Module | Routes |
+|---|---:|
+| `app.api.trade.routes` | `7` |
+| `app.api.trade.execution_tracking_routes` | `3` |
+| `app.api.trade.reconciliation_routes` | `5` |
+| `app.api.trading_runtime` | `8` |
+| `app.api.tradingview` | `6` |
+| `app.api.v1.trading.session` | `5` |
+| `app.api.v1.trading.positions` | `6` |
+| `app.api.advanced_analysis_api` | `1` |
+
+### Path Group Counts
+
+| Path Group | Routes | OpenAPI Operations | Ownership |
+|---|---:|---:|---|
+| `/api/v1/trade` | `15` | `15` | trading-owned |
+| `/api/trading` | `8` | `8` | trading-owned |
+| `/api/tradingview` | `6` | `6` | trading-owned |
+| `/api/v1/trading` | `5` | `5` | trading-owned |
+| `/api/v1/positions` | `6` | `6` | trading-owned |
+| `/api/v1/advanced-analysis/trading-signals` | `1` | `1` | trading-adjacent-unclassified |
+
+All D2.3 candidate routes are currently schema-visible. No runtime-only hidden
+D2.3 trading shim was found in this snapshot.
+
+## Probe Consumer Matrix
+
+Probe scan roots were limited to `.github/workflows/`, `config/`, `scripts/`,
+and root Docker/PM2/package config files. The broader frontend/test/docs
+consumer contract matrix is kept separate.
+
+| Category | Hit Lines |
+|---|---:|
+| `health` | `262` |
+| `metrics` | `140` |
+| `openapi_docs` | `144` |
+| `status` | `28` |
+| `trading` | `26` |
+| `backup` | `0` |
+| `strategy_compat` | `0` |
+
+| Consumer Class | Hit Lines |
+|---|---:|
+| `config` | `187` |
+| `github_workflows` | `40` |
+| `scripts` | `373` |
+
+This matrix is evidence for future route/probe governance. It is not an
+operational truth source and does not authorize endpoint removal, probe rewiring,
+or PM2 execution.
+
+## Consumer Contract Matrix
+
+The route consumer contract matrix records current group-level consumers. It is
+not a parser-level guarantee. Each future implementation lane must inspect caller
+parser expectations, OpenAPI examples, query/path/body parameters, and response
+shape before changing any route.
+
+| Route Group | Frontend Files | Test Files | Script Files | Ops/CI Files | Docs/Governance Files | Minimum Future Gate |
+|---|---:|---:|---:|---:|---:|---|
+| `/api/v1/trade` | `4` | `4` | `2` | `0` | `27` | contract parity review before mutation |
+| `/api/trading` | `11` | `11` | `3` | `0` | `40` | contract parity review before mutation |
+| `/api/tradingview` | `0` | `3` | `0` | `0` | `13` | contract parity review before mutation |
+| `/api/v1/trading` | `0` | `1` | `0` | `0` | `10` | contract parity review before mutation |
+| `/api/v1/positions` | `0` | `3` | `0` | `0` | `6` | contract parity review before mutation |
+| `/api/v1/advanced-analysis/trading-signals` | `1` | `0` | `1` | `1` | `2` | owner decision plus contract parity review before mutation |
+
+Minimum regression checks for any later route implementation lane:
+
+- `app.main` import
+- FastAPI route table diff
+- `app.openapi()` duplicate operationId check
+- Targeted frontend/test consumer parser review
+- Contract parity test for path/query/body/response before route mutation
+
+## Decision Routing
+
+| Candidate | Route/OpenAPI Governance Decision |
+|---|---|
+| Trading-owned groups | Evidence accepted as D2.3 classification input; no action or mutation from this package |
+| `/api/v1/advanced-analysis/trading-signals` | Keep trading-adjacent and unclassified; future owner decision required |
+| `/metrics` duplicate runtime path/method | Route to D2.5 control-plane docs/taxonomy; no runtime or schema change here |
+| Backup/recovery surfaces | Route to D2.4 backup ownership lane |
+| Health/readiness/status/docs/probe surfaces | Route to D2.5 control-plane OpenAPI docs stabilization lane |
+| PM2/stateful workflow evidence | Route to D2.6 PM2 stateful gate approval policy |
+| Compatibility route/schema exposure decisions | Require separate accepted decision with runtime-vs-schema distinction |
+
+## OpenSpec Task Status
+
+Completed in this package:
+
+- Evidence freshness gate
+- Route ownership classification
+- Consumer contract matrix
+- Runtime-vs-schema exposure distinction for D2.3 candidates
+- Decision package creation
+- Explicit no-implementation boundary
+
+Still pending:
+
+- Human review of this decision package
+- Steward tree update after review acceptance
+- Any implementation lane, write scope, tests, or rollback plan for future route
+  changes
+
+## Next Gate
+
+Review this package. If accepted, record the review result in the steward tree
+and only then decide whether any separate child lane is needed. Do not create
+implementation issues or edit source from this package alone.

--- a/governance/mainline/task-cards/pr-121.yaml
+++ b/governance/mainline/task-cards/pr-121.yaml
@@ -1,0 +1,104 @@
+version: "v0.2"
+
+task:
+  id: "pr-121"
+  title: "prepare backend route openapi governance decision package"
+  owner: "main"
+  created_at: "2026-05-22"
+
+mainline:
+  id: "L1-issue92-d2-3-route-openapi-governance-decision-package"
+  objective: "execute D2.3 route/OpenAPI governance evidence tasks and prepare the decision package for review"
+  milestone_id: "L2-architecture-governance-closeout"
+  slice_id: "L3-route-openapi-governance-decision-package"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "refresh-backend-route-openapi-governance"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "api"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "D2.3 route/OpenAPI governance evidence and decision package only; no runtime entrypoint, route, page, shim, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/backend-route-table-2026-05-22.json"
+    - ".planning/codebase/generated/route-openapi-snapshot-2026-05-22.json"
+    - ".planning/codebase/generated/probe-consumer-matrix-2026-05-22.json"
+    - ".planning/codebase/generated/route-consumer-contract-matrix-2026-05-22.json"
+    - "docs/reports/quality/backend-route-openapi-governance-decision-package-2026-05-22.md"
+    - "governance/mainline/task-cards/pr-121.yaml"
+    - "openspec/changes/refresh-backend-route-openapi-governance/tasks.md"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+
+non_goals:
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, or runtime behavior changes"
+  - "No PM2 command execution, service restart, process deletion, or process recreation"
+  - "No downstream implementation issue creation"
+  - "No movement of issue #92 to ready-for-agent"
+  - "No D2.4 backup, D2.5 control-plane docs, or D2.6 PM2 execution work in this PR"
+
+acceptance:
+  checks:
+    - id: "openspec-route-governance-strict"
+      command: "openspec validate refresh-backend-route-openapi-governance --strict"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-route-openapi-governance-decision-package-2026-05-22.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-121.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this decision package is read as implementation approval, route/OpenAPI governance boundaries are broken"
+    - "If current-head artifacts are reused after HEAD changes, route counts and consumer evidence can become stale"
+  rollback_plan: "revert this PR and return D2.3 to approved-for-governance-execution state with no decision package"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "prepare D2.3 route/OpenAPI governance decision package"
+    modified_scope: "current-head evidence artifacts, decision report, OpenSpec task status, steward tree, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is evidence and governance bookkeeping only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if OpenSpec validation, markdown governance, or mainline scope checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-22T00:32:45+08:00"
+    approval_note: "D2.3 proposal approval was recorded in PR #120; this PR only executes governance/evidence task-list items and prepares the decision package for review"
+    secondary_approved: false

--- a/openspec/changes/refresh-backend-route-openapi-governance/tasks.md
+++ b/openspec/changes/refresh-backend-route-openapi-governance/tasks.md
@@ -17,50 +17,50 @@
 
 ## 1. Evidence Freshness Gate
 
-- [ ] Refresh route table against the execution branch and record total routes,
+- [x] Refresh route table against the execution branch and record total routes,
   schema-visible routes, hidden runtime routes, endpoint module count, duplicate
   path/method entries, generated timestamp, git head, and stale-if-head-mismatch
   policy.
-- [ ] Refresh `app.openapi()` and record path count, operation count, schema
+- [x] Refresh `app.openapi()` and record path count, operation count, schema
   count, duplicate operationId warnings, warning count, generated timestamp, git
   head, and stale-if-head-mismatch policy.
-- [ ] Refresh probe consumer matrix across `.github/workflows/`, `config/`,
+- [x] Refresh probe consumer matrix across `.github/workflows/`, `config/`,
   `scripts/`, Docker/PM2/package config, and any approved additional probe
   directories.
-- [ ] Stop and return to review if `app.main` import, route table generation, or
+- [x] Stop and return to review if `app.main` import, route table generation, or
   OpenAPI generation fails.
 
 ## 2. Route Ownership Classification
 
-- [ ] Classify D2.3 trading candidates by endpoint module, path group,
+- [x] Classify D2.3 trading candidates by endpoint module, path group,
   schema-exposure state, ownership class, consumer surface, and follow-up lane.
-- [ ] Treat `/api/v1/advanced-analysis/trading-signals` as trading-adjacent until
+- [x] Treat `/api/v1/advanced-analysis/trading-signals` as trading-adjacent until
   a later accepted owner decision says otherwise.
-- [ ] Classify `/metrics` GET duplicate path/method as a control-plane taxonomy
+- [x] Classify `/metrics` GET duplicate path/method as a control-plane taxonomy
   item before any schema or runtime route change.
-- [ ] Keep backup and recovery routes in the D2.4 ownership lane unless a later
+- [x] Keep backup and recovery routes in the D2.4 ownership lane unless a later
   accepted decision explicitly pulls a narrow item into this change.
-- [ ] Keep health/readiness/status/OpenAPI-docs/probe-facing routes in the D2.5
+- [x] Keep health/readiness/status/OpenAPI-docs/probe-facing routes in the D2.5
   docs/probe stabilization lane unless a later accepted decision explicitly
   pulls a narrow item into this change.
 
 ## 3. Consumer Contract Acceptance
 
-- [ ] For each candidate route group, record path, method, query parameters,
+- [x] For each candidate route group, record path, method, query parameters,
   request body, response shape, caller parser, OpenAPI examples, frontend/test
   consumers, and minimum regression checks.
-- [ ] Distinguish runtime route existence from OpenAPI schema exposure for every
+- [x] Distinguish runtime route existence from OpenAPI schema exposure for every
   compatibility route or shim.
-- [ ] Record explicit exit conditions for keep, hide-from-schema, document,
+- [x] Record explicit exit conditions for keep, hide-from-schema, document,
   migrate, or retire decisions.
 
 ## 4. Decision Package
 
-- [ ] Produce a route/OpenAPI governance decision package that maps each
+- [x] Produce a route/OpenAPI governance decision package that maps each
   candidate route group to one of: no action, docs-only, evidence-only,
   dedicated implementation proposal, D2.4 backup ownership, D2.5 control-plane
   docs stabilization, or D2.6 stateful gate approval.
 - [ ] Update the codebase-map task tree after the decision package is reviewed.
-- [ ] Do not create implementation issues or edit source until the accepted
+- [x] Do not create implementation issues or edit source until the accepted
   decision package identifies the lane, owner, write scope, tests, and rollback
   plan.


### PR DESCRIPTION
## Summary
- Execute approved D2.3 route/OpenAPI governance evidence tasks.
- Add current-head route table, OpenAPI snapshot, probe consumer matrix, and route consumer contract matrix artifacts.
- Add the D2.3 decision package for human review and update the steward tree/task checklist.

## Current-head evidence
- HEAD: c173bbc8d48d5e20ed5905d698ca39001237198a
- Route table: routes=548, schema-visible=536, hidden runtime=12, endpoint modules=99
- OpenAPI: paths=500, operations=536, schemas=301, duplicate operationIds=0, warnings=0
- D2.3 candidates: 41 trading/trading-adjacent routes, all schema-visible
- Duplicate runtime path/method: /metrics GET only, routed to D2.5 control-plane taxonomy

## Boundary
- Governance/evidence and decision package only.
- No backend/frontend source edits, no tests, no generated clients, no docs/API edits, no route behavior changes, no OpenAPI schema/exposure changes, no probe rewrites, no PM2 execution, no implementation issue creation, and no movement of issue #92 to ready-for-agent.

## Verification
- openspec validate refresh-backend-route-openapi-governance --strict
- markdown governance gate: errors=0 checked=2
- mainline scope gate: pass=True
- git diff --check HEAD~1..HEAD
- GitNexus compare vs origin/wip/root-dirty-20260403: low risk, 0 affected symbols/processes