### PR TITLE
refactor(service): inject email service dependency

### DIFF
--- a/docs/reports/quality/backend-email-service-lifecycle-di-implementation-2026-05-22.md
+++ b/docs/reports/quality/backend-email-service-lifecycle-di-implementation-2026-05-22.md
@@ -1,0 +1,146 @@
+# Backend Email Service Lifecycle DI Implementation - 2026-05-22
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: implementation-ready-for-review
+- Workline: G2.3 service lifecycle DI implementation
+- Candidate: `web/backend/app/services/email_service.py`
+- Base HEAD: `6e92dd2942057b2763a4074abc102b761c2b2d76`
+- Branch: `g2-3-email-service-di-implementation`
+- Prepared at: `2026-05-22T16:05:40+08:00`
+
+This implementation executes the G2.2 authorization package accepted through PR
+`#141`. It keeps the scope limited to `email_service.py`, its six
+`notification.py` consumers, focused tests, this report, and the PR task card.
+
+## Authorization Boundary
+
+Authorized by:
+
+- PR `#141`: `docs: prepare email service DI authorization`
+- `docs/reports/quality/backend-email-service-lifecycle-di-implementation-authorization-2026-05-22.md`
+
+This implementation does not modify:
+
+- `web/backend/app/services/email_notification_service.py`
+- strategy, tdx, stock-search, monitoring, or technical-analysis services
+- frontend source
+- generated clients
+- `docs/api/`
+- OpenSpec changes/specs
+- route paths, HTTP methods, response contracts, or OpenAPI exposure behavior
+- PM2/runtime scripts or process state
+
+## GitNexus Pre-Edit Gate
+
+Fresh impact checks before source edits:
+
+| Symbol | File | Risk | Direct callers | Affected processes |
+|---|---|---:|---:|---:|
+| `EmailService` | `web/backend/app/services/email_service.py` | LOW | 0 | 0 |
+| `get_email_service` | `web/backend/app/services/email_service.py` | MEDIUM | 6 | 0 |
+
+The six direct callers were all in `web/backend/app/api/notification.py` and
+were the only route consumers migrated in this batch.
+
+## Implementation Summary
+
+`web/backend/app/services/email_service.py`:
+
+- adds `EMAIL_SERVICE_STATE_KEY`
+- keeps `get_email_service()` as the compatibility getter
+- adds `install_email_service(app, service=None)`
+- adds `get_email_service_dependency(request)`
+- uses `app.state` as the FastAPI lifecycle holder and lazily installs the
+  compatibility singleton when no app-state service exists
+
+`web/backend/app/api/notification.py`:
+
+- imports `EmailService` and `get_email_service_dependency`
+- injects `email_service: EmailService = Depends(get_email_service_dependency)`
+  into all six email routes
+- removes route-body calls to `get_email_service()`
+- preserves existing route paths, request bodies, response payload shapes,
+  permission checks, and background task behavior
+
+Tests:
+
+- adds `web/backend/tests/test_email_service_lifecycle_di.py`
+- updates `web/backend/tests/test_notification_logging.py` to pass fake service
+  instances through the route function parameter instead of monkeypatching the
+  compatibility getter
+
+## Route Consumer Closure
+
+| Route-local path | Function | New access path | Notes |
+|---|---|---|---|
+| `GET /status` | `get_email_service_status` | injected `EmailService` | status behavior unchanged |
+| `POST /email/send` | `send_email` | injected `EmailService` | background task captures injected service |
+| `POST /email/welcome` | `send_welcome_email` | injected `EmailService` | background task captures injected service |
+| `POST /email/newsletter` | `send_daily_newsletter` | injected `EmailService` | logging assertions retained |
+| `POST /email/price-alert` | `send_price_alert` | injected `EmailService` | logging assertions retained |
+| `POST /test-email` | `send_test_email` | injected `EmailService` | immediate send behavior unchanged |
+
+## TDD Evidence
+
+Red run:
+
+```text
+python -m pytest web/backend/tests/test_email_service_lifecycle_di.py -q -n 0 --tb=short --no-cov
+3 failed
+```
+
+Expected failures:
+
+- `get_email_service_dependency` did not exist
+- notification route signatures did not accept `email_service`
+- `send_test_email(..., email_service=fake)` rejected the injected service
+
+Green run:
+
+```text
+python -m pytest web/backend/tests/test_email_service_lifecycle_di.py web/backend/tests/test_notification_logging.py -q -n 0 --tb=short --no-cov
+6 passed in 1.35s
+```
+
+## Verification
+
+| Gate | Result | Notes |
+|---|---|---|
+| Focused pytest | passed | `6 passed in 1.35s` |
+| Ruff touched files | passed | `All checks passed!` |
+| `app.main` import smoke | passed | placeholder env produced `app.main import ok` |
+| OpenSpec changes | not touched | no proposal/spec/task edits |
+| PM2/runtime | not touched | no service start/stop/recreate |
+
+The first `app.main` import smoke failed only because placeholder environment
+variables were incomplete. After adding required placeholder values for
+`POSTGRESQL_HOST`, `POSTGRESQL_USER`, `POSTGRESQL_PASSWORD`, `BACKEND_PORT`, and
+`BACKEND_BACKUP_PORT`, import returned status `0` and printed
+`app.main import ok`. Existing noisy import-time warnings included mock-data
+fallback and GPU dependency version warnings; they are not introduced by this
+batch.
+
+## Rollback
+
+Rollback is path-limited:
+
+1. Restore direct `get_email_service()` calls inside the six notification route
+   bodies.
+2. Remove `EMAIL_SERVICE_STATE_KEY`, `install_email_service`, and
+   `get_email_service_dependency` as one unit.
+3. Remove `test_email_service_lifecycle_di.py`.
+4. Restore `test_notification_logging.py` monkeypatches if the route functions
+   no longer accept injected services.
+5. Do not modify `email_notification_service.py`.
+
+## Next Gate
+
+Review this implementation PR. If accepted, merge as the first `email_service.py`
+service lifecycle DI implementation batch under issue `#79`. Do not generalize
+this pattern to additional service files until a separate candidate packet and
+approval exist.

--- a/governance/mainline/task-cards/pr-142.yaml
+++ b/governance/mainline/task-cards/pr-142.yaml
@@ -1,0 +1,117 @@
+version: "v0.2"
+
+task:
+  id: "pr-142"
+  title: "implement email service lifecycle DI pilot"
+  owner: "main"
+  created_at: "2026-05-22"
+
+mainline:
+  id: "L1-service-lifecycle-di-email-service-implementation"
+  objective: "migrate email_service.py and its notification.py consumers to an app.state-backed FastAPI dependency provider"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-email-service-di-implementation"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow service lifecycle DI pilot authorized by PR #141; route paths, OpenAPI behavior, product surface, and runtime process state are unchanged"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/services/email_service.py"
+    - "web/backend/app/api/notification.py"
+    - "web/backend/tests/test_notification_logging.py"
+    - "web/backend/tests/test_email_service_lifecycle_di.py"
+    - "docs/reports/quality/backend-email-service-lifecycle-di-implementation-2026-05-22.md"
+    - "governance/mainline/task-cards/pr-142.yaml"
+  forbidden_paths:
+    - "web/backend/app/services/email_notification_service.py"
+    - "web/backend/app/services/strategy_service.py"
+    - "web/backend/app/services/tdx_service.py"
+    - "web/backend/app/services/stock_search_service/stock_search_service.py"
+    - "web/backend/app/services/monitoring_service.py"
+    - "web/backend/app/services/technical_analysis_service.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No changes to email_notification_service.py or any other service singleton"
+  - "No route path, method, OpenAPI exposure, response contract, generated client, frontend, PM2, or runtime process changes"
+  - "No new OpenSpec proposal/spec creation or archive execution"
+  - "No issue label changes"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "python -m pytest web/backend/tests/test_email_service_lifecycle_di.py web/backend/tests/test_notification_logging.py -q -n 0 --tb=short --no-cov"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/email_service.py web/backend/app/api/notification.py web/backend/tests/test_notification_logging.py web/backend/tests/test_email_service_lifecycle_di.py"
+      required: true
+    - id: "app-main-import-smoke"
+      command: "placeholder-env python -c 'import app.main; print(\"app.main import ok\")'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-email-service-lifecycle-di-implementation-2026-05-22.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-142.yaml"
+      required: true
+    - id: "staged-gitnexus"
+      command: "gitnexus_detect_changes(scope=staged)"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If only some notification.py callers are migrated, route behavior can silently fall back to the compatibility singleton"
+    - "If email_notification_service.py is edited, the similarly named compatibility getter can be conflated with the target service"
+    - "If tests monkeypatch the old getter only, dependency override behavior is not proven"
+  rollback_plan: "Restore direct get_email_service route-body calls, remove the app.state provider functions and lifecycle DI test, and leave email_notification_service.py untouched"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "implement the first email_service.py service lifecycle DI pilot"
+    modified_scope: "email_service.py, notification.py, focused tests, implementation report, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "get_email_service remains as compatibility getter; notification routes now use injected EmailService"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, ruff, import smoke, mainline scope, staged GitNexus, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-22T16:05:40+08:00"
+    approval_note: "human maintainer approved PR #141 and authorized opening the email_service.py source implementation lane within its exact scope"
+    secondary_approved: false

--- a/web/backend/app/api/notification.py
+++ b/web/backend/app/api/notification.py
@@ -50,7 +50,7 @@ from app.api.notification_support import (
     rate_limit,
 )
 from app.core.responses import create_success_response
-from app.services.email_service import get_email_service
+from app.services.email_service import EmailService, get_email_service_dependency
 
 logger = structlog.get_logger()
 router = APIRouter()
@@ -64,14 +64,16 @@ router = APIRouter()
     responses=NOTIFICATION_STATUS_RESPONSES,
 )
 @rate_limit(limit=10, window=60)  # 每分钟最多10次请求
-async def get_email_service_status(current_user: User = Depends(get_current_user)) -> Dict:
+async def get_email_service_status(
+    current_user: User = Depends(get_current_user),
+    email_service: EmailService = Depends(get_email_service_dependency),
+) -> Dict:
     """
     获取邮件服务状态 - Phase 4C Enhanced
 
     返回邮件服务的详细配置状态和统计信息
     """
     try:
-        email_service = get_email_service()
         is_configured = email_service.is_configured()
 
         status_data = {
@@ -116,6 +118,7 @@ async def send_email(
     background_tasks: BackgroundTasks,
     request: SendEmailRequest = Body(..., openapi_examples=SEND_EMAIL_EXAMPLES),
     current_user: User = Depends(get_current_user),
+    email_service: EmailService = Depends(get_email_service_dependency),
 ) -> Dict:
     """
     发送邮件 - Phase 4C Enhanced（需要管理员权限）
@@ -132,8 +135,6 @@ async def send_email(
                 recipients=len(request.to_addresses),
             )
             raise BusinessException(status_code=403, detail="仅管理员可以发送邮件")
-
-        email_service = get_email_service()
 
         if not email_service.is_configured():
             raise BusinessException(status_code=503, detail="邮件服务未配置，无法发送邮件")
@@ -307,6 +308,7 @@ async def send_welcome_email(
     background_tasks: BackgroundTasks,
     request: SendWelcomeEmailRequest = Body(..., openapi_examples=WELCOME_EMAIL_EXAMPLES),
     current_user: User = Depends(get_current_user),
+    email_service: EmailService = Depends(get_email_service_dependency),
 ) -> Dict:
     """
     发送欢迎邮件 - Phase 4C Enhanced
@@ -314,8 +316,6 @@ async def send_welcome_email(
     支持多语言和个性化欢迎信息
     """
     try:
-        email_service = get_email_service()
-
         if not email_service.is_configured():
             raise BusinessException(status_code=503, detail="邮件服务未配置，无法发送欢迎邮件")
 
@@ -386,12 +386,11 @@ async def send_daily_newsletter(
     background_tasks: BackgroundTasks,
     request: SendNewsletterRequest = Body(..., openapi_examples=NEWSLETTER_EXAMPLES),
     current_user: User = Depends(get_current_user),
+    email_service: EmailService = Depends(get_email_service_dependency),
 ) -> Dict:
     """
     发送每日新闻简报
     """
-    email_service = get_email_service()
-
     if not email_service.is_configured():
         raise BusinessException(status_code=503, detail="邮件服务未配置")
 
@@ -428,12 +427,11 @@ async def send_price_alert(
     background_tasks: BackgroundTasks,
     request: SendPriceAlertRequest = Body(..., openapi_examples=PRICE_ALERT_EXAMPLES),
     current_user: User = Depends(get_current_user),
+    email_service: EmailService = Depends(get_email_service_dependency),
 ) -> Dict:
     """
     发送价格提醒邮件
     """
-    email_service = get_email_service()
-
     if not email_service.is_configured():
         raise BusinessException(status_code=503, detail="邮件服务未配置")
 
@@ -468,7 +466,10 @@ async def send_price_alert(
     "/test-email",
     responses=NOTIFICATION_TEST_EMAIL_RESPONSES,
 )
-async def send_test_email(current_user: User = Depends(get_current_user)) -> Dict:
+async def send_test_email(
+    current_user: User = Depends(get_current_user),
+    email_service: EmailService = Depends(get_email_service_dependency),
+) -> Dict:
     """
     发送测试邮件到当前用户邮箱
 
@@ -543,8 +544,6 @@ async def send_test_email(current_user: User = Depends(get_current_user)) -> Dic
     - 某些邮箱服务商可能将测试邮件标记为垃圾邮件
     - 发送前会检查邮件服务配置状态
     """
-    email_service = get_email_service()
-
     if not email_service.is_configured():
         raise BusinessException(status_code=503, detail="邮件服务未配置")
 

--- a/web/backend/app/services/email_service.py
+++ b/web/backend/app/services/email_service.py
@@ -11,7 +11,9 @@ from datetime import datetime
 from email.header import Header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from typing import Dict, List
+from typing import Any, Dict, List
+
+from fastapi import Request
 
 logger = logging.getLogger(__name__)
 
@@ -317,6 +319,7 @@ class EmailService:
 
 # 全局邮件服务实例（单例模式）
 _email_service = None
+EMAIL_SERVICE_STATE_KEY = "email_service"
 
 
 def get_email_service() -> EmailService:
@@ -330,3 +333,18 @@ def get_email_service() -> EmailService:
     if _email_service is None:
         _email_service = EmailService()
     return _email_service
+
+
+def install_email_service(app: Any, service: EmailService | None = None) -> EmailService:
+    """Install the email service instance on FastAPI app.state."""
+    selected_service = service if service is not None else get_email_service()
+    setattr(app.state, EMAIL_SERVICE_STATE_KEY, selected_service)
+    return selected_service
+
+
+def get_email_service_dependency(request: Request) -> EmailService:
+    """FastAPI dependency provider for the email service."""
+    service = getattr(request.app.state, EMAIL_SERVICE_STATE_KEY, None)
+    if service is None:
+        service = install_email_service(request.app)
+    return service

--- a/web/backend/tests/test_email_service_lifecycle_di.py
+++ b/web/backend/tests/test_email_service_lifecycle_di.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+
+def load_email_service_module():
+    module_name = "email_service_lifecycle_under_test"
+    module_path = Path("web/backend/app/services/email_service.py").resolve()
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+    return module
+
+
+def load_notification_module():
+    api_root = Path("web/backend/app/api").resolve()
+    app_root = Path("web/backend/app").resolve()
+    services_root = Path("web/backend/app/services").resolve()
+    module_name = "app.api.notification"
+    module_paths = {
+        "app.api.notification_models": api_root / "notification_models.py",
+        "app.api.notification_support": api_root / "notification_support.py",
+    }
+
+    fake_app = ModuleType("app")
+    fake_api = ModuleType("app.api")
+    fake_services = ModuleType("app.services")
+    fake_auth = ModuleType("app.api.auth")
+    fake_email_service = ModuleType("app.services.email_service")
+
+    fake_app.__path__ = [str(app_root)]
+    fake_api.__path__ = [str(api_root)]
+    fake_services.__path__ = [str(services_root)]
+    fake_app.api = fake_api
+    fake_app.services = fake_services
+    fake_api.auth = fake_auth
+    fake_services.email_service = fake_email_service
+
+    class FakeEmailService:
+        def is_configured(self):
+            return True
+
+        def send_email(self, **_kwargs):
+            return {"success": True, "message": "ok"}
+
+    fake_auth.User = SimpleNamespace
+    fake_auth.get_current_user = lambda: None
+    fake_auth.get_current_active_user = lambda: None
+    fake_email_service.EmailService = FakeEmailService
+    fake_email_service.get_email_service = lambda: FakeEmailService()
+    fake_email_service.get_email_service_dependency = lambda: FakeEmailService()
+
+    previous = {
+        "app": sys.modules.get("app"),
+        "app.api": sys.modules.get("app.api"),
+        "app.services": sys.modules.get("app.services"),
+        "app.api.auth": sys.modules.get("app.api.auth"),
+        "app.services.email_service": sys.modules.get("app.services.email_service"),
+        module_name: sys.modules.get(module_name),
+    }
+    for dotted_name in module_paths:
+        previous[dotted_name] = sys.modules.get(dotted_name)
+
+    sys.modules["app"] = fake_app
+    sys.modules["app.api"] = fake_api
+    sys.modules["app.services"] = fake_services
+    sys.modules["app.api.auth"] = fake_auth
+    sys.modules["app.services.email_service"] = fake_email_service
+
+    try:
+        for dotted_name, module_path in module_paths.items():
+            spec = importlib.util.spec_from_file_location(dotted_name, module_path)
+            module = importlib.util.module_from_spec(spec)
+            assert spec is not None
+            assert spec.loader is not None
+            sys.modules[dotted_name] = module
+            spec.loader.exec_module(module)
+
+        spec = importlib.util.spec_from_file_location(module_name, api_root / "notification.py")
+        module = importlib.util.module_from_spec(spec)
+        assert spec is not None
+        assert spec.loader is not None
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+    finally:
+        for name, previous_module in previous.items():
+            if previous_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous_module
+
+    return module
+
+
+def test_email_service_dependency_installs_app_state_when_missing(monkeypatch):
+    module = load_email_service_module()
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+    request = SimpleNamespace(app=fake_app)
+
+    monkeypatch.setattr(module, "get_email_service", lambda: fake_service)
+
+    assert module.get_email_service_dependency(request) is fake_service
+    assert getattr(fake_app.state, module.EMAIL_SERVICE_STATE_KEY) is fake_service
+
+
+def test_notification_email_routes_accept_injected_email_service():
+    module = load_notification_module()
+
+    for function_name in [
+        "get_email_service_status",
+        "send_email",
+        "send_welcome_email",
+        "send_daily_newsletter",
+        "send_price_alert",
+        "send_test_email",
+    ]:
+        signature = inspect.signature(getattr(module, function_name))
+        assert "email_service" in signature.parameters
+
+
+@pytest.mark.asyncio
+async def test_send_test_email_uses_injected_email_service():
+    module = load_notification_module()
+
+    class FakeEmailService:
+        def __init__(self):
+            self.sent_to = None
+
+        def is_configured(self):
+            return True
+
+        def send_email(self, *, to_addresses, **_kwargs):
+            self.sent_to = to_addresses
+            return {"success": True, "message": "ok"}
+
+    fake_service = FakeEmailService()
+    current_user = SimpleNamespace(id=1, username="tester", email="tester@example.com")
+
+    response = await module.send_test_email(current_user=current_user, email_service=fake_service)
+
+    assert response["success"] is True
+    assert fake_service.sent_to == ["tester@example.com"]

--- a/web/backend/tests/test_notification_logging.py
+++ b/web/backend/tests/test_notification_logging.py
@@ -37,7 +37,9 @@ def load_notification_module():
     fake_auth.User = SimpleNamespace
     fake_auth.get_current_user = lambda: None
     fake_auth.get_current_active_user = lambda: None
+    fake_email_service.EmailService = SimpleNamespace
     fake_email_service.get_email_service = lambda: SimpleNamespace(is_configured=lambda: False)
+    fake_email_service.get_email_service_dependency = lambda: SimpleNamespace(is_configured=lambda: False)
 
     previous = {
         "app": sys.modules.get("app"),
@@ -60,13 +62,15 @@ def load_notification_module():
     for dotted_name, module_path in module_paths.items():
         spec = importlib.util.spec_from_file_location(dotted_name, module_path)
         module = importlib.util.module_from_spec(spec)
-        assert spec is not None and spec.loader is not None
+        assert spec is not None
+        assert spec.loader is not None
         sys.modules[dotted_name] = module
         spec.loader.exec_module(module)
 
     spec = importlib.util.spec_from_file_location(module_name, api_root / "notification.py")
     module = importlib.util.module_from_spec(spec)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None
+    assert spec.loader is not None
     sys.modules[module_name] = module
     spec.loader.exec_module(module)
 
@@ -99,7 +103,7 @@ async def test_send_daily_newsletter_background_task_logs_success(monkeypatch, c
         def send_daily_newsletter(**_kwargs):
             return {"success": True, "message": "ok"}
 
-    monkeypatch.setattr(module, "get_email_service", lambda: FakeEmailService())
+    email_service = FakeEmailService()
     background_tasks = BackgroundTasks()
     request = module.SendNewsletterRequest(
         user_email="user@example.com",
@@ -108,7 +112,12 @@ async def test_send_daily_newsletter_background_task_logs_success(monkeypatch, c
         news_data=[{"headline": "demo"}],
     )
 
-    response = await module.send_daily_newsletter(request=request, background_tasks=background_tasks, current_user=None)
+    response = await module.send_daily_newsletter(
+        request=request,
+        background_tasks=background_tasks,
+        current_user=None,
+        email_service=email_service,
+    )
     assert response["success"] is True
     assert len(background_tasks.tasks) == 1
 
@@ -133,7 +142,7 @@ async def test_send_price_alert_background_task_logs_failure(monkeypatch, caplog
         def send_price_alert(**_kwargs):
             return {"success": False, "message": "smtp down"}
 
-    monkeypatch.setattr(module, "get_email_service", lambda: FakeEmailService())
+    email_service = FakeEmailService()
     background_tasks = BackgroundTasks()
     request = module.SendPriceAlertRequest(
         user_email="user@example.com",
@@ -145,7 +154,12 @@ async def test_send_price_alert_background_task_logs_failure(monkeypatch, caplog
         alert_price=1550.0,
     )
 
-    response = await module.send_price_alert(request=request, background_tasks=background_tasks, current_user=None)
+    response = await module.send_price_alert(
+        request=request,
+        background_tasks=background_tasks,
+        current_user=None,
+        email_service=email_service,
+    )
     assert response["success"] is True
     assert len(background_tasks.tasks) == 1
 


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary
- migrate `email_service.py` to expose an app.state-backed FastAPI dependency provider while retaining `get_email_service()` as the compatibility getter
- inject `EmailService` into all six `notification.py` email routes instead of calling the module-level getter inside route bodies
- add focused lifecycle DI tests and update notification logging tests to pass fake services through the new dependency seam
- record implementation evidence and PR task card

## Boundary
- follows PR #141 authorization scope
- does not modify `email_notification_service.py` or any other service singleton
- no route path/method/response contract/OpenAPI exposure changes
- no frontend, docs/API, generated client, OpenSpec, PM2, or runtime process changes

## Verification
- TDD red: new lifecycle DI tests failed before implementation with missing provider/signature/injection support
- Focused pytest: `6 passed`
- Ruff touched files: `All checks passed!`
- Markdown governance: `checked_files=1`, `errors=0`
- Mainline scope gate: `pass=True`
- GitNexus staged detect_changes before commit: `changed_files=6`, `risk_level=medium`; hunk review confirmed edits stayed in authorized route/service/test/report/card scope
- `app.main` import smoke with placeholder env: status 0, `app.main import ok`

## Rollback
- restore direct `get_email_service()` route-body calls
- remove provider functions as one unit
- remove lifecycle DI test file
- keep `email_notification_service.py` untouched
