### PR TITLE
docs: record watchlist helper cleanup closeout

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -527,12 +527,15 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 implements that scope by adding constructor-configured
 │   │                 `watchlist_service_provider` seams to both watchlist adapter
 │   │                 helper files while preserving default getter fallback and
-│   │                 leaving route code unchanged; PR `#154` is open with
-│   │                 Mainline Governance Gate and check-compliance passed
-│   └── Next gate: Human review of PR `#154`; if accepted and
-│                  merged, create a separate G2.15 closeout packet with merge
-│                  commit, final checks, and the next service lifecycle DI
-│                  decision gate
+│   │                 leaving route code unchanged; PR `#154` merged at
+│   │                 `1dcb394a49a9d95e939b2119acc431b825954036`; G2.15 now
+│   │                 records the closeout, current-head verification, and
+│   │                 confirms no follow-up implementation is authorized; PR
+│   │                 `#155` is open with Mainline Governance Gate and
+│   │                 check-compliance passed
+│   └── Next gate: Human review of PR `#155`; if accepted,
+│                  create a separate G2.16 decision packet before any further
+│                  service lifecycle DI source edits
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -584,7 +587,8 @@ CODEBASE-MAP Architecture Remediation Program
 
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |
 | `backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md` | G | G2.13 implementation authorization packet merged: future write scope, tests, GitNexus gates, and rollback plan defined for adapter-aware watchlist helper cleanup | Superseded by G2.14 implementation evidence |
-| `backend-watchlist-helper-cleanup-implementation-2026-05-23.md` | G | G2.14 implementation prepared for review: both watchlist adapter/helper files now accept constructor-configured provider seams; route code unchanged | Human review; if accepted and merged, create G2.15 closeout packet |
+| `backend-watchlist-helper-cleanup-implementation-2026-05-23.md` | G | G2.14 implementation merged by PR `#154`: both watchlist adapter/helper files now accept constructor-configured provider seams; route code unchanged | Superseded by G2.15 closeout packet |
+| `backend-watchlist-helper-cleanup-closeout-2026-05-23.md` | G | G2.15 closeout prepared: PR `#154` merged at `1dcb394a49a9d95e939b2119acc431b825954036`, current-head verification rerun, and no follow-up implementation authorized; PR `#155` is open with Mainline Governance Gate and check-compliance passed | Human review of PR `#155`; if accepted, create a separate G2.16 decision packet before any further service lifecycle DI source edits |
 
 ## Completed And Reviewed Ledger
 
@@ -662,7 +666,8 @@ review, PR review, or OpenSpec archive review.
 
 | G2.12 watchlist helper cleanup next-lane decision | G | Selected adapter-aware watchlist helper cleanup authorization as the next service lifecycle DI lane after G2.11 closeout | Reviewed and merged by PR `#152` at `0ccf1fc58d531cba8f64cc1031d53875e636a766`; no backend source, test, OpenSpec, issue label, route, OpenAPI, or runtime change authorized | `docs/reports/quality/backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md`; `.planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json` | Superseded by G2.13 authorization packet |
 | G2.13 watchlist helper cleanup implementation authorization | G | Exact future write scope, TDD plan, GitNexus gates, and rollback boundary prepared for adapter-aware watchlist helper cleanup | Reviewed and merged by PR `#153` at `938682debb90a25392ca208e706d8388d06de786`; no backend source, test, OpenSpec, issue label, route, OpenAPI, or runtime change authorized by that PR | `docs/reports/quality/backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md`; `.planning/codebase/generated/watchlist-helper-cleanup-implementation-authorization-2026-05-23.json` | Superseded by G2.14 implementation evidence |
-| G2.14 watchlist helper cleanup implementation | G | Adapter-aware provider seam implemented for both watchlist helper adapter files with focused TDD coverage | PR `#154` open for review: red `4 failed, 2 passed`; green focused helper `6 passed`; route DI regression `3 passed`; logging regression `3 passed`; ruff passed; OpenAPI smoke `routes=548`, `paths=500`, `duplicate_operation_ids=0`; Mainline Governance Gate and check-compliance passed | `docs/reports/quality/backend-watchlist-helper-cleanup-implementation-2026-05-23.md`; `web/backend/tests/test_watchlist_helper_lifecycle_di.py`; https://github.com/chengjon/mystocks/pull/154 | If accepted and merged, create G2.15 closeout packet |
+| G2.14 watchlist helper cleanup implementation | G | Adapter-aware provider seam implemented for both watchlist helper adapter files with focused TDD coverage | Reviewed and merged by PR `#154` at `1dcb394a49a9d95e939b2119acc431b825954036`: red `4 failed, 2 passed`; green focused helper `6 passed`; route DI regression `3 passed`; logging regression `3 passed`; ruff passed; OpenAPI smoke `routes=548`, `paths=500`, `duplicate_operation_ids=0`; Mainline Governance Gate and check-compliance passed | `docs/reports/quality/backend-watchlist-helper-cleanup-implementation-2026-05-23.md`; `web/backend/tests/test_watchlist_helper_lifecycle_di.py`; https://github.com/chengjon/mystocks/pull/154 | Superseded by G2.15 closeout packet |
+| G2.15 watchlist helper cleanup closeout | G | Adapter-aware watchlist helper cleanup completion recorded after PR `#154` merge | PR `#155` open for review: current-head helper tests `6 passed`; route DI regression `3 passed`; logging regression `3 passed`; ruff passed; OpenAPI smoke `routes=548`, `paths=500`, `duplicate_operation_ids=0`; Mainline Governance Gate and check-compliance passed; issue `#79` remains `OPEN` with `needs-triage`; no source, route, OpenAPI, OpenSpec, frontend, config, PM2, issue-label, or runtime change authorized | `docs/reports/quality/backend-watchlist-helper-cleanup-closeout-2026-05-23.md`; `.planning/codebase/generated/watchlist-helper-cleanup-closeout-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/155 | Human review; if accepted, create a separate G2.16 decision packet before any further service lifecycle DI source edits |
 
 ## OpenSpec Branch Register
 
@@ -744,7 +749,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review G2.11 watchlist service DI closeout | Future service seam lane | G2.11 closeout packet prepared; `watchlist_service.py` route-surface DI is merged, and any fourth candidate or adapter-aware watchlist cleanup requires a separate packet |
+| P2 | Review PR `#155` G2.15 watchlist helper cleanup closeout | Future service seam lane | PR `#154` merged; PR `#155` is open with checks passed; adapter-aware watchlist helper cleanup is complete, and any further service lifecycle DI work requires a separate G2.16 decision packet |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/generated/watchlist-helper-cleanup-closeout-2026-05-23.json
+++ b/.planning/codebase/generated/watchlist-helper-cleanup-closeout-2026-05-23.json
@@ -1,0 +1,70 @@
+{
+  "artifact": "watchlist-helper-cleanup-closeout-2026-05-23",
+  "recorded_at": "2026-05-23T03:05:02+08:00",
+  "workline": "G2.15 adapter-aware watchlist helper cleanup closeout",
+  "status": "completed-and-recorded",
+  "implementation_pr": 154,
+  "implementation_pr_url": "https://github.com/chengjon/mystocks/pull/154",
+  "implementation_commit": "fad638f636060237845ca893dbd16420c4ef92af",
+  "implementation_merge_commit": "1dcb394a49a9d95e939b2119acc431b825954036",
+  "parent_authorization_pr": 153,
+  "parent_authorization_merge_commit": "938682debb90a25392ca208e706d8388d06de786",
+  "closeout_branch": "g2-15-watchlist-helper-cleanup-closeout",
+  "closeout_pr": 155,
+  "closeout_pr_url": "https://github.com/chengjon/mystocks/pull/155",
+  "closeout_pr_checks_at_creation": {
+    "mainline_governance_gate": "pass",
+    "check_compliance": "pass",
+    "weekly_full_scan": "skipped"
+  },
+  "scope": {
+    "completed_runtime_files": [
+      "web/backend/app/services/data_adapters/watchlist.py",
+      "web/backend/app/services/adapters/watchlist_adapter.py"
+    ],
+    "completed_test_files": [
+      "web/backend/tests/test_watchlist_helper_lifecycle_di.py"
+    ],
+    "route_openapi_changed": false,
+    "frontend_changed": false,
+    "openspec_changed": false,
+    "pm2_runtime_changed": false
+  },
+  "github_checks": {
+    "mainline_governance_gate": "pass",
+    "check_compliance": "pass",
+    "weekly_full_scan": "skipped"
+  },
+  "current_head_verification": {
+    "head": "1dcb394a49a9d95e939b2119acc431b825954036",
+    "helper_tests": "6 passed",
+    "route_di_regression_tests": "3 passed",
+    "logging_regression_tests": "3 passed",
+    "ruff_touched": "passed",
+    "openapi_smoke": {
+      "app_import": "ok",
+      "routes": 548,
+      "paths": 500,
+      "operations": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0
+    }
+  },
+  "issue_state_at_closeout": {
+    "issue_79": {
+      "state": "OPEN",
+      "labels": [
+        "needs-triage"
+      ]
+    },
+    "issue_92": {
+      "state": "OPEN",
+      "labels": [
+        "enhancement",
+        "ready-for-human",
+        "ready-for-downstream"
+      ]
+    }
+  },
+  "next_gate": "Human review of G2.15 closeout; if accepted, create a separate G2.16 decision packet before any further service lifecycle DI source edits."
+}

--- a/docs/reports/quality/backend-watchlist-helper-cleanup-closeout-2026-05-23.md
+++ b/docs/reports/quality/backend-watchlist-helper-cleanup-closeout-2026-05-23.md
@@ -1,0 +1,113 @@
+# Backend Watchlist Helper Cleanup Closeout - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: completed-and-recorded
+- Workline: G2.15 adapter-aware watchlist helper cleanup closeout
+- Implementation PR: https://github.com/chengjon/mystocks/pull/154
+- Implementation merge commit:
+  `1dcb394a49a9d95e939b2119acc431b825954036`
+- Implementation commit:
+  `fad638f636060237845ca893dbd16420c4ef92af`
+- Parent authorization PR: https://github.com/chengjon/mystocks/pull/153
+- Parent authorization merge commit:
+  `938682debb90a25392ca208e706d8388d06de786`
+- Closeout branch: `g2-15-watchlist-helper-cleanup-closeout`
+- Closeout PR: https://github.com/chengjon/mystocks/pull/155
+- Closeout PR checks at creation: Mainline Governance Gate passed;
+  check-compliance passed
+- Recorded at: `2026-05-23T03:05:02+08:00`
+
+## Governance Boundary
+
+This closeout is governance bookkeeping only. It records that the G2.14
+adapter-aware watchlist helper cleanup implementation was reviewed through PR
+checks and merged. It does not authorize another service lifecycle DI candidate,
+OpenSpec changes, issue label movement, PM2/runtime work, frontend work,
+route/OpenAPI contract changes, or additional source edits.
+
+## Completed Scope
+
+PR `#154` implemented the G2.13-authorized helper cleanup scope:
+
+- `web/backend/app/services/data_adapters/watchlist.py`
+  - added constructor-configured `watchlist_service_provider` support
+  - preserved lazy default `get_watchlist_service()` fallback
+  - preserved mock fallback behavior while allowing explicit provider injection
+- `web/backend/app/services/adapters/watchlist_adapter.py`
+  - added the same provider seam and compatibility fallback behavior
+- `web/backend/tests/test_watchlist_helper_lifecycle_di.py`
+  - covers provider injection in live mode for both helper adapter classes
+  - covers explicit provider support in mock mode
+  - covers unchanged mock mode behavior when no provider is configured
+
+No route handler, OpenAPI schema, frontend, config, script, OpenSpec, PM2, or
+runtime process-state files were changed by PR `#154`.
+
+## Verification Recorded Before Merge
+
+Local verification from the implementation packet:
+
+| Check | Result |
+|---|---|
+| TDD red run | `4 failed, 2 passed` before implementation |
+| focused helper tests | `6 passed` |
+| route DI regression tests | `3 passed` |
+| watchlist logging regression tests | `3 passed` |
+| touched-file `ruff check` | passed |
+| touched-file `black --check` | passed |
+| Markdown governance | checked_files=2, errors=0 |
+| `app.main` / `app.openapi()` smoke with required placeholder env | routes=548, paths=500, operations=536, duplicate_operation_ids=0, duplicate_operation_id_warnings=0 |
+| Mainline scope gate | pass=True |
+| GitNexus compare against `origin/wip/root-dirty-20260403` | low risk, changed_files=6, affected_processes=0 |
+
+GitHub PR `#154` checks:
+
+| Check | Result |
+|---|---|
+| Mainline Governance Gate | pass |
+| `check-compliance` | pass |
+| `weekly-full-scan` | skipped as expected |
+
+## Current-Head Verification After Merge
+
+The closeout branch is based on the PR `#154` merge commit:
+
+```text
+1dcb394a4 Merge pull request #154 from chengjon/g2-14-watchlist-helper-cleanup-implementation
+```
+
+Verification rerun on this merged HEAD:
+
+| Check | Result |
+|---|---|
+| `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_helper_lifecycle_di.py -q -n 0 --tb=short --no-cov` | 6 passed |
+| `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_lifecycle_di.py -q -n 0 --tb=short --no-cov` | 3 passed |
+| `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_logging.py -q -n 0 --tb=short --no-cov` | 3 passed |
+| `ruff check web/backend/app/services/data_adapters/watchlist.py web/backend/app/services/adapters/watchlist_adapter.py web/backend/tests/test_watchlist_helper_lifecycle_di.py` | passed |
+| `app.main` / `app.openapi()` smoke with required placeholder env | routes=548, paths=500, operations=536, duplicate_operation_ids=0, duplicate_operation_id_warnings=0 |
+
+## Current State After Merge
+
+- Both watchlist helper adapter files now support constructor-configured
+  `watchlist_service_provider` injection.
+- Default `get_watchlist_service()` compatibility fallback remains available.
+- `watchlist_service.py` remains the route-surface app-state provider source from
+  the earlier G2.10/G2.11 lane.
+- Watchlist route handlers remain unchanged by this helper cleanup.
+- Issue `#79` remains `OPEN` with `needs-triage`.
+- Issue `#92` remains `OPEN` with `enhancement`, `ready-for-human`, and
+  `ready-for-downstream`.
+
+## Next Gate
+
+Human review of this G2.15 closeout packet.
+
+If accepted, create a separate G2.16 decision packet before any further service
+lifecycle DI source edits. That packet should decide whether to select another
+route-surface service candidate, run another adapter-aware cleanup, or pause the
+service lifecycle DI sequence and return to another architecture workline.

--- a/governance/mainline/task-cards/pr-155.yaml
+++ b/governance/mainline/task-cards/pr-155.yaml
@@ -1,0 +1,97 @@
+version: "v0.2"
+
+task:
+  id: "pr-155"
+  title: "Record G2.15 watchlist helper cleanup closeout"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-service-lifecycle-di-watchlist-helper-cleanup-closeout"
+  objective: "record that the adapter-aware watchlist helper cleanup implementation was reviewed, merged, and remains bounded to the approved G2.13 scope"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-watchlist-helper-cleanup-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-watchlist-helper-cleanup-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout bookkeeping only; no runtime entrypoint, route, page, shim, service behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/watchlist-helper-cleanup-closeout-2026-05-23.json"
+    - "docs/reports/quality/backend-watchlist-helper-cleanup-closeout-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-155.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, PM2, or runtime behavior changes in this PR"
+  - "No next service lifecycle DI candidate selection in this PR"
+  - "No additional adapter/data-layer cleanup in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-watchlist-helper-cleanup-closeout-2026-05-23.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-155.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is misread as follow-up implementation authorization, issue #79 can expand without a new child packet"
+    - "If another adapter/data helper cleanup is folded into this closeout, the G2.14 boundary is obscured"
+  rollback_plan: "revert this PR and return the steward tree to the G2.14 implementation-merged state recorded by PR #154"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record adapter-aware watchlist helper cleanup completion after PR #154 merge"
+    modified_scope: "steward tree, closeout report, generated closeout artifact, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance bookkeeping only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T03:05:02+08:00"
+    approval_note: "human maintainer approved merging PR #154 and continuing to G2.15 closeout; this PR records closeout only and does not authorize follow-up implementation"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

Records G2.15 closeout after PR #154 was approved and merged.

- Records PR #154 merge commit `1dcb394a49a9d95e939b2119acc431b825954036`.
- Adds the G2.15 closeout report and generated closeout artifact.
- Updates the steward tree so the watchlist helper cleanup is marked complete and the next gate is a separate G2.16 decision packet.
- Adds PR #155 mainline task card for the closeout-only scope.

## Verification

Current-head verification on the PR #154 merge commit:

- `web/backend/tests/test_watchlist_helper_lifecycle_di.py`: 6 passed
- `web/backend/tests/test_watchlist_service_lifecycle_di.py`: 3 passed
- `web/backend/tests/test_watchlist_service_logging.py`: 3 passed
- touched-file `ruff check`: passed
- OpenAPI smoke: `app_import=ok routes=548 paths=500 operations=536 duplicate_operation_ids=0 duplicate_operation_id_warnings=0`

Closeout PR verification:

- JSON artifact parse: passed
- Markdown governance: 2 checked, 0 errors
- Mainline scope gate: pass=True
- `git diff HEAD~1..HEAD --check`: passed
- GitNexus compare against `HEAD~1`: low risk, 4 changed files, 0 affected processes

## Boundary

This is governance bookkeeping only. It does not modify backend source, tests, route/OpenAPI behavior, frontend, config, scripts, OpenSpec files, PM2/runtime state, or issue labels.

If this closeout is accepted, the next step is a separate G2.16 decision packet before any further service lifecycle DI source edits.
