### PR TITLE
docs: refresh service DI candidates after stock search

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -461,8 +461,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-stock-search-service-lifecycle-di-closeout-2026-05-23.md`,
 │   │   `.planning/codebase/generated/stock-search-service-lifecycle-di-closeout-2026-05-23.json`,
 │   │   `backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md`,
-│   │   `.planning/codebase/generated/service-lifecycle-di-next-lane-after-stock-search-2026-05-23.json`
-│   ├── State: service-lifecycle-di-next-lane-after-stock-search-prepared-for-review
+│   │   `.planning/codebase/generated/service-lifecycle-di-next-lane-after-stock-search-2026-05-23.json`,
+│   │   `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md`,
+│   │   `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.json`
+│   ├── State: service-lifecycle-di-candidate-refresh-after-stock-search-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -570,10 +572,20 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 `f8063b512fb7c3aabfabef9d80d05d1d682569b5`; G2.21 now
 │   │                 selects a future G2.22 current-head candidate refresh
 │   │                 before any further service DI source edit or
-│   │                 compatibility getter cleanup
-│   └── Next gate: Human review of the G2.21 decision packet; if accepted,
-│                  create G2.22 current-head candidate refresh before selecting
-│                  any next service lifecycle DI implementation candidate
+│   │                 compatibility getter cleanup; PR `#161` merged at
+│   │                 `d2e799cd2c1cbeb00b70d5cf64897b7c8a8a3b11`; G2.22 now
+│   │                 refreshes current-head service lifecycle candidates,
+│   │                 records 152 service Python files, 42 broad heuristic hit
+│   │                 files, 17 narrow candidate files, no direct next
+│   │                 route-surface implementation candidate, and selects a
+│   │                 future G2.23 stock-search compatibility getter cleanup
+│   │                 authorization / consumer-matrix packet before any source
+│   │                 edit
+│   └── Next gate: Human review of the G2.22 candidate refresh packet; if
+│                  accepted, create G2.23 stock-search compatibility getter
+│                  cleanup authorization / consumer-matrix packet before any
+│                  stock-search getter source edit or broader service DI
+│                  implementation selection
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -623,6 +635,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-technical-pattern-di-pilot-implementation-2026-05-21.md` | D2.1a.1 | First DI lifecycle pilot implementation merged in PR `#112`; route-level provider and dependency override test seam are in place | D2.1a implementation closed; do not infer a second DI pilot from this evidence |
 | `inject-technical-pattern-detection-service-di` task `5.3` closeout | D2.1a.1 | Final OpenSpec checklist governance merged in PR `#113`; issue `#92` received implementation and final governance closeout comments | D2.1a is 100% closed; future DI work requires a new approved child lane |
 
+| G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |
 | `backend-watchlist-helper-cleanup-implementation-authorization-2026-05-23.md` | G | G2.13 implementation authorization packet merged: future write scope, tests, GitNexus gates, and rollback plan defined for adapter-aware watchlist helper cleanup | Superseded by G2.14 implementation evidence |
 | `backend-watchlist-helper-cleanup-implementation-2026-05-23.md` | G | G2.14 implementation merged by PR `#154`: both watchlist adapter/helper files now accept constructor-configured provider seams; route code unchanged | Superseded by G2.15 closeout packet |
@@ -632,7 +645,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.md` | G | G2.18 authorization merged by PR `#158` at `d63b18ab98417d9051dfbf177a975ac7470c96d3`: future write scope limited to `stock_search_service`, five stock-search route handlers, market `get_kline_data`, focused tests, implementation report, and task card | Superseded by G2.19 implementation evidence |
 | `backend-stock-search-service-lifecycle-di-implementation-2026-05-23.md` | G | G2.19 implementation merged by PR `#159` at `25db762ae6484ad4638baf0f8ab42b94a978a403`: app-state provider seam added, compatibility getter preserved, six route-local stock-search service consumers injected, and focused stock-search tests passed | Superseded by G2.20 closeout packet |
 | `backend-stock-search-service-lifecycle-di-closeout-2026-05-23.md` | G | G2.20 closeout merged by PR `#160` at `f8063b512fb7c3aabfabef9d80d05d1d682569b5`: PR `#159` merge recorded, post-merge route-surface scan shows `0` direct getter calls in the approved route files, and no follow-up implementation or next service candidate is authorized | Superseded by G2.21 next-lane decision packet |
-| `backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md` | G | G2.21 decision prepared: current-head quick scan at `f8063b512fb7` shows 152 service files, 20 getter/singleton/provider hit files, 5 completed/reference provider-pattern files, and 15 remaining files needing classification; select G2.22 current-head candidate refresh before implementation or compatibility-getter cleanup | Human review; if accepted, create G2.22 current-head candidate refresh packet |
+| `backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md` | G | G2.21 decision merged by PR `#161` at `d2e799cd2c1cbeb00b70d5cf64897b7c8a8a3b11`: select G2.22 current-head candidate refresh before implementation or compatibility-getter cleanup | Superseded by G2.22 candidate refresh packet |
+| `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md` | G | G2.22 current-head refresh prepared at `d2e799cd2c1c`: scanned 152 service Python files, recorded 42 broad heuristic hit files and 17 narrow service-lifecycle candidate files, found no safe direct next route-surface implementation candidate, and selects future G2.23 `stock_search_service` compatibility getter cleanup authorization / consumer-matrix packet | Human review; if accepted, create G2.23 decision packet before any getter cleanup or broader service DI implementation |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.json
+++ b/.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.json
@@ -1,0 +1,338 @@
+{
+  "artifact": "service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23",
+  "recorded_at": "2026-05-23T11:05:16+08:00",
+  "workline": "G2.22 current-head service lifecycle DI candidate refresh after stock-search",
+  "status": "candidate-refresh-prepared-for-review",
+  "current_head": "d2e799cd2c1c",
+  "remote_base": {
+    "branch": "origin/wip/root-dirty-20260403",
+    "head": "d2e799cd2c1cbeb00b70d5cf64897b7c8a8a3b11"
+  },
+  "stale_if_head_mismatch": true,
+  "target_pr": 162,
+  "target_pr_url": "https://github.com/chengjon/mystocks/pull/162",
+  "parent_issue": {
+    "number": 92,
+    "state": "OPEN",
+    "labels": [
+      "enhancement",
+      "ready-for-human",
+      "ready-for-downstream"
+    ],
+    "url": "https://github.com/chengjon/mystocks/issues/92"
+  },
+  "service_lifecycle_issue": {
+    "number": 79,
+    "state": "OPEN",
+    "labels": [
+      "needs-triage"
+    ],
+    "url": "https://github.com/chengjon/mystocks/issues/79"
+  },
+  "merged_input": {
+    "pr_161": {
+      "state": "MERGED",
+      "merge_commit": "d2e799cd2c1cbeb00b70d5cf64897b7c8a8a3b11"
+    }
+  },
+  "scan_summary": {
+    "service_py_files": 152,
+    "broad_heuristic_hit_files": 42,
+    "narrow_service_lifecycle_candidate_files": 17,
+    "bucket_counts": {
+      "completed-route-surface-di": 4,
+      "broad-market-data-strategy-seam": 7,
+      "hold-no-clear-active-route-surface": 2,
+      "process-runtime-singleton-or-streaming": 2,
+      "registry-integrated-seam": 1,
+      "reference-provider-pattern": 1
+    },
+    "scan_criteria": [
+      "Broad heuristic counts files with getter/singleton/provider signals and is not used as a backlog count by itself.",
+      "Narrow inventory includes service files with get_*service* functions, _instance = None, or service app-state provider/dependency patterns."
+    ]
+  },
+  "candidate_inventory": [
+    {
+      "file": "web/backend/app/services/__init__.py",
+      "getters_or_signals": [
+        "get_integrated_services",
+        "get_market_data_service",
+        "get_trading_data_service",
+        "get_analysis_data_service",
+        "get_data_api_service",
+        "get_database_service",
+        "get_websocket_service",
+        "get_cache_service"
+      ],
+      "api_hits": 8,
+      "test_hits": 11,
+      "non_route_service_hits": 6,
+      "bucket": "registry-integrated-seam"
+    },
+    {
+      "file": "web/backend/app/services/announcement_service.py",
+      "getters_or_signals": [
+        "get_announcement_service",
+        "get_announcement_service_dependency"
+      ],
+      "api_hits": 12,
+      "test_hits": 2,
+      "non_route_service_hits": 0,
+      "bucket": "completed-route-surface-di"
+    },
+    {
+      "file": "web/backend/app/services/data_service.py",
+      "getters_or_signals": [
+        "get_data_service"
+      ],
+      "api_hits": 5,
+      "test_hits": 6,
+      "non_route_service_hits": 0,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/data_service_enhanced.py",
+      "getters_or_signals": [
+        "get_enhanced_data_service"
+      ],
+      "api_hits": 0,
+      "test_hits": 0,
+      "non_route_service_hits": 0,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/email_notification_service.py",
+      "getters_or_signals": [
+        "get_email_service"
+      ],
+      "api_hits": 0,
+      "test_hits": 3,
+      "non_route_service_hits": 2,
+      "bucket": "hold-no-clear-active-route-surface"
+    },
+    {
+      "file": "web/backend/app/services/email_service.py",
+      "getters_or_signals": [
+        "get_email_service",
+        "get_email_service_dependency"
+      ],
+      "api_hits": 7,
+      "test_hits": 6,
+      "non_route_service_hits": 1,
+      "bucket": "completed-route-surface-di"
+    },
+    {
+      "file": "web/backend/app/services/market_data_service/get_market_data_service.py",
+      "getters_or_signals": [
+        "get_market_data_service"
+      ],
+      "api_hits": 8,
+      "test_hits": 11,
+      "non_route_service_hits": 6,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/market_data_service_v2.py",
+      "getters_or_signals": [
+        "get_market_data_service_v2"
+      ],
+      "api_hits": 17,
+      "test_hits": 0,
+      "non_route_service_hits": 0,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/monitoring_service.py",
+      "getters_or_signals": [
+        "_instance = None"
+      ],
+      "api_hits": 0,
+      "test_hits": 0,
+      "non_route_service_hits": 0,
+      "bucket": "process-runtime-singleton-or-streaming"
+    },
+    {
+      "file": "web/backend/app/services/realtime_streaming_service.py",
+      "getters_or_signals": [
+        "get_streaming_service"
+      ],
+      "api_hits": 0,
+      "test_hits": 19,
+      "non_route_service_hits": 2,
+      "bucket": "process-runtime-singleton-or-streaming"
+    },
+    {
+      "file": "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "getters_or_signals": [
+        "get_stock_search_service",
+        "get_stock_search_service_dependency"
+      ],
+      "api_hits": 8,
+      "test_hits": 7,
+      "non_route_service_hits": 4,
+      "bucket": "completed-route-surface-di"
+    },
+    {
+      "file": "web/backend/app/services/strategy_service.py",
+      "getters_or_signals": [
+        "get_strategy_service"
+      ],
+      "api_hits": 4,
+      "test_hits": 1,
+      "non_route_service_hits": 4,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/tdx_service.py",
+      "getters_or_signals": [
+        "get_tdx_service"
+      ],
+      "api_hits": 9,
+      "test_hits": 0,
+      "non_route_service_hits": 0,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/technical_analysis_service.py",
+      "getters_or_signals": [
+        "_instance = None"
+      ],
+      "api_hits": 0,
+      "test_hits": 0,
+      "non_route_service_hits": 0,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/tradingview_widget_service.py",
+      "getters_or_signals": [
+        "get_tradingview_service",
+        "get_tradingview_service_dependency"
+      ],
+      "api_hits": 7,
+      "test_hits": 5,
+      "non_route_service_hits": 0,
+      "bucket": "reference-provider-pattern"
+    },
+    {
+      "file": "web/backend/app/services/watchlist_service.py",
+      "getters_or_signals": [
+        "get_watchlist_service",
+        "get_watchlist_service_dependency"
+      ],
+      "api_hits": 8,
+      "test_hits": 3,
+      "non_route_service_hits": 4,
+      "bucket": "completed-route-surface-di"
+    },
+    {
+      "file": "web/backend/app/services/wencai_service.py",
+      "getters_or_signals": [
+        "get_wencai_service"
+      ],
+      "api_hits": 0,
+      "test_hits": 0,
+      "non_route_service_hits": 0,
+      "bucket": "hold-no-clear-active-route-surface"
+    }
+  ],
+  "gitnexus_spot_checks": [
+    {
+      "target": "get_market_data_service_v2",
+      "risk": "CRITICAL",
+      "direct_impact": 15,
+      "processes_affected": 6,
+      "modules_affected": 2,
+      "interpretation": "Active market_v2 and dashboard surface; not a direct next pilot."
+    },
+    {
+      "target": "get_data_service",
+      "risk": "CRITICAL",
+      "direct_impact": 3,
+      "processes_affected": 7,
+      "modules_affected": 2,
+      "interpretation": "Indicator/strategy data seam; needs design packet before edits."
+    },
+    {
+      "target": "get_stock_search_service",
+      "risk": "CRITICAL",
+      "direct_impact": 6,
+      "processes_affected": 11,
+      "modules_affected": 2,
+      "confidence": 0.5,
+      "interpretation": "Graph still reports old route callers at confidence 0.5; text guard shows route direct calls are 0, so cleanup requires a separate consumer-matrix packet."
+    },
+    {
+      "target": "get_strategy_service",
+      "risk": "HIGH",
+      "direct_impact": 6,
+      "processes_affected": 0,
+      "modules_affected": 4,
+      "interpretation": "Strategy route/adapter/task surface; not a direct next pilot."
+    },
+    {
+      "target": "get_tdx_service",
+      "risk": "HIGH",
+      "direct_impact": 2,
+      "processes_affected": 3,
+      "modules_affected": 1,
+      "interpretation": "Dashboard live-market surface; not a direct next pilot."
+    },
+    {
+      "target": "get_market_data_service",
+      "risk": "LOW",
+      "direct_impact": 0,
+      "processes_affected": 0,
+      "modules_affected": 0,
+      "interpretation": "Text scan still finds API/test/non-route refs; treat as graph-name ambiguity, not safe-proof."
+    },
+    {
+      "target": "get_email_service",
+      "risk": "MEDIUM",
+      "direct_impact": 6,
+      "processes_affected": 0,
+      "modules_affected": 1,
+      "interpretation": "Completed route DI lane; remaining evidence is graph/compatibility cleanup, not a new candidate."
+    }
+  ],
+  "stock_search_text_guard": {
+    "route_files": [
+      {
+        "file": "web/backend/app/api/stock_search/stock_search_result.py",
+        "direct_get_stock_search_service_calls": 0,
+        "dependency_provider_refs": 6
+      },
+      {
+        "file": "web/backend/app/api/market/market_data_request.py",
+        "direct_get_stock_search_service_calls": 0,
+        "dependency_provider_refs": 2
+      }
+    ],
+    "test_files": [
+      {
+        "file": "web/backend/tests/test_runtime_regressions_p0.py",
+        "direct_get_stock_search_service_calls": 3,
+        "dependency_provider_refs": 0
+      },
+      {
+        "file": "web/backend/tests/test_stock_search_service_lifecycle_di.py",
+        "direct_get_stock_search_service_calls": 0,
+        "dependency_provider_refs": 1
+      }
+    ]
+  },
+  "decision": {
+    "next_route_surface_implementation_candidate_selected": false,
+    "selected_next_lane": "G2.23 stock-search compatibility getter cleanup authorization / consumer matrix packet",
+    "source_edits_authorized": false,
+    "openspec_change_required_now": false,
+    "issue_label_movement_authorized": false
+  },
+  "required_g2_23_scope": [
+    "Enumerate all stock_search_service getter, dependency-provider, installer, package re-export, route, and test references at current HEAD.",
+    "Separate route dependency-provider references from direct compatibility getter calls.",
+    "Record GitNexus graph freshness or graph/text divergence for get_stock_search_service.",
+    "Define any future allowed write scope, tests, rollback plan, and forbidden paths if cleanup is later approved.",
+    "Keep source deletion and source edits locked until the G2.23 decision packet is reviewed and a separate implementation authorization is approved."
+  ]
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md
@@ -1,0 +1,203 @@
+# Backend Service Lifecycle DI Candidate Refresh After Stock Search - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: candidate-refresh-prepared-for-review
+- Workline: G2.22 current-head service lifecycle DI candidate refresh after
+  stock-search
+- Base HEAD: `d2e799cd2c1c`
+- Remote base: `origin/wip/root-dirty-20260403` at
+  `d2e799cd2c1cbeb00b70d5cf64897b7c8a8a3b11`
+- Parent issue: `#92` OPEN with `enhancement`, `ready-for-human`,
+  `ready-for-downstream`
+- Service lifecycle issue: `#79` OPEN with `needs-triage`
+- Execution mode: governance/evidence only
+
+Boundary note: this packet refreshes candidate evidence only. It does not
+authorize backend source edits, route edits, tests, OpenAPI changes, OpenSpec
+changes, issue label movement, `ready-for-agent` movement, PM2/runtime work, or
+a G2.23 implementation.
+
+## Governance Boundary
+
+This packet executes the G2.22 current-head refresh requested by G2.21. It does
+not authorize:
+
+- Backend source, test, route, OpenAPI, generated-client, frontend, PM2, or
+  runtime changes
+- OpenSpec change/spec creation, modification, validation archive, or issue
+  publication
+- GitHub issue label movement
+- Selecting a direct next service DI implementation candidate
+- Deleting, retiring, or modifying compatibility getters
+
+## Input State
+
+PR `#161` was merged into `wip/root-dirty-20260403` at
+`d2e799cd2c1cbeb00b70d5cf64897b7c8a8a3b11`. That packet selected this G2.22
+refresh before any further service lifecycle DI source edit or stock-search
+compatibility cleanup.
+
+The immediately preceding stock-search route-surface implementation and closeout
+remain the relevant local context:
+
+- G2.19 added the `stock_search_service` app-state provider seam and injected
+  `StockSearchService` into the approved route-local consumers.
+- G2.20 confirmed the approved route files no longer call
+  `get_stock_search_service()` directly.
+- G2.21 deliberately did not select another implementation candidate. It asked
+  for this current-head refresh first.
+
+## Current-Head Inventory
+
+The refresh scanned `web/backend/app/services/**/*.py` at HEAD `d2e799cd2c1c`.
+The scanner used two levels:
+
+- Broad heuristic: files with getter/singleton/provider signals. This catches
+  storage helpers, app-state providers, registry surfaces, and other false
+  positives, so it is not used as a backlog count by itself.
+- Narrow service-lifecycle inventory: service files with `get_*service*`
+  functions, `_instance = None`, or service app-state provider/dependency
+  patterns. This is the candidate-selection input.
+
+Snapshot:
+
+| Metric | Value |
+|---|---:|
+| Service Python files scanned | 152 |
+| Broad heuristic hit files | 42 |
+| Narrow service-lifecycle candidate files | 17 |
+
+Bucket counts for the narrow inventory:
+
+| Bucket | Count | Meaning |
+|---|---:|---|
+| completed-route-surface-di | 4 | Existing route-surface DI lanes already implemented or retained as reference |
+| broad-market-data-strategy-seam | 7 | Active market/data/strategy seams; not a low-risk direct implementation pick |
+| hold-no-clear-active-route-surface | 2 | No clear active route-surface candidate without more consumer proof |
+| process-runtime-singleton-or-streaming | 2 | Runtime/streaming/process-level behavior; do not batch as ordinary service DI |
+| registry-integrated-seam | 1 | Package registry/integrated service surface |
+| reference-provider-pattern | 1 | Reference provider pattern evidence |
+
+Narrow inventory:
+
+| File | Getter / signal | API hits | Test hits | Non-route service hits | Bucket |
+|---|---|---:|---:|---:|---|
+| `web/backend/app/services/__init__.py` | `get_integrated_services`, `get_market_data_service`, `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, `get_cache_service` | 8 | 11 | 6 | registry-integrated-seam |
+| `web/backend/app/services/announcement_service.py` | `get_announcement_service`, `get_announcement_service_dependency` | 12 | 2 | 0 | completed-route-surface-di |
+| `web/backend/app/services/data_service.py` | `get_data_service` | 5 | 6 | 0 | broad-market-data-strategy-seam |
+| `web/backend/app/services/data_service_enhanced.py` | `get_enhanced_data_service` | 0 | 0 | 0 | broad-market-data-strategy-seam |
+| `web/backend/app/services/email_notification_service.py` | `get_email_service` | 0 | 3 | 2 | hold-no-clear-active-route-surface |
+| `web/backend/app/services/email_service.py` | `get_email_service`, `get_email_service_dependency` | 7 | 6 | 1 | completed-route-surface-di |
+| `web/backend/app/services/market_data_service/get_market_data_service.py` | `get_market_data_service` | 8 | 11 | 6 | broad-market-data-strategy-seam |
+| `web/backend/app/services/market_data_service_v2.py` | `get_market_data_service_v2` | 17 | 0 | 0 | broad-market-data-strategy-seam |
+| `web/backend/app/services/monitoring_service.py` | `_instance = None` | 0 | 0 | 0 | process-runtime-singleton-or-streaming |
+| `web/backend/app/services/realtime_streaming_service.py` | `get_streaming_service` | 0 | 19 | 2 | process-runtime-singleton-or-streaming |
+| `web/backend/app/services/stock_search_service/stock_search_service.py` | `get_stock_search_service`, `get_stock_search_service_dependency` | 8 | 7 | 4 | completed-route-surface-di |
+| `web/backend/app/services/strategy_service.py` | `get_strategy_service` | 4 | 1 | 4 | broad-market-data-strategy-seam |
+| `web/backend/app/services/tdx_service.py` | `get_tdx_service` | 9 | 0 | 0 | broad-market-data-strategy-seam |
+| `web/backend/app/services/technical_analysis_service.py` | `_instance = None` | 0 | 0 | 0 | broad-market-data-strategy-seam |
+| `web/backend/app/services/tradingview_widget_service.py` | `get_tradingview_service`, `get_tradingview_service_dependency` | 7 | 5 | 0 | reference-provider-pattern |
+| `web/backend/app/services/watchlist_service.py` | `get_watchlist_service`, `get_watchlist_service_dependency` | 8 | 3 | 4 | completed-route-surface-di |
+| `web/backend/app/services/wencai_service.py` | `get_wencai_service` | 0 | 0 | 0 | hold-no-clear-active-route-surface |
+
+## GitNexus Spot Checks
+
+GitNexus was used as risk evidence, not as the sole source of truth. Where graph
+results conflict with current text guards, this report records the conflict
+instead of treating it as implementation authorization.
+
+| Target | GitNexus risk | Direct impact | Processes / modules | Current interpretation |
+|---|---:|---:|---|---|
+| `get_market_data_service_v2` | CRITICAL | 15 | 6 processes, 2 modules | Active `market_v2.py` and dashboard surface; not a direct next pilot |
+| `get_data_service` | CRITICAL | 3 | 7 processes, 2 modules | Indicator/strategy data seam; needs design packet before edits |
+| `get_stock_search_service` | CRITICAL | 6 | 11 processes, 2 modules | Graph still reports route callers at confidence `0.5`; text guard shows route direct calls are now `0`, so cleanup requires a separate consumer-matrix packet |
+| `get_strategy_service` | HIGH | 6 | 4 modules | Strategy route/adapter/task surface; not a direct next pilot |
+| `get_tdx_service` | HIGH | 2 | 3 processes, 1 module | Dashboard live-market surface; not a direct next pilot |
+| `get_market_data_service` | LOW | 0 | 0 | Text scan still finds API/test/non-route refs; treat as graph-name ambiguity, not safe-proof |
+| `get_email_service` | MEDIUM | 6 | 1 module | Completed route DI lane; remaining evidence is graph/compatibility cleanup, not a new candidate |
+
+## Stock-Search Compatibility Getter Boundary
+
+Current text guard for the approved route files:
+
+| File | Direct `get_stock_search_service()` calls | Dependency provider refs |
+|---|---:|---:|
+| `web/backend/app/api/stock_search/stock_search_result.py` | 0 | 6 |
+| `web/backend/app/api/market/market_data_request.py` | 0 | 2 |
+
+Current test references:
+
+| File | Direct getter calls | Dependency provider refs |
+|---|---:|---:|
+| `web/backend/tests/test_runtime_regressions_p0.py` | 3 | 0 |
+| `web/backend/tests/test_stock_search_service_lifecycle_di.py` | 0 | 1 |
+
+This means route-surface DI migration is closed for the approved route-local
+consumers, but the module-level compatibility getter is still an intentional
+surface until a later decision packet classifies all remaining service, test,
+and package re-export references.
+
+## Decision
+
+No next route-surface service DI implementation candidate is selected by G2.22.
+
+Rationale:
+
+- The remaining market/data/strategy/dashboard seams are HIGH or CRITICAL by
+  GitNexus or are text-scan active across broad API/test/non-route surfaces.
+- Completed route-surface DI files still appear in scans because their
+  compatibility getters and dependency providers are intentionally retained.
+- `stock_search_service` is the narrowest actionable follow-up, but its next
+  step is not deletion or source editing. It needs a compatibility getter
+  cleanup authorization and consumer-matrix packet first.
+
+Selected next lane:
+
+**G2.23 stock-search compatibility getter cleanup authorization / consumer
+matrix packet.**
+
+This is a decision-only next lane. It should decide whether
+`get_stock_search_service()` remains:
+
+- active public compatibility,
+- test-only fallback,
+- package-internal fallback,
+- or a future retire/delete candidate.
+
+## Required G2.23 Scope
+
+The G2.23 packet should:
+
+1. Enumerate all `stock_search_service` getter, dependency-provider, installer,
+   package re-export, route, and test references at current HEAD.
+2. Separate route dependency-provider references from direct compatibility
+   getter calls, including the current eight route-level
+   `get_stock_search_service_dependency` provider references.
+3. Record GitNexus graph freshness or graph/text divergence for
+   `get_stock_search_service`.
+4. Define any future allowed write scope, tests, rollback plan, and explicit
+   forbidden paths if cleanup is later approved.
+5. Keep source deletion and source edits locked until the G2.23 decision packet
+   is reviewed and a separate implementation authorization is approved.
+
+## Explicit Non-Goals
+
+- No backend source edits
+- No test edits
+- No compatibility getter deletion or rename
+- No route/OpenAPI/docs/API/generated client edits
+- No issue label movement
+- No OpenSpec proposal creation or archive
+- No PM2/runtime verification
+
+## Next Gate
+
+Human review of this G2.22 refresh packet. If accepted, create G2.23 as a
+stock-search compatibility getter cleanup authorization / consumer-matrix packet
+before any stock-search compatibility getter source edit or broader service DI
+implementation selection.

--- a/governance/mainline/task-cards/pr-162.yaml
+++ b/governance/mainline/task-cards/pr-162.yaml
@@ -1,0 +1,100 @@
+version: "v0.2"
+
+task:
+  id: "pr-162"
+  title: "Refresh service DI candidates after stock search"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-service-lifecycle-di-candidate-refresh-after-stock-search"
+  objective: "refresh current-head service lifecycle DI candidate evidence after the stock-search route-surface DI lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-di-candidate-refresh-after-stock-search"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-di-candidate-refresh-after-stock-search"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate refresh packet only; records evidence and next governance lane without changing runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-162.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, validation archive, or issue publication"
+  - "No issue label changes or ready-for-agent movement"
+  - "No next service DI implementation candidate selection in this PR"
+  - "No stock-search compatibility getter cleanup, deletion, rename, or source edit in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-162.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the evidence-only boundary"
+    - "If this PR selects a direct implementation candidate, it bypasses the G2.23 compatibility-getter decision gate"
+    - "If stock-search compatibility getter cleanup is performed here, it bypasses the consumer-matrix packet"
+  rollback_plan: "revert this governance-only PR; previous service DI implementation and closeout PRs remain merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh current-head service lifecycle DI candidate evidence after the stock-search route-surface DI lane"
+    modified_scope: "candidate refresh report, generated refresh artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; compatibility getters remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only refresh PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T11:05:16+08:00"
+    approval_note: "human maintainer approved continuing after PR #161; this packet refreshes candidate evidence only and does not authorize source edits"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

G2.22 refreshes the current-head service lifecycle DI candidate evidence after the merged stock-search route-surface DI lane.

This is governance/evidence only. It does not edit backend source, tests, routes, OpenAPI, docs/API, generated clients, frontend code, PM2/runtime state, OpenSpec changes, or issue labels.

## Findings

- Base HEAD: `d2e799cd2c1c` from PR #161 merge.
- Scanned 152 service Python files.
- Recorded 42 broad heuristic hit files and 17 narrowed service-lifecycle candidate files.
- No direct next route-surface implementation candidate is selected.
- Selected next lane for review: G2.23 stock-search compatibility getter cleanup authorization / consumer-matrix packet.

## Evidence

- `docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md`
- `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.json`
- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
- `governance/mainline/task-cards/pr-162.yaml`

## Verification

- Markdown governance: 2 checked files, 0 errors.
- JSON parse: passed.
- Mainline scope gate: passed after commit.
- `git diff HEAD~1..HEAD --check`: passed.
- GitNexus staged detect before commit: low risk, 0 changed symbols, 0 affected processes.

## Boundary

Do not merge this as source authorization. If accepted, the next step is a separate G2.23 stock-search compatibility getter cleanup authorization / consumer-matrix packet before any getter cleanup or broader service DI implementation.
