### PR TITLE
docs: record stock search getter consumer matrix

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -463,8 +463,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md`,
 │   │   `.planning/codebase/generated/service-lifecycle-di-next-lane-after-stock-search-2026-05-23.json`,
 │   │   `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md`,
-│   │   `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.json`
-│   ├── State: service-lifecycle-di-candidate-refresh-after-stock-search-prepared-for-review
+│   │   `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.json`,
+│   │   `backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md`,
+│   │   `.planning/codebase/generated/stock-search-compatibility-getter-consumer-matrix-2026-05-23.json`
+│   ├── State: stock-search-compatibility-getter-consumer-matrix-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -580,12 +582,19 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 route-surface implementation candidate, and selects a
 │   │                 future G2.23 stock-search compatibility getter cleanup
 │   │                 authorization / consumer-matrix packet before any source
-│   │                 edit
-│   └── Next gate: Human review of the G2.22 candidate refresh packet; if
-│                  accepted, create G2.23 stock-search compatibility getter
-│                  cleanup authorization / consumer-matrix packet before any
-│                  stock-search getter source edit or broader service DI
-│                  implementation selection
+│   │                 edit; PR `#162` merged at
+│   │                 `d186ce78ee0ad4017b36e3788a54533ce3a972df`; G2.23 now
+│   │                 records the stock-search compatibility getter consumer
+│   │                 matrix at current HEAD: two route files use only the
+│   │                 dependency provider, route direct getter calls remain `0`,
+│   │                 package exports and tests still intentionally cover
+│   │                 `get_stock_search_service()`, and the getter is retained
+│   │                 as active compatibility surface with no cleanup
+│   │                 implementation authorized
+│   └── Next gate: Human review of the G2.23 consumer matrix; if accepted, do
+│                  not open a stock-search getter cleanup implementation and
+│                  create a separate broad market/data/strategy service seam
+│                  design packet before any further service DI source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -646,7 +655,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-stock-search-service-lifecycle-di-implementation-2026-05-23.md` | G | G2.19 implementation merged by PR `#159` at `25db762ae6484ad4638baf0f8ab42b94a978a403`: app-state provider seam added, compatibility getter preserved, six route-local stock-search service consumers injected, and focused stock-search tests passed | Superseded by G2.20 closeout packet |
 | `backend-stock-search-service-lifecycle-di-closeout-2026-05-23.md` | G | G2.20 closeout merged by PR `#160` at `f8063b512fb7c3aabfabef9d80d05d1d682569b5`: PR `#159` merge recorded, post-merge route-surface scan shows `0` direct getter calls in the approved route files, and no follow-up implementation or next service candidate is authorized | Superseded by G2.21 next-lane decision packet |
 | `backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md` | G | G2.21 decision merged by PR `#161` at `d2e799cd2c1cbeb00b70d5cf64897b7c8a8a3b11`: select G2.22 current-head candidate refresh before implementation or compatibility-getter cleanup | Superseded by G2.22 candidate refresh packet |
-| `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md` | G | G2.22 current-head refresh prepared at `d2e799cd2c1c`: scanned 152 service Python files, recorded 42 broad heuristic hit files and 17 narrow service-lifecycle candidate files, found no safe direct next route-surface implementation candidate, and selects future G2.23 `stock_search_service` compatibility getter cleanup authorization / consumer-matrix packet | Human review; if accepted, create G2.23 decision packet before any getter cleanup or broader service DI implementation |
+| `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md` | G | G2.22 current-head refresh merged by PR `#162` at `d186ce78ee0ad4017b36e3788a54533ce3a972df`: scanned 152 service Python files, recorded 42 broad heuristic hit files and 17 narrow service-lifecycle candidate files, found no safe direct next route-surface implementation candidate, and selected future G2.23 `stock_search_service` compatibility getter cleanup authorization / consumer-matrix packet | Superseded by G2.23 consumer matrix |
+| `backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md` | G | G2.23 consumer matrix prepared at `d186ce78ee0a`: route direct `get_stock_search_service()` calls remain `0`, route provider refs are `8`, package exports/tests still intentionally cover the compatibility getter, and cleanup implementation is not authorized | Human review; if accepted, retain the getter and create a separate broad market/data/strategy service seam design packet before source edits |
 
 ## Completed And Reviewed Ledger
 
@@ -731,7 +741,9 @@ review, PR review, or OpenSpec archive review.
 | G2.18 stock search service lifecycle DI authorization | G/#79 | Exact future write scope, TDD plan, GitNexus gates, and rollback boundary prepared for route-surface-only `stock_search_service` DI | Reviewed and merged by PR `#158` at `d63b18ab98417d9051dfbf177a975ac7470c96d3`: scope limited to the service package, five stock-search route handlers, market `get_kline_data`, focused tests, implementation report, and task card | `docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.md`; `.planning/codebase/generated/stock-search-service-lifecycle-di-implementation-authorization-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/158 | Superseded by G2.19 implementation evidence |
 | G2.19 stock search service lifecycle DI implementation | G/#79 | Route-surface-only `stock_search_service` DI implemented and merged | Reviewed and merged by PR `#159` at `25db762ae6484ad4638baf0f8ab42b94a978a403`: focused pytest `31 passed`, ruff and black passed, app/OpenAPI smoke `routes=548`, `paths=500`, GitNexus HIGH was expected for the authorized route surface, and GitHub contract/governance checks passed | `docs/reports/quality/backend-stock-search-service-lifecycle-di-implementation-2026-05-23.md`; `web/backend/tests/test_stock_search_service_lifecycle_di.py`; https://github.com/chengjon/mystocks/pull/159 | Superseded by G2.20 closeout packet |
 | G2.20 stock search service lifecycle DI closeout | G/#79 | Closeout records PR `#159` merge result and route-surface scan | Reviewed and merged by PR `#160` at `f8063b512fb7c3aabfabef9d80d05d1d682569b5`: no backend source/test/runtime/OpenSpec/issue-label changes; post-merge scan shows `0` direct `get_stock_search_service()` calls in approved route files and preserves the compatibility getter boundary; no next service candidate selected | `docs/reports/quality/backend-stock-search-service-lifecycle-di-closeout-2026-05-23.md`; `.planning/codebase/generated/stock-search-service-lifecycle-di-closeout-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/160 | Superseded by G2.21 next-lane decision packet |
-| G2.21 service lifecycle DI next-lane after stock-search | G/#79 | Select current-head candidate refresh as the next service lifecycle DI governance lane | Review-ready: current-head quick scan at `f8063b512fb7` shows remaining getter/singleton/provider signal files require classification; no source, test, route, OpenAPI, OpenSpec, issue-label, runtime, PM2, compatibility getter cleanup, or next implementation candidate is authorized | `docs/reports/quality/backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md`; `.planning/codebase/generated/service-lifecycle-di-next-lane-after-stock-search-2026-05-23.json` | Human review; if accepted, create G2.22 current-head candidate refresh packet |
+| G2.21 service lifecycle DI next-lane after stock-search | G/#79 | Select current-head candidate refresh as the next service lifecycle DI governance lane | Reviewed and merged by PR `#161` at `d2e799cd2c1cbeb00b70d5cf64897b7c8a8a3b11`: current-head quick scan at `f8063b512fb7` shows remaining getter/singleton/provider signal files require classification; no source, test, route, OpenAPI, OpenSpec, issue-label, runtime, PM2, compatibility getter cleanup, or next implementation candidate is authorized | `docs/reports/quality/backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md`; `.planning/codebase/generated/service-lifecycle-di-next-lane-after-stock-search-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/161 | Superseded by G2.22 current-head candidate refresh |
+| G2.22 service lifecycle DI candidate refresh after stock-search | G/#79 | Refresh current-head service lifecycle candidates after stock-search route-surface DI | Reviewed and merged by PR `#162` at `d186ce78ee0ad4017b36e3788a54533ce3a972df`: scanned 152 service files, recorded 42 broad heuristic hit files and 17 narrow candidate files, selected G2.23 stock-search compatibility getter consumer matrix, and kept source edits locked | `docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md`; `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/162 | Superseded by G2.23 consumer matrix |
+| G2.23 stock-search compatibility getter consumer matrix | G/#79 | Decide whether `get_stock_search_service()` cleanup is authorized after route-surface DI | Review-ready: route direct getter calls remain `0`; route provider refs are `8`; tests and package exports still intentionally cover compatibility getter, installer, state key, and provider behavior; no source/test/route cleanup implementation is authorized | `docs/reports/quality/backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md`; `.planning/codebase/generated/stock-search-compatibility-getter-consumer-matrix-2026-05-23.json` | Human review; if accepted, retain the getter and open a separate broad service seam design packet before source edits |
 
 ## OpenSpec Branch Register
 

--- a/.planning/codebase/generated/stock-search-compatibility-getter-consumer-matrix-2026-05-23.json
+++ b/.planning/codebase/generated/stock-search-compatibility-getter-consumer-matrix-2026-05-23.json
@@ -1,0 +1,165 @@
+{
+  "artifact": "stock-search-compatibility-getter-consumer-matrix-2026-05-23",
+  "recorded_at": "2026-05-23T11:40:44+08:00",
+  "workline": "G2.23 stock-search compatibility getter cleanup authorization / consumer matrix",
+  "status": "consumer-matrix-prepared-for-review",
+  "current_head": "d186ce78ee0a",
+  "stale_if_head_mismatch": true,
+  "target_pr": 163,
+  "target_pr_url": "pending until created",
+  "input_merge": {
+    "pr_162": {
+      "state": "MERGED",
+      "merge_commit": "d186ce78ee0ad4017b36e3788a54533ce3a972df"
+    }
+  },
+  "scan_tokens": [
+    "get_stock_search_service",
+    "get_stock_search_service_dependency",
+    "install_stock_search_service",
+    "STOCK_SEARCH_SERVICE_STATE_KEY",
+    "StockSearchService"
+  ],
+  "consumer_summary": {
+    "route_files": 2,
+    "service_package_files": 2,
+    "test_files": 5,
+    "governance_doc_files": 17,
+    "runtime_and_test_token_totals": {
+      "get_stock_search_service": 10,
+      "get_stock_search_service_dependency": 12,
+      "install_stock_search_service": 5,
+      "STOCK_SEARCH_SERVICE_STATE_KEY": 7,
+      "StockSearchService": 28
+    }
+  },
+  "route_consumer_matrix": [
+    {
+      "file": "web/backend/app/api/stock_search/stock_search_result.py",
+      "handlers": [
+        "search_stocks",
+        "get_stock_quote",
+        "get_stock_news",
+        "get_market_news",
+        "clear_search_cache"
+      ],
+      "direct_get_stock_search_service_calls": 0,
+      "get_stock_search_service_dependency_refs": 6,
+      "decision": "keep-provider-refs-route-surface-di-complete"
+    },
+    {
+      "file": "web/backend/app/api/market/market_data_request.py",
+      "handlers": [
+        "get_kline_data"
+      ],
+      "direct_get_stock_search_service_calls": 0,
+      "get_stock_search_service_dependency_refs": 2,
+      "decision": "keep-provider-refs-approved-fallback-route-consumer"
+    }
+  ],
+  "service_package_matrix": [
+    {
+      "file": "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "roles": [
+        "defines StockSearchService",
+        "defines get_stock_search_service compatibility getter",
+        "defines install_stock_search_service app-state installer",
+        "defines get_stock_search_service_dependency provider",
+        "defines STOCK_SEARCH_SERVICE_STATE_KEY"
+      ],
+      "decision": "retain-active-compatibility-and-provider-surface"
+    },
+    {
+      "file": "web/backend/app/services/stock_search_service/__init__.py",
+      "roles": [
+        "package re-export for class",
+        "package re-export for compatibility getter",
+        "package re-export for dependency provider",
+        "package re-export for installer",
+        "package re-export for state key"
+      ],
+      "decision": "retain-package-level-exports"
+    }
+  ],
+  "test_consumer_matrix": [
+    {
+      "file": "web/backend/tests/test_runtime_regressions_p0.py",
+      "direct_getter_calls": 3,
+      "dependency_provider_refs": 0,
+      "installer_refs": 0,
+      "state_key_refs": 0,
+      "decision": "keep-compatibility-getter-regression-guard"
+    },
+    {
+      "file": "web/backend/tests/test_stock_search_service_lifecycle_di.py",
+      "direct_getter_calls": 0,
+      "dependency_provider_refs": 1,
+      "installer_refs": 1,
+      "state_key_refs": 2,
+      "decision": "keep-lifecycle-provider-and-installer-guard"
+    },
+    {
+      "file": "web/backend/tests/test_large_file_split_regressions.py",
+      "direct_getter_calls": 0,
+      "dependency_provider_refs": 0,
+      "installer_refs": 0,
+      "state_key_refs": 0,
+      "decision": "keep-package-export-regression-guard"
+    },
+    {
+      "file": "web/backend/tests/test_stock_search_service_logging.py",
+      "direct_getter_calls": 0,
+      "dependency_provider_refs": 0,
+      "installer_refs": 0,
+      "state_key_refs": 0,
+      "decision": "keep-package-export-and-service-construction-guard"
+    },
+    {
+      "file": "tests/001-fix-5-critical/plan.md",
+      "direct_getter_calls": 0,
+      "dependency_provider_refs": 0,
+      "installer_refs": 0,
+      "state_key_refs": 0,
+      "decision": "historical-reference-not-runtime-consumer"
+    }
+  ],
+  "gitnexus_evidence": [
+    {
+      "target": "get_stock_search_service",
+      "risk": "CRITICAL",
+      "direct_impact": 6,
+      "processes_affected": 11,
+      "modules_affected": 2,
+      "route_caller_confidence": 0.5,
+      "interpretation": "Graph still reports pre-DI route callers while text guard shows route direct calls are 0; treat as graph/text divergence before any deletion proposal."
+    },
+    {
+      "target": "get_stock_search_service_dependency",
+      "result": "not-found",
+      "interpretation": "GitNexus index does not expose this post-DI provider symbol yet; use text matrix until index refresh validates it."
+    },
+    {
+      "target": "install_stock_search_service",
+      "result": "not-found",
+      "interpretation": "GitNexus index does not expose this post-DI installer symbol yet; use text matrix until index refresh validates it."
+    },
+    {
+      "target": "StockSearchService",
+      "risk": "LOW",
+      "direct_impact": 0,
+      "processes_affected": 0,
+      "modules_affected": 0,
+      "interpretation": "Class-level graph impact is not enough to justify deleting module-level compatibility functions."
+    }
+  ],
+  "decision": {
+    "get_stock_search_service_status": "retain-active-public-compatibility-surface",
+    "route_surface_direct_getter_calls_remaining": 0,
+    "route_dependency_provider_refs": 8,
+    "stock_search_cleanup_implementation_authorized": false,
+    "source_edits_authorized": false,
+    "openspec_change_required_now": false,
+    "issue_label_movement_authorized": false,
+    "next_gate": "Human review; if accepted, do not open stock-search cleanup implementation. Use a separate future governance lane for broad market/data/strategy service seam design before further service DI source edits."
+  }
+}

--- a/docs/reports/quality/backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md
+++ b/docs/reports/quality/backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md
@@ -1,0 +1,174 @@
+# Backend Stock Search Compatibility Getter Consumer Matrix - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: consumer-matrix-prepared-for-review
+- Workline: G2.23 stock-search compatibility getter cleanup authorization /
+  consumer matrix
+- Base HEAD: `d186ce78ee0a`
+- Parent issue: `#92`
+- Service lifecycle issue: `#79`
+- Execution mode: governance/evidence only
+- Recorded at: `2026-05-23T11:40:44+08:00`
+
+Boundary note: this packet classifies current stock-search service compatibility
+getter consumers only. It does not authorize backend source edits, test edits,
+route edits, OpenAPI changes, OpenSpec changes, issue label movement,
+`ready-for-agent` movement, PM2/runtime work, or a compatibility getter deletion.
+
+## Governance Boundary
+
+This packet executes the G2.23 decision lane selected by G2.22. It is a
+consumer matrix and authorization decision, not an implementation branch. It
+does not create a source edit scope by itself.
+
+The packet answers one narrow question: whether `get_stock_search_service()` can
+be cleaned up after the route-surface DI migration.
+
+## Input State
+
+PR `#162` was merged at
+`d186ce78ee0ad4017b36e3788a54533ce3a972df`. That merge recorded:
+
+- 152 service Python files scanned.
+- 42 broad heuristic service getter/singleton/provider hit files.
+- 17 narrowed service lifecycle candidate files.
+- No direct next route-surface implementation candidate.
+- This G2.23 consumer-matrix lane before any stock-search compatibility getter
+  source edit.
+
+## Consumer Matrix Summary
+
+The scan looked for:
+
+- `get_stock_search_service`
+- `get_stock_search_service_dependency`
+- `install_stock_search_service`
+- `STOCK_SEARCH_SERVICE_STATE_KEY`
+- `StockSearchService`
+
+Scope:
+
+| Area | Files with matches | Interpretation |
+|---|---:|---|
+| Route files | 2 | Canonical dependency-provider references only |
+| Service package files | 2 | Definition and package re-export surface |
+| Test files | 5 | Compatibility, split/regression, and lifecycle DI assertions |
+| Governance docs | 17 | Historical/planning evidence only; not runtime consumers |
+
+Runtime and test token totals, excluding governance docs:
+
+| Token | Count | Meaning |
+|---|---:|---|
+| `get_stock_search_service` | 10 | Definition/re-export plus test compatibility references |
+| `get_stock_search_service_dependency` | 12 | Route provider, package export, provider definition, and lifecycle test |
+| `install_stock_search_service` | 5 | Provider fallback, package export, and lifecycle test |
+| `STOCK_SEARCH_SERVICE_STATE_KEY` | 7 | App-state key used by provider/export/tests |
+| `StockSearchService` | 28 | Route type annotations, service class, and tests |
+
+## Route Consumers
+
+| File | Route handlers | Direct getter calls | Dependency provider refs | Decision |
+|---|---|---:|---:|---|
+| `web/backend/app/api/stock_search/stock_search_result.py` | `search_stocks`, `get_stock_quote`, `get_stock_news`, `get_market_news`, `clear_search_cache` | 0 | 6 | Keep provider refs; route-surface DI is complete |
+| `web/backend/app/api/market/market_data_request.py` | `get_kline_data` | 0 | 2 | Keep provider refs; this is the approved fallback route consumer |
+
+Route conclusion: there are no direct route-local calls to
+`get_stock_search_service()`. The route surface now depends on
+`get_stock_search_service_dependency`, which is the canonical DI provider for
+this lane. The dependency provider is not a cleanup target.
+
+## Service Package Surface
+
+| File | Current role | Decision |
+|---|---|---|
+| `web/backend/app/services/stock_search_service/stock_search_service.py` | Defines `StockSearchService`, module-level compatibility getter, app-state installer, app-state dependency provider, and state key | Keep all current symbols as active compatibility/provider surface |
+| `web/backend/app/services/stock_search_service/__init__.py` | Re-exports `StockSearchService`, `get_stock_search_service`, `get_stock_search_service_dependency`, `install_stock_search_service`, and `STOCK_SEARCH_SERVICE_STATE_KEY` | Keep package-level exports; tests and route imports rely on the package API |
+
+The module-level `get_stock_search_service()` is still used as the default
+fallback by `install_stock_search_service(app, service=None)`. Removing it would
+change the current app-state fallback behavior and would require a separate
+implementation proposal with route/test updates.
+
+## Test Consumers
+
+| File | Current role | Direct getter calls | Decision |
+|---|---|---:|---|
+| `web/backend/tests/test_runtime_regressions_p0.py` | Regression guard for compatibility getter singleton initialization and `StockSearchService` constructor behavior | 3 | Keep; it proves the compatibility getter remains valid |
+| `web/backend/tests/test_stock_search_service_lifecycle_di.py` | App-state provider/installer lifecycle test | 0 direct calls; monkeypatches `get_stock_search_service` and calls provider/installer | Keep; it proves fallback and explicit service injection |
+| `web/backend/tests/test_large_file_split_regressions.py` | Split-package public export regression | 0 direct calls; asserts callable package export | Keep unless package API is explicitly retired later |
+| `web/backend/tests/test_stock_search_service_logging.py` | Logging and split-helper regression | 0 direct calls; asserts callable package export and instantiates service | Keep unless package API is explicitly retired later |
+| `tests/001-fix-5-critical/plan.md` | Historical test plan mention only | 0 | Historical reference; not a runtime consumer |
+
+## GitNexus Evidence
+
+| Target | Result | Interpretation |
+|---|---|---|
+| `get_stock_search_service` | CRITICAL; direct impact 6; processes affected 11; route callers reported at confidence `0.5` | Graph still reports pre-DI route callers; current text guard shows route direct calls are `0`, so this is graph/text divergence and not deletion proof |
+| `get_stock_search_service_dependency` | Target not found | GitNexus index does not yet expose this post-DI provider symbol; use text matrix until index refresh validates it |
+| `install_stock_search_service` | Target not found | GitNexus index does not yet expose this post-DI installer symbol; use text matrix until index refresh validates it |
+| `StockSearchService` | LOW; direct impact 0 | Class-level graph impact is not enough to justify deleting module-level compatibility functions |
+
+## Decision
+
+`get_stock_search_service()` remains **active public compatibility surface**.
+
+No stock-search compatibility getter cleanup implementation is authorized by
+this packet.
+
+Reasons:
+
+- Route files have `0` direct `get_stock_search_service()` calls, so there is no
+  route-local cleanup left.
+- Route files intentionally use `get_stock_search_service_dependency`; that
+  provider is the canonical DI seam, not a legacy getter.
+- Tests still validate the compatibility getter, package export, installer, and
+  fallback behavior.
+- `install_stock_search_service(app, service=None)` currently uses
+  `get_stock_search_service()` as its default fallback.
+- GitNexus still reports stale/heuristic route callers for the compatibility
+  getter at confidence `0.5`; this must be reconciled before any deletion
+  proposal.
+
+## Future Scope If A Later Cleanup Is Requested
+
+Any future stock-search compatibility cleanup would require a separate
+implementation authorization after human review. Its candidate write scope would
+need to be explicit and should not include route files unless a future approved
+plan changes the provider strategy.
+
+Minimum future evidence before source edits:
+
+1. Fresh text matrix showing direct getter calls, provider references, installer
+   references, package exports, and tests.
+2. GitNexus index refresh or an explicit graph-staleness note.
+3. A decision on whether the compatibility getter is public API, test-only
+   fallback, package-internal fallback, or retirement candidate.
+4. Focused tests covering:
+   - `web/backend/tests/test_runtime_regressions_p0.py`
+   - `web/backend/tests/test_stock_search_service_lifecycle_di.py`
+   - `web/backend/tests/test_large_file_split_regressions.py`
+   - `web/backend/tests/test_stock_search_service_logging.py`
+5. Rollback plan preserving route DI provider behavior.
+
+## Explicit Non-Goals
+
+- No backend source edits
+- No test edits
+- No route/OpenAPI/docs/API/generated client edits
+- No compatibility getter deletion, rename, or privatization
+- No issue label movement
+- No OpenSpec proposal creation or archive
+- No PM2/runtime verification
+
+## Next Gate
+
+Human review of this G2.23 matrix. If accepted, keep the stock-search
+compatibility getter as active compatibility surface and do not open a
+stock-search cleanup implementation. The next service lifecycle DI step should
+be a separate governance lane, likely a broad market/data/strategy seam design
+packet, before any further service DI source edits.

--- a/governance/mainline/task-cards/pr-163.yaml
+++ b/governance/mainline/task-cards/pr-163.yaml
@@ -1,0 +1,100 @@
+version: "v0.2"
+
+task:
+  id: "pr-163"
+  title: "Record stock search compatibility getter consumer matrix"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-stock-search-compatibility-getter-consumer-matrix"
+  objective: "decide whether stock_search_service compatibility getter cleanup is authorized after route-surface DI"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-stock-search-compat-getter-matrix"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-stock-search-compatibility-getter-matrix"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Consumer-matrix decision packet only; records stock-search compatibility getter retention and does not change runtime code, tests, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/stock-search-compatibility-getter-consumer-matrix-2026-05-23.json"
+    - "docs/reports/quality/backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-163.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, validation archive, or issue publication"
+  - "No issue label changes or ready-for-agent movement"
+  - "No stock-search compatibility getter cleanup, deletion, rename, privatization, or source edit in this PR"
+  - "No next service DI implementation candidate selection in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/stock-search-compatibility-getter-consumer-matrix-2026-05-23.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-163.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the consumer-matrix boundary"
+    - "If this PR deletes or privatizes get_stock_search_service, it bypasses the decision that the getter remains active compatibility surface"
+    - "If route files are edited, it bypasses the conclusion that route-surface DI is already complete"
+  rollback_plan: "revert this governance-only PR; prior stock_search_service DI implementation remains merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record stock-search compatibility getter consumers and decide cleanup is not authorized now"
+    modified_scope: "consumer matrix report, generated matrix artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; compatibility getter and provider surfaces remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only matrix PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T11:40:44+08:00"
+    approval_note: "human maintainer approved continuing after PR #162; this packet records consumer-matrix evidence only and does not authorize source edits"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

G2.23 records the stock-search compatibility getter consumer matrix selected by G2.22.

This is governance/evidence only. It does not edit backend source, tests, routes, OpenAPI, docs/API, generated clients, frontend code, PM2/runtime state, OpenSpec changes, or issue labels.

## Findings

- Base HEAD: `d186ce78ee0a` from PR #162 merge.
- Route files: 2 files use `get_stock_search_service_dependency`; direct `get_stock_search_service()` route calls remain 0.
- Service package files: 2 files define/re-export the compatibility getter, provider, installer, state key, and class.
- Test files: 5 files include compatibility/export/provider regression coverage.
- GitNexus still reports `get_stock_search_service` route callers at confidence 0.5, while text guard shows direct route calls are 0; this is recorded as graph/text divergence.

## Decision

- Retain `get_stock_search_service()` as active public compatibility surface.
- Do not open a stock-search compatibility getter cleanup implementation from this packet.
- Keep `get_stock_search_service_dependency` as the canonical route DI provider for this lane.
- Next lane, if accepted: a separate broad market/data/strategy service seam design packet before further service DI source edits.

## Evidence

- `docs/reports/quality/backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md`
- `.planning/codebase/generated/stock-search-compatibility-getter-consumer-matrix-2026-05-23.json`
- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
- `governance/mainline/task-cards/pr-163.yaml`

## Verification

- Markdown governance: 2 checked files, 0 errors.
- JSON parse: passed.
- Mainline scope gate: passed after commit.
- `git diff HEAD~1..HEAD --check`: passed.
- GitNexus staged detect before commit: low risk, 0 changed symbols, 0 affected processes.

## Boundary

Do not merge this as source authorization. If accepted, the stock-search compatibility getter remains retained; no stock-search getter cleanup implementation follows unless a separate future authorization reverses that decision.
