### PR TITLE
docs: select service DI candidate refresh lane

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -459,8 +459,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `.planning/codebase/generated/stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.json`,
 │   │   `backend-stock-search-service-lifecycle-di-implementation-2026-05-23.md`,
 │   │   `backend-stock-search-service-lifecycle-di-closeout-2026-05-23.md`,
-│   │   `.planning/codebase/generated/stock-search-service-lifecycle-di-closeout-2026-05-23.json`
-│   ├── State: stock-search-service-di-closeout-prepared-for-review
+│   │   `.planning/codebase/generated/stock-search-service-lifecycle-di-closeout-2026-05-23.json`,
+│   │   `backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md`,
+│   │   `.planning/codebase/generated/service-lifecycle-di-next-lane-after-stock-search-2026-05-23.json`
+│   ├── State: service-lifecycle-di-next-lane-after-stock-search-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -564,10 +566,14 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 `25db762ae6484ad4638baf0f8ab42b94a978a403`; G2.20 now
 │   │                 records that merged result, preserves the compatibility
 │   │                 getter boundary, and confirms no next service candidate is
-│   │                 selected by this closeout
-│   └── Next gate: Human review of the G2.20 closeout packet; if accepted,
-│                  decide a separate next-lane packet before selecting any next
-│                  service lifecycle DI candidate
+│   │                 selected by this closeout; PR `#160` merged at
+│   │                 `f8063b512fb7c3aabfabef9d80d05d1d682569b5`; G2.21 now
+│   │                 selects a future G2.22 current-head candidate refresh
+│   │                 before any further service DI source edit or
+│   │                 compatibility getter cleanup
+│   └── Next gate: Human review of the G2.21 decision packet; if accepted,
+│                  create G2.22 current-head candidate refresh before selecting
+│                  any next service lifecycle DI implementation candidate
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -625,7 +631,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-di-candidate-refresh-2026-05-23.md` | G | G2.17 current-head refresh merged by PR `#157` at `0285d1cbc29b4622b3e39c9a171ba3b02691ed1b`: scanned 152 service Python files, identified 15 service getter files and 11 route-surface related getter files, recorded GitNexus risk, and recommends only a future G2.18 `stock_search_service` authorization packet | Superseded by G2.18 authorization packet |
 | `backend-stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.md` | G | G2.18 authorization merged by PR `#158` at `d63b18ab98417d9051dfbf177a975ac7470c96d3`: future write scope limited to `stock_search_service`, five stock-search route handlers, market `get_kline_data`, focused tests, implementation report, and task card | Superseded by G2.19 implementation evidence |
 | `backend-stock-search-service-lifecycle-di-implementation-2026-05-23.md` | G | G2.19 implementation merged by PR `#159` at `25db762ae6484ad4638baf0f8ab42b94a978a403`: app-state provider seam added, compatibility getter preserved, six route-local stock-search service consumers injected, and focused stock-search tests passed | Superseded by G2.20 closeout packet |
-| `backend-stock-search-service-lifecycle-di-closeout-2026-05-23.md` | G | G2.20 closeout prepared: PR `#159` merge recorded, post-merge route-surface scan shows `0` direct getter calls in the approved route files, and no follow-up implementation or next service candidate is authorized | Human review of the closeout packet; next candidate requires a separate packet |
+| `backend-stock-search-service-lifecycle-di-closeout-2026-05-23.md` | G | G2.20 closeout merged by PR `#160` at `f8063b512fb7c3aabfabef9d80d05d1d682569b5`: PR `#159` merge recorded, post-merge route-surface scan shows `0` direct getter calls in the approved route files, and no follow-up implementation or next service candidate is authorized | Superseded by G2.21 next-lane decision packet |
+| `backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md` | G | G2.21 decision prepared: current-head quick scan at `f8063b512fb7` shows 152 service files, 20 getter/singleton/provider hit files, 5 completed/reference provider-pattern files, and 15 remaining files needing classification; select G2.22 current-head candidate refresh before implementation or compatibility-getter cleanup | Human review; if accepted, create G2.22 current-head candidate refresh packet |
 
 ## Completed And Reviewed Ledger
 
@@ -709,7 +716,8 @@ review, PR review, or OpenSpec archive review.
 | G2.17 service lifecycle DI candidate refresh | G/#79 | Refresh current-head service lifecycle DI candidate inventory before selecting another implementation lane | Reviewed and merged by PR `#157` at `0285d1cbc29b4622b3e39c9a171ba3b02691ed1b`: `stock_search_service` is the only recommended future authorization candidate, and source edits remain locked until G2.18 | `docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-2026-05-23.md`; `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/157 | Superseded by G2.18 authorization packet |
 | G2.18 stock search service lifecycle DI authorization | G/#79 | Exact future write scope, TDD plan, GitNexus gates, and rollback boundary prepared for route-surface-only `stock_search_service` DI | Reviewed and merged by PR `#158` at `d63b18ab98417d9051dfbf177a975ac7470c96d3`: scope limited to the service package, five stock-search route handlers, market `get_kline_data`, focused tests, implementation report, and task card | `docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.md`; `.planning/codebase/generated/stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/158 | Superseded by G2.19 implementation evidence |
 | G2.19 stock search service lifecycle DI implementation | G/#79 | Route-surface-only `stock_search_service` DI implemented and merged | Reviewed and merged by PR `#159` at `25db762ae6484ad4638baf0f8ab42b94a978a403`: focused pytest `31 passed`, ruff and black passed, app/OpenAPI smoke `routes=548`, `paths=500`, GitNexus HIGH was expected for the authorized route surface, and GitHub contract/governance checks passed | `docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-2026-05-23.md`; `web/backend/tests/test_stock_search_service_lifecycle_di.py`; https://github.com/chengjon/mystocks/pull/159 | Superseded by G2.20 closeout packet |
-| G2.20 stock search service lifecycle DI closeout | G/#79 | Closeout records PR `#159` merge result and route-surface scan | Review-ready: no backend source/test/runtime/OpenSpec/issue-label changes; post-merge scan shows `0` direct `get_stock_search_service()` calls in approved route files and preserves the compatibility getter boundary; no next service candidate selected | `docs/reports/quality/backend-stock-search-service-lifecycle-di-closeout-2026-05-23.md`; `.planning/codebase/generated/stock-search-service-lifecycle-di-closeout-2026-05-23.json` | Human review; if accepted, create a separate next-lane packet before more service lifecycle DI work |
+| G2.20 stock search service lifecycle DI closeout | G/#79 | Closeout records PR `#159` merge result and route-surface scan | Reviewed and merged by PR `#160` at `f8063b512fb7c3aabfabef9d80d05d1d682569b5`: no backend source/test/runtime/OpenSpec/issue-label changes; post-merge scan shows `0` direct `get_stock_search_service()` calls in approved route files and preserves the compatibility getter boundary; no next service candidate selected | `docs/reports/quality/backend-stock-search-service-lifecycle-di-closeout-2026-05-23.md`; `.planning/codebase/generated/stock-search-service-lifecycle-di-closeout-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/160 | Superseded by G2.21 next-lane decision packet |
+| G2.21 service lifecycle DI next-lane after stock-search | G/#79 | Select current-head candidate refresh as the next service lifecycle DI governance lane | Review-ready: current-head quick scan at `f8063b512fb7` shows remaining getter/singleton/provider signal files require classification; no source, test, route, OpenAPI, OpenSpec, issue-label, runtime, PM2, compatibility getter cleanup, or next implementation candidate is authorized | `docs/reports/quality/backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md`; `.planning/codebase/generated/service-lifecycle-di-next-lane-after-stock-search-2026-05-23.json` | Human review; if accepted, create G2.22 current-head candidate refresh packet |
 
 ## OpenSpec Branch Register
 

--- a/.planning/codebase/generated/service-lifecycle-di-next-lane-after-stock-search-2026-05-23.json
+++ b/.planning/codebase/generated/service-lifecycle-di-next-lane-after-stock-search-2026-05-23.json
@@ -1,0 +1,86 @@
+{
+  "artifact": "service-lifecycle-di-next-lane-after-stock-search",
+  "date": "2026-05-23",
+  "status": "decision-packet-prepared-for-review",
+  "workline": "G2.21 service lifecycle DI next-lane decision after stock-search closeout",
+  "base_head": "f8063b512fb7",
+  "parent_issue": {
+    "number": 79,
+    "state": "OPEN",
+    "labels": [
+      "needs-triage"
+    ],
+    "url": "https://github.com/chengjon/mystocks/issues/79"
+  },
+  "parent_decision_issue": {
+    "number": 92,
+    "state": "OPEN",
+    "labels": [
+      "enhancement",
+      "ready-for-human",
+      "ready-for-downstream"
+    ],
+    "url": "https://github.com/chengjon/mystocks/issues/92"
+  },
+  "input_prs": {
+    "implementation_pr_159": {
+      "state": "MERGED",
+      "merge_commit": "25db762ae6484ad4638baf0f8ab42b94a978a403"
+    },
+    "closeout_pr_160": {
+      "state": "MERGED",
+      "merge_commit": "f8063b512fb7c3aabfabef9d80d05d1d682569b5"
+    }
+  },
+  "current_head_quick_scan": {
+    "service_python_files_scanned": 152,
+    "getter_singleton_provider_hit_files": 20,
+    "completed_or_reference_provider_pattern_files": [
+      "web/backend/app/services/email_service.py",
+      "web/backend/app/services/announcement_service.py",
+      "web/backend/app/services/watchlist_service.py",
+      "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "web/backend/app/services/tradingview_widget_service.py"
+    ],
+    "remaining_files_requiring_classification": [
+      "web/backend/app/services/market_data_service_v2.py",
+      "web/backend/app/services/email_notification_service.py",
+      "web/backend/app/services/unified_data_service.py",
+      "web/backend/app/services/websocket_service.py",
+      "web/backend/app/services/market_data_service/get_market_data_service.py",
+      "web/backend/app/services/technical_analysis_service.py",
+      "web/backend/app/services/realtime_streaming_service.py",
+      "web/backend/app/services/tdx_service.py",
+      "web/backend/app/services/data_service_enhanced.py",
+      "web/backend/app/services/__init__.py",
+      "web/backend/app/services/advanced_analysis_service.py",
+      "web/backend/app/services/data_service.py",
+      "web/backend/app/services/monitoring_service.py",
+      "web/backend/app/services/wencai_service.py",
+      "web/backend/app/services/strategy_service.py"
+    ]
+  },
+  "decision": {
+    "selected_next_lane": "G2.22 current-head service lifecycle DI candidate refresh",
+    "direct_implementation_candidate_selected": false,
+    "compatibility_getter_cleanup_selected": false,
+    "reason": "G2.17 candidate pool was consumed by stock_search_service; remaining getter/singleton/provider signals require current-head classification before source authorization."
+  },
+  "g2_22_required_scope": [
+    "regenerate current service getter/singleton/provider inventory",
+    "classify all remaining hits",
+    "scan route/API, test, and non-route consumers",
+    "run GitNexus impact/context for recommended candidates",
+    "recommend exactly one next action without editing source"
+  ],
+  "authorization_boundary": {
+    "no_backend_source_or_test_edits": true,
+    "no_compatibility_getter_deletion": true,
+    "no_route_or_openapi_changes": true,
+    "no_issue_label_changes": true,
+    "no_openspec_changes": true,
+    "no_runtime_or_pm2_changes": true,
+    "no_next_implementation_candidate_selected": true
+  },
+  "next_gate": "Human review of G2.21; if accepted, create a separate G2.22 current-head candidate refresh packet."
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md
@@ -1,0 +1,145 @@
+# Backend Service Lifecycle DI Next-Lane After Stock Search - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: decision-packet-prepared-for-review
+- Workline: G2.21 service lifecycle DI next-lane decision after stock-search closeout
+- Base HEAD: `f8063b512fb7`
+- Parent issue: [#79](https://github.com/chengjon/mystocks/issues/79)
+- Parent decision issue: [#92](https://github.com/chengjon/mystocks/issues/92)
+- Recorded at: `2026-05-23T10:24:32+08:00`
+
+## Governance Boundary
+
+This packet is governance-only. It chooses the next service lifecycle DI
+planning lane after the merged stock-search implementation and closeout.
+
+It does not authorize backend source edits, tests, route/OpenAPI changes,
+compatibility getter deletion, issue label movement, OpenSpec changes, PM2
+execution, runtime process changes, docs/API changes, generated clients, or
+frontend work.
+
+## Input State
+
+| Item | Current state | Evidence |
+|---|---|---|
+| PR `#159` | `MERGED` | `25db762ae6484ad4638baf0f8ab42b94a978a403` |
+| PR `#160` | `MERGED` | `f8063b512fb7c3aabfabef9d80d05d1d682569b5` |
+| Issue `#79` | `OPEN`, `needs-triage` | Live GitHub status checked at this worktree |
+| Issue `#92` | `OPEN`, `enhancement`, `ready-for-human`, `ready-for-downstream` | Live GitHub status checked at this worktree |
+| Completed route-surface DI pilots in this sequence | `email_service.py`, `announcement_service.py`, `watchlist_service.py`, `stock_search_service.py` | G2.2-G2.20 reports and merged PRs |
+| Reference service DI pattern | `tradingview_widget_service.py` | Existing reference/provider pattern |
+| Watchlist adapter-aware helper cleanup | Complete | PRs `#152`-`#155` |
+| Stock-search compatibility getter | Preserved | G2.20 closeout; direct route-local calls removed from approved route files |
+
+## Current-Head Quick Scan
+
+This packet ran a lightweight current-head scan at `f8063b512fb7` to determine
+whether the next step can safely be a direct implementation authorization. It
+cannot.
+
+| Metric | Value |
+|---|---:|
+| Service Python files scanned | 152 |
+| Files with getter/singleton/provider signal | 20 |
+| Completed or reference provider-pattern files | 5 |
+| Remaining getter/singleton signal files needing classification | 15 |
+
+Completed or reference provider-pattern files:
+
+- `web/backend/app/services/email_service.py`
+- `web/backend/app/services/announcement_service.py`
+- `web/backend/app/services/watchlist_service.py`
+- `web/backend/app/services/stock_search_service/stock_search_service.py`
+- `web/backend/app/services/tradingview_widget_service.py`
+
+Remaining files requiring fresh classification before any authorization:
+
+- `web/backend/app/services/market_data_service_v2.py`
+- `web/backend/app/services/email_notification_service.py`
+- `web/backend/app/services/unified_data_service.py`
+- `web/backend/app/services/websocket_service.py`
+- `web/backend/app/services/market_data_service/get_market_data_service.py`
+- `web/backend/app/services/technical_analysis_service.py`
+- `web/backend/app/services/realtime_streaming_service.py`
+- `web/backend/app/services/tdx_service.py`
+- `web/backend/app/services/data_service_enhanced.py`
+- `web/backend/app/services/__init__.py`
+- `web/backend/app/services/advanced_analysis_service.py`
+- `web/backend/app/services/data_service.py`
+- `web/backend/app/services/monitoring_service.py`
+- `web/backend/app/services/wencai_service.py`
+- `web/backend/app/services/strategy_service.py`
+
+## Stock-Search Compatibility Getter Boundary
+
+The stock-search implementation removed direct route-local
+`get_stock_search_service()` calls from the approved route files, but the
+compatibility getter remains intentionally present.
+
+Current reference categories:
+
+| Category | Current observation | Disposition |
+|---|---|---|
+| Service package exports/body | Getter and dependency provider remain in `stock_search_service` package | Expected compatibility surface |
+| Approved route files | `0` direct getter calls; dependency-provider references remain | Completed G2.19 route-surface migration |
+| Tests | Runtime regression tests still call the compatibility getter | Do not delete without a separate compatibility-cleanup packet |
+
+Therefore, a compatibility getter cleanup is not safe as an automatic next step.
+It needs its own consumer matrix, test update plan, GitNexus impact evidence,
+and rollback boundary if selected later.
+
+## Decision
+
+Select **G2.22 current-head service lifecycle DI candidate refresh** as the next
+service lifecycle DI lane.
+
+G2.21 does not select a concrete implementation candidate. It deliberately
+chooses a refresh packet because the prior G2.17 candidate pool was consumed by
+G2.18-G2.20, and the remaining service getter/singleton surface contains broad
+market, data, strategy, notification, websocket, monitoring, and registry
+signals that require current-head classification.
+
+## Required G2.22 Scope
+
+The next packet should:
+
+1. regenerate current service getter/singleton/provider inventory from HEAD;
+2. classify every hit into completed, reference pattern, route-surface candidate,
+   adapter/data/helper candidate, registry/integrated seam, external/live-data
+   seam, process-level singleton, false positive, or hold;
+3. scan current route/API consumers for each candidate getter;
+4. scan tests and non-route consumers before recommending compatibility getter
+   cleanup;
+5. run GitNexus impact/context for any recommended candidate symbol before
+   authorizing future source edits;
+6. recommend exactly one next action:
+   - prepare a concrete implementation authorization for one candidate,
+   - prepare a compatibility getter cleanup authorization,
+   - pause G2 and return to another architecture lane, or
+   - perform another evidence-only refinement if candidate risk is still too
+     high.
+
+## Explicit Non-Goals
+
+- No backend source or test edits.
+- No compatibility getter deletion.
+- No route path, request model, response shape, OpenAPI exposure, generated
+  client, frontend, or docs/API changes.
+- No PM2 or runtime process action.
+- No issue label changes and no `ready-for-agent` movement.
+- No OpenSpec proposal, change, spec modification, or archive action.
+- No direct selection of the next service implementation candidate in this
+  packet.
+
+## Next Gate
+
+Human review of this G2.21 decision packet.
+
+If accepted, create a separate G2.22 current-head candidate refresh packet. G2.22
+may gather evidence and recommend a later action, but it must not edit source
+unless a subsequent implementation authorization packet is explicitly accepted.

--- a/governance/mainline/task-cards/pr-161.yaml
+++ b/governance/mainline/task-cards/pr-161.yaml
@@ -1,0 +1,99 @@
+version: "v0.2"
+
+task:
+  id: "pr-161"
+  title: "Decide service DI next lane after stock search"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-service-lifecycle-di-next-lane-after-stock-search"
+  objective: "select the next governance lane after G2.20 stock_search_service closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-di-next-lane-after-stock-search"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-di-next-lane-after-stock-search"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision packet only; records the next governance lane and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-di-next-lane-after-stock-search-2026-05-23.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-161.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No next service implementation candidate selection in this PR"
+  - "No compatibility getter cleanup in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-di-next-lane-after-stock-search-2026-05-23.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-161.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the decision boundary"
+    - "If this PR selects or authorizes a concrete implementation candidate, it bypasses the G2.22 refresh gate"
+  rollback_plan: "revert this governance-only PR; G2.20 stock_search_service closeout remains merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "select current-head candidate refresh as the next service lifecycle DI governance lane"
+    modified_scope: "decision report, generated decision artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; compatibility getters remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only decision PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T10:24:32+08:00"
+    approval_note: "human maintainer approved continuing after G2.20 closeout; this packet selects only a future current-head refresh and does not authorize source edits"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Selects G2.22 current-head service lifecycle DI candidate refresh as the next G2 lane after stock-search closeout.
- Records why direct implementation or stock-search compatibility getter cleanup is not authorized yet.
- Updates the steward tree, generated decision artifact, and PR task-card.

## Governance Boundary
- Governance-only decision packet: no backend source, tests, route/OpenAPI, docs/API, frontend, PM2, runtime, OpenSpec, or issue-label changes.
- Does not select a concrete implementation candidate.
- Does not authorize compatibility getter deletion.

## Verification
- Markdown governance gate -> checked_files=2, errors=0
- JSON parse -> passed
- `git diff HEAD~1..HEAD --check` -> passed
- Mainline scope gate with `governance/mainline/task-cards/pr-161.yaml` -> passed
- GitNexus staged detect -> low risk, 0 changed symbols, 0 affected processes
