### PR TITLE
docs: authorize stock search service DI lane

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -452,8 +452,12 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `.planning/codebase/generated/watchlist-helper-cleanup-next-lane-decision-2026-05-23.json`,
 │   │   `backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md`,
 │   │   `.planning/codebase/generated/watchlist-helper-cleanup-implementation-authorization-2026-05-23.json`,
-│   │   `backend-watchlist-helper-cleanup-implementation-2026-05-23.md`
-│   ├── State: watchlist-helper-cleanup-implementation-prepared-for-review
+│   │   `backend-watchlist-helper-cleanup-implementation-2026-05-23.md`,
+│   │   `backend-service-lifecycle-di-candidate-refresh-2026-05-23.md`,
+│   │   `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-2026-05-23.json`,
+│   │   `backend-stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.md`,
+│   │   `.planning/codebase/generated/stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.json`
+│   ├── State: stock-search-service-di-implementation-authorization-prepared
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -540,11 +544,17 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 refreshes the current-head service getter inventory and
 │   │                 recommends only a future G2.18 `stock_search_service`
 │   │                 authorization packet, with source edits still locked; PR
-│   │                 `#157` is open with Mainline Governance Gate and
-│   │                 check-compliance passed
-│   └── Next gate: Human review of PR `#157`; if accepted,
-│                  create a separate G2.18 authorization packet for
-│                  `stock_search_service` before any source edits
+│   │                 `#157` merged at
+│   │                 `0285d1cbc29b4622b3e39c9a171ba3b02691ed1b`; G2.18 now
+│   │                 records the future `stock_search_service` route-surface DI
+│   │                 write scope, six route-local getter callers, GitNexus
+│   │                 pre-edit gates, TDD requirements, rollback plan, and
+│   │                 forbidden scope; source edits remain locked pending human
+│   │                 review of this authorization packet
+│   └── Next gate: Human review of the G2.18 authorization packet; if accepted,
+│                  create a separate implementation lane for
+│                  `stock_search_service` route-surface DI before any source
+│                  edits
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.json
+++ b/.planning/codebase/generated/stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.json
@@ -1,0 +1,124 @@
+{
+  "recorded_at": "2026-05-23T09:20:07+08:00",
+  "workline": "G2.18 stock-search route-surface service lifecycle DI",
+  "status": "implementation-authorization-prepared-for-review",
+  "current_head": "0285d1cbc29b",
+  "stale_if_head_mismatch": true,
+  "parent_issue": {
+    "number": 79,
+    "url": "https://github.com/chengjon/mystocks/issues/79",
+    "state": "OPEN",
+    "labels": [
+      "needs-triage"
+    ]
+  },
+  "decision_issue": {
+    "number": 92,
+    "url": "https://github.com/chengjon/mystocks/issues/92",
+    "state": "OPEN",
+    "labels": [
+      "enhancement",
+      "ready-for-human",
+      "ready-for-downstream"
+    ]
+  },
+  "input_evidence": {
+    "g2_17_pr": 157,
+    "g2_17_merge_commit": "0285d1cbc29b4622b3e39c9a171ba3b02691ed1b",
+    "candidate_refresh_report": "docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-2026-05-23.md",
+    "candidate_refresh_artifact": ".planning/codebase/generated/service-lifecycle-di-candidate-refresh-2026-05-23.json"
+  },
+  "candidate": {
+    "service_file": "web/backend/app/services/stock_search_service/stock_search_service.py",
+    "service_class": "StockSearchService",
+    "compatibility_getter": "get_stock_search_service",
+    "service_file_loc": 175,
+    "source_edits_authorized_by_this_packet": false
+  },
+  "gitnexus_pre_edit_snapshot": [
+    {
+      "symbol": "StockSearchService",
+      "file": "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "risk": "LOW",
+      "direct_callers": 0,
+      "processes_affected": 0,
+      "disposition": "class-level provider seam is suitable for a focused future implementation"
+    },
+    {
+      "symbol": "get_stock_search_service",
+      "file": "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "risk": "CRITICAL",
+      "direct_callers": 6,
+      "processes_affected": 11,
+      "disposition": "compatibility getter must remain; approved route call sites must migrate deliberately"
+    }
+  ],
+  "direct_route_consumer_matrix": [
+    {
+      "file": "web/backend/app/api/stock_search/stock_search_result.py",
+      "function": "search_stocks",
+      "getter_line": 165,
+      "future_target": "FastAPI Depends(get_stock_search_service_dependency)"
+    },
+    {
+      "file": "web/backend/app/api/stock_search/stock_search_result.py",
+      "function": "get_stock_quote",
+      "getter_line": 260,
+      "future_target": "FastAPI Depends(get_stock_search_service_dependency)"
+    },
+    {
+      "file": "web/backend/app/api/stock_search/stock_search_result.py",
+      "function": "get_stock_news",
+      "getter_line": 356,
+      "future_target": "FastAPI Depends(get_stock_search_service_dependency)"
+    },
+    {
+      "file": "web/backend/app/api/stock_search/stock_search_result.py",
+      "function": "get_market_news",
+      "getter_line": 398,
+      "future_target": "FastAPI Depends(get_stock_search_service_dependency)"
+    },
+    {
+      "file": "web/backend/app/api/stock_search/stock_search_result.py",
+      "function": "clear_search_cache",
+      "getter_line": 488,
+      "future_target": "FastAPI Depends(get_stock_search_service_dependency)"
+    },
+    {
+      "file": "web/backend/app/api/market/market_data_request.py",
+      "function": "get_kline_data",
+      "getter_line": 603,
+      "future_target": "FastAPI Depends(get_stock_search_service_dependency)"
+    }
+  ],
+  "future_allowed_write_scope": [
+    "web/backend/app/services/stock_search_service/stock_search_service.py",
+    "web/backend/app/services/stock_search_service/__init__.py",
+    "web/backend/app/api/stock_search/stock_search_result.py",
+    "web/backend/app/api/market/market_data_request.py",
+    "web/backend/tests/test_stock_search_service_lifecycle_di.py",
+    "web/backend/tests/test_stock_search_service_logging.py",
+    "tests/api/test_stock_search_file.py",
+    "docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-2026-05-23.md",
+    "governance/mainline/task-cards/pr-<future>.yaml"
+  ],
+  "future_required_gates": [
+    "GitNexus impact for StockSearchService before editing",
+    "GitNexus impact for get_stock_search_service before editing",
+    "TDD red/green provider and route dependency tests",
+    "focused pytest for stock-search lifecycle DI and existing stock-search tests",
+    "ruff check on touched backend files",
+    "git diff --check",
+    "staged gitnexus_detect_changes",
+    "Mainline Governance Gate"
+  ],
+  "explicit_non_goals": [
+    "no source edits in this authorization PR",
+    "no services outside stock_search_service",
+    "no route paths or OpenAPI exposure changes",
+    "no removal of get_stock_search_service",
+    "no PM2 or stateful gates",
+    "no issue label movement"
+  ],
+  "next_gate": "Human review of this G2.18 authorization packet. If approved, create a separate implementation lane for stock_search_service route-surface DI."
+}

--- a/docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.md
+++ b/docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.md
@@ -1,0 +1,199 @@
+# Backend Stock Search Service Lifecycle DI Implementation Authorization - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: implementation-authorization-prepared-for-review
+- Workline: G2.18 stock-search route-surface service lifecycle DI
+- Recorded at: 2026-05-23T09:20:07+08:00
+- Current HEAD: `0285d1cbc29b`
+- Parent issue: [#79](https://github.com/chengjon/mystocks/issues/79)
+- Parent decision issue: [#92](https://github.com/chengjon/mystocks/issues/92)
+- Source implementation authorized by this document: no
+
+## Governance Boundary
+
+This packet is an authorization request for a later implementation lane. It
+does not edit backend source, route handlers, tests, OpenSpec changes, runtime
+configuration, issue labels, or PM2/stateful gates.
+
+If approved, a future implementation PR may modify only the files listed in the
+allowed write scope below. Any broader market-data, strategy, data, adapter,
+OpenAPI, or service-lifecycle cleanup must be proposed as a separate lane.
+
+## Current Issue State
+
+| Item | State | Notes |
+|---|---|---|
+| Issue `#79` | `OPEN`, `needs-triage` | Parent service singleton lifecycle DI issue remains open. |
+| Issue `#92` | `OPEN`, `enhancement`, `ready-for-human`, `ready-for-downstream` | Downstream governance remains a decision/control issue, not source authorization. |
+| G2.17 candidate refresh | PR `#157` merged at `0285d1cbc29b` | Selected `stock_search_service` as the next authorization candidate only. |
+| OpenSpec `migrate-backend-singletons-to-lifecycle-di` | Complete | Current work continues under downstream governance reports rather than reopening that completed change. |
+
+## Evidence Inputs
+
+| Evidence | Path / Source | Role |
+|---|---|---|
+| Candidate refresh report | `docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-2026-05-23.md` | Selects `stock_search_service.py` as the conditional G2.18 authorization candidate. |
+| Candidate refresh JSON | `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-2026-05-23.json` | Machine-readable candidate inventory and recommendation. |
+| Existing DI pattern evidence | `email_service.py`, `announcement_service.py`, `watchlist_service.py` | App-state provider plus compatibility getter fallback pattern to reuse. |
+| GitNexus impact | `StockSearchService`, `get_stock_search_service` | Confirms class-level LOW impact but getter-level CRITICAL route surface. |
+| Route scan | current HEAD `0285d1cbc29b` | Confirms six direct `get_stock_search_service()` route calls. |
+
+## Candidate Decision
+
+Authorize `web/backend/app/services/stock_search_service/stock_search_service.py`
+as the next route-surface service lifecycle DI implementation candidate after
+human approval.
+
+Rationale:
+
+- It is the smallest practical remaining route-surface service candidate from
+  the G2.17 scan: `175` LOC.
+- The service class impact is LOW with no direct GitNexus callers or affected
+  processes.
+- The compatibility getter has a narrow but important route surface: five calls
+  in stock-search routes and one call in market K-line data.
+- Existing DI pilots have already established the app-state provider plus
+  compatibility fallback pattern.
+- The next larger candidates (`tdx`, `data`, `market_data_v2`, `strategy`) have
+  broader route, adapter, external-client, or task implications.
+
+## GitNexus Pre-Edit Snapshot
+
+| Symbol | File | Risk | Direct callers | Processes affected | Disposition |
+|---|---|---:|---:|---:|---|
+| `StockSearchService` | `web/backend/app/services/stock_search_service/stock_search_service.py` | LOW | 0 | 0 | Class body is small enough for a focused app-state provider seam. |
+| `get_stock_search_service` | `web/backend/app/services/stock_search_service/stock_search_service.py` | CRITICAL | 6 | 11 | Compatibility getter must remain as fallback; route call sites must be migrated deliberately. |
+
+Direct GitNexus callers of `get_stock_search_service`:
+
+| Caller | File | Future migration target |
+|---|---|---|
+| `search_stocks` | `web/backend/app/api/stock_search/stock_search_result.py` | Inject `StockSearchService` with FastAPI `Depends`. |
+| `get_stock_quote` | `web/backend/app/api/stock_search/stock_search_result.py` | Inject `StockSearchService` with FastAPI `Depends`. |
+| `get_stock_news` | `web/backend/app/api/stock_search/stock_search_result.py` | Inject `StockSearchService` with FastAPI `Depends`. |
+| `get_market_news` | `web/backend/app/api/stock_search/stock_search_result.py` | Inject `StockSearchService` with FastAPI `Depends`. |
+| `clear_search_cache` | `web/backend/app/api/stock_search/stock_search_result.py` | Inject `StockSearchService` with FastAPI `Depends`. |
+| `get_kline_data` | `web/backend/app/api/market/market_data_request.py` | Inject `StockSearchService` with FastAPI `Depends`; do not broaden market service work. |
+
+## Current Direct Caller Surface
+
+| Route file | Function | Current access | Notes |
+|---|---|---|---|
+| `web/backend/app/api/stock_search/stock_search_result.py` | `search_stocks` | `get_stock_search_service()` at line 165 | Calls `service.unified_search(...)`. |
+| `web/backend/app/api/stock_search/stock_search_result.py` | `get_stock_quote` | `get_stock_search_service()` at line 260 | Calls realtime quote helpers. |
+| `web/backend/app/api/stock_search/stock_search_result.py` | `get_stock_news` | `get_stock_search_service()` at line 356 | Calls stock news helpers. |
+| `web/backend/app/api/stock_search/stock_search_result.py` | `get_market_news` | `get_stock_search_service()` at line 398 | Calls market news helpers. |
+| `web/backend/app/api/stock_search/stock_search_result.py` | `clear_search_cache` | `get_stock_search_service()` at line 488 | Calls `service.clear_cache()`. |
+| `web/backend/app/api/market/market_data_request.py` | `get_kline_data` | `get_stock_search_service()` at line 603 | Calls A-stock K-line fallback path. |
+
+## Future Allowed Write Scope
+
+If this packet is approved, a future implementation lane may edit only:
+
+| Path | Allowed change |
+|---|---|
+| `web/backend/app/services/stock_search_service/stock_search_service.py` | Add state key, install provider, FastAPI dependency provider, and keep compatibility getter fallback. |
+| `web/backend/app/services/stock_search_service/__init__.py` | Re-export any new provider/install symbols if needed for route imports. |
+| `web/backend/app/api/stock_search/stock_search_result.py` | Convert only the five direct route-local getter calls to dependency injection. |
+| `web/backend/app/api/market/market_data_request.py` | Convert only the `get_kline_data` stock-search service call to dependency injection. |
+| `web/backend/tests/test_stock_search_service_lifecycle_di.py` | Add focused provider, app-state override, and compatibility fallback tests. |
+| `web/backend/tests/test_stock_search_service_logging.py` | Update only if direct service construction expectations need import-path adjustment. |
+| `tests/api/test_stock_search_file.py` | Update only route-level dependency override coverage if required. |
+| `docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-2026-05-23.md` | Record future implementation evidence. |
+| `governance/mainline/task-cards/pr-<future>.yaml` | Future implementation PR task card. |
+
+## Explicitly Forbidden Scope
+
+The future implementation lane must not:
+
+- edit any service outside `stock_search_service`;
+- edit broader `market_data`, `data_service`, `strategy`, `tdx`, adapter, or
+  task-running services;
+- change route paths, HTTP methods, response models, OpenAPI exposure, or API
+  examples except where unavoidable test-only dependency overrides are needed;
+- remove `get_stock_search_service()`;
+- remove or change runtime fallback behavior;
+- execute PM2/stateful gates;
+- move issue labels or publish a new GitHub implementation issue;
+- treat the CRITICAL GitNexus getter risk as a blocker to all work. It is a
+  reason for a narrow TDD implementation, not a reason to broaden scope.
+
+## Future Implementation Shape
+
+### Service Provider Pattern
+
+The future implementation should follow the already merged service DI pattern:
+
+- keep the current module-level `get_stock_search_service()` compatibility
+  getter;
+- add a stable state key such as `STOCK_SEARCH_SERVICE_STATE_KEY`;
+- add `install_stock_search_service(app, service=None)` to install either a
+  supplied test double or the compatibility getter result onto `app.state`;
+- add `get_stock_search_service_dependency(request: Request)` to read from
+  `request.app.state` and install fallback when missing;
+- avoid changing `StockSearchService.__init__` semantics unless required for
+  tests and explicitly justified.
+
+### Route Injection Pattern
+
+The future route change should:
+
+- import the dependency provider from `app.services.stock_search_service`;
+- add `service: StockSearchService = Depends(get_stock_search_service_dependency)`
+  to each approved route signature;
+- remove only the local `service = get_stock_search_service()` calls in the six
+  approved functions;
+- preserve existing current-user dependencies, validation, response wrappers,
+  exception handling, and cache behavior.
+
+## Required Future Tests
+
+A future implementation PR must include TDD evidence for:
+
+| Test | Required coverage |
+|---|---|
+| `web/backend/tests/test_stock_search_service_lifecycle_di.py` | Red/green provider install, app-state override, fallback install, and route dependency override. |
+| `web/backend/tests/test_stock_search_service_logging.py` | Existing logging behavior remains valid. |
+| `tests/api/test_stock_search_file.py` | Stock-search route smoke remains valid if dependency signatures change. |
+| `web/backend/tests/test_runtime_regressions_p0.py` | Include only if route import/runtime regression coverage is already coupled to stock search. |
+
+## Required Future Quality Gates
+
+Before any future source edit:
+
+- re-run GitNexus impact for `StockSearchService`;
+- re-run GitNexus impact for the exact `get_stock_search_service` symbol;
+- stop and return to review if a new HIGH/CRITICAL dependency appears outside
+  the approved route-surface files.
+
+Before future commit:
+
+- focused pytest for the new lifecycle DI tests and existing stock-search
+  service tests;
+- `ruff check` on touched backend files;
+- `git diff --check`;
+- staged `gitnexus_detect_changes`;
+- Mainline Governance Gate with a future PR task card.
+
+## Rollback Plan
+
+If the future implementation fails, revert the future implementation PR. The
+rollback must restore the six direct route-local `get_stock_search_service()`
+calls, remove the app-state provider dependency from route signatures, and
+preserve the existing compatibility getter.
+
+This authorization packet itself is rollback-safe: revert the governance report,
+JSON artifact, PR task card, and steward-tree update.
+
+## Review Decision Needed
+
+Approve or reject G2.18 as the authorization package for a future
+`stock_search_service` route-surface lifecycle DI implementation.
+
+Approval authorizes only the future implementation scope and gates described
+above. It does not authorize immediate source edits in this PR.

--- a/governance/mainline/task-cards/pr-158.yaml
+++ b/governance/mainline/task-cards/pr-158.yaml
@@ -1,0 +1,100 @@
+version: "v0.2"
+
+task:
+  id: "pr-158"
+  title: "Authorize stock search service DI lane"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-stock-search-service-di-authorization"
+  objective: "prepare the G2.18 stock_search_service route-surface lifecycle DI implementation authorization packet"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-stock-search-service-di-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-stock-search-service-di-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization packet only; no runtime entrypoint, route, page, shim, service behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.json"
+    - "docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-158.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, test, generated client, docs/API, route, OpenAPI, probe, script, config, PM2, or runtime behavior changes in this PR"
+  - "No stock_search_service source edit in this PR"
+  - "No route injection implementation in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.json >/tmp/stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.json"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-158.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the authorization packet is misread as implementation approval, stock_search_service can be edited without the required TDD and GitNexus gates"
+    - "If GitNexus CRITICAL risk on get_stock_search_service is ignored, a later route-surface implementation can affect multiple stock-search and market-data endpoints"
+  rollback_plan: "revert this PR to remove the authorization report, JSON artifact, PR task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize the next stock_search_service route-surface DI implementation lane for review"
+    modified_scope: "steward tree, authorization report, generated evidence artifact, and this PR task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this is governance authorization only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T09:20:07+08:00"
+    approval_note: "human maintainer approved merging PR #157 and starting G2.18 authorization packet creation; this PR is governance-only and does not authorize source implementation"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Prepare G2.18 authorization packet for future stock_search_service route-surface lifecycle DI.
- Record six direct getter route consumers, GitNexus LOW/CRITICAL split, allowed future write scope, TDD gates, and rollback plan.
- Update the steward tree and add machine-readable evidence plus mainline task card.

## Boundaries
- Governance/authorization only.
- No backend source, route, test, OpenSpec, runtime, PM2, or issue label changes.
- Future source implementation still requires human approval of this packet.

## Verification
- python -m json.tool .planning/codebase/generated/stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.json
- python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.md
- python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-158.yaml
- git diff HEAD~1..HEAD --check
- GitNexus detect_changes compare HEAD~1: low, changed_symbols=0, affected_processes=0