### PR TITLE
refactor(service): inject announcement service dependency

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -439,8 +439,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-service-lifecycle-di-second-candidate-selection-2026-05-22.md`,
 │   │   `.planning/codebase/generated/service-lifecycle-di-second-candidate-selection-2026-05-22.json`,
 │   │   `backend-announcement-service-lifecycle-di-implementation-authorization-2026-05-22.md`,
-│   │   `.planning/codebase/generated/announcement-service-lifecycle-di-implementation-authorization-2026-05-22.json`
-│   ├── State: announcement-service-di-authorization-prepared-for-review
+│   │   `.planning/codebase/generated/announcement-service-lifecycle-di-implementation-authorization-2026-05-22.json`,
+│   │   `backend-announcement-service-lifecycle-di-implementation-2026-05-22.md`
+│   ├── State: announcement-service-di-implementation-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -470,13 +471,16 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 records a future implementation authorization packet for
 │   │                 `announcement_service.py`, limited to the announcement
 │   │                 service, announcement routes, focused tests, and an
-│   │                 implementation report/task card
-│   └── Next gate: Human review of the G2.5 implementation authorization packet;
-│                  if accepted, create a separate implementation worktree and PR
-│                  for `announcement_service.py`; no service source edits,
-│                  OpenSpec proposal, issue-label change, PM2 command, or
-│                  `ready-for-agent` movement is authorized by this G2.5
-│                  governance PR itself
+│   │                 implementation report/task card; PR `#145` merged at
+│   │                 `e9d674c01edc5e701a0b3eca80b05f62dfc4986f`; G2.6 now
+│   │                 implements that approved scope by adding an app-state
+│   │                 provider seam to `announcement_service.py` and injecting
+│   │                 `AnnouncementService` into 11 announcement route handlers
+│   └── Next gate: Human review of the G2.6 implementation PR; if merged, create
+│                  a separate closeout record before selecting any third service
+│                  lifecycle DI candidate; no OpenSpec proposal, issue-label
+│                  change, PM2 command, or `ready-for-agent` movement is
+│                  authorized by this implementation PR
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -672,7 +676,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review `announcement_service.py` lifecycle DI authorization | Future service seam lane | G2.5 authorization packet prepared; future implementation may start only after human acceptance and must stay inside the allowed write scope |
+| P2 | Review `announcement_service.py` lifecycle DI implementation | Future service seam lane | G2.6 implementation PR prepared; if merged, create a closeout record before selecting any third service lifecycle DI candidate |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/docs/reports/quality/backend-announcement-service-lifecycle-di-implementation-2026-05-22.md
+++ b/docs/reports/quality/backend-announcement-service-lifecycle-di-implementation-2026-05-22.md
@@ -1,0 +1,198 @@
+# Backend Announcement Service Lifecycle DI Implementation - 2026-05-22
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: implementation-prepared-for-review
+- Workline: G2.6 announcement service lifecycle DI implementation
+- Authorization packet: `backend-announcement-service-lifecycle-di-implementation-authorization-2026-05-22.md`
+- Authorization merge: PR `#145`, `e9d674c01edc5e701a0b3eca80b05f62dfc4986f`
+- Implementation branch: `g2-6-announcement-service-di-implementation`
+- Current HEAD before implementation: `e9d674c01edc5e701a0b3eca80b05f62dfc4986f`
+
+## Authorization Boundary
+
+This implementation stays inside the G2.5 allowed write scope:
+
+- `web/backend/app/services/announcement_service.py`
+- `web/backend/app/api/announcement/routes.py`
+- `web/backend/tests/test_announcement_service_lifecycle_di.py`
+- `docs/reports/quality/backend-announcement-service-lifecycle-di-implementation-2026-05-22.md`
+- `governance/mainline/task-cards/pr-146.yaml`
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+
+No `watchlist_service.py`, adapter/data-layer file, frontend file, `docs/api/`
+file, generated client, OpenSpec proposal/spec, PM2 script, runtime process
+configuration, or issue label was changed.
+
+## GitNexus Pre-Edit Gate
+
+Pre-edit impact was run before source changes:
+
+| Symbol | Risk | Direct callers | Processes affected | Result |
+|---|---:|---:|---:|---|
+| `AnnouncementService` | LOW | 0 | 0 | safe to proceed |
+| `get_announcement_service` | MEDIUM | 11 | 0 | allowed by G2.5; all direct callers are announcement routes |
+
+No HIGH or CRITICAL risk was reported.
+
+## TDD Evidence
+
+RED command:
+
+```bash
+env PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov \
+  web/backend/tests/test_announcement_service_lifecycle_di.py
+```
+
+Expected and observed RED failures:
+
+- `get_announcement_service_dependency` did not exist
+- announcement route signatures did not include `service`
+- `fetch_announcements(..., service=fake_service)` rejected the injected service
+
+GREEN command:
+
+```bash
+env PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov \
+  web/backend/tests/test_announcement_service_lifecycle_di.py
+```
+
+Observed result: `3 passed`.
+
+## Implementation Summary
+
+### `announcement_service.py`
+
+The service now keeps the compatibility singleton getter and adds the app-state
+provider seam:
+
+- `ANNOUNCEMENT_SERVICE_STATE_KEY`
+- `install_announcement_service(app, service=None)`
+- `get_announcement_service_dependency(request)`
+
+The existing `get_announcement_service()` compatibility getter remains in place
+for non-route callers.
+
+### `announcement/routes.py`
+
+The route module now imports:
+
+- `Depends`
+- `AnnouncementService`
+- `get_announcement_service_dependency`
+
+The 11 direct route callers now accept injected `AnnouncementService`:
+
+- `fetch_announcements`
+- `get_announcements`
+- `get_today_announcements`
+- `get_important_announcements`
+- `get_announcement_stats`
+- `get_monitor_rules`
+- `create_monitor_rule`
+- `update_monitor_rule`
+- `delete_monitor_rule`
+- `get_triggered_records`
+- `evaluate_monitor_rules`
+
+Implementation shape check:
+
+- Direct `get_announcement_service()` calls left in `announcement/routes.py`: `0`
+- Route dependency parameters added: `11`
+- Compatibility getter retained in service: yes
+
+### Tests
+
+`web/backend/tests/test_announcement_service_lifecycle_di.py` verifies:
+
+- app-state installation through `get_announcement_service_dependency`
+- every converted route exposes a `service` parameter
+- `fetch_announcements` uses an injected fake service
+
+Existing `web/backend/tests/test_announcement_routes_regressions.py` remains
+unchanged and passing.
+
+## Verification
+
+Focused pytest:
+
+```bash
+env PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov \
+  web/backend/tests/test_announcement_service_lifecycle_di.py \
+  web/backend/tests/test_announcement_routes_regressions.py
+```
+
+Result: `4 passed`.
+
+Ruff:
+
+```bash
+ruff check \
+  web/backend/app/services/announcement_service.py \
+  web/backend/app/api/announcement/routes.py \
+  web/backend/tests/test_announcement_service_lifecycle_di.py \
+  web/backend/tests/test_announcement_routes_regressions.py
+```
+
+Result: `All checks passed!`
+
+Import smoke:
+
+```bash
+env PYTHONPATH=web/backend python - <<'PY'
+from app.services.announcement_service import (
+    AnnouncementService,
+    get_announcement_service,
+    get_announcement_service_dependency,
+    install_announcement_service,
+)
+from app.api.announcement import routes
+
+print("announcement service DI import smoke passed")
+PY
+```
+
+Result: `announcement service DI import smoke passed`.
+
+Staged GitNexus scope check:
+
+```text
+scope=staged, risk_level=low, changed_files=6, changed_count=30,
+affected_count=0, affected_processes=[]
+```
+
+## Not Executed
+
+The following broader gates were not executed because this is a narrow
+route-level service lifecycle DI implementation:
+
+- full backend pytest
+- PM2 stateful workflow
+- route/OpenAPI drift generation
+- generated client rebuild
+- frontend tests
+
+## Rollback
+
+Rollback is straightforward:
+
+1. Remove `ANNOUNCEMENT_SERVICE_STATE_KEY`, `install_announcement_service`, and
+   `get_announcement_service_dependency`.
+2. Restore the 11 route-body `get_announcement_service()` calls.
+3. Remove `service: AnnouncementService = Depends(...)` route parameters.
+4. Remove `test_announcement_service_lifecycle_di.py`.
+
+The compatibility getter was not removed, so non-route rollback risk is low.
+
+## Next Gate
+
+Human review of this implementation PR.
+
+If merged, create a separate closeout record that updates the steward tree from
+`announcement-service-di-implementation-prepared-for-review` to merged and
+recorded. Do not start a third service lifecycle DI candidate until that closeout
+is accepted.

--- a/governance/mainline/task-cards/pr-146.yaml
+++ b/governance/mainline/task-cards/pr-146.yaml
@@ -1,0 +1,120 @@
+version: "v0.2"
+
+task:
+  id: "pr-146"
+  title: "implement announcement service lifecycle DI"
+  owner: "main"
+  created_at: "2026-05-22"
+
+mainline:
+  id: "L1-service-lifecycle-di-announcement-service-implementation"
+  objective: "migrate announcement_service.py and its announcement route consumers to an app.state-backed FastAPI dependency provider"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-announcement-service-di-implementation"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow service lifecycle DI pilot authorized by PR #145; route paths, OpenAPI behavior, product surface, and runtime process state are unchanged"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "web/backend/app/services/announcement_service.py"
+    - "web/backend/app/api/announcement/routes.py"
+    - "web/backend/tests/test_announcement_service_lifecycle_di.py"
+    - "web/backend/tests/test_announcement_routes_regressions.py"
+    - "docs/reports/quality/backend-announcement-service-lifecycle-di-implementation-2026-05-22.md"
+    - "governance/mainline/task-cards/pr-146.yaml"
+  forbidden_paths:
+    - "web/backend/app/services/watchlist_service.py"
+    - "web/backend/app/services/data_adapters/watchlist.py"
+    - "web/backend/app/services/adapters/watchlist_adapter.py"
+    - "web/backend/app/services/email_service.py"
+    - "web/backend/app/services/email_notification_service.py"
+    - "web/backend/app/services/strategy_service.py"
+    - "web/backend/app/services/tdx_service.py"
+    - "web/backend/app/services/stock_search_service/stock_search_service.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No changes to watchlist service, adapter/data-layer services, email service, or any other service singleton"
+  - "No route path, method, OpenAPI exposure, response contract, generated client, frontend, PM2, or runtime process changes"
+  - "No new OpenSpec proposal/spec creation or archive execution"
+  - "No issue label changes"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov web/backend/tests/test_announcement_service_lifecycle_di.py web/backend/tests/test_announcement_routes_regressions.py"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/announcement_service.py web/backend/app/api/announcement/routes.py web/backend/tests/test_announcement_service_lifecycle_di.py web/backend/tests/test_announcement_routes_regressions.py"
+      required: true
+    - id: "announcement-import-smoke"
+      command: "env PYTHONPATH=web/backend python -c 'from app.services.announcement_service import AnnouncementService, get_announcement_service, get_announcement_service_dependency, install_announcement_service; from app.api.announcement import routes; print(\"announcement service DI import smoke passed\")'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-announcement-service-lifecycle-di-implementation-2026-05-22.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-146.yaml"
+      required: true
+    - id: "staged-gitnexus"
+      command: "gitnexus_detect_changes(scope=staged)"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If only some announcement route callers are migrated, route behavior can silently fall back to the compatibility singleton"
+    - "If watchlist or adapter/data-layer files are edited, the implementation violates the G2.4 candidate boundary"
+    - "If tests only monkeypatch the old getter, dependency injection behavior is not proven"
+  rollback_plan: "Restore direct get_announcement_service route-body calls, remove the app.state provider functions and lifecycle DI test, and leave watchlist/adapter/data-layer files untouched"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "implement the second announcement_service.py service lifecycle DI pilot"
+    modified_scope: "announcement_service.py, announcement routes, focused tests, implementation report, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "get_announcement_service remains as compatibility getter; announcement routes now use injected AnnouncementService"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, ruff, import smoke, mainline scope, staged GitNexus, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-22T19:00:04+08:00"
+    approval_note: "human maintainer approved continuation after PR #145 and authorized opening the announcement_service.py source implementation lane within its exact scope"
+    secondary_approved: false

--- a/web/backend/app/api/announcement/routes.py
+++ b/web/backend/app/api/announcement/routes.py
@@ -5,7 +5,7 @@
 from datetime import date, timedelta
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Body, Path, Query
+from fastapi import APIRouter, Body, Depends, Path, Query
 from app.core.exceptions import BusinessException
 from app.core.responses import UnifiedResponse
 from app.api.announcement._responses import (
@@ -37,7 +37,10 @@ try:
         AnnouncementMonitorRecord,
         AnnouncementMonitorRule,
     )
-    from app.services.announcement_service import get_announcement_service
+    from app.services.announcement_service import (
+        AnnouncementService,
+        get_announcement_service_dependency,
+    )
 
     HAS_ANNOUNCEMENT_SERVICE = True
 except Exception:
@@ -103,6 +106,7 @@ if HAS_ANNOUNCEMENT_SERVICE:
         start_date: Optional[date] = Query(None, description="开始日期"),
         end_date: Optional[date] = Query(None, description="结束日期"),
         category: Optional[str] = Query("all", description="公告类别"),
+        service: AnnouncementService = Depends(get_announcement_service_dependency),
     ):
         """
         从数据源获取并保存公告
@@ -117,8 +121,6 @@ if HAS_ANNOUNCEMENT_SERVICE:
             Dict: 获取结果
         """
         try:
-            service = get_announcement_service()
-
             # 默认获取最近7天的公告
             if end_date is None:
                 end_date = date.today()
@@ -148,6 +150,7 @@ if HAS_ANNOUNCEMENT_SERVICE:
         min_importance: Optional[int] = Query(None, ge=0, le=5, description="最小重要性级别"),
         page: int = Query(1, ge=1, description="页码"),
         page_size: int = Query(20, ge=1, le=100, description="每页数量"),
+        service: AnnouncementService = Depends(get_announcement_service_dependency),
     ):
         """
         查询公告列表
@@ -165,8 +168,6 @@ if HAS_ANNOUNCEMENT_SERVICE:
             Dict: 公告列表
         """
         try:
-            service = get_announcement_service()
-
             result = service.get_announcements(
                 stock_code=stock_code,
                 start_date=start_date,
@@ -189,7 +190,8 @@ if HAS_ANNOUNCEMENT_SERVICE:
 
     @router.get("/today", responses=ANNOUNCEMENT_TODAY_RESPONSES)
     async def get_today_announcements(
-        min_importance: Optional[int] = Query(0, ge=0, le=5, description="最小重要性级别")
+        min_importance: Optional[int] = Query(0, ge=0, le=5, description="最小重要性级别"),
+        service: AnnouncementService = Depends(get_announcement_service_dependency),
     ):
         """
         获取今日公告
@@ -201,8 +203,6 @@ if HAS_ANNOUNCEMENT_SERVICE:
             Dict: 今日公告列表
         """
         try:
-            service = get_announcement_service()
-
             today = date.today()
 
             result = service.get_announcements(
@@ -232,6 +232,7 @@ if HAS_ANNOUNCEMENT_SERVICE:
     async def get_important_announcements(
         days: int = Query(7, ge=1, le=30, description="查询天数"),
         min_importance: int = Query(3, ge=0, le=5, description="最小重要性级别"),
+        service: AnnouncementService = Depends(get_announcement_service_dependency),
     ):
         """
         获取重要公告
@@ -244,8 +245,6 @@ if HAS_ANNOUNCEMENT_SERVICE:
             Dict: 重要公告列表
         """
         try:
-            service = get_announcement_service()
-
             end_date = date.today()
             start_date = end_date - timedelta(days=days)
 
@@ -275,7 +274,9 @@ if HAS_ANNOUNCEMENT_SERVICE:
             raise BusinessException(status_code=500, detail=str(e))
 
     @router.get("/stats", responses=ANNOUNCEMENT_STATS_RESPONSES)
-    async def get_announcement_stats():
+    async def get_announcement_stats(
+        service: AnnouncementService = Depends(get_announcement_service_dependency),
+    ):
         """
         获取公告统计信息
 
@@ -283,8 +284,6 @@ if HAS_ANNOUNCEMENT_SERVICE:
             Dict: 统计信息
         """
         try:
-            service = get_announcement_service()
-
             # 获取今日公告
             today_result = service.get_announcements(
                 start_date=date.today(), end_date=date.today(), page=1, page_size=1
@@ -317,7 +316,9 @@ if HAS_ANNOUNCEMENT_SERVICE:
             raise BusinessException(status_code=500, detail=str(e))
 
     @router.get("/monitor-rules", responses=ANNOUNCEMENT_MONITOR_RULE_LIST_RESPONSES)
-    async def get_monitor_rules():
+    async def get_monitor_rules(
+        service: AnnouncementService = Depends(get_announcement_service_dependency),
+    ):
         """
         获取监控规则列表
 
@@ -325,7 +326,6 @@ if HAS_ANNOUNCEMENT_SERVICE:
             List: 监控规则列表
         """
         try:
-            service = get_announcement_service()
             session = service.SessionLocal()
 
             try:
@@ -350,7 +350,8 @@ if HAS_ANNOUNCEMENT_SERVICE:
 
     @router.post("/monitor-rules", responses=ANNOUNCEMENT_MONITOR_RULE_CREATE_RESPONSES)
     async def create_monitor_rule(
-        rule_data: dict = Body(..., openapi_examples=ANNOUNCEMENT_MONITOR_RULE_CREATE_EXAMPLES)
+        rule_data: dict = Body(..., openapi_examples=ANNOUNCEMENT_MONITOR_RULE_CREATE_EXAMPLES),
+        service: AnnouncementService = Depends(get_announcement_service_dependency),
     ):
         """
         创建监控规则
@@ -362,7 +363,6 @@ if HAS_ANNOUNCEMENT_SERVICE:
             Dict: 创建的规则
         """
         try:
-            service = get_announcement_service()
             session = service.SessionLocal()
 
             try:
@@ -413,6 +413,7 @@ if HAS_ANNOUNCEMENT_SERVICE:
     async def update_monitor_rule(
         rule_id: int = Path(..., description="需要更新的公告监控规则ID。"),
         updates: dict = Body(..., openapi_examples=ANNOUNCEMENT_MONITOR_RULE_UPDATE_EXAMPLES),
+        service: AnnouncementService = Depends(get_announcement_service_dependency),
     ):
         """
         更新监控规则
@@ -425,7 +426,6 @@ if HAS_ANNOUNCEMENT_SERVICE:
             Dict: 更新后的规则
         """
         try:
-            service = get_announcement_service()
             session = service.SessionLocal()
 
             try:
@@ -462,7 +462,10 @@ if HAS_ANNOUNCEMENT_SERVICE:
             raise BusinessException(status_code=500, detail=str(e))
 
     @router.delete("/monitor-rules/{rule_id}", responses=ANNOUNCEMENT_MONITOR_RULE_DELETE_RESPONSES)
-    async def delete_monitor_rule(rule_id: int = Path(..., description="需要删除的公告监控规则ID。")):
+    async def delete_monitor_rule(
+        rule_id: int = Path(..., description="需要删除的公告监控规则ID。"),
+        service: AnnouncementService = Depends(get_announcement_service_dependency),
+    ):
         """
         删除监控规则
 
@@ -473,7 +476,6 @@ if HAS_ANNOUNCEMENT_SERVICE:
             Dict: 操作结果
         """
         try:
-            service = get_announcement_service()
             session = service.SessionLocal()
 
             try:
@@ -499,6 +501,7 @@ if HAS_ANNOUNCEMENT_SERVICE:
         stock_code: Optional[str] = Query(None, description="股票代码"),
         page: int = Query(1, ge=1, description="页码"),
         page_size: int = Query(20, ge=1, le=100, description="每页数量"),
+        service: AnnouncementService = Depends(get_announcement_service_dependency),
     ):
         """
         获取触发记录列表
@@ -513,7 +516,6 @@ if HAS_ANNOUNCEMENT_SERVICE:
             Dict: 触发记录列表
         """
         try:
-            service = get_announcement_service()
             session = service.SessionLocal()
 
             try:
@@ -569,7 +571,9 @@ if HAS_ANNOUNCEMENT_SERVICE:
             raise BusinessException(status_code=500, detail=str(e))
 
     @router.post("/monitor/evaluate", responses=ANNOUNCEMENT_MONITOR_EVALUATE_RESPONSES)
-    async def evaluate_monitor_rules():
+    async def evaluate_monitor_rules(
+        service: AnnouncementService = Depends(get_announcement_service_dependency),
+    ):
         """
         评估所有监控规则
 
@@ -579,8 +583,6 @@ if HAS_ANNOUNCEMENT_SERVICE:
             Dict: 评估结果
         """
         try:
-            service = get_announcement_service()
-
             result = service.evaluate_monitor_rules()
 
             if not result["success"]:

--- a/web/backend/app/services/announcement_service.py
+++ b/web/backend/app/services/announcement_service.py
@@ -13,6 +13,7 @@ import logging
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 
+from fastapi import Request
 import pandas as pd
 from sqlalchemy import and_, create_engine, desc
 from sqlalchemy.orm import Session, sessionmaker
@@ -519,6 +520,7 @@ class AnnouncementService:
 
 # 全局单例
 _announcement_service = None
+ANNOUNCEMENT_SERVICE_STATE_KEY = "announcement_service"
 
 
 def get_announcement_service() -> AnnouncementService:
@@ -527,3 +529,18 @@ def get_announcement_service() -> AnnouncementService:
     if _announcement_service is None:
         _announcement_service = AnnouncementService()
     return _announcement_service
+
+
+def install_announcement_service(
+    app: Any, service: AnnouncementService | None = None
+) -> AnnouncementService:
+    selected_service = service if service is not None else get_announcement_service()
+    setattr(app.state, ANNOUNCEMENT_SERVICE_STATE_KEY, selected_service)
+    return selected_service
+
+
+def get_announcement_service_dependency(request: Request) -> AnnouncementService:
+    service = getattr(request.app.state, ANNOUNCEMENT_SERVICE_STATE_KEY, None)
+    if service is None:
+        service = install_announcement_service(request.app)
+    return service

--- a/web/backend/tests/test_announcement_service_lifecycle_di.py
+++ b/web/backend/tests/test_announcement_service_lifecycle_di.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import inspect
+from datetime import date
+from types import SimpleNamespace
+
+import pytest
+
+from app.api.announcement import routes
+from app.services import announcement_service
+
+
+def test_announcement_service_dependency_installs_app_state_when_missing(monkeypatch):
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+    request = SimpleNamespace(app=fake_app)
+
+    monkeypatch.setattr(announcement_service, "get_announcement_service", lambda: fake_service)
+
+    assert announcement_service.get_announcement_service_dependency(request) is fake_service
+    assert getattr(fake_app.state, announcement_service.ANNOUNCEMENT_SERVICE_STATE_KEY) is fake_service
+
+
+def test_announcement_routes_accept_injected_announcement_service():
+    for function_name in [
+        "fetch_announcements",
+        "get_announcements",
+        "get_today_announcements",
+        "get_important_announcements",
+        "get_announcement_stats",
+        "get_monitor_rules",
+        "create_monitor_rule",
+        "update_monitor_rule",
+        "delete_monitor_rule",
+        "get_triggered_records",
+        "evaluate_monitor_rules",
+    ]:
+        signature = inspect.signature(getattr(routes, function_name))
+        assert "service" in signature.parameters
+
+
+@pytest.mark.asyncio
+async def test_fetch_announcements_uses_injected_announcement_service():
+    class FakeAnnouncementService:
+        def __init__(self):
+            self.fetch_kwargs = None
+
+        def fetch_and_save_announcements(self, **kwargs):
+            self.fetch_kwargs = kwargs
+            return {"success": True, "saved": 1}
+
+    fake_service = FakeAnnouncementService()
+    start = date(2026, 5, 1)
+    end = date(2026, 5, 2)
+
+    response = await routes.fetch_announcements(
+        symbol="000001",
+        start_date=start,
+        end_date=end,
+        category="all",
+        service=fake_service,
+    )
+
+    assert response == {"success": True, "saved": 1}
+    assert fake_service.fetch_kwargs == {
+        "symbol": "000001",
+        "start_date": start,
+        "end_date": end,
+        "category": "all",
+    }


### PR DESCRIPTION
## Summary
- Add app.state-backed lifecycle provider helpers for AnnouncementService while preserving get_announcement_service as the compatibility getter.
- Convert 11 announcement route handlers from route-body get_announcement_service() calls to injected AnnouncementService dependencies.
- Add focused TDD coverage for dependency installation, route signatures, and fetch_announcements injected-service behavior.
- Record implementation evidence and update the CODEBASE-MAP steward tree to the G2.6 implementation review gate.

## Boundary
- Authorized by PR #145.
- No watchlist service, adapter/data-layer files, email services, route path/method changes, OpenAPI exposure policy changes, docs/API, generated clients, OpenSpec changes, PM2 commands, frontend files, or issue label changes.

## Verification
- Pre-edit GitNexus impact: AnnouncementService LOW; get_announcement_service MEDIUM with 11 direct announcement route callers and 0 affected processes.
- RED: new announcement lifecycle DI tests failed for missing dependency helper, missing route service parameter, and fetch_announcements rejecting service=.
- GREEN focused pytest: 4 passed.
- ruff touched files: All checks passed.
- announcement import smoke: passed.
- Markdown governance gate: 2 checked files, 0 errors.
- Mainline scope gate: pass=True.
- git diff HEAD~1 HEAD --check: passed.
- GitNexus staged detect_changes: risk_level=low, affected_count=0, affected_processes=[].
