### PR TITLE
docs: record announcement service DI closeout

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -440,8 +440,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `.planning/codebase/generated/service-lifecycle-di-second-candidate-selection-2026-05-22.json`,
 │   │   `backend-announcement-service-lifecycle-di-implementation-authorization-2026-05-22.md`,
 │   │   `.planning/codebase/generated/announcement-service-lifecycle-di-implementation-authorization-2026-05-22.json`,
-│   │   `backend-announcement-service-lifecycle-di-implementation-2026-05-22.md`
-│   ├── State: announcement-service-di-implementation-prepared-for-review
+│   │   `backend-announcement-service-lifecycle-di-implementation-2026-05-22.md`,
+│   │   `backend-announcement-service-lifecycle-di-closeout-2026-05-22.md`
+│   ├── State: announcement-service-di-pilot-merged-and-recorded
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -475,12 +476,16 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 `e9d674c01edc5e701a0b3eca80b05f62dfc4986f`; G2.6 now
 │   │                 implements that approved scope by adding an app-state
 │   │                 provider seam to `announcement_service.py` and injecting
-│   │                 `AnnouncementService` into 11 announcement route handlers
-│   └── Next gate: Human review of the G2.6 implementation PR; if merged, create
-│                  a separate closeout record before selecting any third service
-│                  lifecycle DI candidate; no OpenSpec proposal, issue-label
+│   │                 `AnnouncementService` into 11 announcement route handlers;
+│   │                 PR `#146` was approved by the human maintainer and merged
+│   │                 at `517f47cb86aa32d32514d8588a653b08898f72c7`; G2.7
+│   │                 records the merged result and confirms the closeout
+│   │                 boundary
+│   └── Next gate: Human review of the G2.7 closeout record; do not select or
+│                  implement a third service lifecycle DI candidate until this
+│                  closeout is accepted; no OpenSpec proposal, issue-label
 │                  change, PM2 command, or `ready-for-agent` movement is
-│                  authorized by this implementation PR
+│                  authorized by this closeout
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -642,6 +647,10 @@ review, PR review, or OpenSpec archive review.
 | G2.1 service lifecycle DI candidate classification | Corrected module singleton scan and GitNexus impact comparison | `ecc39139` | 21 module-level singleton-variable files classified; `email_service.py` selected as first future pilot candidate with `EmailService` LOW impact and file-disambiguated `get_email_service` MEDIUM impact; source edits remain locked behind separate G2.2 implementation authorization |
 | G2.2 email service DI authorization | `email_service.py` implementation authorization | `35e9b2b3d` | PR `#141` merged; future source lane was authorized only for `email_service.py`, six `notification.py` consumers, focused tests, report, and task card |
 | G2.3 email service DI implementation | First service lifecycle DI source pilot | `20657e6e` | PR `#142` merged after human approval; `email_service.py` now provides app.state dependency provider, six `notification.py` email routes inject `EmailService`, focused tests passed, GitHub contract/mainline checks passed, and `email_notification_service.py` remains untouched |
+| G2.4 service lifecycle steward retrospective | First-pilot evidence review and second-candidate selection | `f149534f` | PR `#144` merged; steward-tree operating lessons recorded; `announcement_service.py` selected over `watchlist_service.py` as next authorization candidate, with source edits still locked behind a separate authorization packet |
+| G2.5 announcement service DI authorization | `announcement_service.py` implementation authorization | `e9d674c0` | PR `#145` merged; future source lane was authorized only for `announcement_service.py`, announcement routes, focused tests, implementation report, and task card |
+| G2.6 announcement service DI implementation | Second service lifecycle DI source pilot | `517f47cb` | PR `#146` merged after human approval; `announcement_service.py` now provides app.state dependency provider, 11 announcement route handlers inject `AnnouncementService`, focused tests passed, and watchlist/adapter/data-layer files remain untouched |
+| G2.7 announcement service DI closeout | Merged implementation closeout | `517f47cb` | Closeout prepared: record PR `#146` as merged and reviewed; do not start a third service lifecycle DI candidate until this closeout record is accepted |
 
 ## Update Protocol
 
@@ -676,7 +685,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review `announcement_service.py` lifecycle DI implementation | Future service seam lane | G2.6 implementation PR prepared; if merged, create a closeout record before selecting any third service lifecycle DI candidate |
+| P2 | Review `announcement_service.py` lifecycle DI closeout | Future service seam lane | G2.7 closeout record prepared; `announcement_service.py` is merged and recorded, and no third service lifecycle DI candidate is authorized before closeout acceptance |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/docs/reports/quality/backend-announcement-service-lifecycle-di-closeout-2026-05-22.md
+++ b/docs/reports/quality/backend-announcement-service-lifecycle-di-closeout-2026-05-22.md
@@ -1,0 +1,151 @@
+# Backend Announcement Service Lifecycle DI Closeout - 2026-05-22
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: completed-and-recorded
+- Workline: G2.7 service lifecycle DI implementation closeout
+- Completed pilot: `web/backend/app/services/announcement_service.py`
+- Implementation PR: https://github.com/chengjon/mystocks/pull/146
+- Implementation merge commit: `517f47cb86aa32d32514d8588a653b08898f72c7`
+- Closeout branch: `g2-7-announcement-service-di-closeout`
+- Recorded at: `2026-05-22T19:23:37+08:00`
+
+## Decision
+
+The human maintainer approved PR `#146` after the G2.6 implementation review.
+PR `#146` was merged into `wip/root-dirty-20260403` at
+`517f47cb86aa32d32514d8588a653b08898f72c7`.
+
+This closeout records the completed second service lifecycle DI pilot. It does
+not authorize a third service lifecycle DI candidate.
+
+## Completed Scope
+
+PR `#146` completed the exact G2.5 authorized implementation scope:
+
+- `web/backend/app/services/announcement_service.py`
+- `web/backend/app/api/announcement/routes.py`
+- `web/backend/tests/test_announcement_service_lifecycle_di.py`
+- `docs/reports/quality/backend-announcement-service-lifecycle-di-implementation-2026-05-22.md`
+- `governance/mainline/task-cards/pr-146.yaml`
+
+## Functional Result
+
+`announcement_service.py` now follows the same lifecycle DI pattern as the
+earlier `email_service.py` pilot:
+
+- `get_announcement_service()` remains as the compatibility getter.
+- `ANNOUNCEMENT_SERVICE_STATE_KEY` is defined.
+- `install_announcement_service(...)` installs an `AnnouncementService` into
+  `app.state`.
+- `get_announcement_service_dependency(...)` reads from `app.state` and lazily
+  installs the compatibility singleton when needed.
+
+The 11 announcement route handlers now receive `AnnouncementService` through
+FastAPI dependency injection:
+
+- `fetch_announcements`
+- `get_announcements`
+- `get_today_announcements`
+- `get_important_announcements`
+- `get_announcement_stats`
+- `get_monitor_rules`
+- `create_monitor_rule`
+- `update_monitor_rule`
+- `delete_monitor_rule`
+- `get_triggered_records`
+- `evaluate_monitor_rules`
+
+Post-merge shape check:
+
+| Check | Result |
+|---|---:|
+| Direct `get_announcement_service()` calls in `announcement/routes.py` | 0 |
+| Route dependency parameters | 11 |
+| Compatibility getter retained | yes |
+| `ANNOUNCEMENT_SERVICE_STATE_KEY` present | yes |
+| `install_announcement_service` present | yes |
+| `get_announcement_service_dependency` present | yes |
+
+## Preserved Boundaries
+
+PR `#146` did not modify:
+
+- `web/backend/app/services/watchlist_service.py`
+- `web/backend/app/services/data_adapters/watchlist.py`
+- `web/backend/app/services/adapters/watchlist_adapter.py`
+- `web/backend/app/services/email_service.py`
+- `web/backend/app/services/email_notification_service.py`
+- `docs/api/`
+- generated clients
+- OpenSpec proposal/spec files
+- frontend files
+- PM2 scripts or runtime process configuration
+- issue labels
+
+## Verification Summary
+
+Post-merge focused pytest:
+
+```bash
+env PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov \
+  web/backend/tests/test_announcement_service_lifecycle_di.py \
+  web/backend/tests/test_announcement_routes_regressions.py
+```
+
+Result: `4 passed`.
+
+Post-merge ruff:
+
+```bash
+ruff check \
+  web/backend/app/services/announcement_service.py \
+  web/backend/app/api/announcement/routes.py \
+  web/backend/tests/test_announcement_service_lifecycle_di.py \
+  web/backend/tests/test_announcement_routes_regressions.py
+```
+
+Result: `All checks passed!`
+
+Post-merge import smoke:
+
+```bash
+env PYTHONPATH=web/backend python - <<'PY'
+from app.services.announcement_service import (
+    AnnouncementService,
+    get_announcement_service,
+    get_announcement_service_dependency,
+    install_announcement_service,
+)
+from app.api.announcement import routes
+
+print("announcement service DI import smoke passed")
+PY
+```
+
+Result: `announcement service DI import smoke passed`.
+
+PR `#146` implementation verification also recorded:
+
+- Pre-edit GitNexus: `AnnouncementService` LOW, `get_announcement_service`
+  MEDIUM with 11 direct route callers and 0 affected processes.
+- TDD RED observed before implementation.
+- Focused pytest passed.
+- Ruff passed.
+- Import smoke passed.
+- Markdown governance passed.
+- Mainline scope gate passed.
+- GitNexus staged `detect_changes` reported low risk and no affected
+  processes.
+
+## Remaining Gate
+
+Do not start a third service lifecycle DI candidate from issue `#79` until this
+closeout PR is reviewed and accepted.
+
+If accepted, the next service lifecycle lane should begin again at candidate
+selection or authorization, not implementation.

--- a/governance/mainline/task-cards/pr-147.yaml
+++ b/governance/mainline/task-cards/pr-147.yaml
@@ -1,0 +1,97 @@
+version: "v0.2"
+
+task:
+  id: "pr-147"
+  title: "record announcement service DI implementation closeout"
+  owner: "main"
+  created_at: "2026-05-22"
+
+mainline:
+  id: "L1-service-lifecycle-di-announcement-service-closeout"
+  objective: "record that the announcement_service.py lifecycle DI pilot was reviewed, merged, and remains bounded to the approved second candidate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-announcement-service-di-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-announcement-service-di-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout record and steward-tree update only; no runtime entrypoint, route, page, shim, service behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "docs/reports/quality/backend-announcement-service-lifecycle-di-closeout-2026-05-22.md"
+    - "governance/mainline/task-cards/pr-147.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, PM2, or runtime behavior changes"
+  - "No additional service lifecycle DI implementation"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes"
+  - "No movement of issue #79 or #92 to ready-for-agent"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-announcement-service-lifecycle-di-closeout-2026-05-22.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-147.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is misread as approval for a third service migration, issue #79 can expand beyond reviewed scope"
+    - "If issue state is changed here, the governance record diverges from the parent decision trail"
+  rollback_plan: "revert this PR and return the steward tree to the PR #146 merged-but-unrecorded state"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record announcement_service.py lifecycle DI pilot completion after PR #146 merge"
+    modified_scope: "steward tree, closeout report, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance bookkeeping only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-22T19:23:37+08:00"
+    approval_note: "human maintainer approved PR #146 merge; this PR records completion only and does not authorize a third service migration"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Record PR #146 as reviewed, approved, and merged for the announcement_service.py lifecycle DI pilot.
- Update the CODEBASE-MAP steward tree from G2.6 implementation review to G2.7 merged-and-recorded closeout.
- Add the G2.7 closeout report and governance task card.

## Boundary
- Governance-only PR.
- No backend source, frontend source, tests, docs/API, generated clients, OpenSpec changes, issue labels, PM2 commands, or runtime behavior changes.
- Does not authorize a third service lifecycle DI candidate.

## Verification
- Post-merge focused pytest: 4 passed.
- Post-merge ruff touched files: All checks passed.
- Post-merge announcement import smoke: passed.
- Shape check: 0 direct route getter calls; 11 route dependency parameters; compatibility getter/provider helpers present.
- Markdown governance gate: 2 checked files, 0 errors.
- Mainline scope gate: pass=True.
- git diff HEAD~1 HEAD --check: passed.
- GitNexus staged detect_changes: low risk, 0 changed symbols/processes.
