### PR TITLE
refactor: inject stock search service dependency

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -456,8 +456,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-service-lifecycle-di-candidate-refresh-2026-05-23.md`,
 │   │   `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-2026-05-23.json`,
 │   │   `backend-stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.md`,
-│   │   `.planning/codebase/generated/stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.json`
-│   ├── State: stock-search-service-di-implementation-authorization-prepared
+│   │   `.planning/codebase/generated/stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.json`,
+│   │   `backend-stock-search-service-lifecycle-di-implementation-2026-05-23.md`
+│   ├── State: stock-search-service-di-implementation-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -549,12 +550,18 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 records the future `stock_search_service` route-surface DI
 │   │                 write scope, six route-local getter callers, GitNexus
 │   │                 pre-edit gates, TDD requirements, rollback plan, and
-│   │                 forbidden scope; source edits remain locked pending human
-│   │                 review of this authorization packet
-│   └── Next gate: Human review of the G2.18 authorization packet; if accepted,
-│                  create a separate implementation lane for
-│                  `stock_search_service` route-surface DI before any source
-│                  edits
+│   │                 forbidden scope; PR `#158` merged at
+│   │                 `d63b18ab98417d9051dfbf177a975ac7470c96d3`; G2.19 now
+│   │                 implements the approved route-surface DI scope by adding an
+│   │                 app-state provider seam to `stock_search_service`, keeping
+│   │                 `get_stock_search_service()` as compatibility fallback, and
+│   │                 injecting `StockSearchService` into five stock-search route
+│   │                 handlers plus the market `get_kline_data` fallback route;
+│   │                 focused stock-search suite is green and no next service
+│   │                 candidate is selected by this step
+│   └── Next gate: Human review of the G2.19 implementation PR; if accepted,
+│                  merge it and create a separate closeout packet before
+│                  selecting any next service lifecycle DI candidate
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-2026-05-23.md
+++ b/docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-2026-05-23.md
@@ -1,0 +1,132 @@
+# Backend Stock Search Service Lifecycle DI Implementation - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: implementation-prepared-for-review
+- Workline: G2.19 stock-search route-surface service lifecycle DI
+- Recorded at: 2026-05-23T09:43:31+08:00
+- Base HEAD: `d63b18ab9841`
+- Parent authorization: `backend-stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.md`
+- Parent issue: [#79](https://github.com/chengjon/mystocks/issues/79)
+- Parent decision issue: [#92](https://github.com/chengjon/mystocks/issues/92)
+
+## Governance Boundary
+
+This implementation follows the G2.18 authorization packet. It changes only the
+approved `stock_search_service` service seam, two approved route files, one
+focused test file, this evidence report, the steward tree, and this PR task
+card.
+
+It does not change route paths, HTTP methods, response models, OpenAPI exposure,
+docs/API examples, frontend code, PM2/stateful gates, issue labels, or any
+service outside `stock_search_service`.
+
+## Implementation Summary
+
+| Area | Change |
+|---|---|
+| Service seam | Added `STOCK_SEARCH_SERVICE_STATE_KEY`, `install_stock_search_service`, and `get_stock_search_service_dependency`. |
+| Compatibility | Preserved `get_stock_search_service()` as the fallback singleton getter. |
+| Package exports | Re-exported the state key, install function, and dependency provider from `app.services.stock_search_service`. |
+| Stock-search routes | Converted five approved direct route-local getter calls to injected `StockSearchService`. |
+| Market K-line route | Converted the approved `get_kline_data` stock-search fallback call to injected `StockSearchService`. |
+| Tests | Added focused lifecycle DI tests for provider install, explicit install, route signatures, and injected cache-clear behavior. |
+
+## GitNexus Pre-Edit Evidence
+
+| Symbol | File | Risk | Direct callers | Processes affected | Action |
+|---|---|---:|---:|---:|---|
+| `StockSearchService` | `web/backend/app/services/stock_search_service/stock_search_service.py` | LOW | 0 | 0 | Allowed as service seam target. |
+| `get_stock_search_service` | `web/backend/app/services/stock_search_service/stock_search_service.py` | CRITICAL | 6 | 11 | Preserved as compatibility fallback; six approved route callers were migrated. |
+
+The CRITICAL getter-level risk was handled by keeping the compatibility getter
+and limiting route edits to the six callers listed in the authorization packet.
+
+## Route Consumer Closure
+
+| Route file | Function | Previous access | New access |
+|---|---|---|---|
+| `web/backend/app/api/stock_search/stock_search_result.py` | `search_stocks` | `get_stock_search_service()` | `service: StockSearchService = Depends(get_stock_search_service_dependency)` |
+| `web/backend/app/api/stock_search/stock_search_result.py` | `get_stock_quote` | `get_stock_search_service()` | `service: StockSearchService = Depends(get_stock_search_service_dependency)` |
+| `web/backend/app/api/stock_search/stock_search_result.py` | `get_stock_news` | `get_stock_search_service()` | `service: StockSearchService = Depends(get_stock_search_service_dependency)` |
+| `web/backend/app/api/stock_search/stock_search_result.py` | `get_market_news` | `get_stock_search_service()` | `service: StockSearchService = Depends(get_stock_search_service_dependency)` |
+| `web/backend/app/api/stock_search/stock_search_result.py` | `clear_search_cache` | `get_stock_search_service()` | `service: StockSearchService = Depends(get_stock_search_service_dependency)` |
+| `web/backend/app/api/market/market_data_request.py` | `get_kline_data` | local import plus `get_stock_search_service()` | module import plus `service: StockSearchService = Depends(get_stock_search_service_dependency)` |
+
+Current scan result:
+
+- direct `get_stock_search_service()` calls in the two approved route files:
+  `none`
+- injected stock-search service parameters:
+  - stock-search routes: `5`
+  - market K-line route: `1`
+
+## TDD Evidence
+
+RED:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_lifecycle_di.py -q --no-cov --tb=short
+FFFF
+```
+
+Failures were the intended missing behavior:
+
+- missing `get_stock_search_service_dependency`
+- missing `install_stock_search_service`
+- missing route `service` parameters
+- `clear_search_cache()` rejecting injected `service`
+
+GREEN:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_lifecycle_di.py -q --no-cov --tb=short
+4 passed in 2.11s
+```
+
+Focused suite after implementation and ruff cleanup:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_lifecycle_di.py web/backend/tests/test_stock_search_service_logging.py tests/api/test_stock_search_file.py -q --no-cov --tb=short
+31 passed in 1.46s
+```
+
+## Verification Snapshot
+
+| Gate | Result |
+|---|---|
+| Focused lifecycle DI test | `4 passed in 2.11s` |
+| Focused stock-search suite | `31 passed in 1.46s` |
+| `ruff check` touched files | Passed after auto-fixing two lint issues and rerunning. |
+| `black --check` touched files | Passed after manual formatting. |
+| app/main OpenAPI smoke | `routes=548 paths=500` |
+| Markdown governance | 2 files checked, 0 errors. |
+| `git diff --check` | Passed. |
+| Direct getter call scan | `none` in the two approved route files. |
+| staged GitNexus detection | HIGH, 8 files, 37 changed symbols, 11 affected processes. |
+
+The staged GitNexus result is HIGH because the approved implementation changes
+route entrypoints that were already identified by the G2.18 authorization packet:
+`get_stock_quote` and `get_kline_data` process chains. No affected process was
+reported outside the authorized stock-search / market K-line route surface.
+
+Additional pre-commit gates still required after staging:
+
+- Mainline Governance Gate
+- cached diff check
+
+## Rollback Plan
+
+Revert the future PR as one unit. The revert restores the six route-local
+`get_stock_search_service()` calls, removes the new app-state dependency
+provider exports, and removes the focused lifecycle DI test.
+
+## Next Gate
+
+Human review of the G2.19 implementation PR. If accepted, merge it and then
+create a separate closeout packet before selecting any next service lifecycle DI
+candidate.

--- a/governance/mainline/task-cards/pr-159.yaml
+++ b/governance/mainline/task-cards/pr-159.yaml
@@ -1,0 +1,128 @@
+version: "v0.2"
+
+task:
+  id: "pr-159"
+  title: "Implement stock search service lifecycle DI"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-stock-search-service-lifecycle-di-implementation"
+  objective: "implement the G2.19 route-surface-only stock_search_service lifecycle DI lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-stock-search-service-di-implementation"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-stock-search-service-di-implementation"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow service lifecycle DI implementation authorized by PR #158; route paths, OpenAPI behavior, product surface, broader services, and runtime process state are unchanged"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "web/backend/app/services/stock_search_service/stock_search_service.py"
+    - "web/backend/app/services/stock_search_service/__init__.py"
+    - "web/backend/app/api/stock_search/stock_search_result.py"
+    - "web/backend/app/api/market/market_data_request.py"
+    - "web/backend/tests/test_stock_search_service_lifecycle_di.py"
+    - "docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-159.yaml"
+  forbidden_paths:
+    - "web/backend/app/services/email_service.py"
+    - "web/backend/app/services/email_notification_service.py"
+    - "web/backend/app/services/announcement_service.py"
+    - "web/backend/app/services/watchlist_service.py"
+    - "web/backend/app/services/tradingview_widget_service.py"
+    - "web/backend/app/services/strategy_service.py"
+    - "web/backend/app/services/tdx_service.py"
+    - "web/backend/app/services/data_service.py"
+    - "web/backend/app/services/market_data_service.py"
+    - "web/backend/app/services/market_data_service_v2.py"
+    - "web/backend/app/services/data_adapters/**"
+    - "web/backend/app/services/adapters/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No service lifecycle DI work outside stock_search_service"
+  - "No route path, request model, response shape, OpenAPI exposure, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No next service DI candidate selection in this PR"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_lifecycle_di.py web/backend/tests/test_stock_search_service_logging.py tests/api/test_stock_search_file.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/stock_search_service/stock_search_service.py web/backend/app/services/stock_search_service/__init__.py web/backend/app/api/stock_search/stock_search_result.py web/backend/app/api/market/market_data_request.py web/backend/tests/test_stock_search_service_lifecycle_di.py"
+      required: true
+    - id: "black-check-touched"
+      command: "black --check web/backend/app/services/stock_search_service/stock_search_service.py web/backend/app/services/stock_search_service/__init__.py web/backend/app/api/stock_search/stock_search_result.py web/backend/app/api/market/market_data_request.py web/backend/tests/test_stock_search_service_lifecycle_di.py"
+      required: true
+    - id: "app-main-openapi-smoke"
+      command: "env PYTHONPATH=web/backend POSTGRESQL_HOST=localhost POSTGRESQL_USER=postgres POSTGRESQL_PASSWORD=postgres JWT_SECRET_KEY=test-secret-key-for-stock-search-di-smoke BACKEND_PORT=8020 BACKEND_BACKUP_PORT=8021 python -c 'from app.main import app; schema=app.openapi(); print(len(app.routes), len(schema.get(\"paths\", {})))'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-2026-05-23.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-159.yaml"
+      required: true
+    - id: "staged-gitnexus"
+      command: "gitnexus_detect_changes(scope=staged)"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If any broader market/data/strategy service is edited, the PR exceeds the G2.18 authorization boundary"
+    - "If route paths or response contracts change, this PR becomes route/OpenAPI governance work instead of lifecycle DI work"
+  rollback_plan: "revert this PR; restore the six route functions to direct get_stock_search_service() calls; remove the stock-search dependency provider and focused lifecycle DI test as one unit"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "implement route-surface-only stock_search_service lifecycle DI after G2.18 authorization"
+    modified_scope: "stock_search_service package, two approved route files, focused tests, implementation report, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "get_stock_search_service remains as compatibility getter; six route-local callers now use injected StockSearchService"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, ruff, black check, app/OpenAPI smoke, mainline scope, staged GitNexus, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T09:43:31+08:00"
+    approval_note: "human maintainer approved continuation after G2.18 authorization PR #158; this PR implements only the approved stock_search_service route-surface DI scope"
+    secondary_approved: false

--- a/web/backend/app/api/market/market_data_request.py
+++ b/web/backend/app/api/market/market_data_request.py
@@ -35,6 +35,7 @@ from app.schemas.market_schemas import (
     MessageResponse,
 )
 from app.services.market_data_service import MarketDataService, get_market_data_service
+from app.services.stock_search_service import StockSearchService, get_stock_search_service_dependency
 
 router = APIRouter()
 router.include_router(market_heatmap_router)
@@ -67,9 +68,8 @@ from app.api.market._market_data_request_responses import (
     LHB_RESPONSES,
     MARKET_QUOTES_RESPONSES,
     STOCK_LIST_RESPONSES,
-    _error_response_spec,
-    _success_response_spec,
 )
+
 
 @router.get("/fund-flow", summary="查询资金流向", responses=FUND_FLOW_RESPONSES)
 @cache_response("fund_flow", ttl=300)  # 🚀 添加5分钟缓存
@@ -550,6 +550,7 @@ async def get_kline_data(
     adjust: str = Query(default="qfq", description="复权类型: qfq/hfq/空字符串", pattern=r"^(qfq|hfq|)$"),
     start_date: Optional[str] = Query(None, description="开始日期 YYYY-MM-DD"),
     end_date: Optional[str] = Query(None, description="结束日期 YYYY-MM-DD"),
+    service: StockSearchService = Depends(get_stock_search_service_dependency),
 ):
     """
     获取股票K线（蜡烛图）历史数据
@@ -572,8 +573,6 @@ async def get_kline_data(
     """
     try:
         from datetime import datetime as dt_convert
-
-        from app.services.stock_search_service import get_stock_search_service
 
         # 参数验证：日期格式验证（但不转换为datetime对象，因为service层期望字符串）
         if start_date:
@@ -600,7 +599,6 @@ async def get_kline_data(
                 detail="市场数据服务暂不可用，请稍后重试", status_code=503, error_code="MARKET_SERVICE_UNAVAILABLE"
             )
 
-        service = get_stock_search_service()
         try:
             # FIX: 直接传递字符串参数给service层
             result = service.get_a_stock_kline(

--- a/web/backend/app/api/stock_search/stock_search_result.py
+++ b/web/backend/app/api/stock_search/stock_search_result.py
@@ -46,7 +46,7 @@ from app.core.circuit_breaker_manager import get_circuit_breaker  # 导入熔断
 from app.core.exceptions import BusinessException, ForbiddenException, NotFoundException, ValidationException
 from app.core.responses import UnifiedResponse, create_unified_success_response
 from app.schema import StockListQueryModel  # 导入P0改进的验证模型
-from app.services.stock_search_service import get_stock_search_service
+from app.services.stock_search_service import StockSearchService, get_stock_search_service_dependency
 from src.core.exceptions import (
     DatabaseNotFoundError,
     DatabaseOperationError,
@@ -75,6 +75,7 @@ async def search_stocks(
     sort_by: str = Query("relevance", description="排序字段"),
     sort_order: str = Query("desc", description="排序顺序: asc, desc"),
     current_user: User = Depends(get_current_user),
+    service: StockSearchService = Depends(get_stock_search_service_dependency),
 ) -> List[Dict]:
     """
     搜索股票
@@ -162,7 +163,6 @@ async def search_stocks(
                 error_code="SERVICE_UNAVAILABLE",
             )
 
-        service = get_stock_search_service()
         try:
             results = service.unified_search(
                 clean_query,
@@ -217,6 +217,7 @@ async def get_stock_quote(
     symbol: str = Path(..., description="股票代码，例如 A股 `600519`、港股 `00700`"),
     market: str = Query("cn", description="市场类型: cn, hk", pattern=r"^(cn|hk)$"),
     current_user: User = Depends(get_current_user),
+    service: StockSearchService = Depends(get_stock_search_service_dependency),
 ) -> Dict:
     """
     获取股票实时报价
@@ -256,8 +257,6 @@ async def get_stock_quote(
                 raise NotFoundException(resource="股票报价", identifier="查询条件")
 
             return quote_data
-
-        service = get_stock_search_service()
 
         if market.lower() == "cn":
             quote = service.get_a_stock_realtime(validated_symbol)
@@ -340,6 +339,7 @@ async def get_stock_news(
     market: str = Query("cn", description="市场类型: cn, hk", pattern=r"^(cn|hk)$"),
     days: int = Query(7, description="获取最近几天的新闻", ge=1, le=30),
     current_user: User = Depends(get_current_user),
+    service: StockSearchService = Depends(get_stock_search_service_dependency),
 ) -> List[Dict]:
     """
     获取股票新闻
@@ -352,8 +352,6 @@ async def get_stock_news(
     try:
         if _is_stock_search_mock_enabled():
             return _get_mock_stock_data("stock_news", symbol=symbol, market=market, days=days) or []
-
-        service = get_stock_search_service()
 
         if market.lower() == "cn":
             news = service.get_a_stock_news(symbol, days=days)
@@ -386,6 +384,7 @@ async def get_market_news(
     category: str = Path(..., description="市场新闻分类，例如 `general`、`macro`、`industry`"),
     market: str = Query("cn", description="市场类型: cn, hk", pattern=r"^(cn|hk)$"),
     current_user: User = Depends(get_current_user),
+    service: StockSearchService = Depends(get_stock_search_service_dependency),
 ) -> List[Dict]:
     """
     获取市场新闻
@@ -395,8 +394,6 @@ async def get_market_news(
         market: 市场类型（cn=A股, hk=港股）
     """
     try:
-        service = get_stock_search_service()
-
         if market.lower() == "cn":
             news = service.get_a_stock_news(days=7)
         elif market.lower() == "hk":
@@ -467,7 +464,10 @@ async def get_recommendation_trends(
     description="管理员清空股票搜索相关缓存，用于数据源切换、异常恢复和排查缓存脏数据。",
     responses=CACHE_CLEAR_RESPONSES,
 )
-async def clear_search_cache(current_user: User = Depends(get_current_user)) -> UnifiedResponse:
+async def clear_search_cache(
+    current_user: User = Depends(get_current_user),
+    service: StockSearchService = Depends(get_stock_search_service_dependency),
+) -> UnifiedResponse:
     """
     清除搜索缓存
 
@@ -485,7 +485,6 @@ async def clear_search_cache(current_user: User = Depends(get_current_user)) -> 
         # 记录操作分析
         log_search_operation(user=current_user, operation="clear_search_cache", details={"admin_action": True})
 
-        service = get_stock_search_service()
         service.clear_cache()
 
         logger.info("Search cache cleared by admin: {current_user.username}")

--- a/web/backend/app/services/stock_search_service/__init__.py
+++ b/web/backend/app/services/stock_search_service/__init__.py
@@ -1,9 +1,23 @@
 """stock_search_service 拆分包"""
+
 from .parse_datetime_to_timestamp import parse_datetime_to_timestamp  # noqa: F401
 from .parse_datetime_to_timestamp import normalize_stock_code  # noqa: F401
 from .parse_datetime_to_timestamp import StockSearchError  # noqa: F401
 from .parse_datetime_to_timestamp import FinnhubAPIError  # noqa: F401
 from .stock_search_service import StockSearchService  # noqa: F401
+from .stock_search_service import STOCK_SEARCH_SERVICE_STATE_KEY  # noqa: F401
 from .stock_search_service import get_stock_search_service  # noqa: F401
+from .stock_search_service import get_stock_search_service_dependency  # noqa: F401
+from .stock_search_service import install_stock_search_service  # noqa: F401
 
-__all__ = ['parse_datetime_to_timestamp', 'normalize_stock_code', 'StockSearchError', 'FinnhubAPIError', 'StockSearchService', 'get_stock_search_service']
+__all__ = [
+    "parse_datetime_to_timestamp",
+    "normalize_stock_code",
+    "StockSearchError",
+    "FinnhubAPIError",
+    "StockSearchService",
+    "STOCK_SEARCH_SERVICE_STATE_KEY",
+    "get_stock_search_service",
+    "get_stock_search_service_dependency",
+    "install_stock_search_service",
+]

--- a/web/backend/app/services/stock_search_service/stock_search_service.py
+++ b/web/backend/app/services/stock_search_service/stock_search_service.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 import json
 import logging
 import os
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
+from fastapi import Request
 import requests
 
 try:
@@ -71,6 +72,7 @@ if not AKSHARE_AVAILABLE:
 
 
 _stock_search_service = None
+STOCK_SEARCH_SERVICE_STATE_KEY = "stock_search_service"
 
 
 class StockSearchService:
@@ -172,3 +174,16 @@ def get_stock_search_service() -> StockSearchService:
     if _stock_search_service is None:
         _stock_search_service = StockSearchService()
     return _stock_search_service
+
+
+def install_stock_search_service(app: Any, service: StockSearchService | None = None) -> StockSearchService:
+    selected_service = service if service is not None else get_stock_search_service()
+    setattr(app.state, STOCK_SEARCH_SERVICE_STATE_KEY, selected_service)
+    return selected_service
+
+
+def get_stock_search_service_dependency(request: Request) -> StockSearchService:
+    service = getattr(request.app.state, STOCK_SEARCH_SERVICE_STATE_KEY, None)
+    if service is None:
+        service = install_stock_search_service(request.app)
+    return service

--- a/web/backend/tests/test_stock_search_service_lifecycle_di.py
+++ b/web/backend/tests/test_stock_search_service_lifecycle_di.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from app.api.market import market_data_request as market_routes
+from app.api.stock_search import stock_search_result as stock_routes
+from app.services import stock_search_service
+from app.services.stock_search_service import stock_search_service as stock_search_service_module
+
+
+def test_stock_search_service_dependency_installs_app_state_when_missing(monkeypatch):
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+    request = SimpleNamespace(app=fake_app)
+
+    monkeypatch.setattr(stock_search_service_module, "get_stock_search_service", lambda: fake_service)
+
+    assert stock_search_service.get_stock_search_service_dependency(request) is fake_service
+    assert getattr(fake_app.state, stock_search_service.STOCK_SEARCH_SERVICE_STATE_KEY) is fake_service
+
+
+def test_install_stock_search_service_accepts_explicit_service():
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+
+    assert stock_search_service.install_stock_search_service(fake_app, fake_service) is fake_service
+    assert getattr(fake_app.state, stock_search_service.STOCK_SEARCH_SERVICE_STATE_KEY) is fake_service
+
+
+def test_stock_search_routes_accept_injected_stock_search_service():
+    for route_module, function_name in [
+        (stock_routes, "search_stocks"),
+        (stock_routes, "get_stock_quote"),
+        (stock_routes, "get_stock_news"),
+        (stock_routes, "get_market_news"),
+        (stock_routes, "clear_search_cache"),
+        (market_routes, "get_kline_data"),
+    ]:
+        signature = inspect.signature(getattr(route_module, function_name))
+        assert "service" in signature.parameters
+
+
+@pytest.mark.asyncio
+async def test_clear_search_cache_uses_injected_stock_search_service(monkeypatch):
+    class FakeStockSearchService:
+        def __init__(self):
+            self.cleared = False
+
+        def clear_cache(self):
+            self.cleared = True
+
+    fake_service = FakeStockSearchService()
+    current_user = SimpleNamespace(id=42, username="admin", role="admin")
+
+    monkeypatch.setattr(stock_routes, "check_admin_privileges", lambda user: True)
+    monkeypatch.setattr(stock_routes, "log_search_operation", lambda **kwargs: None)
+
+    await stock_routes.clear_search_cache(
+        current_user=current_user,
+        service=fake_service,
+    )
+
+    assert fake_service.cleared is True


### PR DESCRIPTION
## Summary
- Adds an app-state backed provider seam for `StockSearchService` while preserving the existing `get_stock_search_service()` compatibility fallback.
- Injects `StockSearchService` into the approved route surface: five `stock_search_result.py` handlers plus market `get_kline_data`.
- Adds focused lifecycle-DI coverage and records the G2.19 implementation evidence/task-card/steward-tree state.

## Governance Boundary
- No route path, OpenAPI schema, response contract, runtime/PM2, issue-label, or broader service-lifecycle changes.
- Direct route-local stock-search getter calls are removed only from the approved files.
- GitNexus reports HIGH impact through the authorized `get_stock_quote` / `get_kline_data` route surface; no unapproved process scope is intended.

## Verification
- `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_lifecycle_di.py web/backend/tests/test_stock_search_service_logging.py tests/api/test_stock_search_file.py -q --no-cov --tb=short` -> 31 passed
- `ruff check` on changed Python files -> passed
- `black --check` on changed Python files -> passed
- Markdown governance gate on steward tree + implementation report -> passed
- Mainline scope gate with `governance/mainline/task-cards/pr-159.yaml` -> passed
- App import/OpenAPI smoke -> routes=548, paths=500
- GitNexus staged/compare detect -> HIGH, expected/authorized route-surface impact
