### PR TITLE
docs: record adapter lifecycle closeout acceptance

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -382,8 +382,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-adapter-lifecycle-di-triage-2026-05-22.md`,
 │   │   `.planning/codebase/generated/adapter-lifecycle-di-triage-2026-05-22.json`,
 │   │   `backend-adapter-lifecycle-di-disposition-2026-05-22.md`,
-│   │   `.planning/codebase/generated/adapter-lifecycle-di-disposition-2026-05-22.json`
-│   ├── State: disposition-prepared-for-review
+│   │   `.planning/codebase/generated/adapter-lifecycle-di-disposition-2026-05-22.json`,
+│   │   `backend-adapter-lifecycle-di-closeout-acceptance-2026-05-22.md`,
+│   │   `.planning/codebase/generated/adapter-lifecycle-di-closeout-acceptance-2026-05-22.json`
+│   ├── State: closeout-acceptance-recorded
 │   ├── Role: Reconcile and prepare issue `#78` adapter lifecycle DI
 │   │         disposition without opening implementation authority
 │   ├── Current fact: issue `#78` remains `OPEN` with `needs-triage`; issue
@@ -393,14 +395,15 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 `realtime_mtm` has no current adapter file under
 │   │                 `web/backend/app/adapters/`; five service/core files still
 │   │                 require direct getter consumer classification before any
-│   │                 future code migration; recommended disposition is to close
-│   │                 `#78` as reconciled after human review, and route remaining
-│   │                 implementation concerns to separate approved child lanes
-│   └── Next gate: Human review of the G1 disposition packet for `#78`; if
-│                  accepted, post an explicit closeout decision for `#78` before
-│                  starting issue `#79` design/triage; do not create an
-│                  implementation issue, OpenSpec proposal, or `ready-for-agent`
-│                  movement from this packet alone
+│   │                 future code migration; human maintainer accepted closing
+│   │                 `#78` as reconciled governance evidence and routing
+│   │                 remaining implementation concerns to separate approved
+│   │                 child lanes
+│   └── Next gate: After this closeout acceptance record merges, post the
+│                  required issue `#78` closeout comment and close `#78`; then
+│                  start issue `#79` service lifecycle DI design/triage only,
+│                  without implementation authority or `ready-for-agent`
+│                  movement
 │
 ├── E. Candidate Branch: close-backend-schema-dual-directory
 │   ├── Source evidence: backend-schema-dual-directory-closure-2026-05-19.md
@@ -544,6 +547,7 @@ review, PR review, or OpenSpec archive review.
 | G1 adapter lifecycle DI child-lane selection | G1/#78 | Select issue `#78` adapter lifecycle DI triage and evidence reconciliation as the next candidate child lane | Governance-only: issue `#78` is `OPEN` with `needs-triage`; issue `#79` is `OPEN` with `needs-triage` and remains blocked by `#78`; no OpenSpec proposal, implementation issue, label change, source/test/runtime/PM2 change, or `ready-for-agent` movement is authorized | `docs/reports/quality/backend-next-child-lane-selection-2026-05-22.md`; `.planning/codebase/generated/next-child-lane-selection-2026-05-22.json` | Prepare separate G1 evidence/triage packet for `#78` with current-head adapter inventory, pilot reconciliation, exact future write scope, verification gates, and rollback |
 | G1 adapter lifecycle DI triage packet | G1/#78 | Current-head issue `#78` evidence packet prepared for review | Governance/evidence only: issue `#78` remains `OPEN` with `needs-triage`; issue `#79` remains blocked; `eastmoney_adapter`, `eastmoney_enhanced`, `akshare_extension`, `tqlex_adapter`, and `cninfo_adapter` have provider/app-state/test evidence and no `_instance = None`; `realtime_mtm` has no current adapter file under `web/backend/app/adapters`; five service/core files require direct getter consumer classification before any future implementation | `docs/reports/quality/backend-adapter-lifecycle-di-triage-2026-05-22.md`; `.planning/codebase/generated/adapter-lifecycle-di-triage-2026-05-22.json`; PR `#136` | Human review; if accepted, decide whether to close `#78` as reconciled or create a separate implementation authorization with exact write scope |
 | G1 adapter lifecycle DI disposition packet | G1/#78 | Issue `#78` closeout disposition prepared for review | Governance/evidence only: recommends closing `#78` as reconciled after human acceptance; does not close the issue, change labels, create implementation work, or move `#78`/`#79`/`#92` to `ready-for-agent`; remaining direct consumer cleanup, `realtime_mtm` ownership, and composition-root wiring are routed to separate child packets if needed | `docs/reports/quality/backend-adapter-lifecycle-di-disposition-2026-05-22.md`; `.planning/codebase/generated/adapter-lifecycle-di-disposition-2026-05-22.json`; PR `#137` | Human review; if accepted, post closeout/closing comment to `#78`, then begin `#79` service lifecycle design/triage without implementation authority |
+| G1 adapter lifecycle DI closeout acceptance | G1/#78 | Human maintainer accepted issue `#78` disposition | Governance/closeout only: after this record merges, issue `#78` may be closed as reconciled governance evidence; remaining direct consumer cleanup, `realtime_mtm` identity, and composition-root wiring remain separate child-packet concerns; issue `#79` may start design/triage only after #78 closeout, and implementation remains locked | `docs/reports/quality/backend-adapter-lifecycle-di-closeout-acceptance-2026-05-22.md`; `.planning/codebase/generated/adapter-lifecycle-di-closeout-acceptance-2026-05-22.json`; PR `#138` | Post required closeout comment and close `#78`; then prepare issue `#79` service lifecycle DI design/triage packet |
 | D2.1a TechnicalPatternDetectionService DI implementation | D2.1a.1 | First service-tier route-level DI pilot merged; `_technical_patterns_router.py` now exposes `get_technical_pattern_detection_service()`, `detect_patterns()` receives the service through `Depends`, and focused route tests use `app.dependency_overrides` | Reviewed/pass in current thread: PR `#112` checks passed, merge commit `80582643578d587ead81ccb3d23dcd2a52668dba`; route regression `9 passed`; service+route `19 passed`; ruff passed; placeholder-env `app.main` import passed; OpenSpec strict valid; mainline scope gate passed; GitNexus compare low risk with `0` changed symbols and `0` affected processes | `https://github.com/chengjon/mystocks/pull/112`; `docs/reports/quality/backend-technical-pattern-di-pilot-implementation-2026-05-21.md`; `openspec/changes/inject-technical-pattern-detection-service-di/` | D2.1a final OpenSpec checklist governance closeout |
 | D2.1a final OpenSpec checklist governance closeout | D2.1a.1 | OpenSpec task `5.3` marked complete with issue `#92` closeout comment evidence; D2.1a is closed from implementation plus checklist governance perspectives | Reviewed/pass in current thread: PR `#113` checks passed, merge commit `c7e263b8fcdeea4fc952a86d64ac555ca6dde6ce`; changed files limited to `tasks.md` and `pr-113.yaml`; mainline scope gate changed files=`2`, violations=`0`; GitNexus compare low risk with `0` changed symbols and `0` affected processes | `https://github.com/chengjon/mystocks/pull/113`; `https://github.com/chengjon/mystocks/issues/92#issuecomment-4508297089`; `openspec/changes/inject-technical-pattern-detection-service-di/tasks.md` | No further D2.1a work; select a new approved child lane before any additional implementation |
 | D2.x OpenSpec proposal approvals recorded | D2.3-D2.6 | Human maintainer approval recorded for D2.3/D2.4/D2.5/D2.6 proposal task-list entry into governance/evidence execution | Approval-only: each change may execute its governance/evidence `tasks.md` checklist with current-head freshness; no backend source, frontend source, tests, generated client, docs/API edits, route behavior, OpenAPI schema/exposure, probe URL change, PM2 command execution, service restart/recreation, implementation issue creation, or movement of issue `#92` to `ready-for-agent` is authorized | `docs/reports/quality/backend-openspec-d2-proposal-approval-record-2026-05-22.md`; `governance/mainline/task-cards/pr-120.yaml` | Execute approved governance/evidence tasks and keep every downstream decision tied to refreshed evidence |
@@ -581,6 +585,7 @@ review, PR review, or OpenSpec archive review.
 | G1 adapter lifecycle DI selection | Issue `#78` and issue `#79` dependency state | `c45eaa9c` | Select `#78` adapter lifecycle DI triage/reconciliation as next candidate child lane; no implementation or OpenSpec proposal is authorized until a separate G1 evidence packet is accepted |
 | G1 adapter lifecycle DI triage | Current-head adapter provider/app-state/test evidence and direct getter consumer scan | `2dbca6986` | Five adapter targets have provider/app-state/test evidence and no `_instance = None`; `realtime_mtm` is not proven as a current adapter target; five service/core consumers require classification; no implementation, label movement, OpenSpec proposal, source/test/runtime/PM2 mutation, or issue `#78`/`#79`/`#92` `ready-for-agent` movement is authorized |
 | G1 adapter lifecycle DI disposition | Merged triage packet and issue `#78` current state | `299f0aa7` | Recommend closing `#78` as reconciled after human acceptance; keep all remaining implementation concerns in separate approved child packets; `#79` may only start service lifecycle design/triage after the `#78` disposition is accepted |
+| G1 adapter lifecycle DI closeout acceptance | Human acceptance of `#78` disposition in current review thread | `b71ac809` | Closeout accepted: after record merge, post required closeout comment and close `#78`; begin `#79` service lifecycle DI design/triage only after #78 is closed; no implementation or `ready-for-agent` movement is authorized |
 | G. Service seams and singleton pilots | Full service classification plus interface/test-double strategy | `7b097fffd` | Task 6.x proposal path complete; service directory is dirty, no implementation batch is scheduled, and future work needs a clean candidate packet plus approved proposal |
 
 ## Update Protocol

--- a/.planning/codebase/generated/adapter-lifecycle-di-closeout-acceptance-2026-05-22.json
+++ b/.planning/codebase/generated/adapter-lifecycle-di-closeout-acceptance-2026-05-22.json
@@ -1,0 +1,81 @@
+{
+  "artifact": "adapter-lifecycle-di-closeout-acceptance",
+  "generated_at": "2026-05-22T11:37:12+08:00",
+  "generated_at_utc": "2026-05-22T03:37:12Z",
+  "git_branch": "g1-issue78-closeout",
+  "git_head": "b71ac80958373815887e737b55846d6b5d00d866",
+  "accepted_by": "human maintainer in current review thread",
+  "accepted_at": "2026-05-22T11:37:12+08:00",
+  "input_evidence": {
+    "triage_pr": {
+      "number": 136,
+      "merge_commit": "299f0aa7672993859b2cdd1f6515981a99d90f1e",
+      "report": "docs/reports/quality/backend-adapter-lifecycle-di-triage-2026-05-22.md",
+      "artifact": ".planning/codebase/generated/adapter-lifecycle-di-triage-2026-05-22.json"
+    },
+    "disposition_pr": {
+      "number": 137,
+      "merge_commit": "b71ac80958373815887e737b55846d6b5d00d866",
+      "report": "docs/reports/quality/backend-adapter-lifecycle-di-disposition-2026-05-22.md",
+      "artifact": ".planning/codebase/generated/adapter-lifecycle-di-disposition-2026-05-22.json"
+    }
+  },
+  "closeout_decision": {
+    "issue_78_closeout_approved": true,
+    "issue_78_close_mode": "close_as_reconciled_governance_evidence_after_this_record_merges",
+    "issue_78_remains_implementation_backlog": false,
+    "remaining_implementation_concerns_require_separate_child_packets": true,
+    "issue_close_executed_by_this_record": false
+  },
+  "issues": {
+    "primary": {
+      "number": 78,
+      "state_at_record_time": "OPEN",
+      "labels_at_record_time": [
+        "needs-triage"
+      ],
+      "url": "https://github.com/chengjon/mystocks/issues/78"
+    },
+    "next": {
+      "number": 79,
+      "state_at_record_time": "OPEN",
+      "labels_at_record_time": [
+        "needs-triage"
+      ],
+      "next_allowed_mode_after_issue_78_close": "service lifecycle DI design/triage only",
+      "implementation_authorized": false,
+      "url": "https://github.com/chengjon/mystocks/issues/79"
+    },
+    "parent": {
+      "number": 92,
+      "state_at_record_time": "OPEN",
+      "labels_at_record_time": [
+        "enhancement",
+        "ready-for-downstream",
+        "ready-for-human"
+      ],
+      "url": "https://github.com/chengjon/mystocks/issues/92"
+    }
+  },
+  "required_issue_78_closing_comment_points": [
+    "five current adapter targets have provider/app-state/test evidence and no _instance = None",
+    "realtime_mtm is not proved as a current adapter target under web/backend/app/adapters",
+    "remaining implementation concerns require separate approved child packets",
+    "closing issue #78 does not authorize issue #79 implementation",
+    "issue #79 may start service lifecycle design/triage only after this closeout is posted"
+  ],
+  "scope": {
+    "mode": "governance-closeout-acceptance-only",
+    "source_code_changed": false,
+    "tests_changed": false,
+    "runtime_behavior_changed": false,
+    "pm2_commands_executed": false,
+    "implementation_issue_created": false,
+    "openspec_proposal_created_or_modified": false,
+    "issue_labels_changed": false,
+    "issue_78_closed_by_this_pr": false,
+    "issue_78_moved_to_ready_for_agent": false,
+    "issue_79_moved_to_ready_for_agent": false,
+    "issue_92_moved_to_ready_for_agent": false
+  }
+}

--- a/docs/reports/quality/backend-adapter-lifecycle-di-closeout-acceptance-2026-05-22.md
+++ b/docs/reports/quality/backend-adapter-lifecycle-di-closeout-acceptance-2026-05-22.md
@@ -1,0 +1,95 @@
+# Backend Adapter Lifecycle DI Closeout Acceptance
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以
+> `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、
+> 当前代码与最近一次实际验证结果为准。
+
+Date: 2026-05-22
+Status: closeout-acceptance-recorded
+Branch: `g1-issue78-closeout`
+HEAD checked: `b71ac80958373815887e737b55846d6b5d00d866`
+Accepted at: 2026-05-22T11:37:12+08:00
+Primary issue: `#78`
+Parent issue: `#92`
+Next issue: `#79`
+
+## Purpose
+
+This report records human acceptance of the issue `#78` adapter lifecycle DI
+disposition packet.
+
+The accepted disposition is:
+
+- issue `#78` may be closed as reconciled governance evidence
+- issue `#78` must not continue as an implementation backlog
+- remaining direct service/core consumer cleanup, `realtime_mtm` identity, and
+  app composition-root wiring must use separate approved child packets if
+  needed
+- issue `#79` may start service lifecycle DI design/triage only after issue
+  `#78` is closed, but issue `#79` still has no implementation authority
+
+## Input Evidence
+
+| Evidence | State | Reference |
+|---|---|---|
+| G1 triage PR | Merged | PR `#136`, `299f0aa7672993859b2cdd1f6515981a99d90f1e` |
+| G1 triage report | Merged | `docs/reports/quality/backend-adapter-lifecycle-di-triage-2026-05-22.md` |
+| G1 disposition PR | Merged | PR `#137`, `b71ac80958373815887e737b55846d6b5d00d866` |
+| G1 disposition report | Merged | `docs/reports/quality/backend-adapter-lifecycle-di-disposition-2026-05-22.md` |
+| Human review-thread decision | Accepted | Current review thread, 2026-05-22T11:37:12+08:00 |
+
+## Closeout Decision
+
+Issue `#78` is approved for closeout after this closeout acceptance record is
+merged.
+
+The closing comment must state:
+
+- five current adapter targets have provider/app-state/test evidence and no
+  `_instance = None`
+- `realtime_mtm` is not proved as a current adapter target under
+  `web/backend/app/adapters/`
+- remaining implementation concerns require separate approved child packets
+- closing `#78` does not authorize issue `#79` implementation
+- issue `#79` may start service lifecycle design/triage only after this closeout
+  is posted
+
+## Effect On Issue `#79`
+
+After issue `#78` is closed, issue `#79` may enter a service lifecycle DI
+design/triage packet.
+
+That packet must remain governance/design only until separately approved. It
+must include:
+
+- service singleton candidate inventory at current HEAD
+- candidate classification and exclusions
+- interface/test-double strategy
+- exact future write scope
+- verification gates
+- rollback plan
+- GitNexus impact requirement before source edits
+
+## Non-Authorization
+
+This closeout acceptance does not authorize:
+
+- backend source, frontend source, test, generated client, docs/API, route,
+  OpenAPI, probe URL, script, config, runtime, or PM2 changes
+- issue label changes
+- moving issue `#78`, `#79`, or `#92` to `ready-for-agent`
+- creating implementation issues
+- creating or modifying OpenSpec proposals
+- migrating adapter or service singletons
+- starting issue `#79` implementation
+
+## Post-Merge Action
+
+After this record is merged, post the required closeout comment to issue `#78`
+and close the issue.
+
+Structured closeout acceptance evidence is recorded in:
+
+`.planning/codebase/generated/adapter-lifecycle-di-closeout-acceptance-2026-05-22.json`

--- a/governance/mainline/task-cards/pr-138.yaml
+++ b/governance/mainline/task-cards/pr-138.yaml
@@ -1,0 +1,107 @@
+version: "v0.2"
+
+task:
+  id: "pr-138"
+  title: "record adapter lifecycle DI closeout acceptance"
+  owner: "main"
+  created_at: "2026-05-22"
+
+mainline:
+  id: "L1-adapter-lifecycle-di-closeout-acceptance"
+  objective: "record human acceptance of issue #78 adapter lifecycle DI closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g1-adapter-lifecycle-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-adapter-lifecycle-di-closeout-acceptance"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Adapter lifecycle closeout acceptance only; no runtime entrypoint, route, PM2 service, page, shim, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/adapter-lifecycle-di-closeout-acceptance-2026-05-22.json"
+    - "docs/reports/quality/backend-adapter-lifecycle-di-closeout-acceptance-2026-05-22.md"
+    - "governance/mainline/task-cards/pr-138.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, or runtime behavior changes"
+  - "No PM2 command execution, service restart, process deletion, or process recreation"
+  - "No downstream implementation issue creation"
+  - "No issue label changes"
+  - "No issue closing from this PR before merge"
+  - "No movement of issue #78, #79, or #92 to ready-for-agent"
+  - "No adapter or service lifecycle implementation"
+
+acceptance:
+  checks:
+    - id: "closeout-acceptance-recorded"
+      command: "report and JSON record human acceptance of issue #78 disposition and post-merge closeout action"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-adapter-lifecycle-di-closeout-acceptance-2026-05-22.md"
+      required: true
+    - id: "json-validity"
+      command: "python -m json.tool .planning/codebase/generated/adapter-lifecycle-di-closeout-acceptance-2026-05-22.json"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-138.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If closeout acceptance is misread as implementation approval, issue #79 can move into execution prematurely"
+    - "If issue #78 is closed without the required closeout comment, downstream dependency context can be lost"
+  rollback_plan: "revert this PR and reopen issue #78 if the closeout decision is withdrawn"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record human acceptance of issue #78 adapter lifecycle DI closeout"
+    modified_scope: "closeout acceptance report, generated evidence artifact, steward tree, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance/evidence bookkeeping only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR and reopen issue #78 if the closeout decision is withdrawn"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-22T11:37:12+08:00"
+    approval_note: "human accepted issue #78 disposition in current review thread; this record still does not authorize implementation or ready-for-agent movement"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record human acceptance of the #78 adapter lifecycle DI disposition
- authorize post-merge closeout comment and closure of #78 as reconciled governance evidence
- update steward tree and add PR task card for this governance-only closeout record

## Scope
- Governance/closeout acceptance only
- No source, tests, docs/API, OpenSpec, route, OpenAPI, PM2, runtime, or generated-client changes
- No issue label changes or ready-for-agent movement
- #78 will only be closed after this record merges and a closeout comment is posted

## Verification
- JSON validity: passed
- Markdown governance gate: 2 checked files, 0 errors
- GitNexus staged detect_changes: low risk, 4 files, 0 changed symbols, 0 affected processes
- git diff --cached --check: passed
- post-commit mainline scope gate: passed
- git diff HEAD~1 --check: passed
