### PR TITLE
docs: prepare watchlist service DI authorization

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -443,8 +443,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-announcement-service-lifecycle-di-implementation-2026-05-22.md`,
 │   │   `backend-announcement-service-lifecycle-di-closeout-2026-05-22.md`,
 │   │   `backend-service-lifecycle-di-third-candidate-selection-2026-05-22.md`,
-│   │   `.planning/codebase/generated/service-lifecycle-di-third-candidate-selection-2026-05-22.json`
-│   ├── State: third-candidate-selection-prepared-for-review
+│   │   `.planning/codebase/generated/service-lifecycle-di-third-candidate-selection-2026-05-22.json`,
+│   │   `backend-watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.md`,
+│   │   `.planning/codebase/generated/watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.json`
+│   ├── State: watchlist-route-surface-authorization-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -486,12 +488,19 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 `112487d96ad07ad3212c71e729395f2c8accfed1`; G2.8
 │   │                 selects a route-surface-only `watchlist_service.py`
 │   │                 authorization candidate while keeping watchlist adapter and
-│   │                 data-layer helper calls as compatibility surfaces
-│   └── Next gate: Human review of the G2.8 third-candidate selection package;
-│                  if accepted, create a separate G2.9 route-surface-only
-│                  `watchlist_service.py` implementation authorization packet;
-│                  no source edits, OpenSpec proposal, issue-label change, PM2
-│                  command, or `ready-for-agent` movement is authorized by G2.8
+│   │                 data-layer helper calls as compatibility surfaces; PR
+│   │                 `#148` merged at
+│   │                 `ccc4982cd11b47996c6534f087b0c9cb3783877a`; G2.9 now
+│   │                 records the route-surface-only implementation
+│   │                 authorization packet for `watchlist_service.py`, limited to
+│   │                 the service file, seven `watchlist.py` route handlers,
+│   │                 focused tests, an implementation report, and a future task
+│   │                 card while keeping adapter/data helper callers out of scope
+│   └── Next gate: Human review of the G2.9 watchlist implementation
+│                  authorization package; if accepted, create a separate source
+│                  implementation worktree and PR; no source edits, OpenSpec
+│                  proposal, issue-label change, PM2 command, or
+│                  `ready-for-agent` movement is authorized by this G2.9 packet
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -657,7 +666,8 @@ review, PR review, or OpenSpec archive review.
 | G2.5 announcement service DI authorization | `announcement_service.py` implementation authorization | `e9d674c0` | PR `#145` merged; future source lane was authorized only for `announcement_service.py`, announcement routes, focused tests, implementation report, and task card |
 | G2.6 announcement service DI implementation | Second service lifecycle DI source pilot | `517f47cb` | PR `#146` merged after human approval; `announcement_service.py` now provides app.state dependency provider, 11 announcement route handlers inject `AnnouncementService`, focused tests passed, and watchlist/adapter/data-layer files remain untouched |
 | G2.7 announcement service DI closeout | Merged implementation closeout | `112487d9` | PR `#147` merged; `announcement_service.py` is recorded as merged-and-reviewed, and third-candidate work may only begin as a new selection/authorization packet |
-| G2.8 third service DI candidate selection | Post-closeout candidate split decision | `112487d9` | Selection prepared: recommend only a route-surface `watchlist_service.py` authorization packet; keep watchlist adapter/data-layer helper callers out of scope unless a separate adapter-aware packet is accepted |
+| G2.8 third service DI candidate selection | Post-closeout candidate split decision | `ccc4982c` | PR `#148` merged; selection accepted: recommend only a route-surface `watchlist_service.py` authorization packet and keep watchlist adapter/data-layer helper callers out of scope unless a separate adapter-aware packet is accepted |
+| G2.9 watchlist service DI authorization | Route-surface-only `watchlist_service.py` implementation authorization | `ccc4982c` | Authorization packet prepared: future source lane may edit only `watchlist_service.py`, seven `watchlist.py` route handlers, focused tests, implementation report, future task card, and steward-tree evidence; this packet itself changes no source/tests/runtime and does not authorize adapter/data helper migration |
 
 ## Update Protocol
 
@@ -692,7 +702,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review service lifecycle DI third-candidate selection | Future service seam lane | G2.8 selection packet prepared; `watchlist_service.py` is recommended only for a route-surface authorization candidate, with adapter/data-layer helper calls retained as compatibility surfaces |
+| P2 | Review G2.9 watchlist service DI authorization packet | Future service seam lane | G2.9 authorization packet prepared; future implementation remains route-surface-only and may not edit watchlist adapter/data-layer helper callers unless a separate adapter-aware packet is accepted |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/generated/watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.json
+++ b/.planning/codebase/generated/watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.json
@@ -1,0 +1,209 @@
+{
+  "artifact": "watchlist-service-lifecycle-di-implementation-authorization",
+  "generated_at": "2026-05-22T19:52:00+08:00",
+  "status": "for-review",
+  "mode": "governance-authorization-only",
+  "git_branch": "g2-9-watchlist-service-di-authorization",
+  "git_head_checked": "ccc4982cd11b47996c6534f087b0c9cb3783877a",
+  "source_code_changed": false,
+  "tests_changed": false,
+  "runtime_behavior_changed": false,
+  "parent_issues": {
+    "79": {
+      "url": "https://github.com/chengjon/mystocks/issues/79",
+      "state": "OPEN",
+      "labels": [
+        "needs-triage"
+      ]
+    },
+    "92": {
+      "url": "https://github.com/chengjon/mystocks/issues/92",
+      "state": "OPEN",
+      "labels": [
+        "enhancement",
+        "ready-for-human",
+        "ready-for-downstream"
+      ]
+    }
+  },
+  "source_evidence": [
+    "docs/reports/quality/backend-service-lifecycle-di-third-candidate-selection-2026-05-22.md",
+    ".planning/codebase/generated/service-lifecycle-di-third-candidate-selection-2026-05-22.json",
+    "https://github.com/chengjon/mystocks/pull/148",
+    "ccc4982cd11b47996c6534f087b0c9cb3783877a"
+  ],
+  "authorization_decision": {
+    "candidate": "web/backend/app/services/watchlist_service.py",
+    "authorized_future_scope_type": "route-surface-only",
+    "adapter_data_helpers_authorized": false,
+    "source_edits_authorized_by_this_packet": false,
+    "next_step_if_accepted": "Create a separate source implementation worktree and PR for the allowed route-surface scope only."
+  },
+  "gitnexus_impact": {
+    "WatchlistService": {
+      "target": "Class:web/backend/app/services/watchlist_service.py:WatchlistService",
+      "direction": "upstream",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct_callers": 0,
+      "processes_affected": 0,
+      "modules_affected": 0
+    },
+    "get_watchlist_service": {
+      "target": "Function:web/backend/app/services/watchlist_service.py:get_watchlist_service",
+      "direction": "upstream",
+      "risk": "MEDIUM",
+      "impacted_count": 15,
+      "direct_callers": 9,
+      "processes_affected": 0,
+      "modules_affected": [
+        "Data_adapters",
+        "Adapters"
+      ],
+      "direct_callers_detail": [
+        {
+          "file": "web/backend/app/api/watchlist.py",
+          "symbol": "get_user_groups",
+          "future_disposition": "route-surface DI candidate"
+        },
+        {
+          "file": "web/backend/app/api/watchlist.py",
+          "symbol": "create_group",
+          "future_disposition": "route-surface DI candidate"
+        },
+        {
+          "file": "web/backend/app/api/watchlist.py",
+          "symbol": "update_group",
+          "future_disposition": "route-surface DI candidate"
+        },
+        {
+          "file": "web/backend/app/api/watchlist.py",
+          "symbol": "delete_group",
+          "future_disposition": "route-surface DI candidate"
+        },
+        {
+          "file": "web/backend/app/api/watchlist.py",
+          "symbol": "get_watchlist_by_group",
+          "future_disposition": "route-surface DI candidate"
+        },
+        {
+          "file": "web/backend/app/api/watchlist.py",
+          "symbol": "move_stock_to_group",
+          "future_disposition": "route-surface DI candidate"
+        },
+        {
+          "file": "web/backend/app/api/watchlist.py",
+          "symbol": "get_watchlist_with_groups",
+          "future_disposition": "route-surface DI candidate"
+        },
+        {
+          "file": "web/backend/app/services/data_adapters/watchlist.py",
+          "symbol": "_get_watchlist_service",
+          "future_disposition": "retain as compatibility caller"
+        },
+        {
+          "file": "web/backend/app/services/adapters/watchlist_adapter.py",
+          "symbol": "_get_watchlist_service",
+          "future_disposition": "retain as compatibility caller"
+        }
+      ],
+      "transitive_adapter_data_symbols_out_of_scope": [
+        "web/backend/app/services/data_adapters/watchlist.py::_fetch_watchlist_data",
+        "web/backend/app/services/data_adapters/watchlist.py::health_check",
+        "web/backend/app/services/adapters/watchlist_adapter.py::_fetch_watchlist_data",
+        "web/backend/app/services/adapters/watchlist_adapter.py::health_check",
+        "web/backend/app/services/data_adapters/watchlist.py::get_data",
+        "web/backend/app/services/adapters/watchlist_adapter.py::get_data"
+      ]
+    }
+  },
+  "current_route_surface": [
+    {
+      "function": "get_user_groups",
+      "method": "GET",
+      "path": "/groups",
+      "current_getter_line": 497
+    },
+    {
+      "function": "create_group",
+      "method": "POST",
+      "path": "/groups",
+      "current_getter_line": 520
+    },
+    {
+      "function": "update_group",
+      "method": "PUT",
+      "path": "/groups/{group_id}",
+      "current_getter_line": 555
+    },
+    {
+      "function": "delete_group",
+      "method": "DELETE",
+      "path": "/groups/{group_id}",
+      "current_getter_line": 584
+    },
+    {
+      "function": "get_watchlist_by_group",
+      "method": "GET",
+      "path": "/group/{group_id}",
+      "current_getter_line": 609
+    },
+    {
+      "function": "move_stock_to_group",
+      "method": "PUT",
+      "path": "/move",
+      "current_getter_line": 632
+    },
+    {
+      "function": "get_watchlist_with_groups",
+      "method": "GET",
+      "path": "/with-groups",
+      "current_getter_line": 667
+    }
+  ],
+  "future_allowed_write_scope": [
+    "web/backend/app/services/watchlist_service.py",
+    "web/backend/app/api/watchlist.py",
+    "web/backend/tests/test_watchlist_service_lifecycle_di.py",
+    "docs/reports/quality/backend-watchlist-service-lifecycle-di-implementation-2026-05-22.md",
+    "governance/mainline/task-cards/pr-<future-implementation-pr>.yaml",
+    ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+  ],
+  "explicitly_forbidden_scope": [
+    "web/backend/app/services/data_adapters/watchlist.py",
+    "web/backend/app/services/adapters/watchlist_adapter.py",
+    "web/backend/app/services/email_service.py",
+    "web/backend/app/services/email_notification_service.py",
+    "web/backend/app/services/announcement_service.py",
+    "web/backend/app/services/tradingview_widget_service.py",
+    "web/backend/app/services/strategy_service.py",
+    "web/backend/app/services/tdx_service.py",
+    "web/backend/app/services/stock_search_service/",
+    "web/backend/app/services/monitoring_service.py",
+    "web/backend/app/services/technical_analysis_service.py",
+    "web/frontend/**",
+    "docs/api/**",
+    "generated clients",
+    "openspec/changes/**",
+    "openspec/specs/**",
+    "PM2/runtime scripts",
+    "route paths/methods/request models/response contracts/OpenAPI exposure"
+  ],
+  "future_required_gates": [
+    "GitNexus impact before source edits for WatchlistService, get_watchlist_service, and modified route functions",
+    "TDD red/green route dependency override test",
+    "ruff check on changed backend files",
+    "focused watchlist lifecycle DI pytest",
+    "compatibility getter regression",
+    "gitnexus_detect_changes(scope=staged) before future commit",
+    "mainline scope gate for future task card"
+  ],
+  "rollback_plan": [
+    "Restore the seven route functions to direct get_watchlist_service() calls.",
+    "Remove the new focused lifecycle DI test if the provider is reverted.",
+    "Remove provider functions as one unit if they are not retained.",
+    "Leave adapter/data-layer helper callers unchanged.",
+    "Leave route paths, request models, response bodies, error contracts, and OpenAPI behavior unchanged."
+  ],
+  "next_gate": "Human review of this G2.9 authorization packet. If accepted, create a separate implementation worktree and PR for the route-surface-only allowed scope."
+}

--- a/docs/reports/quality/backend-watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.md
+++ b/docs/reports/quality/backend-watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.md
@@ -1,0 +1,270 @@
+# Backend Watchlist Service Lifecycle DI Implementation Authorization - 2026-05-22
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: for-review
+- Workline: G2.9 service lifecycle DI watchlist route-surface authorization
+- Parent issue: https://github.com/chengjon/mystocks/issues/79
+- Parent decision issue: https://github.com/chengjon/mystocks/issues/92
+- Current HEAD checked: `ccc4982cd11b47996c6534f087b0c9cb3783877a`
+- Source code changed by this packet: no
+- Runtime behavior changed by this packet: no
+- Tests changed by this packet: no
+
+## Governance Boundary
+
+This document is an implementation authorization packet, not the implementation.
+It records the exact scope that may be used by a future watchlist route-surface
+DI implementation PR if this packet is reviewed and accepted.
+
+This PR must remain governance-only. It does not authorize backend source edits,
+test edits, OpenSpec changes, route/OpenAPI contract changes, PM2 commands,
+issue label movement, or movement of issue `#79` / `#92` to `ready-for-agent`.
+
+## Current Issue State
+
+- Issue `#79`: `OPEN`, label `needs-triage`
+- Issue `#92`: `OPEN`, labels `enhancement`, `ready-for-human`,
+  `ready-for-downstream`
+- Issue `#92` remains parent decision context only; this packet does not change
+  its disposition.
+
+## Evidence Inputs
+
+- `docs/reports/quality/backend-service-lifecycle-di-third-candidate-selection-2026-05-22.md`
+- `.planning/codebase/generated/service-lifecycle-di-third-candidate-selection-2026-05-22.json`
+- PR `#148`: https://github.com/chengjon/mystocks/pull/148
+- PR `#148` merge commit: `ccc4982cd11b47996c6534f087b0c9cb3783877a`
+- Current-head GitNexus impact checks for `WatchlistService` and
+  `get_watchlist_service`
+- Current source inspection of:
+  - `web/backend/app/services/watchlist_service.py`
+  - `web/backend/app/api/watchlist.py`
+  - `web/backend/app/services/data_adapters/watchlist.py`
+  - `web/backend/app/services/adapters/watchlist_adapter.py`
+
+## Candidate Decision
+
+`watchlist_service.py` is approved only as a route-surface DI authorization
+candidate.
+
+The adapter and data-layer helper callers of `get_watchlist_service` are not
+part of this authorization. They remain compatibility surfaces unless a future
+adapter-aware packet names them explicitly and supplies separate impact,
+verification, and rollback gates.
+
+## GitNexus Pre-Edit Snapshot
+
+### `WatchlistService`
+
+- Target: `Class:web/backend/app/services/watchlist_service.py:WatchlistService`
+- Direction: upstream
+- Risk: LOW
+- Impacted symbols: 0
+- Direct callers: 0
+- Affected processes: 0
+- Affected modules: 0
+
+### `get_watchlist_service`
+
+- Target:
+  `Function:web/backend/app/services/watchlist_service.py:get_watchlist_service`
+- Direction: upstream
+- Risk: MEDIUM
+- Impacted symbols: 15
+- Direct callers: 9
+- Affected processes: 0
+- Affected modules: 2
+- Direct affected modules:
+  - `Data_adapters`
+  - `Adapters`
+
+Direct callers:
+
+| File | Symbol | Future disposition |
+|---|---|---|
+| `web/backend/app/api/watchlist.py` | `get_user_groups` | route-surface DI candidate |
+| `web/backend/app/api/watchlist.py` | `create_group` | route-surface DI candidate |
+| `web/backend/app/api/watchlist.py` | `update_group` | route-surface DI candidate |
+| `web/backend/app/api/watchlist.py` | `delete_group` | route-surface DI candidate |
+| `web/backend/app/api/watchlist.py` | `get_watchlist_by_group` | route-surface DI candidate |
+| `web/backend/app/api/watchlist.py` | `move_stock_to_group` | route-surface DI candidate |
+| `web/backend/app/api/watchlist.py` | `get_watchlist_with_groups` | route-surface DI candidate |
+| `web/backend/app/services/data_adapters/watchlist.py` | `_get_watchlist_service` | retain as compatibility caller |
+| `web/backend/app/services/adapters/watchlist_adapter.py` | `_get_watchlist_service` | retain as compatibility caller |
+
+Transitive adapter/data symbols:
+
+| Depth | File | Symbol | Future disposition |
+|---:|---|---|---|
+| 2 | `web/backend/app/services/data_adapters/watchlist.py` | `_fetch_watchlist_data` | out of scope |
+| 2 | `web/backend/app/services/data_adapters/watchlist.py` | `health_check` | out of scope |
+| 2 | `web/backend/app/services/adapters/watchlist_adapter.py` | `_fetch_watchlist_data` | out of scope |
+| 2 | `web/backend/app/services/adapters/watchlist_adapter.py` | `health_check` | out of scope |
+| 3 | `web/backend/app/services/data_adapters/watchlist.py` | `get_data` | out of scope |
+| 3 | `web/backend/app/services/adapters/watchlist_adapter.py` | `get_data` | out of scope |
+
+## Current Route Surface
+
+Current source facts at HEAD `ccc4982cd11b47996c6534f087b0c9cb3783877a`:
+
+| File | Lines | Current direct getter surface | Existing DI signal |
+|---|---:|---:|---|
+| `web/backend/app/services/watchlist_service.py` | 621 | one singleton getter and `_watchlist_service = None` | no app-state provider |
+| `web/backend/app/api/watchlist.py` | 674 | seven direct route-body calls to `get_watchlist_service()` | existing FastAPI `Depends(...)` usage for auth and request dependencies |
+| `web/backend/app/services/data_adapters/watchlist.py` | 289 | adapter helper uses `get_watchlist_service` | out of scope |
+| `web/backend/app/services/adapters/watchlist_adapter.py` | 290 | adapter helper uses `get_watchlist_service` | out of scope |
+
+Route-surface functions that may be migrated by a future implementation:
+
+| Function | Route surface | Current getter line | Future allowed action |
+|---|---|---:|---|
+| `get_user_groups` | `GET /groups` | 497 | inject `WatchlistService` through route dependency |
+| `create_group` | `POST /groups` | 520 | inject `WatchlistService` through route dependency |
+| `update_group` | `PUT /groups/{group_id}` | 555 | inject `WatchlistService` through route dependency |
+| `delete_group` | `DELETE /groups/{group_id}` | 584 | inject `WatchlistService` through route dependency |
+| `get_watchlist_by_group` | `GET /group/{group_id}` | 609 | inject `WatchlistService` through route dependency |
+| `move_stock_to_group` | `PUT /move` | 632 | inject `WatchlistService` through route dependency |
+| `get_watchlist_with_groups` | `GET /with-groups` | 667 | inject `WatchlistService` through route dependency |
+
+## Future Allowed Write Scope
+
+If this packet is accepted, a separate future implementation PR may edit only:
+
+- `web/backend/app/services/watchlist_service.py`
+- `web/backend/app/api/watchlist.py`
+- one focused watchlist lifecycle DI test file, preferably under
+  `web/backend/tests/`
+- one implementation report under `docs/reports/quality/`
+- one future implementation task card under `governance/mainline/task-cards/`
+- this steward tree, only to record implementation evidence after that future
+  implementation is complete
+
+The future implementation PR must remain route-surface-only. It may not treat
+this packet as permission to migrate adapter/data-layer helpers.
+
+## Explicitly Forbidden Scope
+
+The future implementation PR must not edit:
+
+- `web/backend/app/services/data_adapters/watchlist.py`
+- `web/backend/app/services/adapters/watchlist_adapter.py`
+- `web/backend/app/services/email_service.py`
+- `web/backend/app/services/email_notification_service.py`
+- `web/backend/app/services/announcement_service.py`
+- `web/backend/app/services/tradingview_widget_service.py`
+- `web/backend/app/services/strategy_service.py`
+- `web/backend/app/services/tdx_service.py`
+- `web/backend/app/services/stock_search_service/`
+- `web/backend/app/services/monitoring_service.py`
+- `web/backend/app/services/technical_analysis_service.py`
+- frontend source
+- `docs/api/`
+- generated clients
+- OpenSpec proposal, task, or spec files
+- PM2 scripts or runtime process configuration
+- route paths, methods, response models, request models, or OpenAPI exposure
+  policy
+
+## Future Implementation Shape
+
+### Service Provider Pattern
+
+The future source implementation may follow the already proven email and
+announcement service pattern:
+
+1. Add a watchlist app-state key in `watchlist_service.py`.
+2. Add `install_watchlist_service(app, service=None)` to install or reuse the
+   service from `app.state`.
+3. Add `get_watchlist_service_dependency(request)` for FastAPI route
+   injection.
+4. Retain `get_watchlist_service()` as the compatibility singleton getter for
+   adapter/data-layer helper callers.
+5. Do not change `WatchlistService` business behavior.
+
+### Route Injection Pattern
+
+The future source implementation may update only the seven route handlers listed
+above so they receive:
+
+```python
+service: WatchlistService = Depends(get_watchlist_service_dependency)
+```
+
+The future implementation must not change route path, method, request shape,
+response shape, response model, OpenAPI examples, error contract, or auth
+dependency behavior.
+
+## Required Future Tests
+
+A future implementation PR must use TDD and include a red/green test proving the
+route dependency can be overridden without touching the module-level singleton.
+
+Minimum test expectations:
+
+- a focused watchlist lifecycle DI test with a fake `WatchlistService`
+- proof that at least one migrated route uses `app.dependency_overrides` for the
+  watchlist dependency
+- proof that the route response contract remains unchanged for the exercised
+  route
+- regression coverage that the compatibility `get_watchlist_service()` getter
+  still returns a service for non-route callers
+
+Suggested future verification commands:
+
+```bash
+ruff check web/backend/app/services/watchlist_service.py web/backend/app/api/watchlist.py
+pytest -o addopts= web/backend/tests/test_watchlist_service_lifecycle_di.py -q --no-cov
+pytest -o addopts= web/backend/tests/test_watchlist_service_logging.py -q --no-cov
+```
+
+If the future implementation touches a currently covered route test, it should
+also run the smallest existing watchlist route suite that exercises that path.
+
+## Required Future Quality Gates
+
+Before the future source implementation edits any symbol, it must run GitNexus
+impact on:
+
+- `WatchlistService`
+- `get_watchlist_service`
+- any route function that will be modified
+
+Before future commit, it must stage only the intended files and run:
+
+- `gitnexus_detect_changes(scope="staged")`
+- path-limited `git diff --cached --check`
+- markdown governance for any changed report/task card
+- JSON validity for any generated evidence artifact
+- mainline scope gate for the future task card
+
+If GitNexus reports HIGH or CRITICAL risk for the staged implementation, the
+future PR must stop and return to review instead of widening the batch.
+
+## Rollback Plan
+
+Rollback of the future implementation should be a path-limited revert that:
+
+1. Restores the seven route functions to direct `get_watchlist_service()` calls.
+2. Removes the new watchlist route dependency test file.
+3. Removes the provider functions as a single unit if they are not retained.
+4. Leaves adapter/data-layer helper callers unchanged.
+5. Leaves route paths, request models, response bodies, error contracts, and
+   OpenAPI behavior unchanged.
+
+Because this packet performs no source edits, rollback for this PR is simply to
+revert this authorization report, JSON artifact, steward tree update, and task
+card.
+
+## Next Gate
+
+Human review of this G2.9 authorization packet.
+
+If accepted, create a separate implementation worktree and PR. That future PR
+may edit only the allowed write scope above and must produce an implementation
+report before closeout. No source implementation is authorized by this packet
+until that review acceptance is explicit.

--- a/governance/mainline/task-cards/pr-149.yaml
+++ b/governance/mainline/task-cards/pr-149.yaml
@@ -1,0 +1,101 @@
+version: "v0.2"
+
+task:
+  id: "pr-149"
+  title: "Prepare G2.9 watchlist service DI implementation authorization"
+  owner: "main"
+  created_at: "2026-05-22"
+
+mainline:
+  id: "L1-watchlist-service-lifecycle-di-implementation-authorization"
+  objective: "prepare the G2.9 watchlist_service.py route-surface-only lifecycle DI implementation authorization packet without source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-watchlist-service-di-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-watchlist-service-di-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Implementation authorization report, generated evidence artifact, and steward-tree update only; no runtime entrypoint, route, page, shim, service behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.json"
+    - "docs/reports/quality/backend-watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.md"
+    - "governance/mainline/task-cards/pr-149.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, PM2, or runtime behavior changes in this PR"
+  - "No watchlist_service.py implementation in this PR"
+  - "No watchlist.py route implementation in this PR"
+  - "No adapter/data-layer implementation in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.md"
+      required: true
+    - id: "json-validity"
+      command: "python -m json.tool .planning/codebase/generated/watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.json >/tmp/watchlist-service-lifecycle-di-implementation-authorization.json"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-149.yaml --base-sha origin/wip/root-dirty-20260403 --head-sha HEAD --report /tmp/pr-149-mainline-governance-report.json"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this authorization packet is misread as source implementation, issue #79 can expand before a future implementation PR exists"
+    - "If watchlist adapter/data-layer helper callers are bundled into the future route-surface pilot, the third service DI batch can exceed the proven email/announcement pattern"
+  rollback_plan: "revert this PR and return the steward tree to the G2.8 third-candidate selection state"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "prepare route-surface-only watchlist_service.py lifecycle DI implementation authorization after G2.8 candidate selection"
+    modified_scope: "steward tree, authorization report, generated JSON, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance authorization only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON validity, mainline scope, staged diff, or GitNexus staged checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-22T19:52:00+08:00"
+    approval_note: "human maintainer requested continuation after G2.8; this PR prepares the G2.9 watchlist route-surface implementation authorization packet only and does not authorize source implementation"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- prepare the G2.9 route-surface-only `watchlist_service.py` lifecycle DI implementation authorization packet
- record GitNexus impact evidence for `WatchlistService` and `get_watchlist_service`
- update the steward tree so G2.8 is merged and G2.9 is the current review gate

## Boundary

This PR is governance-only. It does not edit backend source, frontend source, tests, docs/API, OpenSpec changes/specs, generated clients, PM2/runtime config, issue labels, route paths, OpenAPI behavior, or runtime behavior.

If accepted, a future implementation PR may edit only the allowed route-surface scope recorded in the authorization packet. Adapter/data-layer watchlist helper callers remain out of scope.

## Verification

- `python -m json.tool .planning/codebase/generated/watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.json`
- `python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.md` -> errors=0, checked_files=2
- `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-149.yaml --base-sha origin/wip/root-dirty-20260403 --head-sha HEAD --report /tmp/pr-149-mainline-governance-report.json` -> pass=True, violations=[]
- `git diff --check`
- GitNexus `detect_changes(scope=compare, base_ref=origin/wip/root-dirty-20260403)` -> low risk, changed_symbols=0, affected_processes=0
