### PR TITLE
docs: select watchlist helper cleanup next lane

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -447,8 +447,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.md`,
 │   │   `.planning/codebase/generated/watchlist-service-lifecycle-di-implementation-authorization-2026-05-22.json`,
 │   │   `backend-watchlist-service-lifecycle-di-implementation-2026-05-22.md`,
-│   │   `backend-watchlist-service-lifecycle-di-closeout-2026-05-23.md`
-│   ├── State: watchlist-route-surface-implementation-merged-and-recorded
+│   │   `backend-watchlist-service-lifecycle-di-closeout-2026-05-23.md`,
+│   │   `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md`,
+│   │   `.planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json`
+│   ├── State: watchlist-helper-cleanup-next-lane-decision-prepared
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -507,11 +509,16 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 compatibility callers; PR `#150` was approved by the human
 │   │                 maintainer and merged at
 │   │                 `b14ef8421d8ccd6dfd4a714b2a17d4e1ae971419`; G2.11 records
-│   │                 the merged result and confirms the closeout boundary
-│   └── Next gate: Human review of the G2.11 watchlist closeout packet; if
-│                  accepted, decide in a separate packet whether to select a
-│                  fourth service lifecycle DI candidate, create an adapter-aware
-│                  watchlist helper cleanup packet, or pause this sequence
+│   │                 the merged result and confirms the closeout boundary; PR
+│   │                 `#151` merged at
+│   │                 `3caeea24dafb02748c92d58b2809e893ce761d5e`; G2.12 now
+│   │                 selects an adapter-aware watchlist helper cleanup
+│   │                 authorization packet as the next lane instead of selecting
+│   │                 a fourth route-surface service candidate immediately
+│   └── Next gate: Human review of the G2.12 next-lane decision packet; if
+│                  accepted, prepare a separate G2.13 adapter-aware watchlist
+│                  helper cleanup implementation authorization packet. Source
+│                  edits remain locked until that packet is reviewed and accepted
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -560,6 +567,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-error-contract-completion-verification-2026-05-19.md` | I | P3-C5 / #77 main migration resolved | Do not reopen old live-count backlog without current-head contradiction |
 | `backend-technical-pattern-di-pilot-implementation-2026-05-21.md` | D2.1a.1 | First DI lifecycle pilot implementation merged in PR `#112`; route-level provider and dependency override test seam are in place | D2.1a implementation closed; do not infer a second DI pilot from this evidence |
 | `inject-technical-pattern-detection-service-di` task `5.3` closeout | D2.1a.1 | Final OpenSpec checklist governance merged in PR `#113`; issue `#92` received implementation and final governance closeout comments | D2.1a is 100% closed; future DI work requires a new approved child lane |
+
+| `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet prepared: adapter-aware watchlist helper cleanup is selected as the next authorization candidate; no source edits or OpenSpec changes are authorized | Human review; if accepted, prepare separate G2.13 implementation authorization packet |
 
 ## Completed And Reviewed Ledger
 
@@ -634,6 +643,8 @@ review, PR review, or OpenSpec archive review.
 | D2.1a TechnicalPatternDetectionService DI implementation | D2.1a.1 | First service-tier route-level DI pilot merged; `_technical_patterns_router.py` now exposes `get_technical_pattern_detection_service()`, `detect_patterns()` receives the service through `Depends`, and focused route tests use `app.dependency_overrides` | Reviewed/pass in current thread: PR `#112` checks passed, merge commit `80582643578d587ead81ccb3d23dcd2a52668dba`; route regression `9 passed`; service+route `19 passed`; ruff passed; placeholder-env `app.main` import passed; OpenSpec strict valid; mainline scope gate passed; GitNexus compare low risk with `0` changed symbols and `0` affected processes | `https://github.com/chengjon/mystocks/pull/112`; `docs/reports/quality/backend-technical-pattern-di-pilot-implementation-2026-05-21.md`; `openspec/changes/inject-technical-pattern-detection-service-di/` | D2.1a final OpenSpec checklist governance closeout |
 | D2.1a final OpenSpec checklist governance closeout | D2.1a.1 | OpenSpec task `5.3` marked complete with issue `#92` closeout comment evidence; D2.1a is closed from implementation plus checklist governance perspectives | Reviewed/pass in current thread: PR `#113` checks passed, merge commit `c7e263b8fcdeea4fc952a86d64ac555ca6dde6ce`; changed files limited to `tasks.md` and `pr-113.yaml`; mainline scope gate changed files=`2`, violations=`0`; GitNexus compare low risk with `0` changed symbols and `0` affected processes | `https://github.com/chengjon/mystocks/pull/113`; `https://github.com/chengjon/mystocks/issues/92#issuecomment-4508297089`; `openspec/changes/inject-technical-pattern-detection-service-di/tasks.md` | No further D2.1a work; select a new approved child lane before any additional implementation |
 | D2.x OpenSpec proposal approvals recorded | D2.3-D2.6 | Human maintainer approval recorded for D2.3/D2.4/D2.5/D2.6 proposal task-list entry into governance/evidence execution | Approval-only: each change may execute its governance/evidence `tasks.md` checklist with current-head freshness; no backend source, frontend source, tests, generated client, docs/API edits, route behavior, OpenAPI schema/exposure, probe URL change, PM2 command execution, service restart/recreation, implementation issue creation, or movement of issue `#92` to `ready-for-agent` is authorized | `docs/reports/quality/backend-openspec-d2-proposal-approval-record-2026-05-22.md`; `governance/mainline/task-cards/pr-120.yaml` | Execute approved governance/evidence tasks and keep every downstream decision tied to refreshed evidence |
+
+| G2.12 watchlist helper cleanup next-lane decision | G | Selected adapter-aware watchlist helper cleanup authorization as the next service lifecycle DI lane after G2.11 closeout | Prepared for review; no backend source, test, OpenSpec, issue label, route, OpenAPI, or runtime change authorized | `docs/reports/quality/backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md`; `.planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json` | If accepted, draft G2.13 adapter-aware watchlist helper cleanup implementation authorization packet |
 
 ## OpenSpec Branch Register
 

--- a/.planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json
+++ b/.planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json
@@ -1,0 +1,63 @@
+{
+  "artifact": "watchlist-helper-cleanup-next-lane-decision",
+  "generated_at": "2026-05-23T02:01:20+08:00",
+  "git_head": "3caeea24dafb02748c92d58b2809e893ce761d5e",
+  "workline": "G2.12",
+  "status": "decision-packet-prepared-for-review",
+  "boundary": {
+    "source_edits_authorized": false,
+    "test_edits_authorized": false,
+    "openspec_changes_authorized": false,
+    "issue_label_changes_authorized": false,
+    "runtime_behavior_changes_authorized": false
+  },
+  "upstream_evidence": {
+    "g2_11_closeout_pr": 151,
+    "g2_11_merge_commit": "3caeea24dafb02748c92d58b2809e893ce761d5e",
+    "g2_10_implementation_pr": 150,
+    "g2_10_merge_commit": "b14ef8421d8ccd6dfd4a714b2a17d4e1ae971419",
+    "g2_9_authorization_pr": 149,
+    "g2_8_selection_pr": 148
+  },
+  "decision_options": [
+    {
+      "option": "select_fourth_route_surface_service_di_candidate",
+      "decision": "not_selected_now",
+      "reason": "Known accepted candidate evidence does not identify a cleaner fourth route-surface candidate than closing the residual watchlist adapter/data helper seam."
+    },
+    {
+      "option": "adapter_aware_watchlist_helper_cleanup_packet",
+      "decision": "selected_as_next_authorization_candidate",
+      "reason": "G2.9/G2.10 intentionally excluded watchlist adapter/data helper callers; this residual seam should be modeled before widening the service lifecycle DI sequence."
+    },
+    {
+      "option": "pause_service_lifecycle_di_sequence",
+      "decision": "fallback_if_review_rejects_g2_12",
+      "reason": "Available if the maintainer does not want to proceed with adapter-aware cleanup."
+    }
+  ],
+  "future_authorization_candidate": {
+    "suggested_report": "docs/reports/quality/backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md",
+    "candidate_paths": [
+      "web/backend/app/services/watchlist_service.py",
+      "web/backend/app/services/data_adapters/watchlist.py",
+      "web/backend/app/services/adapters/watchlist_adapter.py"
+    ],
+    "default_forbidden_paths_until_authorized": [
+      "web/backend/app/api/watchlist.py",
+      "web/backend/app/services/email_service.py",
+      "web/backend/app/services/announcement_service.py",
+      "web/backend/app/services/tradingview_widget_service.py"
+    ],
+    "required_future_gates": [
+      "exact write scope",
+      "TDD red/green target",
+      "GitNexus pre-edit impact targets",
+      "helper seam strategy",
+      "rollback plan",
+      "route-level G2.10 behavior preservation proof",
+      "unrelated service DI expansion prohibition"
+    ]
+  },
+  "next_gate": "human review; if accepted, prepare G2.13 authorization-only packet"
+}

--- a/docs/reports/quality/backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md
+++ b/docs/reports/quality/backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md
@@ -1,0 +1,121 @@
+# Backend Watchlist Helper Cleanup Next-Lane Decision - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: decision-packet-prepared-for-review
+
+Boundary note: This packet selects the next governance lane only. It does not
+authorize backend source edits, tests, OpenSpec changes, issue label changes, or
+runtime behavior changes.
+
+## Context
+
+G2.11 closed the third route-surface service lifecycle DI pilot:
+
+- PR `#150` merged the `watchlist_service.py` route-surface implementation.
+- PR `#151` merged the closeout report at
+  `3caeea24dafb02748c92d58b2809e893ce761d5e`.
+- The route-surface implementation intentionally kept the watchlist adapter/data
+  helper callers out of scope.
+
+The G2.11 closeout left one explicit decision gate:
+
+1. select a fourth service lifecycle DI candidate,
+2. create an adapter-aware watchlist helper cleanup packet, or
+3. pause the service lifecycle DI sequence.
+
+## Decision
+
+Select option 2: prepare an adapter-aware watchlist helper cleanup authorization
+packet as the next G2 lane.
+
+Do not select a fourth route-surface service DI candidate yet.
+
+## Rationale
+
+The accepted service lifecycle DI sequence has completed three route-surface
+pilots:
+
+| Pilot | Surface | Result |
+|---|---|---|
+| `email_service.py` | notification routes | merged and closed |
+| `announcement_service.py` | announcement routes | merged and closed |
+| `watchlist_service.py` | seven watchlist group route handlers | merged and closed |
+
+The remaining known watchlist lifecycle seam is not another route handler. It is
+the compatibility/helper surface intentionally excluded from G2.9 and G2.10:
+
+- `web/backend/app/services/data_adapters/watchlist.py`
+- `web/backend/app/services/adapters/watchlist_adapter.py`
+
+Earlier G2.8 evidence classified these files as adapter/data helper surfaces, not
+FastAPI route dependency surfaces. Folding them into G2.10 would have expanded
+the approved pilot. Leaving them unmodeled while selecting a fourth service
+candidate would make the service lifecycle sequence wider without closing the
+known residual seam from the third pilot.
+
+`tradingview_widget_service.py` remains reference evidence only because it
+already has the provider/app-state pattern. The accepted candidate evidence does
+not identify a clean fourth route-surface service with lower governance risk
+than closing the watchlist adapter-aware seam.
+
+## Future Authorization Candidate
+
+If this decision packet is accepted, the next packet should be a separate
+implementation authorization packet, not immediate implementation.
+
+Recommended future packet name:
+
+- `backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md`
+
+Recommended future scope to evaluate:
+
+| Area | Candidate path | Default disposition |
+|---|---|---|
+| Service provider seam | `web/backend/app/services/watchlist_service.py` | Inspect only unless a helper-safe seam is required |
+| Data adapter helper | `web/backend/app/services/data_adapters/watchlist.py` | Candidate for adapter-aware cleanup |
+| Service adapter helper | `web/backend/app/services/adapters/watchlist_adapter.py` | Candidate for adapter-aware cleanup |
+| Route layer | `web/backend/app/api/watchlist.py` | Out of scope unless a regression is proven |
+| Tests | focused watchlist helper lifecycle tests | Required in future authorization |
+
+The future authorization packet must define:
+
+- exact write scope,
+- TDD red/green target,
+- GitNexus pre-edit impact targets,
+- whether helper seams should use explicit service injection, factory injection,
+  or compatibility-retention,
+- rollback plan that restores current helper behavior,
+- proof that route-level G2.10 behavior remains unchanged,
+- prohibition on unrelated service DI expansion.
+
+## Non-Goals
+
+- Do not edit backend source in this packet.
+- Do not edit tests in this packet.
+- Do not open a fourth route-surface service implementation lane in this packet.
+- Do not delete `get_watchlist_service()` compatibility behavior.
+- Do not move issue `#79` labels.
+- Do not create or modify OpenSpec change files.
+- Do not touch `email_service.py`, `announcement_service.py`, or
+  `tradingview_widget_service.py`.
+
+## Acceptance Evidence
+
+| Evidence | Status |
+|---|---|
+| G2.11 closeout PR `#151` | merged |
+| Base commit | `3caeea24dafb02748c92d58b2809e893ce761d5e` |
+| Prior watchlist route-surface implementation | PR `#150`, merged at `b14ef8421d8ccd6dfd4a714b2a17d4e1ae971419` |
+| Adapter/data helper files | intentionally excluded from G2.9/G2.10 |
+| Backend source edits in this packet | none |
+
+## Next Gate
+
+Human review of this G2.12 decision packet.
+
+If accepted, prepare a separate G2.13 adapter-aware watchlist helper cleanup
+implementation authorization packet. G2.13 should still be authorization-only;
+source edits remain locked until that packet is reviewed and explicitly accepted.

--- a/governance/mainline/task-cards/pr-152.yaml
+++ b/governance/mainline/task-cards/pr-152.yaml
@@ -1,0 +1,97 @@
+version: "v0.2"
+
+task:
+  id: "pr-152"
+  title: "Select next lane after watchlist service DI closeout"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-service-lifecycle-di-watchlist-helper-cleanup-decision"
+  objective: "record that G2 should next prepare an adapter-aware watchlist helper cleanup authorization packet instead of selecting a fourth route-surface service candidate immediately"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-watchlist-helper-cleanup-decision"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-watchlist-helper-cleanup-decision"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision packet only; no runtime entrypoint, route, page, shim, service behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json"
+    - "docs/reports/quality/backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-152.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, PM2, or runtime behavior changes in this PR"
+  - "No adapter/data-layer watchlist implementation in this PR"
+  - "No fourth service lifecycle DI candidate implementation or authorization in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-152.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet is misread as implementation authorization, adapter/data helper source edits could start without exact scope or tests"
+    - "If a fourth service candidate is selected before closing the known watchlist helper seam, the service lifecycle DI sequence can widen without resolving accepted residual scope"
+  rollback_plan: "revert this PR and return the steward tree to the G2.11 closeout state recorded by PR #151"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "select adapter-aware watchlist helper cleanup authorization as the next G2 lane after G2.11 closeout"
+    modified_scope: "steward tree, decision report, generated decision JSON, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance bookkeeping only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T02:01:20+08:00"
+    approval_note: "human maintainer requested continuation after PR #151 closeout; this PR selects the next authorization candidate only and does not authorize implementation"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records G2.12 as a decision-only next-lane packet after G2.11 closeout
- selects adapter-aware watchlist helper cleanup as the next authorization candidate
- keeps backend source, tests, OpenSpec changes, issue labels, routes, OpenAPI, and runtime behavior locked

## Verification
- markdown governance: errors=0, checked_files=2
- JSON artifact parse: ok
- mainline scope gate: pass=True
- git diff --cached --check: pass before commit
- GitNexus staged/compare: low risk, changed_symbols=0, affected_processes=0

## Next Gate
Human review. If accepted, prepare a separate G2.13 adapter-aware watchlist helper cleanup implementation authorization packet; no source edits are authorized by this PR.