### PR TITLE
docs: prepare announcement service DI authorization

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -437,8 +437,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-email-service-lifecycle-di-closeout-2026-05-22.md`,
 │   │   `CODEBASE-MAP-STEWARD-TREE-RETROSPECTIVE-2026-05-22.md`,
 │   │   `backend-service-lifecycle-di-second-candidate-selection-2026-05-22.md`,
-│   │   `.planning/codebase/generated/service-lifecycle-di-second-candidate-selection-2026-05-22.json`
-│   ├── State: second-candidate-selection-prepared-for-review
+│   │   `.planning/codebase/generated/service-lifecycle-di-second-candidate-selection-2026-05-22.json`,
+│   │   `backend-announcement-service-lifecycle-di-implementation-authorization-2026-05-22.md`,
+│   │   `.planning/codebase/generated/announcement-service-lifecycle-di-implementation-authorization-2026-05-22.json`
+│   ├── State: announcement-service-di-authorization-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -463,13 +465,18 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 retrospective records steward-tree lessons and current-head
 │   │                 second-candidate evidence recommends
 │   │                 `announcement_service.py` as the next authorization
-│   │                 candidate over `watchlist_service.py`
-│   └── Next gate: Human review of the G2.4 retrospective and second-candidate
-│                  selection package; if accepted, create a separate G2.5
-│                  implementation authorization packet for
-│                  `announcement_service.py`; no service source edits,
-│                  OpenSpec proposal, issue-label change, or `ready-for-agent`
-│                  movement is authorized by G2.4
+│   │                 candidate over `watchlist_service.py`; PR `#144` merged at
+│   │                 `f149534f8dd01802cf40cbe266223c51e4475a49`; G2.5 now
+│   │                 records a future implementation authorization packet for
+│   │                 `announcement_service.py`, limited to the announcement
+│   │                 service, announcement routes, focused tests, and an
+│   │                 implementation report/task card
+│   └── Next gate: Human review of the G2.5 implementation authorization packet;
+│                  if accepted, create a separate implementation worktree and PR
+│                  for `announcement_service.py`; no service source edits,
+│                  OpenSpec proposal, issue-label change, PM2 command, or
+│                  `ready-for-agent` movement is authorized by this G2.5
+│                  governance PR itself
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -665,7 +672,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review service lifecycle DI second-candidate selection | Future service seam lane | G2.4 retrospective and selection packet prepared; `announcement_service.py` is recommended as the next authorization-candidate input, but no second service source edit is authorized |
+| P2 | Review `announcement_service.py` lifecycle DI authorization | Future service seam lane | G2.5 authorization packet prepared; future implementation may start only after human acceptance and must stay inside the allowed write scope |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/generated/announcement-service-lifecycle-di-implementation-authorization-2026-05-22.json
+++ b/.planning/codebase/generated/announcement-service-lifecycle-di-implementation-authorization-2026-05-22.json
@@ -1,0 +1,126 @@
+{
+  "artifact": "announcement-service-lifecycle-di-implementation-authorization",
+  "generated_at": "2026-05-22T18:47:20+08:00",
+  "git_branch": "g2-5-announcement-service-di-authorization",
+  "git_head": "f149534f8dd01802cf40cbe266223c51e4475a49",
+  "status": "implementation-authorization-prepared-for-review",
+  "source_code_changed": false,
+  "tests_changed": false,
+  "runtime_behavior_changed": false,
+  "issues": {
+    "service_lifecycle_parent": {
+      "number": 79,
+      "state": "OPEN",
+      "labels": [
+        "needs-triage"
+      ]
+    },
+    "downstream_decision_parent": {
+      "number": 92,
+      "state": "OPEN",
+      "labels": [
+        "enhancement",
+        "ready-for-human",
+        "ready-for-downstream"
+      ]
+    }
+  },
+  "predecessor_prs": {
+    "candidate_classification": {
+      "pr": 140,
+      "merge_commit": "0b5e393e2ff1e5da465d26b338d083a6023faf9b"
+    },
+    "email_authorization": {
+      "pr": 141,
+      "merge_commit": "6e92dd2942057b2763a4074abc102b761c2b2d76"
+    },
+    "email_implementation": {
+      "pr": 142,
+      "merge_commit": "20657e6e86a3423b15c67b6a8d6e165fbaa47b72"
+    },
+    "email_closeout": {
+      "pr": 143,
+      "merge_commit": "68da82084266ca7f9b7be9f5b55da7ac5e64fbd7"
+    },
+    "second_candidate_selection": {
+      "pr": 144,
+      "merge_commit": "f149534f8dd01802cf40cbe266223c51e4475a49"
+    }
+  },
+  "candidate": {
+    "service_file": "web/backend/app/services/announcement_service.py",
+    "route_file": "web/backend/app/api/announcement/routes.py",
+    "service_class": "AnnouncementService",
+    "compatibility_getter": "get_announcement_service",
+    "state_key": "ANNOUNCEMENT_SERVICE_STATE_KEY",
+    "install_helper": "install_announcement_service",
+    "dependency_helper": "get_announcement_service_dependency"
+  },
+  "gitnexus_pre_edit_snapshot": {
+    "AnnouncementService": {
+      "risk": "LOW",
+      "direct_callers": 0,
+      "processes_affected": 0
+    },
+    "get_announcement_service": {
+      "risk": "MEDIUM",
+      "direct_callers": 11,
+      "processes_affected": 0,
+      "modules_affected": [
+        "Announcement"
+      ],
+      "direct_callers_by_file": {
+        "web/backend/app/api/announcement/routes.py": [
+          "fetch_announcements",
+          "get_announcements",
+          "get_today_announcements",
+          "get_important_announcements",
+          "get_announcement_stats",
+          "get_monitor_rules",
+          "create_monitor_rule",
+          "update_monitor_rule",
+          "delete_monitor_rule",
+          "get_triggered_records",
+          "evaluate_monitor_rules"
+        ]
+      }
+    }
+  },
+  "future_allowed_write_scope_if_accepted": [
+    "web/backend/app/services/announcement_service.py",
+    "web/backend/app/api/announcement/routes.py",
+    "web/backend/tests/test_announcement_service_lifecycle_di.py",
+    "web/backend/tests/test_announcement_routes_regressions.py",
+    "docs/reports/quality/backend-announcement-service-lifecycle-di-implementation-*.md",
+    "governance/mainline/task-cards/pr-*.yaml"
+  ],
+  "explicitly_forbidden_scope": [
+    "web/backend/app/services/watchlist_service.py",
+    "web/backend/app/services/data_adapters/watchlist.py",
+    "web/backend/app/services/adapters/watchlist_adapter.py",
+    "web/backend/app/services/email_service.py",
+    "web/backend/app/services/email_notification_service.py",
+    "web/backend/app/services/strategy_service.py",
+    "web/backend/app/services/tdx_service.py",
+    "web/backend/app/services/stock_search_service/",
+    "web/backend/app/api/watchlist.py",
+    "docs/api/",
+    "generated clients",
+    "OpenSpec proposal or spec files",
+    "PM2 scripts or runtime process configuration",
+    "frontend files"
+  ],
+  "future_required_verification": [
+    "GitNexus impact rerun before source edits",
+    "pytest announcement lifecycle DI and route regression tests",
+    "ruff check touched files",
+    "announcement service import smoke",
+    "GitNexus staged detect_changes before commit"
+  ],
+  "approval_semantics": {
+    "this_pr_authorizes_source_edits": false,
+    "human_acceptance_of_this_packet_allows_future_implementation_pr": true,
+    "future_implementation_requires_separate_worktree_and_report": true
+  },
+  "next_gate": "Human review of G2.5 authorization packet; if accepted, create a separate implementation worktree and PR for announcement_service.py only."
+}

--- a/docs/reports/quality/backend-announcement-service-lifecycle-di-implementation-authorization-2026-05-22.md
+++ b/docs/reports/quality/backend-announcement-service-lifecycle-di-implementation-authorization-2026-05-22.md
@@ -1,0 +1,300 @@
+# Backend Announcement Service Lifecycle DI Implementation Authorization - 2026-05-22
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: implementation-authorization-prepared-for-review
+- Workline: G2.5 service lifecycle DI authorization
+- Candidate: `web/backend/app/services/announcement_service.py`
+- Current HEAD: `f149534f8dd01802cf40cbe266223c51e4475a49`
+- Prepared at: `2026-05-22T18:47:20+08:00`
+- Source edits in this package: none
+- Generated artifact: `.planning/codebase/generated/announcement-service-lifecycle-di-implementation-authorization-2026-05-22.json`
+
+## Governance Boundary
+
+This package is an authorization packet for a future implementation PR. This PR
+does not modify source code or tests.
+
+If the human maintainer accepts this packet, the future implementation may edit
+only the explicitly allowed files listed below. Any broader route-contract,
+OpenAPI, adapter/data-layer, schema, generated-client, PM2, or issue-label work
+requires a separate packet.
+
+This package does not authorize:
+
+- backend source edits in this governance PR
+- frontend source edits
+- generated client edits
+- `docs/api/` edits
+- OpenSpec proposal or spec creation
+- issue label changes
+- moving issue `#79` or issue `#92` to `ready-for-agent`
+- PM2 command execution, service restart, process deletion, or process
+  recreation
+
+## Current Issue State
+
+| Issue | State | Labels | Role |
+|---|---|---|---|
+| `#79` | OPEN | `needs-triage` | Parent service lifecycle DI lane |
+| `#92` | OPEN | `enhancement`, `ready-for-human`, `ready-for-downstream` | Parent downstream decision lane |
+
+Relevant predecessor gates:
+
+- PR `#140`: service lifecycle candidate classification accepted
+- PR `#141`: `email_service.py` implementation authorization accepted
+- PR `#142`: `email_service.py` lifecycle DI implementation merged
+- PR `#143`: `email_service.py` closeout recorded
+- PR `#144`: steward-tree retrospective and second-candidate selection merged
+
+## Candidate Decision
+
+`announcement_service.py` is authorized as the next implementation candidate if
+this package is accepted.
+
+It is selected over `watchlist_service.py` because current-head GitNexus
+evidence keeps the impact inside one direct route owner module:
+
+| Candidate | Getter | Risk | Direct callers | Extra impacted symbols | Disposition |
+|---|---|---:|---:|---:|---|
+| `announcement_service.py` | `get_announcement_service` | MEDIUM | 11 | 0 | Authorize as next candidate |
+| `watchlist_service.py` | `get_watchlist_service` | MEDIUM | 9 | 6 | Defer; crosses adapter/data-layer helper surfaces |
+
+## GitNexus Pre-Edit Snapshot
+
+| Symbol | File | Risk | Direct callers | Processes affected | Disposition |
+|---|---|---:|---:|---:|---|
+| `AnnouncementService` | `web/backend/app/services/announcement_service.py` | LOW | 0 | 0 | service class candidate |
+| `get_announcement_service` | `web/backend/app/services/announcement_service.py` | MEDIUM | 11 | 0 | compatibility getter and route seam |
+
+The future implementation PR must rerun GitNexus impact before editing:
+
+```bash
+gitnexus impact --repo mystocks_spec --target AnnouncementService --direction upstream --max-depth 3
+gitnexus impact --repo mystocks_spec --target get_announcement_service --direction upstream --max-depth 3
+```
+
+If either impact result changes to HIGH or CRITICAL, the implementation worker
+must stop and return to review before editing source.
+
+## Current Direct Caller Surface
+
+All current direct route callers are in
+`web/backend/app/api/announcement/routes.py`:
+
+| Route function | Current seam |
+|---|---|
+| `fetch_announcements` | direct `get_announcement_service()` call |
+| `get_announcements` | direct `get_announcement_service()` call |
+| `get_today_announcements` | direct `get_announcement_service()` call |
+| `get_important_announcements` | direct `get_announcement_service()` call |
+| `get_announcement_stats` | direct `get_announcement_service()` call |
+| `get_monitor_rules` | direct `get_announcement_service()` call |
+| `create_monitor_rule` | direct `get_announcement_service()` call |
+| `update_monitor_rule` | direct `get_announcement_service()` call |
+| `delete_monitor_rule` | direct `get_announcement_service()` call |
+| `get_triggered_records` | direct `get_announcement_service()` call |
+| `evaluate_monitor_rules` | direct `get_announcement_service()` call |
+
+The current service file has one module singleton:
+
+```python
+_announcement_service = None
+```
+
+The future implementation must preserve the compatibility getter. The
+implementation target is route-level injection and app-state installation, not
+deleting the legacy getter.
+
+## Future Allowed Write Scope
+
+If this authorization packet is accepted, the future implementation PR may edit:
+
+- `web/backend/app/services/announcement_service.py`
+- `web/backend/app/api/announcement/routes.py`
+- `web/backend/tests/test_announcement_service_lifecycle_di.py`
+- `web/backend/tests/test_announcement_routes_regressions.py`
+- `docs/reports/quality/backend-announcement-service-lifecycle-di-implementation-*.md`
+- `governance/mainline/task-cards/pr-*.yaml`
+
+## Explicitly Forbidden Scope
+
+The future implementation PR must not edit:
+
+- `web/backend/app/services/watchlist_service.py`
+- `web/backend/app/services/data_adapters/watchlist.py`
+- `web/backend/app/services/adapters/watchlist_adapter.py`
+- `web/backend/app/services/email_service.py`
+- `web/backend/app/services/email_notification_service.py`
+- `web/backend/app/services/strategy_service.py`
+- `web/backend/app/services/tdx_service.py`
+- `web/backend/app/services/stock_search_service/`
+- `web/backend/app/api/watchlist.py`
+- `docs/api/`
+- generated clients
+- OpenSpec proposal or spec files
+- PM2 scripts or runtime process configuration
+- frontend files
+
+## Future Implementation Shape
+
+The implementation should mirror the proven `email_service.py` pattern.
+
+### Service Provider Pattern
+
+Add provider helpers while keeping the compatibility getter:
+
+```python
+from typing import Any
+
+from fastapi import Request
+
+_announcement_service = None
+ANNOUNCEMENT_SERVICE_STATE_KEY = "announcement_service"
+
+
+def get_announcement_service() -> AnnouncementService:
+    """Compatibility getter retained for non-route callers."""
+    global _announcement_service
+    if _announcement_service is None:
+        _announcement_service = AnnouncementService()
+    return _announcement_service
+
+
+def install_announcement_service(
+    app: Any, service: AnnouncementService | None = None
+) -> AnnouncementService:
+    selected_service = service if service is not None else get_announcement_service()
+    setattr(app.state, ANNOUNCEMENT_SERVICE_STATE_KEY, selected_service)
+    return selected_service
+
+
+def get_announcement_service_dependency(request: Request) -> AnnouncementService:
+    service = getattr(request.app.state, ANNOUNCEMENT_SERVICE_STATE_KEY, None)
+    if service is None:
+        service = install_announcement_service(request.app)
+    return service
+```
+
+The implementation worker must confirm the file already has or receives the
+imports required for `Any` and `Request`.
+
+### Route Injection Pattern
+
+Each route function that currently calls `get_announcement_service()` should
+accept the injected service:
+
+```python
+from fastapi import APIRouter, Body, Depends, Path, Query
+
+from app.services.announcement_service import (
+    AnnouncementService,
+    get_announcement_service_dependency,
+)
+
+
+async def fetch_announcements(
+    service: AnnouncementService = Depends(get_announcement_service_dependency),
+):
+    ...
+```
+
+Then remove the local line:
+
+```python
+service = get_announcement_service()
+```
+
+from each converted route function.
+
+The existing fallback import behavior around `HAS_ANNOUNCEMENT_SERVICE` must be
+preserved unless the worker first creates a separate decision packet to change
+that compatibility behavior.
+
+## Future Test Plan
+
+### New lifecycle DI test file
+
+Create `web/backend/tests/test_announcement_service_lifecycle_di.py`.
+
+Required checks:
+
+- `install_announcement_service(app, fake_service)` writes to `app.state`
+- `get_announcement_service_dependency(request)` reuses an existing app-state
+  service
+- `get_announcement_service_dependency(request)` installs a service when app
+  state is empty
+- every converted announcement route has a `service` parameter
+- `fetch_announcements` can use an injected fake service without calling the
+  module-level getter
+
+### Existing route regression test
+
+Extend `web/backend/tests/test_announcement_routes_regressions.py` only if the
+implementation changes route import or load behavior. Keep the existing
+`analyze_data` rule-based response test passing.
+
+## Future Verification Commands
+
+The implementation PR must run:
+
+```bash
+env PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov \
+  web/backend/tests/test_announcement_service_lifecycle_di.py \
+  web/backend/tests/test_announcement_routes_regressions.py
+```
+
+```bash
+ruff check \
+  web/backend/app/services/announcement_service.py \
+  web/backend/app/api/announcement/routes.py \
+  web/backend/tests/test_announcement_service_lifecycle_di.py \
+  web/backend/tests/test_announcement_routes_regressions.py
+```
+
+```bash
+env PYTHONPATH=web/backend python - <<'PY'
+from app.services.announcement_service import (
+    AnnouncementService,
+    get_announcement_service,
+    get_announcement_service_dependency,
+    install_announcement_service,
+)
+from app.api.announcement import routes
+
+print("announcement service DI import smoke passed")
+PY
+```
+
+After staging the implementation files, run:
+
+```bash
+gitnexus detect-changes --repo mystocks_spec --scope staged
+```
+
+The implementation report must record the exact command outputs. Full backend
+pytest, PM2, OpenAPI drift, frontend E2E, and generated-client checks are not
+required for this narrow authorization unless the implementation changes their
+surfaces.
+
+## Rollback Plan
+
+If the future implementation fails tests or review:
+
+1. Revert the implementation PR.
+2. Restore route functions to direct `get_announcement_service()` calls.
+3. Remove the new announcement lifecycle DI test file.
+4. Leave the G2.5 authorization packet as historical evidence and mark the
+   implementation attempt as reverted in the steward tree.
+
+## Next Gate
+
+Human review of this G2.5 authorization packet.
+
+If accepted, create a separate implementation worktree and PR. That future PR
+may edit only the allowed write scope above and must produce an implementation
+report before closeout.

--- a/governance/mainline/task-cards/pr-145.yaml
+++ b/governance/mainline/task-cards/pr-145.yaml
@@ -1,0 +1,102 @@
+version: "v0.2"
+
+task:
+  id: "pr-145"
+  title: "prepare announcement service DI implementation authorization"
+  owner: "main"
+  created_at: "2026-05-22"
+
+mainline:
+  id: "L1-service-lifecycle-di-announcement-service-authorization"
+  objective: "prepare the G2.5 announcement_service.py lifecycle DI implementation authorization packet without source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-announcement-service-di-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-announcement-service-di-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Implementation authorization report, generated evidence artifact, and steward-tree update only; no runtime entrypoint, route, page, shim, service behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/announcement-service-lifecycle-di-implementation-authorization-2026-05-22.json"
+    - "docs/reports/quality/backend-announcement-service-lifecycle-di-implementation-authorization-2026-05-22.md"
+    - "governance/mainline/task-cards/pr-145.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, PM2, or runtime behavior changes in this PR"
+  - "No announcement_service.py implementation in this PR"
+  - "No watchlist_service.py work"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes"
+  - "No movement of issue #79 or #92 to ready-for-agent"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-announcement-service-lifecycle-di-implementation-authorization-2026-05-22.md"
+      required: true
+    - id: "json-validity"
+      command: "python -m json.tool .planning/codebase/generated/announcement-service-lifecycle-di-implementation-authorization-2026-05-22.json >/tmp/announcement-service-lifecycle-di-implementation-authorization.json"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-145.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this authorization packet is misread as an implementation PR, source edits could happen before human acceptance"
+    - "If future implementation expands into watchlist or adapter/data-layer files, it will violate the G2.4 selection boundary"
+  rollback_plan: "revert this PR and return the steward tree to the G2.4 second-candidate selection state"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "prepare announcement_service.py lifecycle DI implementation authorization after G2.4 selection"
+    modified_scope: "steward tree, authorization report, generated JSON, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance authorization only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON validity, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-22T18:47:20+08:00"
+    approval_note: "human maintainer requested continuation after G2.4; this PR prepares implementation authorization only and does not itself modify source"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Add G2.5 implementation authorization packet for announcement_service.py lifecycle DI.
- Add generated JSON evidence with GitNexus pre-edit snapshot and allowed/forbidden future scope.
- Update the CODEBASE-MAP steward tree so #79 points to human review of the G2.5 authorization packet.

## Boundary
- Governance-only PR.
- No backend source, frontend source, tests, docs/API, generated clients, OpenSpec changes, issue labels, PM2 commands, or runtime behavior changes.
- If accepted, a future implementation PR may edit only announcement_service.py, announcement routes, focused tests, implementation report, and task card.

## Verification
- Markdown governance gate: 2 checked files, 0 errors.
- JSON validity: passed.
- Mainline scope gate: pass=True.
- git diff HEAD~1 HEAD --check: passed.
- GitNexus staged detect_changes before commit: low risk, 0 changed symbols/processes.
- GitNexus pre-edit snapshots recorded: AnnouncementService LOW; get_announcement_service MEDIUM with 11 direct callers and 0 affected processes.
