### PR TITLE
docs: select service DI candidate refresh

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -531,11 +531,15 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 `1dcb394a49a9d95e939b2119acc431b825954036`; G2.15 now
 │   │                 records the closeout, current-head verification, and
 │   │                 confirms no follow-up implementation is authorized; PR
-│   │                 `#155` is open with Mainline Governance Gate and
+│   │                 `#155` merged at
+│   │                 `03c48f74d73f1de505470698966776f6624a0ec7`; G2.16 now
+│   │                 selects current-head candidate refresh as the next service
+│   │                 lifecycle DI governance lane, not source implementation; PR
+│   │                 `#156` is open with Mainline Governance Gate and
 │   │                 check-compliance passed
-│   └── Next gate: Human review of PR `#155`; if accepted,
-│                  create a separate G2.16 decision packet before any further
-│                  service lifecycle DI source edits
+│   └── Next gate: Human review of PR `#156`; if accepted,
+│                  create a separate G2.17 current-head candidate refresh before
+│                  any further service lifecycle DI source edits
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -588,7 +592,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |
 | `backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md` | G | G2.13 implementation authorization packet merged: future write scope, tests, GitNexus gates, and rollback plan defined for adapter-aware watchlist helper cleanup | Superseded by G2.14 implementation evidence |
 | `backend-watchlist-helper-cleanup-implementation-2026-05-23.md` | G | G2.14 implementation merged by PR `#154`: both watchlist adapter/helper files now accept constructor-configured provider seams; route code unchanged | Superseded by G2.15 closeout packet |
-| `backend-watchlist-helper-cleanup-closeout-2026-05-23.md` | G | G2.15 closeout prepared: PR `#154` merged at `1dcb394a49a9d95e939b2119acc431b825954036`, current-head verification rerun, and no follow-up implementation authorized; PR `#155` is open with Mainline Governance Gate and check-compliance passed | Human review of PR `#155`; if accepted, create a separate G2.16 decision packet before any further service lifecycle DI source edits |
+| `backend-watchlist-helper-cleanup-closeout-2026-05-23.md` | G | G2.15 closeout merged by PR `#155` at `03c48f74d73f1de505470698966776f6624a0ec7`: PR `#154` merge recorded, current-head verification rerun, and no follow-up implementation authorized | Superseded by G2.16 next-lane decision packet |
+| `backend-service-lifecycle-di-next-lane-decision-2026-05-23.md` | G | G2.16 decision prepared: select G2.17 current-head candidate refresh before any further service lifecycle DI source edits; PR `#156` is open with Mainline Governance Gate and check-compliance passed | Human review of PR `#156`; if accepted, create a separate G2.17 current-head service lifecycle DI candidate refresh packet |
 
 ## Completed And Reviewed Ledger
 
@@ -667,7 +672,8 @@ review, PR review, or OpenSpec archive review.
 | G2.12 watchlist helper cleanup next-lane decision | G | Selected adapter-aware watchlist helper cleanup authorization as the next service lifecycle DI lane after G2.11 closeout | Reviewed and merged by PR `#152` at `0ccf1fc58d531cba8f64cc1031d53875e636a766`; no backend source, test, OpenSpec, issue label, route, OpenAPI, or runtime change authorized | `docs/reports/quality/backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md`; `.planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json` | Superseded by G2.13 authorization packet |
 | G2.13 watchlist helper cleanup implementation authorization | G | Exact future write scope, TDD plan, GitNexus gates, and rollback boundary prepared for adapter-aware watchlist helper cleanup | Reviewed and merged by PR `#153` at `938682debb90a25392ca208e706d8388d06de786`; no backend source, test, OpenSpec, issue label, route, OpenAPI, or runtime change authorized by that PR | `docs/reports/quality/backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md`; `.planning/codebase/generated/watchlist-helper-cleanup-implementation-authorization-2026-05-23.json` | Superseded by G2.14 implementation evidence |
 | G2.14 watchlist helper cleanup implementation | G | Adapter-aware provider seam implemented for both watchlist helper adapter files with focused TDD coverage | Reviewed and merged by PR `#154` at `1dcb394a49a9d95e939b2119acc431b825954036`: red `4 failed, 2 passed`; green focused helper `6 passed`; route DI regression `3 passed`; logging regression `3 passed`; ruff passed; OpenAPI smoke `routes=548`, `paths=500`, `duplicate_operation_ids=0`; Mainline Governance Gate and check-compliance passed | `docs/reports/quality/backend-watchlist-helper-cleanup-implementation-2026-05-23.md`; `web/backend/tests/test_watchlist_helper_lifecycle_di.py`; https://github.com/chengjon/mystocks/pull/154 | Superseded by G2.15 closeout packet |
-| G2.15 watchlist helper cleanup closeout | G | Adapter-aware watchlist helper cleanup completion recorded after PR `#154` merge | PR `#155` open for review: current-head helper tests `6 passed`; route DI regression `3 passed`; logging regression `3 passed`; ruff passed; OpenAPI smoke `routes=548`, `paths=500`, `duplicate_operation_ids=0`; Mainline Governance Gate and check-compliance passed; issue `#79` remains `OPEN` with `needs-triage`; no source, route, OpenAPI, OpenSpec, frontend, config, PM2, issue-label, or runtime change authorized | `docs/reports/quality/backend-watchlist-helper-cleanup-closeout-2026-05-23.md`; `.planning/codebase/generated/watchlist-helper-cleanup-closeout-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/155 | Human review; if accepted, create a separate G2.16 decision packet before any further service lifecycle DI source edits |
+| G2.15 watchlist helper cleanup closeout | G | Adapter-aware watchlist helper cleanup completion recorded after PR `#154` merge | Reviewed and merged by PR `#155` at `03c48f74d73f1de505470698966776f6624a0ec7`: current-head helper tests `6 passed`; route DI regression `3 passed`; logging regression `3 passed`; ruff passed; OpenAPI smoke `routes=548`, `paths=500`, `duplicate_operation_ids=0`; no source, route, OpenAPI, OpenSpec, frontend, config, PM2, issue-label, or runtime change authorized | `docs/reports/quality/backend-watchlist-helper-cleanup-closeout-2026-05-23.md`; `.planning/codebase/generated/watchlist-helper-cleanup-closeout-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/155 | Superseded by G2.16 next-lane decision packet |
+| G2.16 service lifecycle DI next-lane decision | G/#79 | Select current-head candidate refresh as the next service lifecycle DI governance lane | PR `#156` open for review: prior low/medium candidate queue is consumed (`email_service.py`, `announcement_service.py`, `watchlist_service.py`), watchlist helper seam is closed, Mainline Governance Gate and check-compliance passed, issue `#79` remains `OPEN` with `needs-triage`, and no fourth implementation target or adapter cleanup is authorized | `docs/reports/quality/backend-service-lifecycle-di-next-lane-decision-2026-05-23.md`; `.planning/codebase/generated/service-lifecycle-di-next-lane-decision-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/156 | Human review; if accepted, create G2.17 current-head candidate refresh packet |
 
 ## OpenSpec Branch Register
 
@@ -749,7 +755,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review PR `#155` G2.15 watchlist helper cleanup closeout | Future service seam lane | PR `#154` merged; PR `#155` is open with checks passed; adapter-aware watchlist helper cleanup is complete, and any further service lifecycle DI work requires a separate G2.16 decision packet |
+| P2 | Review PR `#156` G2.16 service lifecycle DI next-lane decision | Future service seam lane | PR `#155` merged; PR `#156` is open with checks passed; G2.16 selects G2.17 current-head candidate refresh before any further service lifecycle DI source edits |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/generated/service-lifecycle-di-next-lane-decision-2026-05-23.json
+++ b/.planning/codebase/generated/service-lifecycle-di-next-lane-decision-2026-05-23.json
@@ -1,0 +1,53 @@
+{
+  "artifact": "service-lifecycle-di-next-lane-decision-2026-05-23",
+  "recorded_at": "2026-05-23T03:19:24+08:00",
+  "workline": "G2.16 service lifecycle DI next-lane decision",
+  "status": "decision-packet-prepared-for-review",
+  "current_head": "03c48f74d73f1de505470698966776f6624a0ec7",
+  "decision_pr": 156,
+  "decision_pr_url": "https://github.com/chengjon/mystocks/pull/156",
+  "decision_pr_checks_at_creation": {
+    "mainline_governance_gate": "pass",
+    "check_compliance": "pass",
+    "weekly_full_scan": "skipped"
+  },
+  "decision": "select-g2-17-current-head-candidate-refresh",
+  "not_selected": [
+    "fourth-route-surface-service-implementation-candidate",
+    "another-adapter-aware-cleanup",
+    "issue-label-movement",
+    "openspec-change",
+    "source-implementation"
+  ],
+  "input_state": {
+    "pr_154": {
+      "state": "MERGED",
+      "merge_commit": "1dcb394a49a9d95e939b2119acc431b825954036"
+    },
+    "pr_155": {
+      "state": "MERGED",
+      "merge_commit": "03c48f74d73f1de505470698966776f6624a0ec7"
+    },
+    "issue_79": {
+      "state": "OPEN",
+      "labels": [
+        "needs-triage"
+      ]
+    },
+    "issue_92": {
+      "state": "OPEN",
+      "labels": [
+        "enhancement",
+        "ready-for-human",
+        "ready-for-downstream"
+      ]
+    }
+  },
+  "completed_sequence_inputs": [
+    "email_service.py route-surface DI",
+    "announcement_service.py route-surface DI",
+    "watchlist_service.py route-surface DI",
+    "watchlist helper adapter-aware cleanup"
+  ],
+  "next_gate": "Human review of G2.16 decision; if accepted, create G2.17 current-head service lifecycle DI candidate refresh before any further source edits."
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-next-lane-decision-2026-05-23.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-next-lane-decision-2026-05-23.md
@@ -1,0 +1,104 @@
+# Backend Service Lifecycle DI Next-Lane Decision - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: decision-packet-prepared-for-review
+- Workline: G2.16 service lifecycle DI next-lane decision
+- Current branch: `g2-16-service-di-next-decision`
+- Current HEAD: `03c48f74d73f1de505470698966776f6624a0ec7`
+- Parent issue: https://github.com/chengjon/mystocks/issues/92
+- Service lifecycle issue: https://github.com/chengjon/mystocks/issues/79
+- Decision PR: https://github.com/chengjon/mystocks/pull/156
+- Decision PR checks at creation: Mainline Governance Gate passed;
+  check-compliance passed
+- Recorded at: `2026-05-23T03:19:24+08:00`
+
+Boundary note: This packet selects the next governance lane only. It does not
+authorize backend source edits, frontend edits, tests, generated clients,
+route/OpenAPI changes, PM2/runtime work, OpenSpec changes, issue label movement,
+or `ready-for-agent` movement.
+
+## Input State
+
+| Item | Current state | Evidence |
+|---|---|---|
+| PR `#154` | `MERGED` | `1dcb394a49a9d95e939b2119acc431b825954036` |
+| PR `#155` | `MERGED` | `03c48f74d73f1de505470698966776f6624a0ec7` |
+| Issue `#79` | `OPEN`, `needs-triage` | Live GitHub status checked from this worktree |
+| Issue `#92` | `OPEN`, `enhancement`, `ready-for-human`, `ready-for-downstream` | Live GitHub status checked from this worktree |
+| G2.1 candidate classification | Accepted historical input | `email_service.py` selected; `announcement_service.py` and `watchlist_service.py` deferred |
+| G2.4/G2.8 candidate selections | Consumed | `announcement_service.py` and `watchlist_service.py` were selected and completed in later packets |
+| G2.12-G2.15 helper cleanup | Complete | Adapter-aware watchlist helper seam selected, authorized, implemented, and closed out |
+
+## Decision
+
+Select a G2.17 current-head service lifecycle DI candidate refresh as the next
+lane.
+
+Do not select a fourth route-surface service implementation candidate in this
+packet. Do not start another adapter-aware cleanup in this packet. Do not move
+issue `#79` or issue `#92` labels in this packet.
+
+## Rationale
+
+The accepted low/medium-risk candidate queue has been consumed:
+
+- `email_service.py` was the first future service lifecycle DI pilot.
+- `announcement_service.py` was selected as the second candidate and completed.
+- `watchlist_service.py` was selected as the third candidate and completed.
+- The explicit watchlist adapter/data helper seam left by G2.11 was closed by
+  G2.14 and recorded by G2.15.
+
+The prior G2.1 classification was useful, but it is now stale as a selection
+source for further source edits. It was measured before multiple service DI
+commits and before the watchlist helper cleanup. It also did not identify a clean
+fourth route-surface service with lower governance risk than closing the
+watchlist adapter-aware seam.
+
+The next safe step is therefore evidence refresh, not implementation
+authorization.
+
+## G2.17 Refresh Scope
+
+If this decision is accepted, G2.17 should create a current-head evidence packet
+that:
+
+- regenerates the service singleton/getter inventory under
+  `web/backend/app/services`;
+- records current HEAD, generation timestamp, and stale-if-head-mismatch status;
+- distinguishes completed route-surface DI pilots, completed helper cleanups,
+  candidates still requiring source edits, and false positives;
+- rechecks GitNexus context/impact for any candidate recommended for a future
+  authorization packet;
+- classifies candidates by route-surface service, helper/adapter seam,
+  process-level singleton, external client/session-backed service, cache/task
+  runner, and false positive;
+- recommends either a G2.18 implementation authorization candidate or a pause of
+  the service lifecycle DI sequence.
+
+G2.17 remains evidence/design only. Source edits remain locked until a later
+authorization packet names exact files, tests, rollback plan, and GitNexus gates.
+
+## Explicit Non-Goals
+
+This decision packet does not authorize:
+
+- editing `web/backend/app/services/**`;
+- editing route handlers or OpenAPI contracts;
+- creating or modifying OpenSpec changes/specs;
+- changing GitHub issue labels;
+- moving issue `#79` or issue `#92` to `ready-for-agent`;
+- creating a new implementation issue;
+- starting a fourth service lifecycle DI source implementation;
+- running PM2/stateful gates.
+
+## Next Gate
+
+Human review of this G2.16 decision packet.
+
+If accepted, create a separate G2.17 current-head candidate refresh packet before
+any further service lifecycle DI source edits.

--- a/governance/mainline/task-cards/pr-156.yaml
+++ b/governance/mainline/task-cards/pr-156.yaml
@@ -1,0 +1,97 @@
+version: "v0.2"
+
+task:
+  id: "pr-156"
+  title: "Select G2.17 service DI candidate refresh"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-service-lifecycle-di-next-lane-decision"
+  objective: "select a current-head candidate refresh as the next service lifecycle DI governance lane before any further source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-di-next-lane-decision"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-di-next-lane-decision"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision packet only; no runtime entrypoint, route, page, shim, service behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-di-next-lane-decision-2026-05-23.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-next-lane-decision-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-156.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, PM2, or runtime behavior changes in this PR"
+  - "No fourth service lifecycle DI implementation candidate authorization in this PR"
+  - "No additional adapter/data-layer cleanup authorization in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-next-lane-decision-2026-05-23.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-156.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this decision is misread as implementation authorization, issue #79 can expand without current-head candidate evidence"
+    - "If old G2.1/G2.4/G2.8 candidate evidence is reused without refresh, stale candidate assumptions can drive the next source edit"
+  rollback_plan: "revert this PR and return the steward tree to the G2.15 closeout-merged state recorded by PR #155"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "select current-head service lifecycle DI candidate refresh as the next governance lane"
+    modified_scope: "steward tree, decision report, generated decision artifact, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance decision bookkeeping only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T03:19:24+08:00"
+    approval_note: "human maintainer approved merging PR #155 and continuing; this PR selects G2.17 evidence refresh only and does not authorize follow-up implementation"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

Creates the G2.16 service lifecycle DI next-lane decision packet.

- Records that PR #155 merged the G2.15 watchlist helper cleanup closeout.
- Selects a G2.17 current-head candidate refresh before any further service lifecycle DI source edits.
- Updates the steward tree with the new next gate.
- Adds the generated decision artifact and PR #156 mainline task card.

## Decision

Do not select a fourth route-surface service implementation candidate yet.
Do not start another adapter-aware cleanup yet.
Do not move issue #79 or #92 labels.

The next lane is G2.17 current-head evidence refresh because the previous low/medium candidate queue has been consumed:

- `email_service.py` completed.
- `announcement_service.py` completed.
- `watchlist_service.py` completed.
- watchlist helper adapter-aware seam completed.

## Verification

- JSON artifact parse: passed
- Markdown governance: 2 checked, 0 errors
- Mainline scope gate: pass=True
- `git diff HEAD~1..HEAD --check`: passed
- GitNexus compare against `HEAD~1`: low risk, 4 changed files, 0 affected processes

## Boundary

This is governance decision bookkeeping only. It does not modify backend source, frontend source, tests, route/OpenAPI behavior, docs/API, config, scripts, OpenSpec files, PM2/runtime state, or issue labels.

If accepted, the next step is a separate G2.17 current-head candidate refresh packet.
