### PR TITLE
docs: authorize watchlist helper cleanup

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -449,8 +449,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-watchlist-service-lifecycle-di-implementation-2026-05-22.md`,
 │   │   `backend-watchlist-service-lifecycle-di-closeout-2026-05-23.md`,
 │   │   `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md`,
-│   │   `.planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json`
-│   ├── State: watchlist-helper-cleanup-next-lane-decision-prepared
+│   │   `.planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json`,
+│   │   `backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md`,
+│   │   `.planning/codebase/generated/watchlist-helper-cleanup-implementation-authorization-2026-05-23.json`
+│   ├── State: watchlist-helper-cleanup-implementation-authorization-prepared
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -514,11 +516,16 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 `3caeea24dafb02748c92d58b2809e893ce761d5e`; G2.12 now
 │   │                 selects an adapter-aware watchlist helper cleanup
 │   │                 authorization packet as the next lane instead of selecting
-│   │                 a fourth route-surface service candidate immediately
-│   └── Next gate: Human review of the G2.12 next-lane decision packet; if
-│                  accepted, prepare a separate G2.13 adapter-aware watchlist
-│                  helper cleanup implementation authorization packet. Source
-│                  edits remain locked until that packet is reviewed and accepted
+│   │                 a fourth route-surface service candidate immediately; PR
+│   │                 `#152` merged at
+│   │                 `0ccf1fc58d531cba8f64cc1031d53875e636a766`; G2.13 now
+│   │                 records the future adapter-aware helper cleanup write scope,
+│   │                 TDD gates, GitNexus gates, and rollback boundary
+│   └── Next gate: Human review of the G2.13 implementation authorization
+│                  packet; if accepted, create a separate G2.14 implementation
+│                  branch limited to `data_adapters/watchlist.py`,
+│                  `adapters/watchlist_adapter.py`, optional tiny
+│                  `watchlist_service.py` helper support, and focused tests
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -568,7 +575,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-technical-pattern-di-pilot-implementation-2026-05-21.md` | D2.1a.1 | First DI lifecycle pilot implementation merged in PR `#112`; route-level provider and dependency override test seam are in place | D2.1a implementation closed; do not infer a second DI pilot from this evidence |
 | `inject-technical-pattern-detection-service-di` task `5.3` closeout | D2.1a.1 | Final OpenSpec checklist governance merged in PR `#113`; issue `#92` received implementation and final governance closeout comments | D2.1a is 100% closed; future DI work requires a new approved child lane |
 
-| `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet prepared: adapter-aware watchlist helper cleanup is selected as the next authorization candidate; no source edits or OpenSpec changes are authorized | Human review; if accepted, prepare separate G2.13 implementation authorization packet |
+| `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |
+| `backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md` | G | G2.13 implementation authorization packet prepared: future write scope, tests, GitNexus gates, and rollback plan defined for adapter-aware watchlist helper cleanup | Human review; if accepted, create separate G2.14 implementation branch |
 
 ## Completed And Reviewed Ledger
 
@@ -644,7 +652,8 @@ review, PR review, or OpenSpec archive review.
 | D2.1a final OpenSpec checklist governance closeout | D2.1a.1 | OpenSpec task `5.3` marked complete with issue `#92` closeout comment evidence; D2.1a is closed from implementation plus checklist governance perspectives | Reviewed/pass in current thread: PR `#113` checks passed, merge commit `c7e263b8fcdeea4fc952a86d64ac555ca6dde6ce`; changed files limited to `tasks.md` and `pr-113.yaml`; mainline scope gate changed files=`2`, violations=`0`; GitNexus compare low risk with `0` changed symbols and `0` affected processes | `https://github.com/chengjon/mystocks/pull/113`; `https://github.com/chengjon/mystocks/issues/92#issuecomment-4508297089`; `openspec/changes/inject-technical-pattern-detection-service-di/tasks.md` | No further D2.1a work; select a new approved child lane before any additional implementation |
 | D2.x OpenSpec proposal approvals recorded | D2.3-D2.6 | Human maintainer approval recorded for D2.3/D2.4/D2.5/D2.6 proposal task-list entry into governance/evidence execution | Approval-only: each change may execute its governance/evidence `tasks.md` checklist with current-head freshness; no backend source, frontend source, tests, generated client, docs/API edits, route behavior, OpenAPI schema/exposure, probe URL change, PM2 command execution, service restart/recreation, implementation issue creation, or movement of issue `#92` to `ready-for-agent` is authorized | `docs/reports/quality/backend-openspec-d2-proposal-approval-record-2026-05-22.md`; `governance/mainline/task-cards/pr-120.yaml` | Execute approved governance/evidence tasks and keep every downstream decision tied to refreshed evidence |
 
-| G2.12 watchlist helper cleanup next-lane decision | G | Selected adapter-aware watchlist helper cleanup authorization as the next service lifecycle DI lane after G2.11 closeout | Prepared for review; no backend source, test, OpenSpec, issue label, route, OpenAPI, or runtime change authorized | `docs/reports/quality/backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md`; `.planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json` | If accepted, draft G2.13 adapter-aware watchlist helper cleanup implementation authorization packet |
+| G2.12 watchlist helper cleanup next-lane decision | G | Selected adapter-aware watchlist helper cleanup authorization as the next service lifecycle DI lane after G2.11 closeout | Reviewed and merged by PR `#152` at `0ccf1fc58d531cba8f64cc1031d53875e636a766`; no backend source, test, OpenSpec, issue label, route, OpenAPI, or runtime change authorized | `docs/reports/quality/backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md`; `.planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json` | Superseded by G2.13 authorization packet |
+| G2.13 watchlist helper cleanup implementation authorization | G | Exact future write scope, TDD plan, GitNexus gates, and rollback boundary prepared for adapter-aware watchlist helper cleanup | Prepared for review; no backend source, test, OpenSpec, issue label, route, OpenAPI, or runtime change authorized by this PR | `docs/reports/quality/backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md`; `.planning/codebase/generated/watchlist-helper-cleanup-implementation-authorization-2026-05-23.json` | If accepted, create G2.14 implementation branch limited to the authorized helper scope |
 
 ## OpenSpec Branch Register
 

--- a/.planning/codebase/generated/watchlist-helper-cleanup-implementation-authorization-2026-05-23.json
+++ b/.planning/codebase/generated/watchlist-helper-cleanup-implementation-authorization-2026-05-23.json
@@ -1,0 +1,114 @@
+{
+  "artifact": "watchlist-helper-cleanup-implementation-authorization",
+  "generated_at": "2026-05-23T02:13:37+08:00",
+  "git_head": "0ccf1fc58d531cba8f64cc1031d53875e636a766",
+  "workline": "G2.13",
+  "status": "for-review",
+  "boundary": {
+    "this_packet_source_edits": false,
+    "this_packet_test_edits": false,
+    "this_packet_openspec_changes": false,
+    "this_packet_runtime_changes": false,
+    "future_source_edits_allowed_only_after_human_acceptance": true
+  },
+  "parent_context": {
+    "issue_79": {
+      "state": "OPEN",
+      "labels": [
+        "needs-triage"
+      ]
+    },
+    "issue_92": {
+      "state": "OPEN",
+      "labels": [
+        "enhancement",
+        "ready-for-human",
+        "ready-for-downstream"
+      ]
+    },
+    "g2_12_pr": 152,
+    "g2_12_merge_commit": "0ccf1fc58d531cba8f64cc1031d53875e636a766"
+  },
+  "current_helper_surface": {
+    "web/backend/app/services/watchlist_service.py": {
+      "lines": 637,
+      "get_watchlist_service_tokens": 3,
+      "helper_tokens": 0,
+      "depends_tokens": 0,
+      "provider_or_app_state_tokens": 8
+    },
+    "web/backend/app/services/data_adapters/watchlist.py": {
+      "lines": 289,
+      "get_watchlist_service_tokens": 11,
+      "helper_tokens": 9,
+      "depends_tokens": 0,
+      "provider_or_app_state_tokens": 0
+    },
+    "web/backend/app/services/adapters/watchlist_adapter.py": {
+      "lines": 290,
+      "get_watchlist_service_tokens": 11,
+      "helper_tokens": 9,
+      "depends_tokens": 0,
+      "provider_or_app_state_tokens": 0
+    },
+    "web/backend/app/api/watchlist.py": {
+      "lines": 677,
+      "get_watchlist_service_tokens": 8,
+      "helper_tokens": 0,
+      "depends_tokens": 22,
+      "provider_or_app_state_tokens": 8
+    }
+  },
+  "gitnexus_snapshot": {
+    "WatchlistService": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "affected_processes": 0
+    },
+    "get_watchlist_service": {
+      "risk": "MEDIUM",
+      "impacted_count": 15,
+      "direct_callers": 9,
+      "affected_processes": 0,
+      "direct_affected_modules": [
+        "Data_adapters",
+        "Adapters"
+      ]
+    },
+    "WatchlistDataSourceAdapter_data_adapters": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "future_allowed_paths": [
+    "web/backend/app/services/data_adapters/watchlist.py",
+    "web/backend/app/services/adapters/watchlist_adapter.py",
+    "web/backend/app/services/watchlist_service.py",
+    "web/backend/tests/test_watchlist_helper_lifecycle_di.py",
+    "docs/reports/quality/backend-watchlist-helper-cleanup-implementation-2026-05-23.md",
+    "governance/mainline/task-cards/pr-154.yaml"
+  ],
+  "future_forbidden_paths": [
+    "web/backend/app/api/watchlist.py",
+    "web/backend/app/services/email_service.py",
+    "web/backend/app/services/announcement_service.py",
+    "web/backend/app/services/tradingview_widget_service.py",
+    "openspec/changes/**",
+    "openspec/specs/**",
+    "web/frontend/**",
+    "docs/api/**",
+    "config/**",
+    "scripts/**"
+  ],
+  "future_required_gates": [
+    "TDD red-green for both adapter helper files",
+    "architecture/STANDARDS.md read before source edits",
+    "GitNexus context/impact before editing selected symbols",
+    "ruff on touched backend files",
+    "focused watchlist helper and route DI tests",
+    "GitNexus detect_changes(scope=staged)",
+    "mainline scope gate"
+  ],
+  "next_gate": "human review; if accepted, create G2.14 implementation branch"
+}

--- a/docs/reports/quality/backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md
+++ b/docs/reports/quality/backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md
@@ -1,0 +1,218 @@
+# Backend Watchlist Helper Cleanup Implementation Authorization - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: for-review
+- Workline: G2.13 adapter-aware watchlist helper cleanup authorization
+- Parent issue: https://github.com/chengjon/mystocks/issues/79
+- Parent decision issue: https://github.com/chengjon/mystocks/issues/92
+- Current HEAD checked: `0ccf1fc58d531cba8f64cc1031d53875e636a766`
+- Source code changed by this packet: no
+- Runtime behavior changed by this packet: no
+- Tests changed by this packet: no
+
+## Governance Boundary
+
+This document is an implementation authorization packet, not the implementation.
+It records the exact scope that may be used by a future adapter-aware watchlist
+helper cleanup PR if this packet is reviewed and accepted.
+
+This PR must remain governance-only. It does not authorize backend source edits,
+test edits, OpenSpec changes, route/OpenAPI contract changes, PM2 commands,
+issue label movement, or movement of issue `#79` / `#92` to `ready-for-agent`.
+
+## Current Issue State
+
+- Issue `#79`: `OPEN`, label `needs-triage`
+- Issue `#92`: `OPEN`, labels `enhancement`, `ready-for-human`,
+  `ready-for-downstream`
+- Issue `#92` remains parent decision context only; this packet does not change
+  its disposition.
+
+## Evidence Inputs
+
+- `docs/reports/quality/backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md`
+- `.planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json`
+- PR `#152`: https://github.com/chengjon/mystocks/pull/152
+- PR `#152` merge commit:
+  `0ccf1fc58d531cba8f64cc1031d53875e636a766`
+- Prior route-surface implementation PR `#150`, merged at
+  `b14ef8421d8ccd6dfd4a714b2a17d4e1ae971419`
+- Current source inspection of:
+  - `web/backend/app/services/watchlist_service.py`
+  - `web/backend/app/services/data_adapters/watchlist.py`
+  - `web/backend/app/services/adapters/watchlist_adapter.py`
+  - `web/backend/app/api/watchlist.py`
+- Current GitNexus impact snapshots for `WatchlistService`,
+  `get_watchlist_service`, and `WatchlistDataSourceAdapter`
+
+## Current-Head Helper Surface
+
+| File | Lines | Current watchlist getter/helper state |
+|---|---:|---|
+| `web/backend/app/services/watchlist_service.py` | 637 | owns `get_watchlist_service()`, `install_watchlist_service()`, and `get_watchlist_service_dependency()` |
+| `web/backend/app/services/data_adapters/watchlist.py` | 289 | has `_get_watchlist_service()` helper and direct getter-backed lazy cache |
+| `web/backend/app/services/adapters/watchlist_adapter.py` | 290 | has `_get_watchlist_service()` helper and direct getter-backed lazy cache |
+| `web/backend/app/api/watchlist.py` | 677 | route-surface DI already migrated by G2.10; no route handler calls the getter directly |
+
+Current token counts from HEAD `0ccf1fc58d`:
+
+| File | `get_watchlist_service` tokens | `_get_watchlist_service` tokens | `Depends(...)` tokens | provider/app-state tokens |
+|---|---:|---:|---:|---:|
+| `watchlist_service.py` | 3 | 0 | 0 | 8 |
+| `data_adapters/watchlist.py` | 11 | 9 | 0 | 0 |
+| `adapters/watchlist_adapter.py` | 11 | 9 | 0 | 0 |
+| `api/watchlist.py` | 8 | 0 | 22 | 8 |
+
+## GitNexus Pre-Edit Snapshot
+
+### `WatchlistService`
+
+- Target: `Class:web/backend/app/services/watchlist_service.py:WatchlistService`
+- Risk: `LOW`
+- Impacted count: `0`
+- Affected processes: `0`
+
+### `get_watchlist_service`
+
+- Target: `Function:web/backend/app/services/watchlist_service.py:get_watchlist_service`
+- Risk: `MEDIUM`
+- Impacted count: `15`
+- Direct callers: `9`
+- Affected processes: `0`
+- Direct affected modules:
+  - `Data_adapters`
+  - `Adapters`
+
+GitNexus direct callers still include the seven route handlers from the earlier
+index, but current source inspection confirms those route handlers are already
+using the G2.10 dependency seam. Future implementation must refresh GitNexus
+before editing and treat stale graph entries as a reconciliation item, not a
+reason to edit route code.
+
+### `WatchlistDataSourceAdapter`
+
+- Target resolved by GitNexus:
+  `Class:web/backend/app/services/data_adapters/watchlist.py:WatchlistDataSourceAdapter`
+- Risk: `LOW`
+- Impacted count: `0`
+- Affected processes: `0`
+
+The same class name also exists in
+`web/backend/app/services/adapters/watchlist_adapter.py`; future implementation
+must use file-disambiguated GitNexus context/impact or direct file-path evidence
+before editing either adapter.
+
+## Future Allowed Write Scope
+
+If this authorization packet is accepted, a future implementation PR may edit
+only the following paths:
+
+| Path | Allowed purpose |
+|---|---|
+| `web/backend/app/services/data_adapters/watchlist.py` | Replace direct singleton getter dependency with an adapter-aware provider/factory seam while preserving current behavior by default |
+| `web/backend/app/services/adapters/watchlist_adapter.py` | Apply the same adapter-aware provider/factory seam to the parallel adapter wrapper |
+| `web/backend/app/services/watchlist_service.py` | Inspect only by default; edit only if a tiny typed provider alias or helper is strictly needed |
+| `web/backend/tests/test_watchlist_helper_lifecycle_di.py` | Add focused TDD coverage for adapter/helper provider injection and fallback behavior |
+| `docs/reports/quality/backend-watchlist-helper-cleanup-implementation-2026-05-23.md` | Record future implementation evidence |
+| `governance/mainline/task-cards/pr-154.yaml` | Record future implementation PR scope |
+
+## Explicitly Forbidden Scope
+
+The future implementation PR must not edit:
+
+- `web/backend/app/api/watchlist.py`
+- `web/backend/app/services/email_service.py`
+- `web/backend/app/services/announcement_service.py`
+- `web/backend/app/services/tradingview_widget_service.py`
+- unrelated service lifecycle DI candidates
+- OpenSpec change/spec files
+- frontend files
+- docs/API route contract files
+- PM2, Docker, CI, deployment, or runtime configuration
+
+If the future implementation discovers that route code must change, stop and
+return for a new authorization packet instead of expanding this scope.
+
+## Future Implementation Shape
+
+The intended implementation is adapter-aware cleanup, not a route-surface DI
+rewrite.
+
+The preferred minimal shape is:
+
+1. Preserve `get_watchlist_service()` in `watchlist_service.py` as a compatibility
+   getter.
+2. In both adapter files, introduce an injectable provider/factory seam sourced
+   from constructor config, for example `watchlist_service_provider`.
+3. Keep current lazy default behavior by using `get_watchlist_service` as the
+   default provider when no explicit provider is supplied and `mode != "mock"`.
+4. Keep mock mode returning `None` for the real service unless an explicit test
+   provider is supplied.
+5. Avoid touching route handlers because G2.10 already completed the route
+   dependency seam.
+
+The implementation should prefer a small local seam over a new abstraction unless
+the future diff proves both adapter files can share a helper without widening
+scope.
+
+## Required Future TDD Tests
+
+Future implementation must be test-first. Suggested initial failing tests:
+
+1. `data_adapters/watchlist.py` adapter uses an injected fake provider in live
+   mode and does not call the global getter.
+2. `adapters/watchlist_adapter.py` adapter uses an injected fake provider in live
+   mode and does not call the global getter.
+3. Both adapters preserve mock-mode fallback behavior when no provider is
+   supplied.
+4. Existing watchlist route dependency-injection tests still pass unchanged.
+
+Suggested future commands:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_helper_lifecycle_di.py -q -n 0 --tb=short --no-cov
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_lifecycle_di.py -q -n 0 --tb=short --no-cov
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist.py -q -n 0 --tb=short --no-cov
+```
+
+## Required Future Quality Gates
+
+Before future source edits:
+
+- read `architecture/STANDARDS.md`
+- refresh current branch/HEAD state
+- run GitNexus context/impact for:
+  - `get_watchlist_service`
+  - `WatchlistDataSourceAdapter` in each adapter file
+  - any concrete helper symbol selected for edit
+- if any impact is `HIGH` or `CRITICAL`, stop and return for review
+
+After future source edits:
+
+- run the focused TDD commands above
+- run ruff on touched backend files
+- run app import/OpenAPI smoke if the future diff touches imports broadly
+- run GitNexus `detect_changes(scope="staged")`
+- run mainline scope gate against the future PR task card
+
+## Rollback Plan
+
+The future implementation rollback is straightforward:
+
+1. revert the future implementation commit,
+2. restore both adapter helper methods to direct `get_watchlist_service()` lazy
+   getter behavior,
+3. rerun the focused watchlist helper and route DI tests,
+4. record rollback evidence in the future implementation report.
+
+## Next Gate
+
+Human review of this G2.13 authorization packet.
+
+If accepted, create a separate G2.14 implementation branch limited to this
+packet's allowed paths. Until then, backend source edits remain locked.

--- a/governance/mainline/task-cards/pr-153.yaml
+++ b/governance/mainline/task-cards/pr-153.yaml
@@ -1,0 +1,97 @@
+version: "v0.2"
+
+task:
+  id: "pr-153"
+  title: "Authorize adapter-aware watchlist helper cleanup"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-service-lifecycle-di-watchlist-helper-cleanup-authorization"
+  objective: "record exact future write scope, tests, risk gates, and rollback plan for adapter-aware watchlist helper cleanup after G2.12 selected the lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-watchlist-helper-cleanup-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-watchlist-helper-cleanup-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization packet only; no runtime entrypoint, route, page, shim, service behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/watchlist-helper-cleanup-implementation-authorization-2026-05-23.json"
+    - "docs/reports/quality/backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-153.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, PM2, or runtime behavior changes in this PR"
+  - "No adapter/data-layer watchlist implementation in this PR"
+  - "No fourth service lifecycle DI candidate selection or implementation in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-153.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet is misread as implementation, adapter/helper source edits may start before human acceptance"
+    - "If future implementation expands to route code, it can disturb the already-merged G2.10 route-surface DI seam"
+  rollback_plan: "revert this PR and return the steward tree to the G2.12 next-lane decision state recorded by PR #152"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize, for future review only, the exact scope for adapter-aware watchlist helper cleanup"
+    modified_scope: "steward tree, authorization report, generated authorization JSON, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance bookkeeping only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T02:13:37+08:00"
+    approval_note: "human maintainer requested continuation after PR #152; this PR records future authorization scope only and does not authorize implementation"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records G2.13 as an authorization-only packet after PR #152 selected the watchlist helper cleanup lane
- defines exact future scope for adapter-aware watchlist helper cleanup, including allowed paths, forbidden paths, TDD gates, GitNexus gates, and rollback
- keeps backend source, tests, OpenSpec changes, issue labels, routes, OpenAPI, and runtime behavior locked in this PR

## Verification
- markdown governance: errors=0, checked_files=2
- JSON artifact parse: ok
- mainline scope gate: pass=True
- git diff --cached --check: pass before commit
- GitNexus staged/compare: low risk, changed_symbols=0, affected_processes=0

## Next Gate
Human review. If accepted, create a separate G2.14 implementation branch limited to the authorized helper cleanup scope; no source edits are authorized by this PR.