### PR TITLE
refactor: inject watchlist helper service providers

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -451,8 +451,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md`,
 │   │   `.planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json`,
 │   │   `backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md`,
-│   │   `.planning/codebase/generated/watchlist-helper-cleanup-implementation-authorization-2026-05-23.json`
-│   ├── State: watchlist-helper-cleanup-implementation-authorization-prepared
+│   │   `.planning/codebase/generated/watchlist-helper-cleanup-implementation-authorization-2026-05-23.json`,
+│   │   `backend-watchlist-helper-cleanup-implementation-2026-05-23.md`
+│   ├── State: watchlist-helper-cleanup-implementation-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -520,12 +521,18 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 `#152` merged at
 │   │                 `0ccf1fc58d531cba8f64cc1031d53875e636a766`; G2.13 now
 │   │                 records the future adapter-aware helper cleanup write scope,
-│   │                 TDD gates, GitNexus gates, and rollback boundary
-│   └── Next gate: Human review of the G2.13 implementation authorization
-│                  packet; if accepted, create a separate G2.14 implementation
-│                  branch limited to `data_adapters/watchlist.py`,
-│                  `adapters/watchlist_adapter.py`, optional tiny
-│                  `watchlist_service.py` helper support, and focused tests
+│   │                 TDD gates, GitNexus gates, and rollback boundary; PR `#153`
+│   │                 merged at
+│   │                 `938682debb90a25392ca208e706d8388d06de786`; G2.14 now
+│   │                 implements that scope by adding constructor-configured
+│   │                 `watchlist_service_provider` seams to both watchlist adapter
+│   │                 helper files while preserving default getter fallback and
+│   │                 leaving route code unchanged; PR `#154` is open with
+│   │                 Mainline Governance Gate and check-compliance passed
+│   └── Next gate: Human review of PR `#154`; if accepted and
+│                  merged, create a separate G2.15 closeout packet with merge
+│                  commit, final checks, and the next service lifecycle DI
+│                  decision gate
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -576,7 +583,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `inject-technical-pattern-detection-service-di` task `5.3` closeout | D2.1a.1 | Final OpenSpec checklist governance merged in PR `#113`; issue `#92` received implementation and final governance closeout comments | D2.1a is 100% closed; future DI work requires a new approved child lane |
 
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |
-| `backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md` | G | G2.13 implementation authorization packet prepared: future write scope, tests, GitNexus gates, and rollback plan defined for adapter-aware watchlist helper cleanup | Human review; if accepted, create separate G2.14 implementation branch |
+| `backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md` | G | G2.13 implementation authorization packet merged: future write scope, tests, GitNexus gates, and rollback plan defined for adapter-aware watchlist helper cleanup | Superseded by G2.14 implementation evidence |
+| `backend-watchlist-helper-cleanup-implementation-2026-05-23.md` | G | G2.14 implementation prepared for review: both watchlist adapter/helper files now accept constructor-configured provider seams; route code unchanged | Human review; if accepted and merged, create G2.15 closeout packet |
 
 ## Completed And Reviewed Ledger
 
@@ -653,7 +661,8 @@ review, PR review, or OpenSpec archive review.
 | D2.x OpenSpec proposal approvals recorded | D2.3-D2.6 | Human maintainer approval recorded for D2.3/D2.4/D2.5/D2.6 proposal task-list entry into governance/evidence execution | Approval-only: each change may execute its governance/evidence `tasks.md` checklist with current-head freshness; no backend source, frontend source, tests, generated client, docs/API edits, route behavior, OpenAPI schema/exposure, probe URL change, PM2 command execution, service restart/recreation, implementation issue creation, or movement of issue `#92` to `ready-for-agent` is authorized | `docs/reports/quality/backend-openspec-d2-proposal-approval-record-2026-05-22.md`; `governance/mainline/task-cards/pr-120.yaml` | Execute approved governance/evidence tasks and keep every downstream decision tied to refreshed evidence |
 
 | G2.12 watchlist helper cleanup next-lane decision | G | Selected adapter-aware watchlist helper cleanup authorization as the next service lifecycle DI lane after G2.11 closeout | Reviewed and merged by PR `#152` at `0ccf1fc58d531cba8f64cc1031d53875e636a766`; no backend source, test, OpenSpec, issue label, route, OpenAPI, or runtime change authorized | `docs/reports/quality/backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md`; `.planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json` | Superseded by G2.13 authorization packet |
-| G2.13 watchlist helper cleanup implementation authorization | G | Exact future write scope, TDD plan, GitNexus gates, and rollback boundary prepared for adapter-aware watchlist helper cleanup | Prepared for review; no backend source, test, OpenSpec, issue label, route, OpenAPI, or runtime change authorized by this PR | `docs/reports/quality/backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md`; `.planning/codebase/generated/watchlist-helper-cleanup-implementation-authorization-2026-05-23.json` | If accepted, create G2.14 implementation branch limited to the authorized helper scope |
+| G2.13 watchlist helper cleanup implementation authorization | G | Exact future write scope, TDD plan, GitNexus gates, and rollback boundary prepared for adapter-aware watchlist helper cleanup | Reviewed and merged by PR `#153` at `938682debb90a25392ca208e706d8388d06de786`; no backend source, test, OpenSpec, issue label, route, OpenAPI, or runtime change authorized by that PR | `docs/reports/quality/backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md`; `.planning/codebase/generated/watchlist-helper-cleanup-implementation-authorization-2026-05-23.json` | Superseded by G2.14 implementation evidence |
+| G2.14 watchlist helper cleanup implementation | G | Adapter-aware provider seam implemented for both watchlist helper adapter files with focused TDD coverage | PR `#154` open for review: red `4 failed, 2 passed`; green focused helper `6 passed`; route DI regression `3 passed`; logging regression `3 passed`; ruff passed; OpenAPI smoke `routes=548`, `paths=500`, `duplicate_operation_ids=0`; Mainline Governance Gate and check-compliance passed | `docs/reports/quality/backend-watchlist-helper-cleanup-implementation-2026-05-23.md`; `web/backend/tests/test_watchlist_helper_lifecycle_di.py`; https://github.com/chengjon/mystocks/pull/154 | If accepted and merged, create G2.15 closeout packet |
 
 ## OpenSpec Branch Register
 

--- a/docs/reports/quality/backend-watchlist-helper-cleanup-implementation-2026-05-23.md
+++ b/docs/reports/quality/backend-watchlist-helper-cleanup-implementation-2026-05-23.md
@@ -1,0 +1,117 @@
+# Backend Watchlist Helper Cleanup Implementation - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: implementation-prepared-for-review
+- Workline: G2.14 adapter-aware watchlist helper cleanup implementation
+- Parent authorization PR: https://github.com/chengjon/mystocks/pull/153
+- Parent authorization merge commit:
+  `938682debb90a25392ca208e706d8388d06de786`
+- Current implementation branch: `g2-14-watchlist-helper-cleanup-implementation`
+- Implementation PR: https://github.com/chengjon/mystocks/pull/154
+- PR checks at creation: Mainline Governance Gate passed; check-compliance passed
+- Source code changed by this packet: yes, within authorized helper scope
+- Runtime route/OpenAPI contract changed by this packet: no
+- OpenSpec files changed by this packet: no
+
+## Governance Boundary
+
+This implementation follows the G2.13 authorization packet. It is limited to the
+adapter-aware watchlist helper cleanup lane and does not authorize any fourth
+service lifecycle DI candidate.
+
+This PR must not be treated as permission to edit route code, OpenAPI contracts,
+frontend code, PM2/runtime configuration, issue labels, or unrelated services.
+
+## Implemented Scope
+
+| Path | Change |
+|---|---|
+| `web/backend/app/services/data_adapters/watchlist.py` | Added constructor-configured `watchlist_service_provider` seam while preserving default lazy getter fallback |
+| `web/backend/app/services/adapters/watchlist_adapter.py` | Added the same provider seam to the parallel watchlist adapter wrapper |
+| `web/backend/tests/test_watchlist_helper_lifecycle_di.py` | Added focused TDD coverage for live-mode provider injection, mock-mode explicit provider behavior, and mock-mode no-provider fallback |
+
+No changes were made to `web/backend/app/api/watchlist.py`.
+
+## TDD Evidence
+
+Red run before implementation:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_helper_lifecycle_di.py -q -n 0 --tb=short --no-cov
+4 failed, 2 passed
+```
+
+Expected red failures:
+
+- both adapter classes ignored `watchlist_service_provider` in live mode and
+  called the global getter,
+- both adapter classes returned `None` in mock mode even when an explicit
+  provider was supplied.
+
+Green run after implementation:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_helper_lifecycle_di.py -q -n 0 --tb=short --no-cov
+6 passed in 1.45s
+```
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `black` on touched Python files | passed; one adapter file reformatted |
+| `ruff check` on touched Python files | passed |
+| `test_watchlist_helper_lifecycle_di.py` | 6 passed |
+| `test_watchlist_service_lifecycle_di.py` | 3 passed |
+| `test_watchlist_service_logging.py` | 3 passed |
+| placeholder-env `app.main` / `app.openapi()` smoke | `routes=548`, `paths=500`, `operations=536`, `duplicate_operation_ids=0`, `duplicate_operation_id_warnings=0` |
+
+## Current-Head Helper Surface After Implementation
+
+| File | Lines | Provider seam |
+|---|---:|---|
+| `web/backend/app/services/data_adapters/watchlist.py` | 295 | `watchlist_service_provider` accepted from constructor config |
+| `web/backend/app/services/adapters/watchlist_adapter.py` | 294 | `watchlist_service_provider` accepted from constructor config |
+| `web/backend/app/services/watchlist_service.py` | 637 | unchanged |
+| `web/backend/app/api/watchlist.py` | 677 | unchanged route-surface DI |
+
+The adapter helper methods still preserve the compatibility fallback to
+`get_watchlist_service()` when no explicit provider is supplied and the adapter
+is not in mock mode.
+
+## GitNexus Evidence
+
+Pre-edit impact/context checks:
+
+- `get_watchlist_service`: `MEDIUM`, impacted count `15`, affected processes `0`
+- `WatchlistDataSourceAdapter` in `data_adapters/watchlist.py`: `LOW`,
+  impacted count `0`, affected processes `0`
+- `WatchlistDataSourceAdapter` in `adapters/watchlist_adapter.py`: context
+  resolved by file path; no execution flows reported
+
+The implementation did not edit `watchlist_service.py` and did not edit route
+handlers, so the stale GitNexus route direct-caller entries remain a graph
+freshness concern rather than a code change requirement.
+
+## Rollback Plan
+
+Revert the implementation commit to restore both adapter helper methods to the
+previous direct lazy getter behavior. Then rerun:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_helper_lifecycle_di.py -q -n 0 --tb=short --no-cov
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_lifecycle_di.py -q -n 0 --tb=short --no-cov
+```
+
+## Next Gate
+
+Human review of PR #154.
+
+If accepted and merged, create a separate G2.15 closeout packet to update the
+steward tree with the merge commit, final checks, and next service lifecycle DI
+decision gate.

--- a/governance/mainline/task-cards/pr-154.yaml
+++ b/governance/mainline/task-cards/pr-154.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-154"
+  title: "Implement adapter-aware watchlist helper cleanup"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-service-lifecycle-di-watchlist-helper-cleanup-implementation"
+  objective: "implement the G2.14 adapter-aware watchlist helper cleanup within the exact G2.13 authorized scope"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-watchlist-helper-cleanup-implementation"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-watchlist-helper-cleanup-implementation"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow adapter-aware watchlist helper lifecycle DI cleanup authorized by PR #153; route paths, OpenAPI behavior, product surface, route handlers, and runtime process state are unchanged"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "web/backend/app/services/data_adapters/watchlist.py"
+    - "web/backend/app/services/adapters/watchlist_adapter.py"
+    - "web/backend/tests/test_watchlist_helper_lifecycle_di.py"
+    - "docs/reports/quality/backend-watchlist-helper-cleanup-implementation-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-154.yaml"
+  forbidden_paths:
+    - "web/backend/app/api/watchlist.py"
+    - "web/backend/app/services/watchlist_service.py"
+    - "web/backend/app/services/email_service.py"
+    - "web/backend/app/services/announcement_service.py"
+    - "web/backend/app/services/tradingview_widget_service.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No route handler, OpenAPI, frontend, generated client, docs/API, PM2, script, config, or OpenSpec changes in this PR"
+  - "No fourth service lifecycle DI candidate selection or implementation in this PR"
+  - "No deletion of get_watchlist_service compatibility behavior"
+  - "No issue label changes or ready-for-agent movement"
+
+acceptance:
+  checks:
+    - id: "focused-helper-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_helper_lifecycle_di.py -q -n 0 --tb=short --no-cov"
+      required: true
+    - id: "route-di-regression-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_lifecycle_di.py -q -n 0 --tb=short --no-cov"
+      required: true
+    - id: "watchlist-logging-regression-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_logging.py -q -n 0 --tb=short --no-cov"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/data_adapters/watchlist.py web/backend/app/services/adapters/watchlist_adapter.py web/backend/tests/test_watchlist_helper_lifecycle_di.py"
+      required: true
+    - id: "black-check-touched"
+      command: "black --check web/backend/app/services/data_adapters/watchlist.py web/backend/app/services/adapters/watchlist_adapter.py web/backend/tests/test_watchlist_helper_lifecycle_di.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-watchlist-helper-cleanup-implementation-2026-05-23.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-154.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If provider injection changes default behavior, live watchlist adapter calls could fail"
+    - "If route code is modified, the G2.10 route-surface boundary would be violated"
+  rollback_plan: "revert this PR and rerun focused helper and route DI tests"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "add adapter-aware provider seam to watchlist helper adapters"
+    modified_scope: "two watchlist adapter/helper files, focused tests, implementation report, steward tree, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "compatibility getter fallback preserved"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused helper tests, route DI regression, ruff, black, mainline scope, or GitNexus staged checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-23T02:26:27+08:00"
+    approval_note: "human maintainer requested continuation after PR #153 authorization; implementation is limited to authorized adapter-aware watchlist helper cleanup scope"
+    secondary_approved: false

--- a/web/backend/app/services/adapters/watchlist_adapter.py
+++ b/web/backend/app/services/adapters/watchlist_adapter.py
@@ -4,7 +4,7 @@
 
 import time
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 from app.services.data_source_interface import (
     HealthStatus,
@@ -30,6 +30,7 @@ class WatchlistDataSourceAdapter(IDataSource):
 
         # Lazy initialization of services (only when needed)
         self._watchlist_service = None
+        self._watchlist_service_provider: Callable[[], Any] | None = config.get("watchlist_service_provider")
         self._mock_manager = None
 
         self.metrics = DataSourceMetrics()
@@ -38,11 +39,14 @@ class WatchlistDataSourceAdapter(IDataSource):
 
     def _get_watchlist_service(self):
         """Lazy initialization of watchlist service"""
-        if self._watchlist_service is None and self.mode != "mock":
+        if self._watchlist_service is None:
             try:
-                from app.services.watchlist_service import get_watchlist_service
+                if self._watchlist_service_provider is not None:
+                    self._watchlist_service = self._watchlist_service_provider()
+                elif self.mode != "mock":
+                    from app.services.watchlist_service import get_watchlist_service
 
-                self._watchlist_service = get_watchlist_service()
+                    self._watchlist_service = get_watchlist_service()
             except Exception as e:
                 self._watchlist_service = None
                 raise RuntimeError(f"Failed to initialize watchlist service: {e}")

--- a/web/backend/app/services/data_adapters/watchlist.py
+++ b/web/backend/app/services/data_adapters/watchlist.py
@@ -1,10 +1,11 @@
 """
 自选股管理数据源适配器
 """
+
 import time
 import logging
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 from app.services.data_source_interface import (
     HealthStatus,
@@ -14,6 +15,7 @@ from app.services.data_source_interface import (
 from .base import DataSourceMetrics
 
 logger = logging.getLogger(__name__)
+
 
 class WatchlistDataSourceAdapter(IDataSource):
     """自选股管理数据源适配器 - 集成现有自选股服务到数据源工厂模式"""
@@ -27,6 +29,7 @@ class WatchlistDataSourceAdapter(IDataSource):
 
         # Lazy initialization of services (only when needed)
         self._watchlist_service = None
+        self._watchlist_service_provider: Callable[[], Any] | None = config.get("watchlist_service_provider")
         self._mock_manager = None
 
         self.metrics = DataSourceMetrics()
@@ -35,11 +38,14 @@ class WatchlistDataSourceAdapter(IDataSource):
 
     def _get_watchlist_service(self):
         """Lazy initialization of watchlist service"""
-        if self._watchlist_service is None and self.mode != "mock":
+        if self._watchlist_service is None:
             try:
-                from app.services.watchlist_service import get_watchlist_service
+                if self._watchlist_service_provider is not None:
+                    self._watchlist_service = self._watchlist_service_provider()
+                elif self.mode != "mock":
+                    from app.services.watchlist_service import get_watchlist_service
 
-                self._watchlist_service = get_watchlist_service()
+                    self._watchlist_service = get_watchlist_service()
             except Exception as e:
                 self._watchlist_service = None
                 raise RuntimeError(f"Failed to initialize watchlist service: {e}")

--- a/web/backend/tests/test_watchlist_helper_lifecycle_di.py
+++ b/web/backend/tests/test_watchlist_helper_lifecycle_di.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services import watchlist_service
+from app.services.adapters.watchlist_adapter import (
+    WatchlistDataSourceAdapter as LegacyWatchlistDataSourceAdapter,
+)
+from app.services.data_adapters.watchlist import (
+    WatchlistDataSourceAdapter as DataWatchlistDataSourceAdapter,
+)
+
+
+@pytest.mark.parametrize(
+    "adapter_cls",
+    [
+        DataWatchlistDataSourceAdapter,
+        LegacyWatchlistDataSourceAdapter,
+    ],
+)
+def test_watchlist_adapters_use_injected_provider_in_live_mode(monkeypatch, adapter_cls):
+    fake_service = object()
+    provider_calls = 0
+
+    def fail_global_getter():
+        raise AssertionError("global watchlist getter should not be called")
+
+    def provider():
+        nonlocal provider_calls
+        provider_calls += 1
+        return fake_service
+
+    monkeypatch.setattr(watchlist_service, "get_watchlist_service", fail_global_getter)
+
+    adapter = adapter_cls(
+        {
+            "mode": "live",
+            "watchlist_service_provider": provider,
+        }
+    )
+
+    assert adapter._get_watchlist_service() is fake_service
+    assert adapter._get_watchlist_service() is fake_service
+    assert provider_calls == 1
+
+
+@pytest.mark.parametrize(
+    "adapter_cls",
+    [
+        DataWatchlistDataSourceAdapter,
+        LegacyWatchlistDataSourceAdapter,
+    ],
+)
+def test_watchlist_adapters_allow_explicit_provider_in_mock_mode(adapter_cls):
+    fake_service = object()
+
+    adapter = adapter_cls(
+        {
+            "mode": "mock",
+            "watchlist_service_provider": lambda: fake_service,
+        }
+    )
+
+    assert adapter._get_watchlist_service() is fake_service
+
+
+@pytest.mark.parametrize(
+    "adapter_cls",
+    [
+        DataWatchlistDataSourceAdapter,
+        LegacyWatchlistDataSourceAdapter,
+    ],
+)
+def test_watchlist_adapters_preserve_mock_mode_without_provider(adapter_cls):
+    adapter = adapter_cls({"mode": "mock"})
+
+    assert adapter._get_watchlist_service() is None


### PR DESCRIPTION
## Summary

Implements G2.14 adapter-aware watchlist helper lifecycle DI cleanup within the PR #153 authorization boundary.

- Adds `watchlist_service_provider` support to both watchlist helper adapter classes.
- Preserves lazy default `get_watchlist_service()` fallback for compatibility.
- Keeps mock-mode fallback behavior while allowing explicit provider injection in tests or future callers.
- Does not modify route handlers, OpenAPI behavior, frontend, config, or runtime process state.

## Scope

Changed runtime files:

- `web/backend/app/services/data_adapters/watchlist.py`
- `web/backend/app/services/adapters/watchlist_adapter.py`

Added evidence/governance/test files:

- `web/backend/tests/test_watchlist_helper_lifecycle_di.py`
- `docs/reports/quality/backend-watchlist-helper-cleanup-implementation-2026-05-23.md`
- `governance/mainline/task-cards/pr-154.yaml`
- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`

## Verification

TDD red first:

- `web/backend/tests/test_watchlist_helper_lifecycle_di.py`: 4 failed, 2 passed before implementation.

Final verification in the G2.14 worktree:

- `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_helper_lifecycle_di.py -q -n 0 --tb=short --no-cov`: 6 passed
- `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_lifecycle_di.py -q -n 0 --tb=short --no-cov`: 3 passed
- `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_logging.py -q -n 0 --tb=short --no-cov`: 3 passed
- `ruff check web/backend/app/services/data_adapters/watchlist.py web/backend/app/services/adapters/watchlist_adapter.py web/backend/tests/test_watchlist_helper_lifecycle_di.py`: passed
- `black --check web/backend/app/services/data_adapters/watchlist.py web/backend/app/services/adapters/watchlist_adapter.py web/backend/tests/test_watchlist_helper_lifecycle_di.py`: passed
- `python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-watchlist-helper-cleanup-implementation-2026-05-23.md`: 2 checked, 0 errors
- OpenAPI smoke: `app_import=ok routes=548 paths=500 operations=536 duplicate_operation_ids=0 duplicate_operation_id_warnings=0`
- `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-154.yaml`: pass=True
- GitNexus compare against `origin/wip/root-dirty-20260403`: low risk, 6 changed files, 0 affected processes

## Boundary

This PR does not authorize or perform G2.15 closeout. If accepted, the next step is a separate closeout packet and steward tree update recording the merged implementation result.
