### PR TITLE
docs: record watchlist service DI closeout

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -446,8 +446,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `.planning/codebase/generated/service-lifecycle-di-third-candidate-selection-2026-05-22.json`,
 │   │   `backend-watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.md`,
 │   │   `.planning/codebase/generated/watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.json`,
-│   │   `backend-watchlist-service-lifecycle-di-implementation-2026-05-22.md`
-│   ├── State: watchlist-route-surface-implementation-prepared-for-review
+│   │   `backend-watchlist-service-lifecycle-di-implementation-2026-05-22.md`,
+│   │   `backend-watchlist-service-lifecycle-di-closeout-2026-05-23.md`
+│   ├── State: watchlist-route-surface-implementation-merged-and-recorded
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -503,11 +504,14 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 app-state provider seam to `watchlist_service.py` and
 │   │                 injecting `WatchlistService` into seven `watchlist.py`
 │   │                 group route handlers while preserving adapter/data helper
-│   │                 compatibility callers
-│   └── Next gate: Human review of the G2.10 watchlist implementation PR; if
-│                  accepted, merge and create a separate closeout packet that
-│                  records the merge commit, GitHub checks, and whether a fourth
-│                  service lifecycle DI candidate should be selected
+│   │                 compatibility callers; PR `#150` was approved by the human
+│   │                 maintainer and merged at
+│   │                 `b14ef8421d8ccd6dfd4a714b2a17d4e1ae971419`; G2.11 records
+│   │                 the merged result and confirms the closeout boundary
+│   └── Next gate: Human review of the G2.11 watchlist closeout packet; if
+│                  accepted, decide in a separate packet whether to select a
+│                  fourth service lifecycle DI candidate, create an adapter-aware
+│                  watchlist helper cleanup packet, or pause this sequence
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -675,7 +679,8 @@ review, PR review, or OpenSpec archive review.
 | G2.7 announcement service DI closeout | Merged implementation closeout | `112487d9` | PR `#147` merged; `announcement_service.py` is recorded as merged-and-reviewed, and third-candidate work may only begin as a new selection/authorization packet |
 | G2.8 third service DI candidate selection | Post-closeout candidate split decision | `ccc4982c` | PR `#148` merged; selection accepted: recommend only a route-surface `watchlist_service.py` authorization packet and keep watchlist adapter/data-layer helper callers out of scope unless a separate adapter-aware packet is accepted |
 | G2.9 watchlist service DI authorization | Route-surface-only `watchlist_service.py` implementation authorization | `bddb764c` | PR `#149` merged; future source lane authorized only `watchlist_service.py`, seven `watchlist.py` route handlers, focused tests, implementation report, future task card, and steward-tree evidence; adapter/data helper migration remains out of scope |
-| G2.10 watchlist service DI implementation | Third route-surface service lifecycle DI source pilot | `bddb764c` | Implementation prepared for review: `watchlist_service.py` now exposes an app-state provider dependency, seven `watchlist.py` group route handlers inject `WatchlistService`, focused tests and compatibility guards passed, and watchlist adapter/data helper files remain untouched |
+| G2.10 watchlist service DI implementation | Third route-surface service lifecycle DI source pilot | `b14ef842` | PR `#150` merged after human approval; `watchlist_service.py` now exposes an app-state provider dependency, seven `watchlist.py` group route handlers inject `WatchlistService`, focused tests and GitHub checks passed, and watchlist adapter/data helper files remain untouched |
+| G2.11 watchlist service DI closeout | Merged implementation closeout | `b14ef842` | Closeout recorded: `watchlist_service.py` is recorded as merged-and-reviewed; next service lifecycle DI movement requires a separate fourth-candidate, adapter-aware cleanup, or pause/resume decision packet |
 
 ## Update Protocol
 
@@ -710,7 +715,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review G2.10 watchlist service DI implementation PR | Future service seam lane | G2.10 implementation prepared; `watchlist_service.py` route-surface DI is implemented for seven group route handlers, with adapter/data-layer helper callers retained as compatibility surfaces |
+| P2 | Review G2.11 watchlist service DI closeout | Future service seam lane | G2.11 closeout packet prepared; `watchlist_service.py` route-surface DI is merged, and any fourth candidate or adapter-aware watchlist cleanup requires a separate packet |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/docs/reports/quality/backend-watchlist-service-lifecycle-di-closeout-2026-05-23.md
+++ b/docs/reports/quality/backend-watchlist-service-lifecycle-di-closeout-2026-05-23.md
@@ -1,0 +1,111 @@
+# Backend Watchlist Service Lifecycle DI Closeout - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: completed-and-recorded
+- Workline: G2.11 service lifecycle DI implementation closeout
+- Completed pilot: `web/backend/app/services/watchlist_service.py`
+- Implementation PR: https://github.com/chengjon/mystocks/pull/150
+- Implementation merge commit: `b14ef8421d8ccd6dfd4a714b2a17d4e1ae971419`
+- Implementation commit: `480c7aad9da84b058a05025c1304a94556780aef`
+- Authorization PR: https://github.com/chengjon/mystocks/pull/149
+- Authorization merge commit: `bddb764c79355e6c0c366fdd9a28d64a685700bf`
+- Closeout branch: `g2-11-watchlist-service-di-closeout`
+- Recorded at: `2026-05-23T01:50:00+08:00`
+
+## Governance Boundary
+
+This closeout is governance bookkeeping only. It records that the G2.10
+watchlist route-surface DI implementation was reviewed through PR checks and
+merged. It does not authorize a fourth service DI candidate, adapter/data-layer
+migration, OpenSpec changes, issue label movement, PM2/runtime work, frontend
+work, route/OpenAPI contract changes, or additional source edits.
+
+## Completed Scope
+
+PR `#150` implemented the G2.9-authorized route-surface-only scope:
+
+- `web/backend/app/services/watchlist_service.py`
+  - added `WATCHLIST_SERVICE_STATE_KEY`
+  - added `install_watchlist_service(app, service=None)`
+  - added `get_watchlist_service_dependency(request)`
+  - retained `get_watchlist_service()` as the compatibility getter
+- `web/backend/app/api/watchlist.py`
+  - injected `WatchlistService` into seven watchlist group route handlers
+  - removed route-body direct `get_watchlist_service()` calls from those seven
+    handlers
+- `web/backend/tests/test_watchlist_service_lifecycle_di.py`
+  - added focused TDD coverage for provider installation, route signatures, and
+    fake-service injection
+- `docs/reports/quality/backend-watchlist-service-lifecycle-di-implementation-2026-05-22.md`
+  - recorded implementation evidence and rollback boundaries
+- `governance/mainline/task-cards/pr-150.yaml`
+  - recorded implementation scope and gates
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+  - recorded G2.10 as implementation prepared for review
+
+## Preserved Compatibility Boundary
+
+The implementation did not edit:
+
+- `web/backend/app/services/data_adapters/watchlist.py`
+- `web/backend/app/services/adapters/watchlist_adapter.py`
+
+Those adapter/data helper callers continue to use `get_watchlist_service()` as a
+compatibility surface. Any future adapter-aware cleanup must be created as a
+separate child packet with its own impact evidence, exact write scope, tests,
+rollback plan, and review gate.
+
+## Verification Recorded Before Merge
+
+Local verification from the implementation packet:
+
+| Check | Result |
+|---|---|
+| TDD red run | 3 expected failures before implementation |
+| `ruff check web/backend/app/services/watchlist_service.py web/backend/app/api/watchlist.py web/backend/tests/test_watchlist_service_lifecycle_di.py` | passed |
+| `black --check web/backend/app/services/watchlist_service.py web/backend/app/api/watchlist.py web/backend/tests/test_watchlist_service_lifecycle_di.py` | passed |
+| focused + existing watchlist tests | 42 passed |
+| `app.main` / `app.openapi()` smoke with required placeholder env | routes=548, paths=500, operations=536, duplicate_operation_ids=0 |
+| Markdown governance | checked_files=2, errors=0 |
+| Mainline scope gate | pass=True, violations=[] |
+| GitNexus staged/compare checks | low risk, affected_processes=0 |
+
+GitHub PR `#150` checks:
+
+| Check | Result |
+|---|---|
+| `Validate API Contracts` | pass |
+| `Generate TypeScript Types` | pass |
+| `Detect Breaking Changes` | pass |
+| `Generate Contract Validation Report` | pass |
+| `Mainline Governance Gate` | pass |
+| `check-compliance` | pass |
+| weekly/notify jobs | skipped as expected |
+
+## Current State After Merge
+
+- `watchlist_service.py` is now the third merged route-surface service lifecycle
+  DI source pilot after `email_service.py` and `announcement_service.py`.
+- `get_watchlist_service()` remains the legacy compatibility getter.
+- Seven watchlist group route handlers use injected `WatchlistService`.
+- Watchlist adapter/data helper callers remain intentionally unmigrated.
+- Issue `#79` remains the parent service lifecycle DI issue and should not be
+  moved to implementation-ready state by this closeout.
+
+## Next Gate
+
+Human review of this closeout packet.
+
+If accepted, decide in a separate packet whether to:
+
+1. select a fourth route-surface service DI candidate,
+2. create an adapter-aware watchlist helper cleanup packet, or
+3. pause the service lifecycle DI sequence and return to another architecture
+   workline.
+
+This closeout does not itself authorize any of those follow-up actions.

--- a/governance/mainline/task-cards/pr-151.yaml
+++ b/governance/mainline/task-cards/pr-151.yaml
@@ -1,0 +1,96 @@
+version: "v0.2"
+
+task:
+  id: "pr-151"
+  title: "Record G2.11 watchlist service DI implementation closeout"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-service-lifecycle-di-watchlist-service-closeout"
+  objective: "record that the watchlist_service.py route-surface lifecycle DI pilot was reviewed, merged, and remains bounded to the approved third candidate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-watchlist-service-di-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-watchlist-service-di-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout bookkeeping only; no runtime entrypoint, route, page, shim, service behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "docs/reports/quality/backend-watchlist-service-lifecycle-di-closeout-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-151.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, PM2, or runtime behavior changes in this PR"
+  - "No fourth service lifecycle DI candidate selection in this PR"
+  - "No adapter/data-layer watchlist cleanup in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-watchlist-service-lifecycle-di-closeout-2026-05-23.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-151.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is misread as follow-up implementation authorization, issue #79 can expand without a new child packet"
+    - "If adapter/data helper cleanup is folded into this closeout, the G2.10 boundary is obscured"
+  rollback_plan: "revert this PR and return the steward tree to the G2.10 implementation-merged state recorded by PR #150"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record watchlist_service.py route-surface lifecycle DI pilot completion after PR #150 merge"
+    modified_scope: "steward tree, closeout report, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance bookkeeping only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T01:50:00+08:00"
+    approval_note: "human maintainer requested continuation after PR #150; this PR records closeout only and does not authorize follow-up implementation"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- record that PR #150 merged the route-surface-only `watchlist_service.py` lifecycle DI implementation
- update the steward tree to mark G2.10 as merged and G2.11 as the closeout gate
- preserve the boundary that adapter/data-layer watchlist helper callers remain outside this closeout

## Boundary

This PR is governance-only. It does not edit backend source, frontend source, tests, docs/API, generated clients, OpenSpec changes/specs, PM2/runtime state, issue labels, route paths, OpenAPI behavior, or product behavior.

It does not authorize a fourth service DI candidate or adapter-aware watchlist cleanup. Those require separate packets.

## Verification

- `python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-watchlist-service-lifecycle-di-closeout-2026-05-23.md` -> errors=0, checked_files=2
- `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-151.yaml --base-sha origin/wip/root-dirty-20260403 --head-sha HEAD --report /tmp/pr-151-mainline-postcommit.json` -> pass=True, violations=[]
- `git diff --check`
- GitNexus `detect_changes(scope=compare, base_ref=origin/wip/root-dirty-20260403)` -> low risk, changed_symbols=0, affected_processes=0
