### PR TITLE
docs: refresh service DI candidates

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -532,14 +532,19 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 records the closeout, current-head verification, and
 │   │                 confirms no follow-up implementation is authorized; PR
 │   │                 `#155` merged at
-│   │                 `03c48f74d73f1de505470698966776f6624a0ec7`; G2.16 now
-│   │                 selects current-head candidate refresh as the next service
+│   │                 `03c48f74d73f1de505470698966776f6624a0ec7`; G2.16
+│   │                 selected current-head candidate refresh as the next service
 │   │                 lifecycle DI governance lane, not source implementation; PR
-│   │                 `#156` is open with Mainline Governance Gate and
+│   │                 `#156` merged at
+│   │                 `33e75acddf5c7c363a2e33ba4a3d01923b46edde`; G2.17 now
+│   │                 refreshes the current-head service getter inventory and
+│   │                 recommends only a future G2.18 `stock_search_service`
+│   │                 authorization packet, with source edits still locked; PR
+│   │                 `#157` is open with Mainline Governance Gate and
 │   │                 check-compliance passed
-│   └── Next gate: Human review of PR `#156`; if accepted,
-│                  create a separate G2.17 current-head candidate refresh before
-│                  any further service lifecycle DI source edits
+│   └── Next gate: Human review of PR `#157`; if accepted,
+│                  create a separate G2.18 authorization packet for
+│                  `stock_search_service` before any source edits
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -593,7 +598,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md` | G | G2.13 implementation authorization packet merged: future write scope, tests, GitNexus gates, and rollback plan defined for adapter-aware watchlist helper cleanup | Superseded by G2.14 implementation evidence |
 | `backend-watchlist-helper-cleanup-implementation-2026-05-23.md` | G | G2.14 implementation merged by PR `#154`: both watchlist adapter/helper files now accept constructor-configured provider seams; route code unchanged | Superseded by G2.15 closeout packet |
 | `backend-watchlist-helper-cleanup-closeout-2026-05-23.md` | G | G2.15 closeout merged by PR `#155` at `03c48f74d73f1de505470698966776f6624a0ec7`: PR `#154` merge recorded, current-head verification rerun, and no follow-up implementation authorized | Superseded by G2.16 next-lane decision packet |
-| `backend-service-lifecycle-di-next-lane-decision-2026-05-23.md` | G | G2.16 decision prepared: select G2.17 current-head candidate refresh before any further service lifecycle DI source edits; PR `#156` is open with Mainline Governance Gate and check-compliance passed | Human review of PR `#156`; if accepted, create a separate G2.17 current-head service lifecycle DI candidate refresh packet |
+| `backend-service-lifecycle-di-next-lane-decision-2026-05-23.md` | G | G2.16 decision merged by PR `#156` at `33e75acddf5c7c363a2e33ba4a3d01923b46edde`: select G2.17 current-head candidate refresh before any further service lifecycle DI source edits | Superseded by G2.17 candidate refresh packet |
+| `backend-service-lifecycle-di-candidate-refresh-2026-05-23.md` | G | G2.17 current-head refresh prepared: scanned 152 service Python files, identified 15 service getter files and 11 route-surface related getter files, recorded GitNexus risk, and recommends only a future G2.18 `stock_search_service` authorization packet; PR `#157` is open with Mainline Governance Gate and check-compliance passed; no source edits are authorized | Human review of PR `#157`; if accepted, create G2.18 authorization packet before editing source |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/service-lifecycle-di-candidate-refresh-2026-05-23.json
+++ b/.planning/codebase/generated/service-lifecycle-di-candidate-refresh-2026-05-23.json
@@ -1,0 +1,167 @@
+{
+  "artifact": "service-lifecycle-di-candidate-refresh-2026-05-23",
+  "recorded_at": "2026-05-23T03:38:20+08:00",
+  "workline": "G2.17 current-head service lifecycle DI candidate refresh",
+  "status": "candidate-refresh-prepared-for-review",
+  "current_head": "33e75acddf5c7c363a2e33ba4a3d01923b46edde",
+  "stale_if_head_mismatch": true,
+  "refresh_pr": 157,
+  "refresh_pr_url": "https://github.com/chengjon/mystocks/pull/157",
+  "refresh_pr_checks_at_creation": {
+    "mainline_governance_gate": "pass",
+    "check_compliance": "pass",
+    "weekly_full_scan": "skipped"
+  },
+  "parent_issue": {
+    "number": 92,
+    "state": "OPEN",
+    "labels": [
+      "enhancement",
+      "ready-for-human",
+      "ready-for-downstream"
+    ]
+  },
+  "service_lifecycle_issue": {
+    "number": 79,
+    "state": "OPEN",
+    "labels": [
+      "needs-triage"
+    ]
+  },
+  "merged_input": {
+    "pr_156": {
+      "state": "MERGED",
+      "merge_commit": "33e75acddf5c7c363a2e33ba4a3d01923b46edde"
+    }
+  },
+  "scan_summary": {
+    "service_py_files": 152,
+    "service_getter_files": 15,
+    "route_surface_related_getter_files": 11,
+    "app_state_provider_files": [
+      "web/backend/app/services/email_service.py",
+      "web/backend/app/services/announcement_service.py",
+      "web/backend/app/services/watchlist_service.py",
+      "web/backend/app/services/tradingview_widget_service.py"
+    ]
+  },
+  "route_surface_getters": [
+    {
+      "getter": "get_stock_search_service",
+      "file": "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "loc": 175,
+      "app_state_occurrences": 0,
+      "api_files": 2,
+      "api_hits": 8,
+      "api_refs": [
+        "web/backend/app/api/stock_search/stock_search_result.py",
+        "web/backend/app/api/market/market_data_request.py"
+      ],
+      "classification": "recommended-next-authorization-candidate"
+    },
+    {
+      "getter": "get_tdx_service",
+      "file": "web/backend/app/services/tdx_service.py",
+      "loc": 280,
+      "app_state_occurrences": 0,
+      "api_files": 2,
+      "api_hits": 9,
+      "classification": "defer-external-live-market-surface"
+    },
+    {
+      "getter": "get_data_service",
+      "file": "web/backend/app/services/data_service.py",
+      "loc": 472,
+      "app_state_occurrences": 0,
+      "api_files": 2,
+      "api_hits": 5,
+      "classification": "defer-indicator-strategy-data-surface"
+    },
+    {
+      "getter": "get_market_data_service_v2",
+      "file": "web/backend/app/services/market_data_service_v2.py",
+      "loc": 668,
+      "app_state_occurrences": 0,
+      "api_files": 2,
+      "api_hits": 17,
+      "classification": "defer-broad-market-dashboard-surface"
+    },
+    {
+      "getter": "get_market_data_service",
+      "file": "web/backend/app/services/market_data_service/get_market_data_service.py",
+      "loc": 33,
+      "app_state_occurrences": 0,
+      "api_files": 1,
+      "api_hits": 8,
+      "classification": "defer-graph-name-ambiguity"
+    },
+    {
+      "getter": "get_strategy_service",
+      "file": "web/backend/app/services/strategy_service.py",
+      "loc": 461,
+      "app_state_occurrences": 0,
+      "api_files": 1,
+      "api_hits": 4,
+      "classification": "defer-strategy-adapter-task-surface"
+    }
+  ],
+  "gitnexus_evidence": [
+    {
+      "target": "StockSearchService",
+      "file": "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "risk": "LOW",
+      "direct_impact": 0,
+      "affected_processes": 0
+    },
+    {
+      "target": "get_stock_search_service",
+      "file": "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "risk": "CRITICAL",
+      "direct_impact": 6,
+      "affected_processes": 11
+    },
+    {
+      "target": "get_tdx_service",
+      "file": "web/backend/app/services/tdx_service.py",
+      "risk": "CRITICAL",
+      "direct_impact": 2,
+      "affected_processes": 5
+    },
+    {
+      "target": "get_data_service",
+      "file": "web/backend/app/services/data_service.py",
+      "risk": "CRITICAL",
+      "direct_impact": 3,
+      "affected_processes": 7
+    },
+    {
+      "target": "get_market_data_service_v2",
+      "file": "web/backend/app/services/market_data_service_v2.py",
+      "risk": "CRITICAL",
+      "direct_impact": 15,
+      "affected_processes": 6
+    },
+    {
+      "target": "get_market_data_service",
+      "file": "web/backend/app/services/market_data_service/get_market_data_service.py",
+      "risk": "LOW",
+      "direct_impact": 0,
+      "affected_processes": 0,
+      "note": "Text scan finds active route dependency; treat as graph/name ambiguity, not safe-proof."
+    },
+    {
+      "target": "get_strategy_service",
+      "file": "web/backend/app/services/strategy_service.py",
+      "risk": "CRITICAL",
+      "direct_impact": 6,
+      "affected_processes": 0
+    }
+  ],
+  "recommendation": {
+    "next_gate": "Create G2.18 authorization packet for stock_search_service route-surface DI candidate after human review.",
+    "recommended_candidate": "web/backend/app/services/stock_search_service/stock_search_service.py",
+    "source_edits_authorized": false,
+    "openspec_change_required_now": false,
+    "issue_label_movement_authorized": false
+  }
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-2026-05-23.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-2026-05-23.md
@@ -1,0 +1,166 @@
+# Backend Service Lifecycle DI Candidate Refresh - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: candidate-refresh-prepared-for-review
+- Workline: G2.17 current-head service lifecycle DI candidate refresh
+- Current branch: `g2-17-service-di-candidate-refresh`
+- Current HEAD: `33e75acddf5c7c363a2e33ba4a3d01923b46edde`
+- Parent issue: https://github.com/chengjon/mystocks/issues/92
+- Service lifecycle issue: https://github.com/chengjon/mystocks/issues/79
+- Refresh PR: https://github.com/chengjon/mystocks/pull/157
+- Refresh PR checks at creation: Mainline Governance Gate passed;
+  check-compliance passed
+- Recorded at: `2026-05-23T03:38:20+08:00`
+
+Boundary note: this packet refreshes candidate evidence only. It does not
+authorize backend source edits, route edits, tests, OpenAPI changes, OpenSpec
+changes, issue label movement, `ready-for-agent` movement, PM2/runtime work, or
+a G2.18 implementation.
+
+## Input State
+
+| Item | Current state | Evidence |
+|---|---|---|
+| PR `#156` | `MERGED` | `33e75acddf5c7c363a2e33ba4a3d01923b46edde` |
+| Issue `#79` | `OPEN`, `needs-triage` | Live GitHub status checked from this worktree |
+| Issue `#92` | `OPEN`, `enhancement`, `ready-for-human`, `ready-for-downstream` | Live GitHub status checked from this worktree |
+| Prior route-surface pilots | Complete | `email_service.py`, `announcement_service.py`, `watchlist_service.py` |
+| Prior helper cleanup | Complete | Watchlist adapter/data helper provider seam completed by PR `#154` and closed out by PR `#155` |
+
+## Current-Head Inventory Summary
+
+The refresh scanned `web/backend/app/services` at current HEAD.
+
+| Metric | Value |
+|---|---:|
+| Service Python files scanned | 152 |
+| Files with service getter or singleton shape | 15 |
+| Route-surface related getter files | 11 |
+| Files already using app-state provider pattern | 4 |
+
+Completed app-state provider files:
+
+- `web/backend/app/services/email_service.py`
+- `web/backend/app/services/announcement_service.py`
+- `web/backend/app/services/watchlist_service.py`
+- `web/backend/app/services/tradingview_widget_service.py`
+
+## Candidate Classification
+
+| Class | Files | Disposition |
+|---|---|---|
+| Completed route-surface DI | `email_service.py`, `announcement_service.py`, `watchlist_service.py` | No further service DI source work required in this lane |
+| Reference provider pattern | `tradingview_widget_service.py` | Keep as reference; route already uses app-state dependency provider |
+| Recommended next authorization candidate | `stock_search_service/stock_search_service.py` | Prepare a separate G2.18 authorization packet before any source edit |
+| Defer: market/dashboard/external data surface | `tdx_service.py`, `market_data_service_v2.py`, `market_data_service/get_market_data_service.py`, `data_service.py` | Broader market/data paths; do not select before stock-search candidate review |
+| Defer: strategy/helper/task surface | `strategy_service.py` | Route plus adapter/task callers; needs separate adapter-aware decision if selected later |
+| Hold: no active route surface in this scan | `email_notification_service.py`, `wencai_service.py`, `realtime_streaming_service.py`, `data_service_enhanced.py` | Not a route-surface DI pilot candidate from this refresh |
+| Registry / integrated seam | `services/__init__.py` | Treat as package registry/integration seam, not a G2.18 pilot |
+
+## Route-Surface Getter Evidence
+
+| Getter | Service file | API files | API hits | Notes |
+|---|---|---:|---:|---|
+| `get_stock_search_service` | `stock_search_service/stock_search_service.py` | 2 | 8 | Smallest practical remaining route-surface candidate; direct calls in stock-search routes plus one market kline path |
+| `get_tdx_service` | `tdx_service.py` | 2 | 9 | External/live-market surface; defer |
+| `get_data_service` | `data_service.py` | 2 | 5 | Indicator/strategy data surface; defer |
+| `get_market_data_service_v2` | `market_data_service_v2.py` | 2 | 17 | Broad market-v2/dashboard surface; defer |
+| `get_market_data_service` | `market_data_service/get_market_data_service.py` and package exports | 1 | 8 | Scanner sees active route dependency; GitNexus graph currently reports 0 impact, so treat as graph/name-ambiguity evidence rather than LOW-risk proof |
+| `get_strategy_service` | `strategy_service.py` | 1 | 4 | Route plus adapter/task callers; defer |
+| `get_email_service_dependency` | `email_service.py` | 1 | 7 | Completed pattern |
+| `get_announcement_service_dependency` | `announcement_service.py` | 1 | 12 | Completed pattern |
+| `get_watchlist_service_dependency` | `watchlist_service.py` | 1 | 8 | Completed pattern |
+| `get_tradingview_service_dependency` | `tradingview_widget_service.py` | 1 | 7 | Existing reference pattern |
+
+## GitNexus Evidence
+
+| Target | File | Risk | Direct impact | Affected processes | Disposition |
+|---|---|---:|---:|---:|---|
+| `StockSearchService` | `stock_search_service/stock_search_service.py` | LOW | 0 | 0 | Class shape is low blast radius |
+| `get_stock_search_service` | `stock_search_service/stock_search_service.py` | CRITICAL | 6 | 11 | Candidate only with explicit G2.18 authorization, TDD, route dependency override tests, and rollback |
+| `get_tdx_service` | `tdx_service.py` | CRITICAL | 2 | 5 | Defer; dashboard/live data path |
+| `get_data_service` | `data_service.py` | CRITICAL | 3 | 7 | Defer; indicators/strategy path |
+| `get_market_data_service_v2` | `market_data_service_v2.py` | CRITICAL | 15 | 6 | Defer; broad market-v2/dashboard path |
+| `get_market_data_service` | `market_data_service/get_market_data_service.py` | LOW | 0 | 0 | Do not rely on graph risk alone because text scan finds active route dependency |
+| `get_strategy_service` | `strategy_service.py` | CRITICAL | 6 | 0 | Defer; adapter/task callers present |
+
+GitNexus CRITICAL risk on `get_stock_search_service` is not ignored. It means
+the next packet, if accepted, must be an implementation authorization packet with
+exact changed files, TDD red/green plan, route dependency override tests,
+GitNexus pre-edit impact, staged `detect_changes`, and rollback instructions.
+This G2.17 packet does not authorize those edits.
+
+## Recommendation
+
+Select `web/backend/app/services/stock_search_service/stock_search_service.py`
+as the conditional G2.18 authorization candidate.
+
+Rationale:
+
+- It is the smallest practical remaining route-surface service file from the
+  current scan (`175` LOC).
+- `StockSearchService` class impact is LOW with no affected symbols or
+  processes.
+- Existing tests already reference stock-search behavior:
+  `test_stock_search_service_logging.py`,
+  `test_stock_search_runtime_fallback.py`, plus runtime/regression guards.
+- The remaining alternatives are broader market, dashboard, data, strategy,
+  external-client, adapter, or task surfaces.
+
+G2.18 should be authorization-only unless a human explicitly approves source
+implementation after reviewing the G2.18 packet.
+
+## Required G2.18 Authorization Scope
+
+If this recommendation is accepted, prepare a separate G2.18 authorization
+packet with these boundaries:
+
+- Allowed future source candidates:
+  - `web/backend/app/services/stock_search_service/stock_search_service.py`
+  - `web/backend/app/api/stock_search/stock_search_result.py`
+  - `web/backend/app/api/market/market_data_request.py`
+  - focused tests for stock-search service lifecycle DI
+- Required future design:
+  - add an app-state provider dependency while preserving
+    `get_stock_search_service()` as compatibility fallback;
+  - convert only approved route call sites to dependency injection;
+  - avoid market/data/strategy service changes outside the two named route
+    files;
+  - include rollback that restores direct getter calls and removes provider
+    override tests.
+- Required future gates:
+  - GitNexus impact for `StockSearchService` and exact
+    `get_stock_search_service` symbol before editing;
+  - TDD red/green for provider injection and compatibility fallback;
+  - focused route tests or dependency override tests;
+  - `ruff check` on touched files;
+  - staged `gitnexus_detect_changes`;
+  - Mainline Governance Gate for the implementation PR.
+
+## Explicit Non-Goals
+
+This refresh packet does not authorize:
+
+- editing `web/backend/app/services/**`;
+- editing `web/backend/app/api/**`;
+- editing tests;
+- creating or modifying OpenSpec changes/specs;
+- changing issue `#79` or issue `#92` labels;
+- moving any issue to `ready-for-agent`;
+- creating a GitHub implementation issue;
+- executing PM2/stateful gates;
+- treating `get_market_data_service` GitNexus LOW result as proof that the
+  market-data route dependency is safe.
+
+## Next Gate
+
+Human review of this G2.17 candidate refresh packet.
+
+If accepted, create a separate G2.18 authorization packet for the conditional
+`stock_search_service` route-surface service DI candidate. Source edits remain
+locked until that later authorization packet is explicitly approved.

--- a/governance/mainline/task-cards/pr-157.yaml
+++ b/governance/mainline/task-cards/pr-157.yaml
@@ -1,0 +1,97 @@
+version: "v0.2"
+
+task:
+  id: "pr-157"
+  title: "Refresh service DI candidate inventory"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-service-lifecycle-di-candidate-refresh"
+  objective: "refresh current-head service lifecycle DI candidates before selecting any further implementation lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-di-candidate-refresh"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-di-candidate-refresh"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate refresh evidence packet only; no runtime entrypoint, route, page, shim, service behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-di-candidate-refresh-2026-05-23.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-157.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, PM2, or runtime behavior changes in this PR"
+  - "No G2.18 implementation authorization in this PR"
+  - "No stock_search_service source edit in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-2026-05-23.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-157.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the candidate refresh is misread as implementation authorization, stock_search_service can be edited without the required G2.18 TDD and GitNexus gates"
+    - "If GitNexus CRITICAL risk on get_stock_search_service is ignored, a later route-surface implementation can affect multiple stock-search and market-data endpoints"
+  rollback_plan: "revert this PR and return the steward tree to the G2.16 decision-merged state recorded by PR #156"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh current-head service lifecycle DI candidates and select the next authorization candidate"
+    modified_scope: "steward tree, candidate refresh report, generated evidence artifact, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance evidence only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T03:38:20+08:00"
+    approval_note: "human maintainer approved merging PR #156 and starting G2.17 candidate refresh; this PR is evidence/design only and does not authorize source implementation"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record G2.17 current-head service lifecycle DI candidate refresh
- classify remaining service getter surfaces after email, announcement, watchlist, and watchlist-helper closeout
- recommend only a future G2.18 stock_search_service authorization packet; no source edits are authorized

## Test Plan
- JSON artifact parse
- markdown governance gate
- git diff check
- mainline scope gate
- GitNexus compare