### PR TITLE
docs: record email service DI closeout

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -432,10 +432,13 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-service-lifecycle-di-candidate-classification-2026-05-22.md`,
 │   │   `.planning/codebase/generated/service-lifecycle-di-candidate-classification-2026-05-22.json`,
 │   │   `backend-email-service-lifecycle-di-implementation-authorization-2026-05-22.md`,
-│   │   `.planning/codebase/generated/email-service-lifecycle-di-implementation-authorization-2026-05-22.json`
-│   ├── State: implementation-authorization-prepared-for-review
-│   ├── Role: Classify issue `#79` service lifecycle DI candidates and select a
-│   │         future pilot candidate while keeping implementation locked
+│   │   `.planning/codebase/generated/email-service-lifecycle-di-implementation-authorization-2026-05-22.json`,
+│   │   `backend-email-service-lifecycle-di-implementation-2026-05-22.md`,
+│   │   `backend-email-service-lifecycle-di-closeout-2026-05-22.md`
+│   ├── State: email-service-di-pilot-merged-and-recorded
+│   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
+│   │         authorization, and first implementation pilot while preventing
+│   │         unapproved expansion to additional services
 │   ├── Current fact: issue `#78` is `CLOSED`; issue `#79` remains `OPEN` with
 │   │                 `needs-triage`; current-head service scan covers 152
 │   │                 service files, with broad singleton/getter heuristic hits
@@ -449,11 +452,13 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 G2.2 now records exact future write scope, six
 │   │                 `notification.py` callers, GitNexus pre-edit gates, test
 │   │                 plan, rollback plan, and forbidden scope for
-│   │                 `email_notification_service.py`
-│   └── Next gate: Human review of the G2.2 implementation authorization
-│                  packet; source edits remain locked until that packet is
-│                  explicitly accepted, and no OpenSpec proposal, issue-label
-│                  change, or `ready-for-agent` movement is authorized here
+│   │                 `email_notification_service.py`; PR `#142` was reviewed,
+│   │                 all checks completed successfully, and merged at
+│   │                 `20657e6e86a3423b15c67b6a8d6e165fbaa47b72`
+│   └── Next gate: Review first-pilot evidence before selecting any second
+│                  service lifecycle DI candidate; no further service source
+│                  edits, OpenSpec proposal, issue-label change, or
+│                  `ready-for-agent` movement is authorized by this closeout
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -613,7 +618,8 @@ review, PR review, or OpenSpec archive review.
 | G1 adapter lifecycle DI closeout acceptance | Human acceptance of `#78` disposition in current review thread | `b71ac809` | Closeout accepted: after record merge, post required closeout comment and close `#78`; begin `#79` service lifecycle DI design/triage only after #78 is closed; no implementation or `ready-for-agent` movement is authorized |
 | G2 service lifecycle DI design/triage | Issue `#78` closed state and current-head service scan | `9be035fd` | #79 can begin design/triage only: scan recorded 152 service files, 104 broad heuristic hits, 4 `_instance = None` files, 16 service getter files, one provider/app-state pattern, and one completed route-level DI pilot; next step is candidate classification/pilot authorization, not implementation |
 | G2.1 service lifecycle DI candidate classification | Corrected module singleton scan and GitNexus impact comparison | `ecc39139` | 21 module-level singleton-variable files classified; `email_service.py` selected as first future pilot candidate with `EmailService` LOW impact and file-disambiguated `get_email_service` MEDIUM impact; source edits remain locked behind separate G2.2 implementation authorization |
-| G. Service seams and singleton pilots | G2.2 `email_service.py` implementation authorization prepared for review | `0b5e393e2` | PR `#140` candidate classification accepted; first future pilot is `email_service.py`, but source edits remain locked until the G2.2 authorization packet is reviewed and explicitly accepted |
+| G2.2 email service DI authorization | `email_service.py` implementation authorization | `35e9b2b3d` | PR `#141` merged; future source lane was authorized only for `email_service.py`, six `notification.py` consumers, focused tests, report, and task card |
+| G2.3 email service DI implementation | First service lifecycle DI source pilot | `20657e6e` | PR `#142` merged after human approval; `email_service.py` now provides app.state dependency provider, six `notification.py` email routes inject `EmailService`, focused tests passed, GitHub contract/mainline checks passed, and `email_notification_service.py` remains untouched |
 
 ## Update Protocol
 

--- a/docs/reports/quality/backend-email-service-lifecycle-di-closeout-2026-05-22.md
+++ b/docs/reports/quality/backend-email-service-lifecycle-di-closeout-2026-05-22.md
@@ -1,0 +1,115 @@
+# Backend Email Service Lifecycle DI Closeout - 2026-05-22
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: completed-and-recorded
+- Workline: G2.3 service lifecycle DI implementation closeout
+- Completed pilot: `web/backend/app/services/email_service.py`
+- Merge commit: `20657e6e86a3423b15c67b6a8d6e165fbaa47b72`
+- PR: https://github.com/chengjon/mystocks/pull/142
+- Recorded at: `2026-05-22`
+
+## Decision
+
+The human maintainer approved PR `#142` after the G2.2 authorization package
+was merged by PR `#141`. PR `#142` was merged and is now the completed first
+service lifecycle DI source pilot under issue `#79`.
+
+This closeout records completion only. It does not authorize another service
+lifecycle migration, OpenSpec proposal, issue label change, or movement of issue
+`#79` / `#92` to `ready-for-agent`.
+
+## Completed Scope
+
+Merged files from PR `#142`:
+
+- `web/backend/app/services/email_service.py`
+- `web/backend/app/api/notification.py`
+- `web/backend/tests/test_email_service_lifecycle_di.py`
+- `web/backend/tests/test_notification_logging.py`
+- `docs/reports/quality/backend-email-service-lifecycle-di-implementation-2026-05-22.md`
+- `governance/mainline/task-cards/pr-142.yaml`
+
+## Functional Result
+
+`email_service.py` now provides:
+
+- retained compatibility getter: `get_email_service()`
+- app-state key: `EMAIL_SERVICE_STATE_KEY`
+- installer: `install_email_service(app, service=None)`
+- FastAPI dependency provider: `get_email_service_dependency(request)`
+
+The six notification email routes now receive an injected `EmailService`:
+
+- `get_email_service_status`
+- `send_email`
+- `send_welcome_email`
+- `send_daily_newsletter`
+- `send_price_alert`
+- `send_test_email`
+
+The implementation intentionally preserved route paths, HTTP methods, request
+models, response payload shape, OpenAPI exposure, and background-task behavior.
+
+## Preserved Boundaries
+
+The following remained untouched:
+
+- `web/backend/app/services/email_notification_service.py`
+- other service singleton candidates
+- frontend source
+- generated clients
+- `docs/api/`
+- OpenSpec changes/specs
+- PM2/runtime scripts or process state
+
+## Verification Summary
+
+Local verification before PR publication:
+
+| Gate | Result |
+|---|---|
+| TDD red | observed missing provider/signature/injection failures before implementation |
+| Focused pytest | `6 passed` |
+| Ruff touched files | passed |
+| Markdown governance | `checked_files=1`, `errors=0` |
+| Mainline scope gate | `pass=True` |
+| GitNexus staged detect_changes | `risk_level=medium`; hunk review confirmed authorized scope |
+| `app.main` import smoke | status `0`, `app.main import ok` with placeholder env |
+
+GitHub PR checks before merge:
+
+- `check-compliance`: success
+- `Mainline Governance Gate`: success
+- `Validate API Contracts`: success
+- `Generate TypeScript Types`: success
+- `Detect Breaking Changes`: success or skipped duplicate
+- contract validation report: success
+
+## Current Issue State
+
+At closeout recording time:
+
+- issue `#79`: `OPEN`, labels `needs-triage`
+- issue `#92`: `OPEN`, labels `enhancement`, `ready-for-downstream`,
+  `ready-for-human`
+
+This closeout does not change either issue's label or state.
+
+## Next Gate
+
+Before any second service lifecycle DI candidate is selected, create a separate
+candidate/authorization packet with:
+
+- candidate file path and same-name collision review
+- current-head GitNexus impact
+- exact write scope
+- tests and rollback plan
+- explicit human approval
+
+Do not generalize the `email_service.py` implementation to additional services
+from this closeout alone.

--- a/governance/mainline/task-cards/pr-143.yaml
+++ b/governance/mainline/task-cards/pr-143.yaml
@@ -1,0 +1,97 @@
+version: "v0.2"
+
+task:
+  id: "pr-143"
+  title: "record email service DI implementation closeout"
+  owner: "main"
+  created_at: "2026-05-22"
+
+mainline:
+  id: "L1-service-lifecycle-di-email-service-closeout"
+  objective: "record that the email_service.py lifecycle DI pilot was reviewed, merged, and remains bounded to the approved first candidate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-email-service-di-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-email-service-di-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout record and steward-tree update only; no runtime entrypoint, route, page, shim, service behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "docs/reports/quality/backend-email-service-lifecycle-di-closeout-2026-05-22.md"
+    - "governance/mainline/task-cards/pr-143.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, PM2, or runtime behavior changes"
+  - "No additional service lifecycle DI implementation"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes"
+  - "No movement of issue #79 or #92 to ready-for-agent"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-email-service-lifecycle-di-closeout-2026-05-22.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-143.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is misread as approval for a second service migration, issue #79 can expand beyond reviewed scope"
+    - "If issue state is changed here, the governance record diverges from the parent decision trail"
+  rollback_plan: "revert this PR and return the steward tree to the PR #142 merged-but-unrecorded state"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record email_service.py lifecycle DI pilot completion after PR #142 merge"
+    modified_scope: "steward tree, closeout report, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance bookkeeping only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-22T16:35:31+08:00"
+    approval_note: "human maintainer approved PR #142 merge; this PR records completion only and does not authorize a second service migration"
+    secondary_approved: false


### PR DESCRIPTION
> *This was generated by AI during triage.*

## Summary
- record that PR #142 was reviewed, approved, and merged as the first `email_service.py` service lifecycle DI pilot
- update the steward tree G branch to `email-service-di-pilot-merged-and-recorded`
- add closeout report and PR task card

## Boundary
- governance bookkeeping only
- no backend source, frontend source, tests, OpenSpec, docs/API, generated client, PM2, route, OpenAPI, or runtime changes
- does not authorize a second service lifecycle DI migration
- does not move issue #79 or #92 to ready-for-agent

## Verification
- Markdown governance: 2 checked files, 0 errors
- Mainline scope gate: pass=True
- GitNexus staged detect_changes: 3 files, 0 symbols, 0 affected processes, low risk
- git diff --cached --check: passed
