### PR TITLE
refactor: inject watchlist service in group routes

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -445,8 +445,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-service-lifecycle-di-third-candidate-selection-2026-05-22.md`,
 │   │   `.planning/codebase/generated/service-lifecycle-di-third-candidate-selection-2026-05-22.json`,
 │   │   `backend-watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.md`,
-│   │   `.planning/codebase/generated/watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.json`
-│   ├── State: watchlist-route-surface-authorization-prepared-for-review
+│   │   `.planning/codebase/generated/watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.json`,
+│   │   `backend-watchlist-service-lifecycle-di-implementation-2026-05-22.md`
+│   ├── State: watchlist-route-surface-implementation-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -495,12 +496,18 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 authorization packet for `watchlist_service.py`, limited to
 │   │                 the service file, seven `watchlist.py` route handlers,
 │   │                 focused tests, an implementation report, and a future task
-│   │                 card while keeping adapter/data helper callers out of scope
-│   └── Next gate: Human review of the G2.9 watchlist implementation
-│                  authorization package; if accepted, create a separate source
-│                  implementation worktree and PR; no source edits, OpenSpec
-│                  proposal, issue-label change, PM2 command, or
-│                  `ready-for-agent` movement is authorized by this G2.9 packet
+│   │                 card while keeping adapter/data helper callers out of scope;
+│   │                 PR `#149` merged at
+│   │                 `bddb764c79355e6c0c366fdd9a28d64a685700bf`; G2.10 now
+│   │                 implements that approved route-surface scope by adding an
+│   │                 app-state provider seam to `watchlist_service.py` and
+│   │                 injecting `WatchlistService` into seven `watchlist.py`
+│   │                 group route handlers while preserving adapter/data helper
+│   │                 compatibility callers
+│   └── Next gate: Human review of the G2.10 watchlist implementation PR; if
+│                  accepted, merge and create a separate closeout packet that
+│                  records the merge commit, GitHub checks, and whether a fourth
+│                  service lifecycle DI candidate should be selected
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -667,7 +674,8 @@ review, PR review, or OpenSpec archive review.
 | G2.6 announcement service DI implementation | Second service lifecycle DI source pilot | `517f47cb` | PR `#146` merged after human approval; `announcement_service.py` now provides app.state dependency provider, 11 announcement route handlers inject `AnnouncementService`, focused tests passed, and watchlist/adapter/data-layer files remain untouched |
 | G2.7 announcement service DI closeout | Merged implementation closeout | `112487d9` | PR `#147` merged; `announcement_service.py` is recorded as merged-and-reviewed, and third-candidate work may only begin as a new selection/authorization packet |
 | G2.8 third service DI candidate selection | Post-closeout candidate split decision | `ccc4982c` | PR `#148` merged; selection accepted: recommend only a route-surface `watchlist_service.py` authorization packet and keep watchlist adapter/data-layer helper callers out of scope unless a separate adapter-aware packet is accepted |
-| G2.9 watchlist service DI authorization | Route-surface-only `watchlist_service.py` implementation authorization | `ccc4982c` | Authorization packet prepared: future source lane may edit only `watchlist_service.py`, seven `watchlist.py` route handlers, focused tests, implementation report, future task card, and steward-tree evidence; this packet itself changes no source/tests/runtime and does not authorize adapter/data helper migration |
+| G2.9 watchlist service DI authorization | Route-surface-only `watchlist_service.py` implementation authorization | `bddb764c` | PR `#149` merged; future source lane authorized only `watchlist_service.py`, seven `watchlist.py` route handlers, focused tests, implementation report, future task card, and steward-tree evidence; adapter/data helper migration remains out of scope |
+| G2.10 watchlist service DI implementation | Third route-surface service lifecycle DI source pilot | `bddb764c` | Implementation prepared for review: `watchlist_service.py` now exposes an app-state provider dependency, seven `watchlist.py` group route handlers inject `WatchlistService`, focused tests and compatibility guards passed, and watchlist adapter/data helper files remain untouched |
 
 ## Update Protocol
 
@@ -702,7 +710,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review G2.9 watchlist service DI authorization packet | Future service seam lane | G2.9 authorization packet prepared; future implementation remains route-surface-only and may not edit watchlist adapter/data-layer helper callers unless a separate adapter-aware packet is accepted |
+| P2 | Review G2.10 watchlist service DI implementation PR | Future service seam lane | G2.10 implementation prepared; `watchlist_service.py` route-surface DI is implemented for seven group route handlers, with adapter/data-layer helper callers retained as compatibility surfaces |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/docs/reports/quality/backend-watchlist-service-lifecycle-di-implementation-2026-05-22.md
+++ b/docs/reports/quality/backend-watchlist-service-lifecycle-di-implementation-2026-05-22.md
@@ -1,0 +1,158 @@
+# Backend Watchlist Service Lifecycle DI Implementation - 2026-05-22
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: implementation-prepared-for-review
+- Workline: G2.10 watchlist service lifecycle DI implementation
+- Parent issue: https://github.com/chengjon/mystocks/issues/79
+- Parent decision issue: https://github.com/chengjon/mystocks/issues/92
+- Authorization PR: https://github.com/chengjon/mystocks/pull/149
+- Authorization merge commit: `bddb764c79355e6c0c366fdd9a28d64a685700bf`
+- Implementation branch: `g2-10-watchlist-service-di-implementation`
+- Source implementation scope: route-surface-only
+
+## Governance Boundary
+
+This implementation follows the G2.9 authorization packet. It edits only the
+watchlist service provider, seven watchlist group route handlers, focused tests,
+this report, the steward tree, and the PR task card.
+
+It does not modify watchlist adapter/data-layer helper files, route paths,
+request models, response shapes, OpenAPI exposure policy, generated clients,
+frontend source, OpenSpec changes/specs, PM2 scripts, runtime process state, or
+issue labels.
+
+## Pre-Edit Gates
+
+`architecture/STANDARDS.md` was read before source edits. The applicable
+constraints are:
+
+- preserve compatibility surfaces during migration
+- do not delete or retire shim/compatibility callers based only on static search
+- keep route/API layer changes scoped to the authorized seam
+- keep implementation tied to evidence, tests, and rollback boundaries
+
+GitNexus pre-edit impact:
+
+| Target | Risk | Impact summary |
+|---|---:|---|
+| `WatchlistService` | LOW | 0 impacted symbols, 0 direct callers, 0 affected processes |
+| `get_watchlist_service` | MEDIUM | 15 impacted symbols, 9 direct callers, 0 affected processes |
+
+The `get_watchlist_service` direct callers split into:
+
+- seven `web/backend/app/api/watchlist.py` route handlers migrated in this PR
+- two adapter/data helper callers intentionally retained as compatibility
+  surfaces:
+  - `web/backend/app/services/data_adapters/watchlist.py::_get_watchlist_service`
+  - `web/backend/app/services/adapters/watchlist_adapter.py::_get_watchlist_service`
+
+## TDD Evidence
+
+New test:
+
+- `web/backend/tests/test_watchlist_service_lifecycle_di.py`
+
+Red run before implementation:
+
+```text
+3 failed
+AttributeError: module 'app.services.watchlist_service' has no attribute 'get_watchlist_service_dependency'
+AssertionError: 'service' not in get_user_groups signature
+TypeError: get_user_groups() got an unexpected keyword argument 'service'
+```
+
+Green run after implementation:
+
+```text
+3 passed in 1.61s
+```
+
+Post-format rerun:
+
+```text
+3 passed in 1.64s
+```
+
+## Implementation Summary
+
+`web/backend/app/services/watchlist_service.py` now provides:
+
+- `WATCHLIST_SERVICE_STATE_KEY`
+- `install_watchlist_service(app, service=None)`
+- `get_watchlist_service_dependency(request)`
+
+`get_watchlist_service()` remains unchanged as the compatibility singleton
+getter for adapter/data-layer helper callers.
+
+`web/backend/app/api/watchlist.py` now injects `WatchlistService` into these
+seven route handlers:
+
+| Function | Route surface | Change |
+|---|---|---|
+| `get_user_groups` | `GET /groups` | route receives injected `service` |
+| `create_group` | `POST /groups` | route receives injected `service` |
+| `update_group` | `PUT /groups/{group_id}` | route receives injected `service` |
+| `delete_group` | `DELETE /groups/{group_id}` | route receives injected `service` |
+| `get_watchlist_by_group` | `GET /group/{group_id}` | route receives injected `service` |
+| `move_stock_to_group` | `PUT /move` | route receives injected `service` |
+| `get_watchlist_with_groups` | `GET /with-groups` | route receives injected `service` |
+
+## Compatibility Guard
+
+Post-implementation static guard:
+
+```text
+web/backend/app/api/watchlist.py: get_watchlist_service()=0, dependency_tokens=8
+web/backend/app/services/data_adapters/watchlist.py: get_watchlist_service()=9, dependency_tokens=0
+web/backend/app/services/adapters/watchlist_adapter.py: get_watchlist_service()=9, dependency_tokens=0
+```
+
+All seven migrated route functions have the injected service parameter and no
+route-body `get_watchlist_service()` call.
+
+The two adapter/data helper files were not modified.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `ruff check web/backend/app/services/watchlist_service.py web/backend/app/api/watchlist.py web/backend/tests/test_watchlist_service_lifecycle_di.py` | passed |
+| `black --check web/backend/app/services/watchlist_service.py web/backend/app/api/watchlist.py web/backend/tests/test_watchlist_service_lifecycle_di.py` | passed; 3 files unchanged after formatting |
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_lifecycle_di.py -q --no-cov --tb=short` | 3 passed |
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_lifecycle_di.py web/backend/tests/test_watchlist_service_logging.py tests/api/file_tests/test_watchlist_api.py tests/api/test_watchlist_file.py -q --no-cov --tb=short` | 42 passed |
+| `app.main` import with required placeholder env | routes=548 |
+| `app.openapi()` smoke with required placeholder env | paths=500, operations=536, duplicate_operation_ids=0 |
+
+The initial `app.main` smoke without placeholder env failed because the checkout
+lacked required environment variables:
+
+```text
+POSTGRESQL_HOST, POSTGRESQL_USER, POSTGRESQL_PASSWORD, JWT_SECRET_KEY,
+BACKEND_PORT, BACKEND_BACKUP_PORT
+```
+
+The placeholder-env smoke passed and did not expose a route/OpenAPI regression.
+
+## Rollback Plan
+
+If review or CI rejects this implementation:
+
+1. Revert this PR.
+2. Restore the seven watchlist group route handlers to direct
+   `get_watchlist_service()` calls.
+3. Remove `get_watchlist_service_dependency`, `install_watchlist_service`, and
+   `WATCHLIST_SERVICE_STATE_KEY` as one unit if the provider seam is reverted.
+4. Remove `web/backend/tests/test_watchlist_service_lifecycle_di.py`.
+5. Leave watchlist adapter/data helper files unchanged.
+
+## Next Gate
+
+PR review and merge decision for this route-surface-only implementation.
+
+After merge, create a separate closeout packet that records the merge commit,
+GitHub checks, and whether a fourth service DI candidate should be selected.

--- a/governance/mainline/task-cards/pr-150.yaml
+++ b/governance/mainline/task-cards/pr-150.yaml
@@ -1,0 +1,125 @@
+version: "v0.2"
+
+task:
+  id: "pr-150"
+  title: "Implement G2.10 watchlist service route-surface lifecycle DI"
+  owner: "main"
+  created_at: "2026-05-22"
+
+mainline:
+  id: "L1-watchlist-service-lifecycle-di-implementation"
+  objective: "implement the G2.10 route-surface-only watchlist_service.py lifecycle DI pilot"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-watchlist-service-di-implementation"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-watchlist-service-di-implementation"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow service lifecycle DI pilot authorized by PR #149; route paths, OpenAPI behavior, product surface, adapter/data helper callers, and runtime process state are unchanged"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "web/backend/app/services/watchlist_service.py"
+    - "web/backend/app/api/watchlist.py"
+    - "web/backend/tests/test_watchlist_service_lifecycle_di.py"
+    - "docs/reports/quality/backend-watchlist-service-lifecycle-di-implementation-2026-05-22.md"
+    - "governance/mainline/task-cards/pr-150.yaml"
+  forbidden_paths:
+    - "web/backend/app/services/data_adapters/watchlist.py"
+    - "web/backend/app/services/adapters/watchlist_adapter.py"
+    - "web/backend/app/services/email_service.py"
+    - "web/backend/app/services/email_notification_service.py"
+    - "web/backend/app/services/announcement_service.py"
+    - "web/backend/app/services/tradingview_widget_service.py"
+    - "web/backend/app/services/strategy_service.py"
+    - "web/backend/app/services/tdx_service.py"
+    - "web/backend/app/services/stock_search_service/stock_search_service.py"
+    - "web/backend/app/services/monitoring_service.py"
+    - "web/backend/app/services/technical_analysis_service.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No watchlist adapter/data-layer implementation in this PR"
+  - "No route path, request model, response shape, OpenAPI exposure, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No fourth service DI candidate selection in this PR"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_lifecycle_di.py web/backend/tests/test_watchlist_service_logging.py tests/api/file_tests/test_watchlist_api.py tests/api/test_watchlist_file.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/watchlist_service.py web/backend/app/api/watchlist.py web/backend/tests/test_watchlist_service_lifecycle_di.py"
+      required: true
+    - id: "black-check-touched"
+      command: "black --check web/backend/app/services/watchlist_service.py web/backend/app/api/watchlist.py web/backend/tests/test_watchlist_service_lifecycle_di.py"
+      required: true
+    - id: "app-main-openapi-smoke"
+      command: "env PYTHONPATH=web/backend POSTGRESQL_HOST=localhost POSTGRESQL_USER=postgres POSTGRESQL_PASSWORD=postgres JWT_SECRET_KEY=test-secret-key-for-watchlist-di-smoke BACKEND_PORT=8020 BACKEND_BACKUP_PORT=8021 python -c 'from app.main import app; schema=app.openapi(); print(len(app.routes), len(schema.get(\"paths\", {})))'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-watchlist-service-lifecycle-di-implementation-2026-05-22.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-150.yaml"
+      required: true
+    - id: "staged-gitnexus"
+      command: "gitnexus_detect_changes(scope=staged)"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If adapter/data helper callers are edited in the same PR, the route-surface pilot exceeds the G2.9 authorization boundary"
+    - "If route paths or response contracts change, this PR becomes route/OpenAPI governance work instead of lifecycle DI work"
+  rollback_plan: "revert this PR; restore the seven route functions to direct get_watchlist_service() calls; remove the watchlist dependency provider and focused lifecycle DI test as one unit"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "implement route-surface-only watchlist_service.py lifecycle DI after G2.9 authorization"
+    modified_scope: "watchlist_service.py, watchlist.py, focused tests, implementation report, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "get_watchlist_service remains as compatibility getter for adapter/data helper callers; seven watchlist group routes now use injected WatchlistService"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, ruff, black check, app/OpenAPI smoke, mainline scope, staged GitNexus, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-22T20:24:00+08:00"
+    approval_note: "human maintainer requested continuation after G2.9 authorization PR #149; this PR implements only the approved route-surface watchlist service DI scope"
+    secondary_approved: false

--- a/web/backend/app/api/watchlist.py
+++ b/web/backend/app/api/watchlist.py
@@ -13,7 +13,11 @@ from app.api.auth import User, get_current_user
 from app.core.exceptions import BusinessException, NotFoundException
 from app.openapi_config import COMMON_RESPONSES
 from app.services.data_source_factory import DataSourceFactory
-from app.services.watchlist_service import WatchlistError, get_watchlist_service
+from app.services.watchlist_service import (
+    WatchlistError,
+    WatchlistService,
+    get_watchlist_service_dependency,
+)
 
 WATCHLIST_ROUTE_RESPONSES = {
     400: COMMON_RESPONSES[400],
@@ -27,15 +31,11 @@ router = APIRouter(tags=["watchlist"], responses=WATCHLIST_ROUTE_RESPONSES)
 
 
 from web.backend.app.api._watchlist_responses import (
-    _success_response_spec,
     WATCHLIST_ADD_REQUEST_EXAMPLES,
     WATCHLIST_CREATE_GROUP_REQUEST_EXAMPLES,
     WATCHLIST_UPDATE_GROUP_REQUEST_EXAMPLES,
     WATCHLIST_MOVE_REQUEST_EXAMPLES,
     WATCHLIST_NOTES_REQUEST_EXAMPLES,
-    WATCHLIST_ITEM_EXAMPLE,
-    WATCHLIST_GROUP_EXAMPLE,
-    WATCHLIST_GROUP_STOCK_EXAMPLE,
     WATCHLIST_LIST_RESPONSES,
     WATCHLIST_SYMBOLS_RESPONSES,
     WATCHLIST_REMOVE_RESPONSES,
@@ -50,9 +50,8 @@ from web.backend.app.api._watchlist_responses import (
     WATCHLIST_NOTES_RESPONSES,
     WATCHLIST_GROUP_CREATE_RESPONSES,
     WATCHLIST_GROUP_UPDATE_RESPONSES,
-    WATCHLIST_MOVE_RESPONSES
+    WATCHLIST_MOVE_RESPONSES,
 )
-
 
 
 class WatchlistItem(BaseModel):
@@ -489,12 +488,14 @@ async def clear_watchlist(current_user: User = Depends(get_current_user)) -> Dic
     description="获取当前用户已创建的全部自选股分组，用于分组筛选、分组迁移和分组视图初始化。",
     responses=WATCHLIST_GROUP_LIST_RESPONSES,
 )
-async def get_user_groups(current_user: User = Depends(get_current_user)) -> List[Dict]:
+async def get_user_groups(
+    current_user: User = Depends(get_current_user),
+    service: WatchlistService = Depends(get_watchlist_service_dependency),
+) -> List[Dict]:
     """
     获取当前用户的所有自选股分组
     """
     try:
-        service = get_watchlist_service()
         groups = service.get_user_groups(current_user.id)
         return groups
     except Exception as e:
@@ -512,12 +513,12 @@ async def get_user_groups(current_user: User = Depends(get_current_user)) -> Lis
 async def create_group(
     request: CreateGroupRequest = Body(..., openapi_examples=WATCHLIST_CREATE_GROUP_REQUEST_EXAMPLES),
     current_user: User = Depends(get_current_user),
+    service: WatchlistService = Depends(get_watchlist_service_dependency),
 ) -> Dict:
     """
     创建新的自选股分组
     """
     try:
-        service = get_watchlist_service()
         group = service.create_group(current_user.id, request.group_name)
 
         if not group:
@@ -547,12 +548,12 @@ async def update_group(
     request: UpdateGroupRequest = Body(..., openapi_examples=WATCHLIST_UPDATE_GROUP_REQUEST_EXAMPLES),
     group_id: int = Path(..., description="分组ID", ge=1),
     current_user: User = Depends(get_current_user),
+    service: WatchlistService = Depends(get_watchlist_service_dependency),
 ) -> Dict:
     """
     修改分组名称
     """
     try:
-        service = get_watchlist_service()
         success = service.update_group(current_user.id, group_id, request.group_name)
 
         if not success:
@@ -575,13 +576,14 @@ async def update_group(
     responses=WATCHLIST_GROUP_DELETE_RESPONSES,
 )
 async def delete_group(
-    group_id: int = Path(..., description="分组ID", ge=1), current_user: User = Depends(get_current_user)
+    group_id: int = Path(..., description="分组ID", ge=1),
+    current_user: User = Depends(get_current_user),
+    service: WatchlistService = Depends(get_watchlist_service_dependency),
 ) -> Dict:
     """
     删除分组（会同时删除该分组下的所有自选股）
     """
     try:
-        service = get_watchlist_service()
         success = service.delete_group(current_user.id, group_id)
 
         if not success:
@@ -600,13 +602,14 @@ async def delete_group(
     responses=WATCHLIST_GROUP_DETAIL_RESPONSES,
 )
 async def get_watchlist_by_group(
-    group_id: int = Path(..., description="分组ID", ge=1), current_user: User = Depends(get_current_user)
+    group_id: int = Path(..., description="分组ID", ge=1),
+    current_user: User = Depends(get_current_user),
+    service: WatchlistService = Depends(get_watchlist_service_dependency),
 ) -> List[Dict]:
     """
     获取指定分组的自选股列表
     """
     try:
-        service = get_watchlist_service()
         watchlist = service.get_watchlist_by_group(current_user.id, group_id)
         return watchlist
     except Exception as e:
@@ -624,12 +627,12 @@ async def get_watchlist_by_group(
 async def move_stock_to_group(
     request: MoveStockRequest = Body(..., openapi_examples=WATCHLIST_MOVE_REQUEST_EXAMPLES),
     current_user: User = Depends(get_current_user),
+    service: WatchlistService = Depends(get_watchlist_service_dependency),
 ) -> Dict:
     """
     将股票从一个分组移动到另一个分组
     """
     try:
-        service = get_watchlist_service()
         success = service.move_stock_to_group(
             user_id=current_user.id,
             symbol=request.symbol,
@@ -659,12 +662,12 @@ async def move_stock_to_group(
 )
 async def get_watchlist_with_groups(
     current_user: User = Depends(get_current_user),
+    service: WatchlistService = Depends(get_watchlist_service_dependency),
 ) -> Dict:
     """
     获取所有分组及其包含的自选股（分组视图）
     """
     try:
-        service = get_watchlist_service()
         result = service.get_watchlist_with_groups(current_user.id)
         return result
     except Exception as e:

--- a/web/backend/app/services/watchlist_service.py
+++ b/web/backend/app/services/watchlist_service.py
@@ -7,8 +7,9 @@
 import logging
 import os
 from datetime import date, datetime
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
+from fastapi import Request
 import psycopg2
 from psycopg2.extras import RealDictCursor
 
@@ -603,8 +604,10 @@ class WatchlistService(WatchlistGroupQueriesMixin):
             self._log_database_error("删除分组时发生错误", e)
             return False
 
+
 # 创建全局实例
 _watchlist_service = None
+WATCHLIST_SERVICE_STATE_KEY = "watchlist_service"
 
 
 def get_watchlist_service() -> WatchlistService:
@@ -618,3 +621,16 @@ def get_watchlist_service() -> WatchlistService:
     if _watchlist_service is None:
         _watchlist_service = WatchlistService()
     return _watchlist_service
+
+
+def install_watchlist_service(app: Any, service: WatchlistService | None = None) -> WatchlistService:
+    selected_service = service if service is not None else get_watchlist_service()
+    setattr(app.state, WATCHLIST_SERVICE_STATE_KEY, selected_service)
+    return selected_service
+
+
+def get_watchlist_service_dependency(request: Request) -> WatchlistService:
+    service = getattr(request.app.state, WATCHLIST_SERVICE_STATE_KEY, None)
+    if service is None:
+        service = install_watchlist_service(request.app)
+    return service

--- a/web/backend/tests/test_watchlist_service_lifecycle_di.py
+++ b/web/backend/tests/test_watchlist_service_lifecycle_di.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from app.api import watchlist as routes
+from app.services import watchlist_service
+
+
+def test_watchlist_service_dependency_installs_app_state_when_missing(monkeypatch):
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+    request = SimpleNamespace(app=fake_app)
+
+    monkeypatch.setattr(watchlist_service, "get_watchlist_service", lambda: fake_service)
+
+    assert watchlist_service.get_watchlist_service_dependency(request) is fake_service
+    assert getattr(fake_app.state, watchlist_service.WATCHLIST_SERVICE_STATE_KEY) is fake_service
+
+
+def test_watchlist_group_routes_accept_injected_watchlist_service():
+    for function_name in [
+        "get_user_groups",
+        "create_group",
+        "update_group",
+        "delete_group",
+        "get_watchlist_by_group",
+        "move_stock_to_group",
+        "get_watchlist_with_groups",
+    ]:
+        signature = inspect.signature(getattr(routes, function_name))
+        assert "service" in signature.parameters
+
+
+@pytest.mark.asyncio
+async def test_get_user_groups_uses_injected_watchlist_service():
+    class FakeWatchlistService:
+        def __init__(self):
+            self.user_id = None
+
+        def get_user_groups(self, user_id):
+            self.user_id = user_id
+            return [{"id": 1, "group_name": "默认分组"}]
+
+    fake_service = FakeWatchlistService()
+    current_user = SimpleNamespace(id=42)
+
+    response = await routes.get_user_groups(
+        current_user=current_user,
+        service=fake_service,
+    )
+
+    assert response == [{"id": 1, "group_name": "默认分组"}]
+    assert fake_service.user_id == 42


### PR DESCRIPTION
## Summary

- add an app.state lifecycle dependency provider for `WatchlistService`
- inject `WatchlistService` into the seven watchlist group route handlers
- add focused TDD coverage and steward-tree implementation evidence

## Boundary

This implements only the G2.9-approved route-surface scope from PR #149.

It does not modify watchlist adapter/data-layer helper files, route paths, request models, response shapes, OpenAPI exposure policy, generated clients, frontend source, OpenSpec changes/specs, PM2 scripts, runtime process state, or issue labels.

## Verification

- TDD red run: `web/backend/tests/test_watchlist_service_lifecycle_di.py` failed with the expected missing provider/signature failures before implementation
- `ruff check web/backend/app/services/watchlist_service.py web/backend/app/api/watchlist.py web/backend/tests/test_watchlist_service_lifecycle_di.py` -> passed
- `black --check web/backend/app/services/watchlist_service.py web/backend/app/api/watchlist.py web/backend/tests/test_watchlist_service_lifecycle_di.py` -> passed, 3 files unchanged
- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_lifecycle_di.py web/backend/tests/test_watchlist_service_logging.py tests/api/file_tests/test_watchlist_api.py tests/api/test_watchlist_file.py -q --no-cov --tb=short` -> 42 passed
- `app.main` / `app.openapi()` smoke with required placeholder env -> routes=548, paths=500, operations=536, duplicate_operation_ids=0
- `python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-watchlist-service-lifecycle-di-implementation-2026-05-22.md` -> errors=0, checked_files=2
- `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-150.yaml --base-sha origin/wip/root-dirty-20260403 --head-sha HEAD --report /tmp/pr-150-mainline-postcommit.json` -> pass=True, violations=[]
- `git diff --cached --check` before commit and `git diff --check` after commit -> no output
- GitNexus `detect_changes(scope=staged)` and compare against base -> low risk, affected_processes=0
