### PR TITLE
docs: prepare third service DI candidate selection

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -441,8 +441,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-announcement-service-lifecycle-di-implementation-authorization-2026-05-22.md`,
 │   │   `.planning/codebase/generated/announcement-service-lifecycle-di-implementation-authorization-2026-05-22.json`,
 │   │   `backend-announcement-service-lifecycle-di-implementation-2026-05-22.md`,
-│   │   `backend-announcement-service-lifecycle-di-closeout-2026-05-22.md`
-│   ├── State: announcement-service-di-pilot-merged-and-recorded
+│   │   `backend-announcement-service-lifecycle-di-closeout-2026-05-22.md`,
+│   │   `backend-service-lifecycle-di-third-candidate-selection-2026-05-22.md`,
+│   │   `.planning/codebase/generated/service-lifecycle-di-third-candidate-selection-2026-05-22.json`
+│   ├── State: third-candidate-selection-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -480,12 +482,16 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 PR `#146` was approved by the human maintainer and merged
 │   │                 at `517f47cb86aa32d32514d8588a653b08898f72c7`; G2.7
 │   │                 records the merged result and confirms the closeout
-│   │                 boundary
-│   └── Next gate: Human review of the G2.7 closeout record; do not select or
-│                  implement a third service lifecycle DI candidate until this
-│                  closeout is accepted; no OpenSpec proposal, issue-label
-│                  change, PM2 command, or `ready-for-agent` movement is
-│                  authorized by this closeout
+│   │                 boundary; PR `#147` merged at
+│   │                 `112487d96ad07ad3212c71e729395f2c8accfed1`; G2.8
+│   │                 selects a route-surface-only `watchlist_service.py`
+│   │                 authorization candidate while keeping watchlist adapter and
+│   │                 data-layer helper calls as compatibility surfaces
+│   └── Next gate: Human review of the G2.8 third-candidate selection package;
+│                  if accepted, create a separate G2.9 route-surface-only
+│                  `watchlist_service.py` implementation authorization packet;
+│                  no source edits, OpenSpec proposal, issue-label change, PM2
+│                  command, or `ready-for-agent` movement is authorized by G2.8
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -650,7 +656,8 @@ review, PR review, or OpenSpec archive review.
 | G2.4 service lifecycle steward retrospective | First-pilot evidence review and second-candidate selection | `f149534f` | PR `#144` merged; steward-tree operating lessons recorded; `announcement_service.py` selected over `watchlist_service.py` as next authorization candidate, with source edits still locked behind a separate authorization packet |
 | G2.5 announcement service DI authorization | `announcement_service.py` implementation authorization | `e9d674c0` | PR `#145` merged; future source lane was authorized only for `announcement_service.py`, announcement routes, focused tests, implementation report, and task card |
 | G2.6 announcement service DI implementation | Second service lifecycle DI source pilot | `517f47cb` | PR `#146` merged after human approval; `announcement_service.py` now provides app.state dependency provider, 11 announcement route handlers inject `AnnouncementService`, focused tests passed, and watchlist/adapter/data-layer files remain untouched |
-| G2.7 announcement service DI closeout | Merged implementation closeout | `517f47cb` | Closeout prepared: record PR `#146` as merged and reviewed; do not start a third service lifecycle DI candidate until this closeout record is accepted |
+| G2.7 announcement service DI closeout | Merged implementation closeout | `112487d9` | PR `#147` merged; `announcement_service.py` is recorded as merged-and-reviewed, and third-candidate work may only begin as a new selection/authorization packet |
+| G2.8 third service DI candidate selection | Post-closeout candidate split decision | `112487d9` | Selection prepared: recommend only a route-surface `watchlist_service.py` authorization packet; keep watchlist adapter/data-layer helper callers out of scope unless a separate adapter-aware packet is accepted |
 
 ## Update Protocol
 
@@ -685,7 +692,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review `announcement_service.py` lifecycle DI closeout | Future service seam lane | G2.7 closeout record prepared; `announcement_service.py` is merged and recorded, and no third service lifecycle DI candidate is authorized before closeout acceptance |
+| P2 | Review service lifecycle DI third-candidate selection | Future service seam lane | G2.8 selection packet prepared; `watchlist_service.py` is recommended only for a route-surface authorization candidate, with adapter/data-layer helper calls retained as compatibility surfaces |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/generated/service-lifecycle-di-third-candidate-selection-2026-05-22.json
+++ b/.planning/codebase/generated/service-lifecycle-di-third-candidate-selection-2026-05-22.json
@@ -1,0 +1,140 @@
+{
+  "artifact": "service-lifecycle-di-third-candidate-selection",
+  "generated_at": "2026-05-22T19:35:12+08:00",
+  "git_branch": "g2-8-third-service-di-candidate-selection",
+  "git_head": "112487d96ad07ad3212c71e729395f2c8accfed1",
+  "status": "for-review",
+  "mode": "candidate-selection-only",
+  "source_code_changed": false,
+  "tests_changed": false,
+  "runtime_behavior_changed": false,
+  "issues": {
+    "service_lifecycle_parent": {
+      "number": 79,
+      "state": "OPEN",
+      "labels": [
+        "needs-triage"
+      ]
+    },
+    "downstream_decision_parent": {
+      "number": 92,
+      "state": "OPEN",
+      "labels": [
+        "enhancement",
+        "ready-for-human",
+        "ready-for-downstream"
+      ]
+    }
+  },
+  "completed_pilots": [
+    {
+      "candidate": "web/backend/app/services/email_service.py",
+      "implementation_pr": 142,
+      "implementation_merge_commit": "20657e6e86a3423b15c67b6a8d6e165fbaa47b72",
+      "closeout_pr": 143
+    },
+    {
+      "candidate": "web/backend/app/services/announcement_service.py",
+      "implementation_pr": 146,
+      "implementation_merge_commit": "517f47cb86aa32d32514d8588a653b08898f72c7",
+      "closeout_pr": 147,
+      "closeout_merge_commit": "112487d96ad07ad3212c71e729395f2c8accfed1"
+    }
+  ],
+  "candidate_comparison": [
+    {
+      "candidate": "web/backend/app/services/watchlist_service.py",
+      "service_class": "WatchlistService",
+      "getter": "get_watchlist_service",
+      "class_impact": {
+        "risk": "LOW",
+        "direct_callers": 0,
+        "processes_affected": 0
+      },
+      "getter_impact": {
+        "risk": "MEDIUM",
+        "direct_callers": 9,
+        "impacted_count": 15,
+        "processes_affected": 0,
+        "modules_affected": [
+          "Data_adapters",
+          "Adapters"
+        ]
+      },
+      "direct_owner_files": [
+        "web/backend/app/api/watchlist.py",
+        "web/backend/app/services/data_adapters/watchlist.py",
+        "web/backend/app/services/adapters/watchlist_adapter.py"
+      ],
+      "selection_result": "recommended_route_surface_authorization_candidate_only"
+    },
+    {
+      "candidate": "web/backend/app/services/tradingview_widget_service.py",
+      "service_class": "TradingViewWidgetService",
+      "getter": "get_tradingview_service",
+      "class_impact": {
+        "risk": "LOW",
+        "direct_callers": 0,
+        "processes_affected": 0
+      },
+      "getter_impact": {
+        "risk": "LOW",
+        "direct_callers": 1,
+        "impacted_count": 1,
+        "processes_affected": 0
+      },
+      "selection_result": "reference_only_already_has_provider_app_state_pattern"
+    }
+  ],
+  "recommended_next_candidate": "web/backend/app/services/watchlist_service.py",
+  "recommended_scope": "route-surface-only",
+  "future_packet_required": {
+    "workline": "G2.9",
+    "type": "implementation-authorization",
+    "source_edits_authorized_by_this_artifact": false,
+    "minimum_future_scope_to_evaluate": [
+      "web/backend/app/services/watchlist_service.py",
+      "web/backend/app/api/watchlist.py",
+      "focused tests for watchlist route dependency behavior"
+    ],
+    "must_define": [
+      "exact backend source write scope",
+      "exact test write scope",
+      "route functions to convert",
+      "app-state/provider installation pattern",
+      "compatibility getter retention rule",
+      "adapter/data-layer compatibility-retention rule",
+      "GitNexus pre-edit impact commands",
+      "rollback plan",
+      "targeted tests",
+      "lint and import smoke commands",
+      "forbidden scope"
+    ]
+  },
+  "explicitly_out_of_scope_for_future_g2_9_unless_separately_approved": [
+    "web/backend/app/services/data_adapters/watchlist.py",
+    "web/backend/app/services/adapters/watchlist_adapter.py",
+    "web/backend/app/services/email_service.py",
+    "web/backend/app/services/announcement_service.py",
+    "web/backend/app/services/tradingview_widget_service.py",
+    "route/OpenAPI contract rewrites",
+    "docs/API edits",
+    "generated clients",
+    "PM2 commands",
+    "issue label changes",
+    "OpenSpec proposal or spec creation"
+  ],
+  "forbidden_scope": [
+    "backend source edits",
+    "frontend source edits",
+    "test edits",
+    "generated client edits",
+    "docs/API edits",
+    "OpenSpec proposal or spec creation",
+    "issue label changes",
+    "PM2 commands",
+    "runtime rollout",
+    "ready-for-agent movement"
+  ],
+  "next_gate": "Human review of the G2.8 selection package; if accepted, create a separate G2.9 route-surface-only watchlist_service.py implementation authorization packet."
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-third-candidate-selection-2026-05-22.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-third-candidate-selection-2026-05-22.md
@@ -1,0 +1,169 @@
+# Backend Service Lifecycle DI Third Candidate Selection - 2026-05-22
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: for-review
+- Workline: G2.8 service lifecycle DI third candidate selection
+- Parent issue: https://github.com/chengjon/mystocks/issues/79
+- Parent decision issue: https://github.com/chengjon/mystocks/issues/92
+- Current HEAD checked: `112487d96ad07ad3212c71e729395f2c8accfed1`
+- Current branch: `g2-8-third-service-di-candidate-selection`
+- Generated artifact: `.planning/codebase/generated/service-lifecycle-di-third-candidate-selection-2026-05-22.json`
+
+Boundary note: This package is a candidate-selection packet only. It does not
+authorize backend source edits, frontend source edits, tests, generated client
+updates, docs/API edits, OpenSpec proposal creation, issue label changes, PM2
+commands, runtime rollout, or movement of issue `#79` or issue `#92` to
+`ready-for-agent`.
+
+## Input State
+
+Two service lifecycle DI source pilots are now merged and recorded:
+
+| Pilot | PR | Merge commit | Closeout |
+|---|---:|---|---|
+| `email_service.py` | `#142` | `20657e6e86a3423b15c67b6a8d6e165fbaa47b72` | PR `#143` |
+| `announcement_service.py` | `#146` | `517f47cb86aa32d32514d8588a653b08898f72c7` | PR `#147` |
+
+Current GitHub state checked during this packet:
+
+| Issue | State | Labels | Meaning for this packet |
+|---|---|---|---|
+| `#79` | OPEN | `needs-triage` | Parent service lifecycle DI lane remains open, but no third service source edit is authorized |
+| `#92` | OPEN | `enhancement`, `ready-for-human`, `ready-for-downstream` | Downstream decision governance remains active; this packet is a review input only |
+
+## Candidate Source
+
+The accepted G2.1 candidate classification and G2.4 second-candidate selection
+remain the source for narrowing the next choice:
+
+- `backend-service-lifecycle-di-candidate-classification-2026-05-22.md`
+- `.planning/codebase/generated/service-lifecycle-di-candidate-classification-2026-05-22.json`
+- `backend-service-lifecycle-di-second-candidate-selection-2026-05-22.md`
+- `.planning/codebase/generated/service-lifecycle-di-second-candidate-selection-2026-05-22.json`
+
+After `email_service.py` and `announcement_service.py`, the remaining practical
+candidate is `watchlist_service.py`, but it is not a clean single-route-surface
+candidate.
+
+## Current-HEAD Candidate Comparison
+
+| Candidate | Getter | GitNexus risk | Direct callers | Extra impacted symbols | Direct owner surface | Selection result |
+|---|---|---:|---:|---:|---|---|
+| `watchlist_service.py` | `get_watchlist_service` | MEDIUM | 9 | 6 transitive adapter/data symbols | route + adapter/data helper surfaces | Candidate only for a split route-surface authorization packet |
+| `tradingview_widget_service.py` | `get_tradingview_service` | LOW | 1 | 0 | already has provider/app-state pattern | Reference evidence only; no migration candidate |
+
+## GitNexus Evidence
+
+### `WatchlistService`
+
+- Target: `Class:web/backend/app/services/watchlist_service.py:WatchlistService`
+- Risk: LOW
+- Direct callers: 0
+- Processes affected: 0
+
+### `get_watchlist_service`
+
+- Target: `Function:web/backend/app/services/watchlist_service.py:get_watchlist_service`
+- Risk: MEDIUM
+- Impacted count: 15
+- Direct callers: 9
+- Processes affected: 0
+- Modules affected: `Data_adapters`, `Adapters`
+
+Direct caller files:
+
+- `web/backend/app/api/watchlist.py`
+- `web/backend/app/services/data_adapters/watchlist.py`
+- `web/backend/app/services/adapters/watchlist_adapter.py`
+
+The route direct callers are:
+
+- `get_user_groups`
+- `create_group`
+- `update_group`
+- `delete_group`
+- `get_watchlist_by_group`
+- `move_stock_to_group`
+- `get_watchlist_with_groups`
+
+The adapter/data-layer direct callers are helper functions named
+`_get_watchlist_service` in:
+
+- `web/backend/app/services/data_adapters/watchlist.py`
+- `web/backend/app/services/adapters/watchlist_adapter.py`
+
+## Current Shape Evidence
+
+| File | Lines | Current direct getter surface | Existing DI signal | Disposition |
+|---|---:|---:|---:|---|
+| `web/backend/app/services/watchlist_service.py` | 621 | `_watchlist_service = None`; compatibility getter exists | no app-state provider yet | candidate service file |
+| `web/backend/app/api/watchlist.py` | 674 | 7 route-level getter calls | 15 existing `Depends(...)` uses | route-surface candidate |
+| `web/backend/app/services/data_adapters/watchlist.py` | 289 | helper uses getter | no FastAPI route DI surface | leave out of route-surface pilot |
+| `web/backend/app/services/adapters/watchlist_adapter.py` | 290 | helper uses getter | no FastAPI route DI surface | leave out of route-surface pilot |
+| `web/backend/app/services/tradingview_widget_service.py` | 358 | provider pattern already exists | `install_tradingview_service`, `get_tradingview_service_dependency` | reference only |
+
+## Recommendation
+
+Prepare a future G2.9 authorization packet for a route-surface-only
+`watchlist_service.py` lifecycle DI pilot.
+
+That packet should not claim full getter retirement. It should authorize only:
+
+- adding app-state provider helpers to `watchlist_service.py`
+- converting the 7 direct route handlers in `web/backend/app/api/watchlist.py`
+  to inject `WatchlistService`
+- adding focused tests for watchlist route dependency injection
+- keeping adapter/data-layer `_get_watchlist_service` helper calls as
+  compatibility callers
+
+The adapter/data-layer files should remain out of scope unless a separate
+adapter-aware authorization packet explicitly accepts their broader surface.
+
+## Future G2.9 Authorization Packet Requirements
+
+If this G2.8 selection is accepted, the next packet must define:
+
+- exact backend source write scope
+- exact test write scope
+- route functions to convert from direct getter calls to dependency injection
+- app-state/provider installation pattern
+- compatibility getter retention rule
+- adapter/data-layer compatibility-retention rule
+- GitNexus pre-edit impact commands
+- rollback plan
+- targeted tests
+- lint and import smoke commands
+- forbidden scope
+
+Minimum future write scope to evaluate, not yet authorized:
+
+- `web/backend/app/services/watchlist_service.py`
+- `web/backend/app/api/watchlist.py`
+- focused tests for watchlist route dependency behavior
+
+Explicitly out of scope for the future G2.9 packet unless separately approved:
+
+- `web/backend/app/services/data_adapters/watchlist.py`
+- `web/backend/app/services/adapters/watchlist_adapter.py`
+- `email_service.py`
+- `announcement_service.py`
+- `tradingview_widget_service.py`
+- route/OpenAPI contract rewrites
+- docs/API edits
+- generated clients
+- PM2 commands
+- issue label changes
+- OpenSpec proposal/spec creation
+
+## Next Gate
+
+Human review of this G2.8 selection package.
+
+If accepted, create a separate G2.9 implementation authorization package for
+the route-surface-only `watchlist_service.py` pilot. Source edits remain locked
+until that G2.9 packet is reviewed and explicitly approved.

--- a/governance/mainline/task-cards/pr-148.yaml
+++ b/governance/mainline/task-cards/pr-148.yaml
@@ -1,0 +1,102 @@
+version: "v0.2"
+
+task:
+  id: "pr-148"
+  title: "prepare third service DI candidate selection"
+  owner: "main"
+  created_at: "2026-05-22"
+
+mainline:
+  id: "L1-service-lifecycle-di-third-candidate-selection"
+  objective: "prepare the G2.8 third service lifecycle DI candidate selection packet without source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-third-service-di-candidate-selection"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-third-service-di-candidate-selection"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate selection report, generated evidence artifact, and steward-tree update only; no runtime entrypoint, route, page, shim, service behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-di-third-candidate-selection-2026-05-22.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-third-candidate-selection-2026-05-22.md"
+    - "governance/mainline/task-cards/pr-148.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, PM2, or runtime behavior changes in this PR"
+  - "No watchlist_service.py implementation in this PR"
+  - "No adapter/data-layer implementation in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes"
+  - "No movement of issue #79 or #92 to ready-for-agent"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-third-candidate-selection-2026-05-22.md"
+      required: true
+    - id: "json-validity"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-di-third-candidate-selection-2026-05-22.json >/tmp/service-lifecycle-di-third-candidate-selection.json"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-148.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this selection packet is misread as source implementation authorization, issue #79 can expand before a G2.9 authorization package exists"
+    - "If watchlist adapter/data-layer files are bundled into a route-surface pilot, the third candidate can exceed the proven email/announcement pattern"
+  rollback_plan: "revert this PR and return the steward tree to the G2.7 announcement service closeout state"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "prepare route-surface-only watchlist_service.py third candidate selection after G2.7 closeout"
+    modified_scope: "steward tree, candidate-selection report, generated JSON, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance selection only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON validity, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-22T19:35:12+08:00"
+    approval_note: "human maintainer requested continuation after G2.7; this PR prepares third candidate selection only and does not authorize source implementation"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Record PR #147 closeout merge and move the steward tree to G2.8 third-candidate selection review.
- Add a governance-only selection packet for the next service lifecycle DI candidate.
- Recommend watchlist_service.py only as a future route-surface authorization candidate, with adapter/data-layer helper calls retained as compatibility surfaces.

## Boundary
- Governance-only PR.
- No backend source, frontend source, tests, docs/API, generated clients, OpenSpec changes, issue labels, PM2 commands, or runtime behavior changes.
- Does not authorize watchlist_service.py implementation; a separate G2.9 authorization packet is required before source edits.

## Evidence
- get_watchlist_service: MEDIUM, 9 direct callers, 15 impacted symbols, 0 affected processes.
- WatchlistService: LOW, 0 direct callers, 0 affected processes.
- get_tradingview_service: LOW, existing provider/app-state reference only.
- watchlist route surface has 7 route-level getter calls; watchlist adapter/data-layer helpers remain a separate compatibility surface.

## Verification
- Markdown governance gate: 2 checked files, 0 errors.
- JSON validity: passed.
- Mainline scope gate: pass=True.
- git diff HEAD~1 HEAD --check: passed.
- GitNexus staged detect_changes: low risk, 0 changed symbols/processes.
