### PR TITLE
docs: record steward tree retrospective

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -434,8 +434,11 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-email-service-lifecycle-di-implementation-authorization-2026-05-22.md`,
 │   │   `.planning/codebase/generated/email-service-lifecycle-di-implementation-authorization-2026-05-22.json`,
 │   │   `backend-email-service-lifecycle-di-implementation-2026-05-22.md`,
-│   │   `backend-email-service-lifecycle-di-closeout-2026-05-22.md`
-│   ├── State: email-service-di-pilot-merged-and-recorded
+│   │   `backend-email-service-lifecycle-di-closeout-2026-05-22.md`,
+│   │   `CODEBASE-MAP-STEWARD-TREE-RETROSPECTIVE-2026-05-22.md`,
+│   │   `backend-service-lifecycle-di-second-candidate-selection-2026-05-22.md`,
+│   │   `.planning/codebase/generated/service-lifecycle-di-second-candidate-selection-2026-05-22.json`
+│   ├── State: second-candidate-selection-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -454,11 +457,19 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 plan, rollback plan, and forbidden scope for
 │   │                 `email_notification_service.py`; PR `#142` was reviewed,
 │   │                 all checks completed successfully, and merged at
-│   │                 `20657e6e86a3423b15c67b6a8d6e165fbaa47b72`
-│   └── Next gate: Review first-pilot evidence before selecting any second
-│                  service lifecycle DI candidate; no further service source
-│                  edits, OpenSpec proposal, issue-label change, or
-│                  `ready-for-agent` movement is authorized by this closeout
+│   │                 `20657e6e86a3423b15c67b6a8d6e165fbaa47b72`; PR `#143`
+│   │                 recorded closeout at
+│   │                 `68da82084266ca7f9b7be9f5b55da7ac5e64fbd7`; G2.4
+│   │                 retrospective records steward-tree lessons and current-head
+│   │                 second-candidate evidence recommends
+│   │                 `announcement_service.py` as the next authorization
+│   │                 candidate over `watchlist_service.py`
+│   └── Next gate: Human review of the G2.4 retrospective and second-candidate
+│                  selection package; if accepted, create a separate G2.5
+│                  implementation authorization packet for
+│                  `announcement_service.py`; no service source edits,
+│                  OpenSpec proposal, issue-label change, or `ready-for-agent`
+│                  movement is authorized by G2.4
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -654,7 +665,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review `email_service.py` lifecycle DI authorization before implementation | Future service seam lane | G2.2 authorization packet prepared; candidate proposal/source implementation remains uncreated until human approval |
+| P2 | Review service lifecycle DI second-candidate selection | Future service seam lane | G2.4 retrospective and selection packet prepared; `announcement_service.py` is recommended as the next authorization-candidate input, but no second service source edit is authorized |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/CODEBASE-MAP-STEWARD-TREE-RETROSPECTIVE-2026-05-22.md
+++ b/.planning/codebase/CODEBASE-MAP-STEWARD-TREE-RETROSPECTIVE-2026-05-22.md
@@ -1,0 +1,284 @@
+# CODEBASE-MAP Steward Tree Retrospective - 2026-05-22
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: for-review
+- Workline: steward tree retrospective and next operating model
+- Steward index: `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- Current HEAD checked: `68da82084266ca7f9b7be9f5b55da7ac5e64fbd7`
+- Prepared at: `2026-05-22`
+- Scope: governance analysis only
+
+Boundary note: This document records operating lessons for the steward tree. It
+does not authorize backend source edits, frontend source edits, tests, generated
+client updates, docs/API edits, OpenSpec proposal creation, issue label changes,
+PM2 commands, runtime rollout, or movement of issue `#79` or issue `#92` to
+`ready-for-agent`.
+
+## What The Steward Tree Has Done
+
+The steward tree has become the coordination layer between the codebase map,
+OpenSpec branches, GitHub issues, PRs, implementation reports, and human review
+decisions. Its main value is not that it replaces those artifacts; its value is
+that it records how they relate and what gate must happen next.
+
+### 1. Sequenced Parallel Worklines
+
+The tree converted a broad architecture remediation program into ordered lanes:
+
+| Lane | Steward role |
+|---|---|
+| Route/OpenAPI governance | Keep route evidence, OpenAPI exposure, compatibility shims, and control-plane endpoints in one route-governance vocabulary |
+| Core split governance | Keep Core Batch 2 blocked until explicit reconciliation gates are satisfied |
+| Service lifecycle DI | Separate adapter closeout, service candidate classification, implementation authorization, implementation, and closeout |
+| CSRF/schema/error-contract/control-plane | Preserve decision-only or evidence-only state until a later approved branch exists |
+
+This prevented unrelated worklines from using a shared architecture concern as
+implicit approval for code changes.
+
+### 2. Preserved The Authorization Boundary
+
+The tree repeatedly made the same distinction explicit:
+
+- evidence package
+- decision package
+- implementation authorization package
+- source implementation
+- closeout record
+
+That separation was important in issue `#92` and issue `#79`. It allowed the
+project to accept planning and evidence while keeping source changes locked
+until a smaller, reviewed implementation packet existed.
+
+### 3. Made State Recoverable After Context Loss
+
+Several threads spanned many reviews, worktrees, PRs, and commits. The steward
+tree gave later sessions enough context to resume without re-litigating old
+decisions. A usable row always included:
+
+- parent lane
+- source evidence
+- state
+- current fact
+- next gate
+- forbidden scope
+
+This was especially useful after the `email_service.py` lifecycle DI lane:
+candidate classification in PR `#140`, implementation authorization in PR
+`#141`, implementation in PR `#142`, and closeout in PR `#143` remained
+traceable as one state machine instead of four disconnected PRs.
+
+### 4. Reduced Scope Creep
+
+The tree caught and constrained recurring failure modes:
+
+- treating evidence-only work as permission to edit backend code
+- turning route governance into a broad route migration
+- starting a second service DI candidate before the first pilot was closed
+- reopening completed P3-C5 error-contract work from stale counts
+- treating compatibility wrappers as automatically deletable
+
+The strongest pattern was to write the non-goals next to the current gate, not
+in a separate document only.
+
+### 5. Preserved Freshness And Evidence Context
+
+The tree encouraged recording commit hashes, PR numbers, issue state, and
+artifact paths. This mattered when generated route tables, OpenAPI counts,
+GitNexus impact results, and runtime reports were produced at different HEADs.
+
+The practical rule that emerged:
+
+- If two artifacts disagree and were produced at different HEADs, mark older
+  evidence as stale-aware.
+- If two artifacts disagree at the same HEAD, create a reconciliation task.
+- Do not unblock dependent implementation work from stale evidence.
+
+## Operating Lessons
+
+### Lesson 1: Closeout Is A Real Phase
+
+Implementation completion is not the same as governance completion. The project
+needed PR `#143` after PR `#142` so that the tree could record the merged
+functional result and the next gate. Without closeout, later agents would see a
+merged implementation but not know whether a second candidate was authorized.
+
+### Lesson 2: Candidate Classification Must Precede Authorization
+
+The service lifecycle DI lane showed that broad singleton counts are not an
+implementation backlog. A useful candidate packet must classify:
+
+- already converted patterns
+- completed pilot evidence
+- first future candidates
+- name-collision risks
+- critical or broad route-impact exclusions
+- large or cross-cutting exclusions
+- domain-heavy medium candidates
+- real-time or process-level singleton designs
+
+This helped avoid choosing a high-impact service just because it matched a
+singleton regex.
+
+### Lesson 3: The Tree Needs Both Human And Machine-Readable State
+
+Natural-language rows are readable, but automated guards need stable fields.
+The tree worked best when paired with generated JSON artifacts and PR task
+cards. Future rows should carry stable state values instead of only narrative
+phrases.
+
+### Lesson 4: Exact Forbidden Scope Prevents Misexecution
+
+Short forbidden-scope lists such as "no source edits" were useful, but the most
+effective rows named the exact forbidden surfaces:
+
+- backend source
+- frontend source
+- tests
+- generated clients
+- docs/API
+- OpenSpec proposals/specs
+- issue labels
+- `ready-for-agent` movement
+- PM2 commands
+- runtime rollout
+
+This made review comments easier to absorb without accidentally broadening the
+work.
+
+### Lesson 5: Issue Labels And Tree State Can Diverge
+
+GitHub labels are workflow signals, not full architecture state. The tree must
+continue to record the real gate even when issue labels are coarse. Current
+example: issue `#79` remains `OPEN` with `needs-triage` after the first
+`email_service.py` pilot closed; that does not mean a second service migration
+is already authorized.
+
+## Improvement Opportunities
+
+### 1. Add A Machine-Readable Steward Node Index
+
+Create `.planning/codebase/generated/steward-tree-nodes-YYYY-MM-DD.json` with
+one object per branch:
+
+```json
+{
+  "node_id": "G2.4",
+  "parent": "G",
+  "state": "second-candidate-selection-prepared-for-review",
+  "source_evidence": [],
+  "current_head_checked": "",
+  "next_gate": "",
+  "authorized_scope": [],
+  "forbidden_scope": []
+}
+```
+
+The Markdown tree can remain the human-facing map, while the JSON index becomes
+the guard-friendly state source.
+
+### 2. Standardize State Transitions
+
+Recommended lifecycle:
+
+1. `candidate-observed`
+2. `evidence-classified`
+3. `authorization-prepared`
+4. `approved-for-implementation`
+5. `implemented`
+6. `reviewed`
+7. `merged`
+8. `recorded`
+9. `archived` or `deferred`
+
+Rows should not jump from `evidence-classified` to `implemented`. The missing
+state should become a review blocker.
+
+### 3. Split Narrative Tree From Active Gate Register
+
+Keep the current tree as the long-form map, but add a compact "Active Gate
+Register" with only open gates:
+
+| Gate | Owner lane | Current blocker | Next allowed action | Forbidden action |
+|---|---|---|---|---|
+
+This would make daily continuation faster and reduce accidental work on closed
+branches.
+
+### 4. Add Freshness Fields To Every Generated Artifact
+
+Every generated evidence artifact should include:
+
+- `generated_at`
+- `git_head`
+- `current_head_checked_at_review`
+- `stale_if_head_mismatch`
+- `source_artifact_paths`
+- `review_disposition`
+
+This should apply to route tables, OpenAPI counts, GitNexus impact summaries,
+singleton inventories, and issue-state snapshots.
+
+### 5. Add A Steward-Tree Guard
+
+A lightweight guard could check:
+
+- every source evidence path exists
+- every active OpenSpec change exists if named
+- every issue/PR link has a captured state
+- no row contains implementation authorization without an authorization packet
+- no closed implementation row lacks a closeout artifact
+- no future source edit appears in an evidence-only row
+
+This would turn several recurring review findings into pre-review failures.
+
+### 6. Keep Graph Memory As A Digest, Not A Truth Source
+
+Graphiti is useful for recording durable decisions and cross-thread summaries.
+It should store concise digests:
+
+- what was accepted
+- what remains forbidden
+- what the next gate is
+- which commit/PR/report anchors the decision
+
+It should not replace the actual Markdown reports, OpenSpec tasks, GitHub
+issues, or current code.
+
+## Recommended Operating Model
+
+For each future architecture branch:
+
+1. Create or update evidence package.
+2. Record candidate classification and exclusions.
+3. Create an implementation authorization packet only after review.
+4. Implement exactly the authorized write scope.
+5. Run scoped verification and GitNexus staged-change detection when code is
+   changed.
+6. Merge only after review.
+7. Create a closeout/update PR for the steward tree.
+8. Do not start the next candidate until the closeout row says the next
+   selection gate is open.
+
+## Immediate Next Use
+
+The next steward-tree use should be G2.4: review the first
+`email_service.py` pilot evidence and select a second service lifecycle DI
+candidate package without source edits.
+
+Current-head candidate comparison supports `announcement_service.py` as the
+next authorization-candidate input, not as an implementation approval:
+
+| Candidate | GitNexus risk | Direct callers | Extra affected symbols | Disposition |
+|---|---:|---:|---:|---|
+| `announcement_service.py` / `get_announcement_service` | MEDIUM | 11 | 0 transitive symbols reported | Better next candidate; one route module owns the direct callers |
+| `watchlist_service.py` / `get_watchlist_service` | MEDIUM | 9 | 6 transitive symbols through data adapter layers | Defer; adapter/data-layer coupling makes it a larger design surface |
+
+Next gate: human review of the G2.4 selection package. If accepted, create a
+separate G2.5 implementation authorization packet for `announcement_service.py`
+with exact write scope, tests, rollback plan, GitNexus pre-edit gate, and
+forbidden scope. No service source edit is authorized by this retrospective.

--- a/.planning/codebase/generated/service-lifecycle-di-second-candidate-selection-2026-05-22.json
+++ b/.planning/codebase/generated/service-lifecycle-di-second-candidate-selection-2026-05-22.json
@@ -1,0 +1,107 @@
+{
+  "artifact": "service-lifecycle-di-second-candidate-selection",
+  "generated_at": "2026-05-22T17:02:24+08:00",
+  "git_branch": "g2-4-steward-tree-retrospective-next-candidate",
+  "git_head": "68da82084266ca7f9b7be9f5b55da7ac5e64fbd7",
+  "status": "for-review",
+  "mode": "candidate-selection-only",
+  "source_code_changed": false,
+  "tests_changed": false,
+  "runtime_behavior_changed": false,
+  "issues": {
+    "service_lifecycle_parent": {
+      "number": 79,
+      "state": "OPEN",
+      "labels": [
+        "needs-triage"
+      ]
+    },
+    "downstream_decision_parent": {
+      "number": 92,
+      "state": "OPEN",
+      "labels": [
+        "enhancement",
+        "ready-for-human",
+        "ready-for-downstream"
+      ]
+    }
+  },
+  "completed_first_pilot": {
+    "candidate": "web/backend/app/services/email_service.py",
+    "implementation_pr": 142,
+    "implementation_merge_commit": "20657e6e86a3423b15c67b6a8d6e165fbaa47b72",
+    "closeout_pr": 143,
+    "closeout_merge_commit": "68da82084266ca7f9b7be9f5b55da7ac5e64fbd7"
+  },
+  "candidate_comparison": [
+    {
+      "candidate": "web/backend/app/services/announcement_service.py",
+      "getter": "get_announcement_service",
+      "gitnexus_risk": "MEDIUM",
+      "direct_callers": 11,
+      "impacted_count": 11,
+      "processes_affected": 0,
+      "modules_affected": [
+        "Announcement"
+      ],
+      "direct_owner_files": [
+        "web/backend/app/api/announcement/routes.py"
+      ],
+      "selection_result": "recommended_next_authorization_candidate"
+    },
+    {
+      "candidate": "web/backend/app/services/watchlist_service.py",
+      "getter": "get_watchlist_service",
+      "gitnexus_risk": "MEDIUM",
+      "direct_callers": 9,
+      "impacted_count": 15,
+      "processes_affected": 0,
+      "modules_affected": [
+        "Data_adapters",
+        "Adapters"
+      ],
+      "direct_owner_files": [
+        "web/backend/app/api/watchlist.py",
+        "web/backend/app/services/data_adapters/watchlist.py",
+        "web/backend/app/services/adapters/watchlist_adapter.py"
+      ],
+      "selection_result": "defer_due_adapter_data_layer_coupling"
+    }
+  ],
+  "recommended_next_candidate": "web/backend/app/services/announcement_service.py",
+  "future_packet_required": {
+    "workline": "G2.5",
+    "type": "implementation-authorization",
+    "source_edits_authorized_by_this_artifact": false,
+    "minimum_future_scope_to_evaluate": [
+      "web/backend/app/services/announcement_service.py",
+      "web/backend/app/api/announcement/routes.py",
+      "focused tests for announcement service lifecycle dependency behavior"
+    ],
+    "must_define": [
+      "exact backend source write scope",
+      "exact test write scope",
+      "route functions to convert",
+      "app-state/provider installation pattern",
+      "compatibility getter retention rule",
+      "GitNexus pre-edit impact commands",
+      "rollback plan",
+      "targeted tests",
+      "lint and import smoke commands",
+      "forbidden scope"
+    ]
+  },
+  "forbidden_scope": [
+    "backend source edits",
+    "frontend source edits",
+    "test edits",
+    "generated client edits",
+    "docs/API edits",
+    "OpenSpec proposal or spec creation",
+    "issue label changes",
+    "PM2 commands",
+    "runtime rollout",
+    "ready-for-agent movement"
+  ],
+  "next_gate": "Human review of the G2.4 selection package; if accepted, create a separate G2.5 implementation authorization package for announcement_service.py."
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-second-candidate-selection-2026-05-22.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-second-candidate-selection-2026-05-22.md
@@ -1,0 +1,166 @@
+# Backend Service Lifecycle DI Second Candidate Selection - 2026-05-22
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: for-review
+- Workline: G2.4 service lifecycle DI second candidate selection
+- Parent issue: https://github.com/chengjon/mystocks/issues/79
+- Parent decision issue: https://github.com/chengjon/mystocks/issues/92
+- Current HEAD checked: `68da82084266ca7f9b7be9f5b55da7ac5e64fbd7`
+- Current branch: `g2-4-steward-tree-retrospective-next-candidate`
+- Generated artifact: `.planning/codebase/generated/service-lifecycle-di-second-candidate-selection-2026-05-22.json`
+
+Boundary note: This package is a candidate-selection packet only. It does not
+authorize backend source edits, frontend source edits, tests, generated client
+updates, docs/API edits, OpenSpec proposal creation, issue label changes, PM2
+commands, runtime rollout, or movement of issue `#79` or issue `#92` to
+`ready-for-agent`.
+
+## Input State
+
+The first service lifecycle DI implementation pilot is complete:
+
+- PR `#140`: candidate classification accepted
+- PR `#141`: `email_service.py` implementation authorization accepted
+- PR `#142`: `email_service.py` lifecycle DI implementation merged at
+  `20657e6e86a3423b15c67b6a8d6e165fbaa47b72`
+- PR `#143`: closeout recorded at
+  `68da82084266ca7f9b7be9f5b55da7ac5e64fbd7`
+
+Current GitHub state checked during this packet:
+
+| Issue | State | Labels | Meaning for this packet |
+|---|---|---|---|
+| `#79` | OPEN | `needs-triage` | Parent service lifecycle DI lane remains open, but no second service source edit is authorized |
+| `#92` | OPEN | `enhancement`, `ready-for-human`, `ready-for-downstream` | Downstream decision governance remains active; this packet is a review input only |
+
+## Candidate Source
+
+The current candidate source is the accepted G2.1 classification:
+
+- `backend-service-lifecycle-di-candidate-classification-2026-05-22.md`
+- `.planning/codebase/generated/service-lifecycle-di-candidate-classification-2026-05-22.json`
+
+That packet deferred two medium candidates after `email_service.py`:
+
+- `web/backend/app/services/announcement_service.py`
+- `web/backend/app/services/watchlist_service.py`
+
+This packet rechecks those two candidates at current HEAD after the first pilot
+was merged and recorded.
+
+## Current-HEAD Candidate Comparison
+
+| Candidate | Getter | GitNexus risk | Direct callers | Extra impacted symbols | Direct owner surface | Selection result |
+|---|---|---:|---:|---:|---|---|
+| `web/backend/app/services/announcement_service.py` | `get_announcement_service` | MEDIUM | 11 | 0 transitive symbols reported | `web/backend/app/api/announcement/routes.py` | Recommended next authorization candidate |
+| `web/backend/app/services/watchlist_service.py` | `get_watchlist_service` | MEDIUM | 9 | 6 transitive symbols through adapter/data layers | `web/backend/app/api/watchlist.py`, `web/backend/app/services/data_adapters/watchlist.py`, `web/backend/app/services/adapters/watchlist_adapter.py` | Defer |
+
+## GitNexus Evidence
+
+### `get_announcement_service`
+
+- Target: `Function:web/backend/app/services/announcement_service.py:get_announcement_service`
+- Risk: MEDIUM
+- Impacted count: 11
+- Direct callers: 11
+- Processes affected: 0
+- Modules affected: 1 (`Announcement`)
+- Direct caller file: `web/backend/app/api/announcement/routes.py`
+
+Direct caller functions:
+
+- `fetch_announcements`
+- `get_announcements`
+- `get_today_announcements`
+- `get_important_announcements`
+- `get_announcement_stats`
+- `get_monitor_rules`
+- `create_monitor_rule`
+- `update_monitor_rule`
+- `delete_monitor_rule`
+- `get_triggered_records`
+- `evaluate_monitor_rules`
+
+### `get_watchlist_service`
+
+- Target: `Function:web/backend/app/services/watchlist_service.py:get_watchlist_service`
+- Risk: MEDIUM
+- Impacted count: 15
+- Direct callers: 9
+- Processes affected: 0
+- Modules affected: 2 (`Data_adapters`, `Adapters`)
+- Direct caller files:
+  - `web/backend/app/api/watchlist.py`
+  - `web/backend/app/services/data_adapters/watchlist.py`
+  - `web/backend/app/services/adapters/watchlist_adapter.py`
+
+`watchlist_service.py` remains a valid future candidate, but it is not the best
+second pilot because it crosses route and adapter/data-layer helper surfaces.
+
+## Local Shape Evidence
+
+| File | Lines | Singleton pattern | Getter calls in file | Route decorators | Notes |
+|---|---:|---|---:|---:|---|
+| `web/backend/app/services/announcement_service.py` | 530 | `_announcement_service = None` | 1 | 0 | Service file only |
+| `web/backend/app/api/announcement/routes.py` | 595 | none | 11 | 14 | Single direct route owner surface |
+| `web/backend/app/services/watchlist_service.py` | 621 | `_watchlist_service = None` | 1 | 0 | Service file only |
+| `web/backend/app/api/watchlist.py` | 674 | none | 7 | 15 | Existing route-level dependency use exists, but service getter remains direct |
+| `web/backend/app/services/data_adapters/watchlist.py` | 289 | none | 10 | 0 | Adapter/data layer coupling |
+| `web/backend/app/services/adapters/watchlist_adapter.py` | 290 | none | 10 | 0 | Adapter/data layer coupling |
+
+## Recommendation
+
+Select `web/backend/app/services/announcement_service.py` as the next service
+lifecycle DI implementation authorization candidate.
+
+This is not an approval to edit source. It only means the next package, if the
+human maintainer accepts this selection, should be a G2.5 implementation
+authorization packet for `announcement_service.py`.
+
+## Required Future G2.5 Authorization Packet
+
+If this selection is accepted, the next packet must define:
+
+- exact backend source write scope
+- exact test write scope
+- route functions to convert from direct getter calls to dependency injection
+- app-state/provider installation pattern
+- compatibility getter retention rule
+- GitNexus pre-edit impact commands
+- rollback plan
+- targeted tests
+- lint and import smoke commands
+- forbidden scope
+
+Minimum future write scope to evaluate, not yet authorized:
+
+- `web/backend/app/services/announcement_service.py`
+- `web/backend/app/api/announcement/routes.py`
+- focused tests for announcement service lifecycle dependency behavior
+
+Explicitly out of scope for the next authorization packet unless separately
+approved:
+
+- `watchlist_service.py`
+- `email_service.py`
+- `email_notification_service.py`
+- adapter/data-layer services
+- route/OpenAPI contract rewrites
+- docs/API edits
+- generated clients
+- PM2 commands
+- issue label changes
+- OpenSpec proposal/spec creation
+
+## Next Gate
+
+Human review of this G2.4 selection package.
+
+If accepted, create a separate G2.5 implementation authorization package for
+`announcement_service.py`. Source edits remain locked until that G2.5 packet is
+reviewed and explicitly approved.

--- a/governance/mainline/task-cards/pr-144.yaml
+++ b/governance/mainline/task-cards/pr-144.yaml
@@ -1,0 +1,102 @@
+version: "v0.2"
+
+task:
+  id: "pr-144"
+  title: "record steward tree retrospective and second service DI candidate selection"
+  owner: "main"
+  created_at: "2026-05-22"
+
+mainline:
+  id: "L1-steward-tree-retrospective-second-candidate-selection"
+  objective: "record steward-tree operating lessons and prepare a governance-only second service lifecycle DI candidate selection packet"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-second-service-di-candidate-selection"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-steward-tree-retrospective-second-candidate-selection"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance retrospective, candidate selection report, generated evidence artifact, and steward-tree update only; no runtime entrypoint, route, page, shim, service behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/CODEBASE-MAP-STEWARD-TREE-RETROSPECTIVE-2026-05-22.md"
+    - ".planning/codebase/generated/service-lifecycle-di-second-candidate-selection-2026-05-22.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-second-candidate-selection-2026-05-22.md"
+    - "governance/mainline/task-cards/pr-144.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, PM2, or runtime behavior changes"
+  - "No second service lifecycle DI implementation"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes"
+  - "No movement of issue #79 or #92 to ready-for-agent"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md .planning/codebase/CODEBASE-MAP-STEWARD-TREE-RETROSPECTIVE-2026-05-22.md docs/reports/quality/backend-service-lifecycle-di-second-candidate-selection-2026-05-22.md"
+      required: true
+    - id: "json-validity"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-di-second-candidate-selection-2026-05-22.json >/tmp/service-lifecycle-di-second-candidate-selection.json"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-144.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this selection packet is misread as source implementation authorization, issue #79 can expand before a G2.5 authorization package exists"
+    - "If the steward retrospective is treated as a truth source, it can drift from current code, OpenSpec tasks, and GitHub issue state"
+  rollback_plan: "revert this PR and return the steward tree to the PR #143 email-service closeout state"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record steward-tree operating lessons and prepare the second service lifecycle DI candidate-selection packet"
+    modified_scope: "steward tree, retrospective, candidate-selection report, generated JSON, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance bookkeeping only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON validity, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-22T17:02:24+08:00"
+    approval_note: "human maintainer requested steward-tree retrospective and continuation; this PR records governance-only selection evidence and does not authorize a second service implementation"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Add steward-tree retrospective for the CODEBASE-MAP operating model.
- Add G2.4 second service lifecycle DI candidate-selection package and generated JSON evidence.
- Update the steward tree so issue #79 points to human review of the G2.4 selection packet before any G2.5 authorization package.

## Boundary
- Governance-only change.
- No backend source, frontend source, tests, docs/API, generated clients, OpenSpec changes, issue labels, PM2 commands, or runtime behavior changes.
- Does not authorize a second service lifecycle DI implementation.

## Verification
- Markdown governance gate: 3 checked files, 0 errors.
- JSON validity: passed.
- Mainline scope gate: pass=True.
- git diff HEAD~1 HEAD --check: passed.
- GitNexus staged detect_changes before commit: low risk, 0 changed symbols/processes.
