### PR TITLE
docs: classify service lifecycle DI candidates

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -428,21 +428,26 @@ CODEBASE-MAP Architecture Remediation Program
 │   ├── Source evidence:
 │   │   `backend-singleton-lifecycle-routing-matrix-2026-05-19.md`,
 │   │   `backend-service-lifecycle-di-design-triage-2026-05-22.md`,
-│   │   `.planning/codebase/generated/service-lifecycle-di-design-triage-2026-05-22.json`
-│   ├── State: design-triage-prepared-for-review
-│   ├── Role: Start issue `#79` service lifecycle DI design/triage after issue
-│   │         `#78` closeout, while keeping implementation locked
+│   │   `.planning/codebase/generated/service-lifecycle-di-design-triage-2026-05-22.json`,
+│   │   `backend-service-lifecycle-di-candidate-classification-2026-05-22.md`,
+│   │   `.planning/codebase/generated/service-lifecycle-di-candidate-classification-2026-05-22.json`
+│   ├── State: candidate-classification-prepared-for-review
+│   ├── Role: Classify issue `#79` service lifecycle DI candidates and select a
+│   │         future pilot candidate while keeping implementation locked
 │   ├── Current fact: issue `#78` is `CLOSED`; issue `#79` remains `OPEN` with
 │   │                 `needs-triage`; current-head service scan covers 152
 │   │                 service files, with broad singleton/getter heuristic hits
-│   │                 in 104 files but only narrow decision signals of
-│   │                 `_instance = None` in 4 files, `get_*service` in 16 files,
-│   │                 one provider/app-state pattern, and one completed
-│   │                 route-level DI pilot
-│   └── Next gate: Human review of the issue `#79` design/triage packet; then
-│                  prepare a separate candidate classification and pilot
-│                  authorization packet before any source edits, OpenSpec
-│                  proposal, issue-label change, or `ready-for-agent` movement
+│   │                 in 104 files but this is not a backlog; corrected
+│   │                 module-level singleton-variable scan finds 21 files;
+│   │                 `tradingview_widget_service.py` is reference evidence,
+│   │                 `technical_pattern_detection_service.py` is completed
+│   │                 pilot evidence, and `email_service.py` is selected as the
+│   │                 recommended first future implementation candidate
+│   └── Next gate: Human review of the candidate classification packet; if
+│                  accepted, prepare a separate G2.2 `email_service.py`
+│                  implementation authorization with exact write scope and
+│                  GitNexus impact before any source edits, OpenSpec proposal,
+│                  issue-label change, or `ready-for-agent` movement
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -561,6 +566,7 @@ review, PR review, or OpenSpec archive review.
 | G1 adapter lifecycle DI disposition packet | G1/#78 | Issue `#78` closeout disposition prepared for review | Governance/evidence only: recommends closing `#78` as reconciled after human acceptance; does not close the issue, change labels, create implementation work, or move `#78`/`#79`/`#92` to `ready-for-agent`; remaining direct consumer cleanup, `realtime_mtm` ownership, and composition-root wiring are routed to separate child packets if needed | `docs/reports/quality/backend-adapter-lifecycle-di-disposition-2026-05-22.md`; `.planning/codebase/generated/adapter-lifecycle-di-disposition-2026-05-22.json`; PR `#137` | Human review; if accepted, post closeout/closing comment to `#78`, then begin `#79` service lifecycle design/triage without implementation authority |
 | G1 adapter lifecycle DI closeout acceptance | G1/#78 | Human maintainer accepted issue `#78` disposition | Governance/closeout only: after this record merges, issue `#78` may be closed as reconciled governance evidence; remaining direct consumer cleanup, `realtime_mtm` identity, and composition-root wiring remain separate child-packet concerns; issue `#79` may start design/triage only after #78 closeout, and implementation remains locked | `docs/reports/quality/backend-adapter-lifecycle-di-closeout-acceptance-2026-05-22.md`; `.planning/codebase/generated/adapter-lifecycle-di-closeout-acceptance-2026-05-22.json`; PR `#138` | Post required closeout comment and close `#78`; then prepare issue `#79` service lifecycle DI design/triage packet |
 | G2 service lifecycle DI design/triage | G2/#79 | Issue `#79` design/triage packet prepared after issue `#78` closeout | Governance/design only: issue `#78` is `CLOSED`; issue `#79` remains `OPEN` with `needs-triage`; 152 service files scanned; broad singleton/getter heuristic hit 104 files but is not a backlog; narrow signals are `_instance = None` in 4 files, `get_*service` in 16 files, one provider/app-state pattern, and one completed route-level DI pilot; no source/test/runtime/PM2/OpenSpec/label/`ready-for-agent` movement is authorized | `docs/reports/quality/backend-service-lifecycle-di-design-triage-2026-05-22.md`; `.planning/codebase/generated/service-lifecycle-di-design-triage-2026-05-22.json`; PR `#139` | Human review; next packet must select/classify candidates and define exact write scope before implementation |
+| G2.1 service lifecycle DI candidate classification | G2.1/#79 | Candidate classification and first future pilot selection prepared | Governance/design only: corrected module-level singleton-variable scan finds 21 files; `tradingview_widget_service.py` is reference evidence, `technical_pattern_detection_service.py` is completed pilot evidence, and `email_service.py` is selected as the recommended first future implementation candidate; `strategy`, `tdx`, and `stock_search` are excluded by CRITICAL impact; `monitoring` and `technical_analysis` are excluded as large/cross-cutting; no source/test/runtime/PM2/OpenSpec/label/`ready-for-agent` movement is authorized | `docs/reports/quality/backend-service-lifecycle-di-candidate-classification-2026-05-22.md`; `.planning/codebase/generated/service-lifecycle-di-candidate-classification-2026-05-22.json`; PR `#140` | Human review; if accepted, prepare separate G2.2 `email_service.py` implementation authorization with exact write scope |
 | D2.1a TechnicalPatternDetectionService DI implementation | D2.1a.1 | First service-tier route-level DI pilot merged; `_technical_patterns_router.py` now exposes `get_technical_pattern_detection_service()`, `detect_patterns()` receives the service through `Depends`, and focused route tests use `app.dependency_overrides` | Reviewed/pass in current thread: PR `#112` checks passed, merge commit `80582643578d587ead81ccb3d23dcd2a52668dba`; route regression `9 passed`; service+route `19 passed`; ruff passed; placeholder-env `app.main` import passed; OpenSpec strict valid; mainline scope gate passed; GitNexus compare low risk with `0` changed symbols and `0` affected processes | `https://github.com/chengjon/mystocks/pull/112`; `docs/reports/quality/backend-technical-pattern-di-pilot-implementation-2026-05-21.md`; `openspec/changes/inject-technical-pattern-detection-service-di/` | D2.1a final OpenSpec checklist governance closeout |
 | D2.1a final OpenSpec checklist governance closeout | D2.1a.1 | OpenSpec task `5.3` marked complete with issue `#92` closeout comment evidence; D2.1a is closed from implementation plus checklist governance perspectives | Reviewed/pass in current thread: PR `#113` checks passed, merge commit `c7e263b8fcdeea4fc952a86d64ac555ca6dde6ce`; changed files limited to `tasks.md` and `pr-113.yaml`; mainline scope gate changed files=`2`, violations=`0`; GitNexus compare low risk with `0` changed symbols and `0` affected processes | `https://github.com/chengjon/mystocks/pull/113`; `https://github.com/chengjon/mystocks/issues/92#issuecomment-4508297089`; `openspec/changes/inject-technical-pattern-detection-service-di/tasks.md` | No further D2.1a work; select a new approved child lane before any additional implementation |
 | D2.x OpenSpec proposal approvals recorded | D2.3-D2.6 | Human maintainer approval recorded for D2.3/D2.4/D2.5/D2.6 proposal task-list entry into governance/evidence execution | Approval-only: each change may execute its governance/evidence `tasks.md` checklist with current-head freshness; no backend source, frontend source, tests, generated client, docs/API edits, route behavior, OpenAPI schema/exposure, probe URL change, PM2 command execution, service restart/recreation, implementation issue creation, or movement of issue `#92` to `ready-for-agent` is authorized | `docs/reports/quality/backend-openspec-d2-proposal-approval-record-2026-05-22.md`; `governance/mainline/task-cards/pr-120.yaml` | Execute approved governance/evidence tasks and keep every downstream decision tied to refreshed evidence |
@@ -600,6 +606,7 @@ review, PR review, or OpenSpec archive review.
 | G1 adapter lifecycle DI disposition | Merged triage packet and issue `#78` current state | `299f0aa7` | Recommend closing `#78` as reconciled after human acceptance; keep all remaining implementation concerns in separate approved child packets; `#79` may only start service lifecycle design/triage after the `#78` disposition is accepted |
 | G1 adapter lifecycle DI closeout acceptance | Human acceptance of `#78` disposition in current review thread | `b71ac809` | Closeout accepted: after record merge, post required closeout comment and close `#78`; begin `#79` service lifecycle DI design/triage only after #78 is closed; no implementation or `ready-for-agent` movement is authorized |
 | G2 service lifecycle DI design/triage | Issue `#78` closed state and current-head service scan | `9be035fd` | #79 can begin design/triage only: scan recorded 152 service files, 104 broad heuristic hits, 4 `_instance = None` files, 16 service getter files, one provider/app-state pattern, and one completed route-level DI pilot; next step is candidate classification/pilot authorization, not implementation |
+| G2.1 service lifecycle DI candidate classification | Corrected module singleton scan and GitNexus impact comparison | `ecc39139` | 21 module-level singleton-variable files classified; `email_service.py` selected as first future pilot candidate with `EmailService` LOW impact and file-disambiguated `get_email_service` MEDIUM impact; source edits remain locked behind separate G2.2 implementation authorization |
 | G. Service seams and singleton pilots | Full service classification plus interface/test-double strategy | `7b097fffd` | Task 6.x proposal path complete; service directory is dirty, no implementation batch is scheduled, and future work needs a clean candidate packet plus approved proposal |
 
 ## Update Protocol

--- a/.planning/codebase/generated/service-lifecycle-di-candidate-classification-2026-05-22.json
+++ b/.planning/codebase/generated/service-lifecycle-di-candidate-classification-2026-05-22.json
@@ -1,0 +1,208 @@
+{
+  "artifact": "service-lifecycle-di-candidate-classification",
+  "generated_at": "2026-05-22T12:04:41+08:00",
+  "generated_at_utc": "2026-05-22T04:04:41Z",
+  "git_branch": "g2-issue79-candidate-classification",
+  "git_head": "ecc391393dbbba8b961fb351c94cc4a1ad82be95",
+  "issues": {
+    "closed_prerequisite": {
+      "number": 78,
+      "state": "CLOSED",
+      "role": "adapter lifecycle DI prerequisite reconciled and closed",
+      "closeout_comment": "https://github.com/chengjon/mystocks/issues/78#issuecomment-4514804591",
+      "url": "https://github.com/chengjon/mystocks/issues/78"
+    },
+    "primary": {
+      "number": 79,
+      "state": "OPEN",
+      "labels": [
+        "needs-triage"
+      ],
+      "role": "service lifecycle DI candidate classification lane",
+      "url": "https://github.com/chengjon/mystocks/issues/79"
+    },
+    "parent": {
+      "number": 92,
+      "state": "OPEN",
+      "labels": [
+        "enhancement",
+        "ready-for-downstream",
+        "ready-for-human"
+      ],
+      "role": "parent downstream decision index",
+      "url": "https://github.com/chengjon/mystocks/issues/92"
+    }
+  },
+  "input_evidence": {
+    "design_triage_pr": 139,
+    "design_triage_merge_commit": "ecc391393dbbba8b961fb351c94cc4a1ad82be95",
+    "design_triage_report": "docs/reports/quality/backend-service-lifecycle-di-design-triage-2026-05-22.md",
+    "design_triage_artifact": ".planning/codebase/generated/service-lifecycle-di-design-triage-2026-05-22.json"
+  },
+  "corrected_inventory": {
+    "service_files_scanned": 152,
+    "module_level_singleton_variable_files": 21,
+    "service_getter_files_from_prior_packet": 16,
+    "existing_provider_app_state_pattern": 1,
+    "completed_route_level_di_pilot": 1,
+    "module_level_singleton_pattern": "_[name]_(service|manager|registry|client|provider|instance|adapter)* = None",
+    "is_implementation_backlog": false
+  },
+  "classification": {
+    "already_has_provider_app_state_pattern": [
+      "web/backend/app/services/tradingview_widget_service.py"
+    ],
+    "completed_route_level_di_pilot": [
+      "web/backend/app/services/technical_pattern_detection_service.py"
+    ],
+    "recommended_first_future_pilot": [
+      "web/backend/app/services/email_service.py"
+    ],
+    "name_collision_disambiguation_required": [
+      "web/backend/app/services/email_notification_service.py"
+    ],
+    "critical_or_broad_route_impact_excluded": [
+      "web/backend/app/services/strategy_service.py",
+      "web/backend/app/services/tdx_service.py",
+      "web/backend/app/services/stock_search_service/stock_search_service.py"
+    ],
+    "large_or_cross_cutting_excluded": [
+      "web/backend/app/services/monitoring_service.py",
+      "web/backend/app/services/technical_analysis_service.py"
+    ],
+    "domain_heavy_medium_candidates_deferred": [
+      "web/backend/app/services/announcement_service.py",
+      "web/backend/app/services/watchlist_service.py"
+    ],
+    "real_time_room_streaming_state_requires_separate_design": [
+      "web/backend/app/services/realtime_streaming_service.py",
+      "web/backend/app/services/room_socketio_adapter.py",
+      "web/backend/app/services/room_management.py",
+      "web/backend/app/services/room_permission_service.py"
+    ],
+    "central_data_integration_services_require_separate_design": [
+      "web/backend/app/services/data_service.py",
+      "web/backend/app/services/data_service_enhanced.py",
+      "web/backend/app/services/market_data_service_v2.py",
+      "web/backend/app/services/unified_data_service.py",
+      "web/backend/app/services/multi_source_manager.py"
+    ]
+  },
+  "gitnexus_impact_evidence": {
+    "TradingViewWidgetService": {
+      "file": "web/backend/app/services/tradingview_widget_service.py",
+      "risk": "LOW",
+      "direct_callers": 0,
+      "processes_affected": 0,
+      "disposition": "reference evidence only"
+    },
+    "get_tradingview_service": {
+      "file": "web/backend/app/services/tradingview_widget_service.py",
+      "risk": "LOW",
+      "direct_callers": 1,
+      "processes_affected": 0,
+      "disposition": "reference evidence only"
+    },
+    "get_tradingview_service_dependency": {
+      "file": "web/backend/app/services/tradingview_widget_service.py",
+      "risk": "LOW",
+      "direct_callers": 0,
+      "processes_affected": 0,
+      "disposition": "reference provider pattern"
+    },
+    "EmailService": {
+      "file": "web/backend/app/services/email_service.py",
+      "risk": "LOW",
+      "direct_callers": 0,
+      "processes_affected": 0,
+      "disposition": "candidate service class"
+    },
+    "get_email_service": {
+      "file": "web/backend/app/services/email_service.py",
+      "risk": "MEDIUM",
+      "direct_callers": 6,
+      "processes_affected": 0,
+      "disposition": "recommended first future pilot"
+    },
+    "get_announcement_service": {
+      "file": "web/backend/app/services/announcement_service.py",
+      "risk": "MEDIUM",
+      "direct_callers": 11,
+      "processes_affected": 0,
+      "disposition": "defer"
+    },
+    "get_watchlist_service": {
+      "file": "web/backend/app/services/watchlist_service.py",
+      "risk": "MEDIUM",
+      "direct_callers": 9,
+      "processes_affected": 0,
+      "disposition": "defer"
+    },
+    "get_strategy_service": {
+      "file": "web/backend/app/services/strategy_service.py",
+      "risk": "CRITICAL",
+      "direct_callers": 6,
+      "processes_affected": 0,
+      "disposition": "exclude from first pilot"
+    },
+    "get_tdx_service": {
+      "file": "web/backend/app/services/tdx_service.py",
+      "risk": "CRITICAL",
+      "direct_callers": 2,
+      "processes_affected": 5,
+      "disposition": "exclude from first pilot"
+    },
+    "get_stock_search_service": {
+      "file": "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "risk": "CRITICAL",
+      "direct_callers": 6,
+      "processes_affected": 11,
+      "disposition": "exclude from first pilot"
+    }
+  },
+  "future_implementation_authorization_scope_if_accepted": {
+    "candidate": "web/backend/app/services/email_service.py",
+    "write_scope": [
+      "web/backend/app/services/email_service.py",
+      "web/backend/app/api/notification.py",
+      "web/backend/tests/test_notification_logging.py",
+      "web/backend/tests/test_email_service_lifecycle_di.py",
+      "governance/mainline/task-cards/pr-*.yaml",
+      "docs/reports/quality/backend-email-service-lifecycle-di-implementation-*.md"
+    ],
+    "explicitly_out_of_scope": [
+      "web/backend/app/services/email_notification_service.py",
+      "web/backend/app/services/strategy_service.py",
+      "web/backend/app/services/tdx_service.py",
+      "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "web/backend/app/services/monitoring_service.py",
+      "web/backend/app/services/technical_analysis_service.py",
+      "PM2",
+      "OpenAPI schema behavior",
+      "generated clients",
+      "frontend",
+      "docs/api"
+    ],
+    "source_edits_authorized_by_this_packet": false
+  },
+  "required_future_gates": [
+    "GitNexus impact for EmailService and file-disambiguated get_email_service before source edits",
+    "current-head write scope verification",
+    "notification.py route consumer matrix",
+    "dependency override test plan",
+    "rollback instructions restoring direct get_email_service calls",
+    "staged gitnexus_detect_changes before commit"
+  ],
+  "scope": {
+    "mode": "governance-candidate-classification-only",
+    "source_code_changed": false,
+    "tests_changed": false,
+    "runtime_behavior_changed": false,
+    "pm2_commands_executed": false,
+    "implementation_issue_created": false,
+    "openspec_proposal_created_or_modified": false,
+    "issue_labels_changed": false,
+    "issue_79_moved_to_ready_for_agent": false,
+    "issue_92_moved_to_ready_for_agent": false
+  }
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-candidate-classification-2026-05-22.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-candidate-classification-2026-05-22.md
@@ -1,0 +1,162 @@
+# Backend Service Lifecycle DI Candidate Classification
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以
+> `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、
+> 当前代码与最近一次实际验证结果为准。
+
+Date: 2026-05-22
+Status: candidate-classification-prepared-for-review
+Branch: `g2-issue79-candidate-classification`
+HEAD checked: `ecc391393dbbba8b961fb351c94cc4a1ad82be95`
+Generated at: 2026-05-22T12:04:41+08:00
+Primary issue: `#79`
+Parent issue: `#92`
+
+## Purpose
+
+This report classifies issue `#79` service lifecycle DI candidates after the G2
+design/triage packet and selects the next candidate for a future implementation
+authorization packet.
+
+This is still governance and design evidence only. It does not create an
+implementation issue, does not create or modify an OpenSpec proposal, does not
+change issue labels, and does not authorize backend source, tests, route,
+OpenAPI, docs/API, runtime, PM2, script, config, or generated-client changes.
+
+## Input State
+
+| Input | State | Evidence |
+|---|---|---|
+| Issue `#78` | `CLOSED` | Adapter lifecycle DI prerequisite closed as reconciled governance evidence |
+| Issue `#79` | `OPEN`, `needs-triage` | Service lifecycle DI lane |
+| Issue `#92` | `OPEN`, `ready-for-downstream`, `ready-for-human` | Parent downstream decision index |
+| G2 design/triage | Merged | PR `#139`, `ecc391393dbbba8b961fb351c94cc4a1ad82be95` |
+
+## Corrected Candidate Inventory
+
+The previous G2 design/triage packet intentionally used narrow signals but
+counted only `_instance = None`. G2.1 adds a broader and more accurate
+module-level singleton variable pattern:
+
+`_[name]_(service|manager|registry|client|provider|instance|adapter)* = None`
+
+Current corrected count:
+
+- service files scanned: 152
+- module-level singleton variable files: 21
+- service getter files from the prior packet: 16
+- existing provider/app-state pattern: 1
+- completed route-level DI pilot: 1
+
+The 21 module-level singleton variable files are classification input, not an
+implementation backlog.
+
+## Candidate Classification
+
+| Class | Candidate files | Disposition |
+|---|---:|---|
+| Already has provider/app-state pattern | `tradingview_widget_service.py` | Reference evidence; do not reopen as first new implementation pilot |
+| Completed route-level DI pilot | `technical_pattern_detection_service.py` | Completed D2.1a evidence; do not reopen without current-head contradiction |
+| Recommended first future pilot | `email_service.py` | Suitable for a separate implementation authorization packet |
+| Name-collision / disambiguation required | `email_notification_service.py` | Do not include in the first pilot unless explicitly scoped; it also defines `get_email_service` |
+| Critical or broad route impact | `strategy_service.py`, `tdx_service.py`, `stock_search_service.py` | Exclude from first pilot |
+| Large or cross-cutting stateful service | `monitoring_service.py`, `technical_analysis_service.py` | Exclude from first pilot |
+| Domain-heavy medium candidates | `announcement_service.py`, `watchlist_service.py` | Defer until after a smaller pilot proves the pattern |
+| Real-time / room / streaming state | `realtime_streaming_service.py`, `room_socketio_adapter.py`, `room_management.py`, `room_permission_service.py` | Requires separate lifecycle/connection-state design |
+| Central data/integration services | `data_service.py`, `data_service_enhanced.py`, `market_data_service_v2.py`, `unified_data_service.py`, `multi_source_manager.py` | Requires separate data-boundary design before DI migration |
+
+## GitNexus Impact Evidence
+
+| Symbol | File | Risk | Direct callers | Processes affected | Disposition |
+|---|---|---:|---:|---:|---|
+| `TradingViewWidgetService` | `tradingview_widget_service.py` | LOW | 0 | 0 | Reference only; pattern already exists |
+| `get_tradingview_service` | `tradingview_widget_service.py` | LOW | 1 | 0 | Reference only; route already uses dependency provider |
+| `get_tradingview_service_dependency` | `tradingview_widget_service.py` | LOW | 0 | 0 | Reference provider pattern |
+| `EmailService` | `email_service.py` | LOW | 0 | 0 | Candidate service class |
+| `get_email_service` | `email_service.py` | MEDIUM | 6 | 0 | Recommended first future pilot with exact scope |
+| `get_announcement_service` | `announcement_service.py` | MEDIUM | 11 | 0 | Defer; broader domain route surface |
+| `get_watchlist_service` | `watchlist_service.py` | MEDIUM | 9 | 0 | Defer; adapter and route consumers |
+| `get_strategy_service` | `strategy_service.py` | CRITICAL | 6 | 0 | Exclude from first pilot |
+| `get_tdx_service` | `tdx_service.py` | CRITICAL | 2 | 5 | Exclude from first pilot |
+| `get_stock_search_service` | `stock_search_service.py` | CRITICAL | 6 | 11 | Exclude from first pilot |
+
+## Recommended First Future Pilot
+
+Select `web/backend/app/services/email_service.py` as the first future service
+lifecycle implementation candidate, but do not implement it in this packet.
+
+Reasons:
+
+- `EmailService` class impact is LOW with 0 affected symbols/processes.
+- `get_email_service` impact is MEDIUM with 6 direct route callers and 0
+  affected processes.
+- Direct route surface is concentrated in `web/backend/app/api/notification.py`.
+- Existing notification logging tests already patch `get_email_service`, which
+  gives a concrete test seam for dependency override conversion.
+- The service is small enough to review as a pilot and is less cross-cutting
+  than strategy, market data, watchlist, announcement, monitoring, or technical
+  analysis services.
+
+Important disambiguation:
+
+- `web/backend/app/services/email_service.py` and
+  `web/backend/app/services/email_notification_service.py` both define
+  `get_email_service`.
+- A future implementation packet must target the `email_service.py` symbol by
+  file path and must not modify `email_notification_service.py` unless that file
+  is explicitly added to scope.
+
+## Future Implementation Authorization Scope
+
+If this classification is accepted, the next packet may request a separate
+G2.2 implementation authorization with this exact proposed write scope:
+
+- `web/backend/app/services/email_service.py`
+- `web/backend/app/api/notification.py`
+- `web/backend/tests/test_notification_logging.py`
+- `web/backend/tests/test_email_service_lifecycle_di.py`
+- one future `governance/mainline/task-cards/pr-*.yaml`
+- one future implementation report under `docs/reports/quality/`
+
+Expected implementation shape for that future packet:
+
+- retain `get_email_service()` as a compatibility getter
+- add a FastAPI dependency provider for route injection
+- route notification endpoints through `Depends(...)`
+- keep SMTP behavior unchanged
+- use dependency override or monkeypatch tests with a fake email service
+- avoid `email_notification_service.py`
+- avoid PM2, OpenAPI, generated-client, frontend, docs/API, and broader route
+  changes
+
+## Required Future Gates
+
+Before source edits in any G2.2 packet:
+
+- run GitNexus impact for `EmailService` and the exact `get_email_service`
+  symbol in `web/backend/app/services/email_service.py`
+- prove the write scope is still current at HEAD
+- include a route consumer matrix for `notification.py`
+- include a dependency override test plan
+- include rollback instructions that restore direct `get_email_service()` calls
+- run staged `gitnexus_detect_changes(scope="staged")` before commit
+
+## Non-Authorization
+
+This packet does not authorize:
+
+- backend source, frontend source, test, generated client, docs/API, route,
+  OpenAPI, probe URL, script, config, runtime, or PM2 changes
+- issue label changes
+- creating implementation issues
+- moving issue `#79` or `#92` to `ready-for-agent`
+- creating or modifying OpenSpec proposals
+- migrating service singletons
+
+## Evidence Artifact
+
+Structured candidate classification evidence is recorded in:
+
+`.planning/codebase/generated/service-lifecycle-di-candidate-classification-2026-05-22.json`

--- a/governance/mainline/task-cards/pr-140.yaml
+++ b/governance/mainline/task-cards/pr-140.yaml
@@ -1,0 +1,106 @@
+version: "v0.2"
+
+task:
+  id: "pr-140"
+  title: "classify service lifecycle DI candidates"
+  owner: "main"
+  created_at: "2026-05-22"
+
+mainline:
+  id: "L1-service-lifecycle-di-candidate-classification"
+  objective: "classify issue #79 service lifecycle DI candidates and select a future pilot candidate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-candidate-classification"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-di-candidate-classification"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Service lifecycle candidate classification evidence only; no runtime entrypoint, route, PM2 service, page, shim, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-di-candidate-classification-2026-05-22.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-candidate-classification-2026-05-22.md"
+    - "governance/mainline/task-cards/pr-140.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, or runtime behavior changes"
+  - "No PM2 command execution, service restart, process deletion, or process recreation"
+  - "No downstream implementation issue creation"
+  - "No issue label changes"
+  - "No movement of issue #79 or #92 to ready-for-agent"
+  - "No service lifecycle implementation"
+
+acceptance:
+  checks:
+    - id: "candidate-classification-recorded"
+      command: "report and JSON record issue #79 candidate classification and future pilot selection while stating no implementation authority"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-candidate-classification-2026-05-22.md"
+      required: true
+    - id: "json-validity"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-di-candidate-classification-2026-05-22.json"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-140.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the classification is misread as implementation approval, issue #79 can move into source edits prematurely"
+    - "If the email service candidate is implemented without path disambiguation, email_notification_service.py can be modified accidentally"
+  rollback_plan: "revert this PR and return issue #79 to design/triage state without a selected future pilot candidate"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "classify issue #79 service lifecycle DI candidates and select email_service.py as future pilot candidate"
+    modified_scope: "candidate classification report, generated evidence artifact, steward tree, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance/evidence bookkeeping only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, mainline scope, JSON validity, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-22T12:04:41+08:00"
+    approval_note: "candidate-classification-only PR; future email_service.py implementation still requires separate approval and does not move issue #79 to ready-for-agent"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- classify issue #79 service lifecycle DI candidates after G2 design/triage
- correct module-level singleton-variable inventory and select email_service.py as the first future implementation candidate
- update steward tree and add PR task card for this governance-only packet

## Scope
- Governance/candidate classification only
- No source, tests, docs/API, OpenSpec, route, OpenAPI, PM2, runtime, or generated-client changes
- No issue label changes or ready-for-agent movement
- Does not authorize service lifecycle implementation

## Verification
- JSON validity: passed
- Markdown governance gate: 2 checked files, 0 errors
- GitNexus impact comparison recorded for selected/excluded candidates
- GitNexus staged detect_changes: low risk, 4 files, 0 changed symbols, 0 affected processes
- git diff --cached --check: passed
- post-commit mainline scope gate: passed
- git diff HEAD~1 --check: passed
