### PR TITLE
docs: record broad service seam design

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -465,8 +465,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md`,
 │   │   `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.json`,
 │   │   `backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md`,
-│   │   `.planning/codebase/generated/stock-search-compatibility-getter-consumer-matrix-2026-05-23.json`
-│   ├── State: stock-search-compatibility-getter-consumer-matrix-prepared-for-review
+│   │   `.planning/codebase/generated/stock-search-compatibility-getter-consumer-matrix-2026-05-23.json`,
+│   │   `backend-broad-service-seam-design-2026-05-23.md`,
+│   │   `.planning/codebase/generated/broad-service-seam-design-2026-05-23.json`
+│   ├── State: broad-service-seam-design-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -590,11 +592,19 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 package exports and tests still intentionally cover
 │   │                 `get_stock_search_service()`, and the getter is retained
 │   │                 as active compatibility surface with no cleanup
-│   │                 implementation authorized
-│   └── Next gate: Human review of the G2.23 consumer matrix; if accepted, do
-│                  not open a stock-search getter cleanup implementation and
-│                  create a separate broad market/data/strategy service seam
-│                  design packet before any further service DI source edit
+│   │                 implementation authorized; PR `#163` merged at
+│   │                 `18f5b43275bbd1fc7f53c739063da37c6a753b11`; G2.24 now
+│   │                 records broad market/data/strategy service seam evidence at
+│   │                 that HEAD, finds CRITICAL impact for
+│   │                 `get_market_data_service_v2`, `get_data_service`,
+│   │                 `get_strategy_service`, and `get_tdx_service`, records the
+│   │                 `get_market_data_service` graph/text mismatch, rejects a
+│   │                 mixed implementation batch, and selects a future G2.25
+│   │                 market-data provider design packet before any source edit
+│   └── Next gate: Human review of the G2.24 design packet; if accepted, create
+│                  a separate G2.25 market-data provider design packet before
+│                  any `market_data_service` or `market_data_service_v2`
+│                  source edits
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -657,6 +667,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md` | G | G2.21 decision merged by PR `#161` at `d2e799cd2c1cbeb00b70d5cf64897b7c8a8a3b11`: select G2.22 current-head candidate refresh before implementation or compatibility-getter cleanup | Superseded by G2.22 candidate refresh packet |
 | `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md` | G | G2.22 current-head refresh merged by PR `#162` at `d186ce78ee0ad4017b36e3788a54533ce3a972df`: scanned 152 service Python files, recorded 42 broad heuristic hit files and 17 narrow service-lifecycle candidate files, found no safe direct next route-surface implementation candidate, and selected future G2.23 `stock_search_service` compatibility getter cleanup authorization / consumer-matrix packet | Superseded by G2.23 consumer matrix |
 | `backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md` | G | G2.23 consumer matrix prepared at `d186ce78ee0a`: route direct `get_stock_search_service()` calls remain `0`, route provider refs are `8`, package exports/tests still intentionally cover the compatibility getter, and cleanup implementation is not authorized | Human review; if accepted, retain the getter and create a separate broad market/data/strategy service seam design packet before source edits |
+| `backend-broad-service-seam-design-2026-05-23.md` | G | G2.24 design packet prepared at `18f5b43275bb`: broad market/data/strategy seams are split into separate future design lanes; market/data/strategy/tdx representative getters show CRITICAL impact except `get_market_data_service`, which has a graph/text mismatch; no source implementation is authorized | Human review; if accepted, create G2.25 market-data provider design packet before any market data service source edits |
 
 ## Completed And Reviewed Ledger
 
@@ -744,6 +755,7 @@ review, PR review, or OpenSpec archive review.
 | G2.21 service lifecycle DI next-lane after stock-search | G/#79 | Select current-head candidate refresh as the next service lifecycle DI governance lane | Reviewed and merged by PR `#161` at `d2e799cd2c1cbeb00b70d5cf64897b7c8a8a3b11`: current-head quick scan at `f8063b512fb7` shows remaining getter/singleton/provider signal files require classification; no source, test, route, OpenAPI, OpenSpec, issue-label, runtime, PM2, compatibility getter cleanup, or next implementation candidate is authorized | `docs/reports/quality/backend-service-lifecycle-di-next-lane-after-stock-search-2026-05-23.md`; `.planning/codebase/generated/service-lifecycle-di-next-lane-after-stock-search-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/161 | Superseded by G2.22 current-head candidate refresh |
 | G2.22 service lifecycle DI candidate refresh after stock-search | G/#79 | Refresh current-head service lifecycle candidates after stock-search route-surface DI | Reviewed and merged by PR `#162` at `d186ce78ee0ad4017b36e3788a54533ce3a972df`: scanned 152 service files, recorded 42 broad heuristic hit files and 17 narrow candidate files, selected G2.23 stock-search compatibility getter consumer matrix, and kept source edits locked | `docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md`; `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/162 | Superseded by G2.23 consumer matrix |
 | G2.23 stock-search compatibility getter consumer matrix | G/#79 | Decide whether `get_stock_search_service()` cleanup is authorized after route-surface DI | Review-ready: route direct getter calls remain `0`; route provider refs are `8`; tests and package exports still intentionally cover compatibility getter, installer, state key, and provider behavior; no source/test/route cleanup implementation is authorized | `docs/reports/quality/backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md`; `.planning/codebase/generated/stock-search-compatibility-getter-consumer-matrix-2026-05-23.json` | Human review; if accepted, retain the getter and open a separate broad service seam design packet before source edits |
+| G2.24 broad service seam design | G/#79 | Decompose broad market/data/strategy service seams before selecting another implementation lane | Review-ready: PR `#163` merged at `18f5b43275bbd1fc7f53c739063da37c6a753b11`; current-head text scan covers `market_data_service_v2`, `market_data_service`, `data_service`, `strategy_service`, `tdx_service`, `enhanced_data_service`, and `technical_analysis_service`; GitNexus spot checks classify most broad seams as CRITICAL and select no mixed implementation batch | `docs/reports/quality/backend-broad-service-seam-design-2026-05-23.md`; `.planning/codebase/generated/broad-service-seam-design-2026-05-23.json` | Human review; if accepted, create G2.25 market-data provider design packet before source edits |
 
 ## OpenSpec Branch Register
 
@@ -825,7 +837,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review PR `#156` G2.16 service lifecycle DI next-lane decision | Future service seam lane | PR `#155` merged; PR `#156` is open with checks passed; G2.16 selects G2.17 current-head candidate refresh before any further service lifecycle DI source edits |
+| P2 | Review G2.24 broad service seam design packet | Future service seam lane | PR `#163` merged; G2.24 is review-ready and selects a future G2.25 market-data provider design packet before any market/data/strategy source edits |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/generated/broad-service-seam-design-2026-05-23.json
+++ b/.planning/codebase/generated/broad-service-seam-design-2026-05-23.json
@@ -1,0 +1,213 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-05-23T12:01:41+08:00",
+  "workline": "G2.24 broad market/data/strategy service seam design",
+  "status": "design-packet-prepared-for-review",
+  "base_head": "18f5b43275bbd1fc7f53c739063da37c6a753b11",
+  "branch": "g2-24-broad-service-seam-design",
+  "parent_pr": 163,
+  "parent_pr_merge_commit": "18f5b43275bbd1fc7f53c739063da37c6a753b11",
+  "governance_boundary": {
+    "source_edits_authorized": false,
+    "test_edits_authorized": false,
+    "route_edits_authorized": false,
+    "openapi_edits_authorized": false,
+    "openspec_edits_authorized": false,
+    "issue_label_changes_authorized": false,
+    "mixed_market_data_strategy_batch_authorized": false
+  },
+  "text_scan": {
+    "root": "web/backend/app",
+    "targets": [
+      {
+        "id": "market_data_service_v2",
+        "service_file": "web/backend/app/services/market_data_service_v2.py",
+        "service_loc": 668,
+        "text_hit_files": 3,
+        "route_files": 2,
+        "service_files": 1,
+        "route_surfaces": [
+          {
+            "file": "web/backend/app/api/market_v2.py",
+            "owners": [
+              "get_fund_flow",
+              "refresh_fund_flow",
+              "get_etf_list",
+              "refresh_etf_spot",
+              "get_lhb_detail",
+              "refresh_lhb_detail",
+              "get_sector_fund_flow",
+              "refresh_sector_fund_flow",
+              "get_stock_dividend",
+              "refresh_stock_dividend",
+              "get_stock_blocktrade",
+              "refresh_stock_blocktrade",
+              "refresh_all_market_data"
+            ]
+          },
+          {
+            "file": "web/backend/app/api/dashboard_data_source.py",
+            "owners": [
+              "_get_market_overview_data",
+              "prewarm_dashboard_market_overview_cache"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "market_data_service",
+        "service_file": "web/backend/app/services/market_data_service/get_market_data_service.py",
+        "service_loc": 33,
+        "text_hit_files": 8,
+        "route_files": 3,
+        "service_files": 5,
+        "route_surfaces": [
+          {
+            "file": "web/backend/app/api/market/market_data_request.py",
+            "owners": [
+              "refresh_fund_flow",
+              "get_etf_list",
+              "refresh_etf_data",
+              "get_chip_race",
+              "refresh_chip_race",
+              "get_lhb_detail",
+              "refresh_lhb_detail"
+            ],
+            "pattern": "Depends(get_market_data_service)"
+          }
+        ],
+        "notes": "GitNexus reports LOW/0 upstream impact; text scan shows active route dependency-provider references. Future design must reconcile this before any deletion or no-op conclusion."
+      },
+      {
+        "id": "data_service",
+        "service_file": "web/backend/app/services/data_service.py",
+        "service_loc": 472,
+        "text_hit_files": 5,
+        "route_files": 4,
+        "service_files": 1,
+        "route_surfaces": [
+          "web/backend/app/api/v1/system/health.py",
+          "web/backend/app/api/v1/strategy/ml_runtime_helpers.py",
+          "web/backend/app/api/v1/strategy/indicators.py",
+          "web/backend/app/api/indicators/indicator_cache.py"
+        ]
+      },
+      {
+        "id": "strategy_service",
+        "service_file": "web/backend/app/services/strategy_service.py",
+        "service_loc": 461,
+        "text_hit_files": 5,
+        "route_files": 1,
+        "service_files": 3,
+        "other_files": 1,
+        "surfaces": [
+          "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+          "web/backend/app/services/adapters/strategy_adapter.py",
+          "web/backend/app/services/data_adapters/strategy.py",
+          "web/backend/app/tasks/backtest_tasks.py"
+        ]
+      },
+      {
+        "id": "tdx_service",
+        "service_file": "web/backend/app/services/tdx_service.py",
+        "service_loc": 280,
+        "text_hit_files": 3,
+        "route_files": 2,
+        "service_files": 1,
+        "route_surfaces": [
+          "web/backend/app/api/tdx.py",
+          "web/backend/app/api/dashboard_data_source.py"
+        ]
+      },
+      {
+        "id": "enhanced_data_service",
+        "service_file": "web/backend/app/services/data_service_enhanced.py",
+        "service_loc": 630,
+        "text_hit_files": 1,
+        "route_files": 0,
+        "service_files": 1,
+        "notes": "v1/system/health.py constructs EnhancedDataService through a local helper; classify as control-plane provider design, not ordinary route-surface DI."
+      },
+      {
+        "id": "technical_analysis_service",
+        "service_file": "web/backend/app/services/technical_analysis_service.py",
+        "service_loc": 751,
+        "text_hit_files": 1,
+        "route_files": 0,
+        "service_files": 1,
+        "notes": "No route-surface consumer found; hold for later service-internal seam design."
+      }
+    ]
+  },
+  "gitnexus_impact": [
+    {
+      "target": "get_market_data_service_v2",
+      "risk": "CRITICAL",
+      "impacted_count": 18,
+      "direct": 15,
+      "processes_affected": 6,
+      "modules_affected": 2
+    },
+    {
+      "target": "get_market_data_service",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct": 0,
+      "processes_affected": 0,
+      "modules_affected": 0
+    },
+    {
+      "target": "get_data_service",
+      "risk": "CRITICAL",
+      "impacted_count": 5,
+      "direct": 3,
+      "processes_affected": 7,
+      "modules_affected": 2
+    },
+    {
+      "target": "get_strategy_service",
+      "risk": "CRITICAL",
+      "impacted_count": 13,
+      "direct": 6,
+      "processes_affected": 0,
+      "modules_affected": 5
+    },
+    {
+      "target": "get_tdx_service",
+      "risk": "CRITICAL",
+      "impacted_count": 6,
+      "direct": 2,
+      "processes_affected": 5,
+      "modules_affected": 1
+    },
+    {
+      "target": "get_enhanced_data_service",
+      "risk": "LOW",
+      "impacted_count": 3,
+      "direct": 1,
+      "processes_affected": 0,
+      "modules_affected": 0
+    },
+    {
+      "target": "TechnicalAnalysisService",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct": 0,
+      "processes_affected": 0,
+      "modules_affected": 0
+    }
+  ],
+  "decision": {
+    "broad_source_implementation_authorized": false,
+    "mixed_migration_authorized": false,
+    "recommended_next_lane": "G2.25 market-data provider design packet",
+    "recommended_next_lane_scope": "governance-only design packet to reconcile market_data_service graph/text evidence and decide market_data_service versus market_data_service_v2 provider pattern before any source edits",
+    "future_lanes": [
+      "TDX live-market provider design",
+      "data/indicator/backtest provider interface design",
+      "strategy adapter/task seam design",
+      "control-plane/system-health provider design",
+      "technical-analysis service-internal seam design"
+    ]
+  }
+}

--- a/docs/reports/quality/backend-broad-service-seam-design-2026-05-23.md
+++ b/docs/reports/quality/backend-broad-service-seam-design-2026-05-23.md
@@ -1,0 +1,171 @@
+# Backend Broad Service Seam Design Packet
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Date: 2026-05-23
+
+Status: design-packet-prepared-for-review
+
+Workline: G2.24 broad market/data/strategy service seam design
+
+Base HEAD: `18f5b43275bbd1fc7f53c739063da37c6a753b11`
+
+Parent evidence: PR `#163` merged the G2.23 stock-search compatibility getter consumer matrix at `18f5b43275bbd1fc7f53c739063da37c6a753b11`.
+
+Boundary note: this packet classifies current broad market/data/strategy service
+seams only. It does not authorize backend source edits, test edits, route edits,
+OpenAPI changes, OpenSpec changes, issue label movement, `ready-for-agent`
+movement, PM2/runtime work, or any mixed service implementation batch.
+
+## Governance Boundary
+
+This packet is evidence and design routing only.
+
+It does not authorize:
+
+- backend source, route, test, OpenAPI, response-contract, PM2, or runtime changes
+- OpenSpec proposal/spec creation or archive work
+- issue label movement or ready-for-agent changes
+- any mixed market/data/strategy implementation batch
+- deletion, privatization, or compatibility-wrapper cleanup
+
+The purpose is to decide how the next service lifecycle DI lane should be decomposed after stock-search route-surface DI and compatibility-getter retention were accepted.
+
+## Current-Head Evidence
+
+Generated at: 2026-05-23T12:01:41+08:00
+
+Current checkout:
+
+- branch: `g2-24-broad-service-seam-design`
+- base branch: `origin/wip/root-dirty-20260403`
+- HEAD: `18f5b4327 Merge pull request #163 from chengjon/g2-23-stock-search-compat-getter-matrix`
+- source guard before packet: no staged or unstaged `web/backend`, `src`, or `tests` changes
+
+OpenSpec context:
+
+- `migrate-backend-singletons-to-lifecycle-di` is listed as complete.
+- This packet does not create a new OpenSpec change. Any future implementation lane still requires a separate approved authorization packet or OpenSpec proposal when the chosen design changes architecture or behavior.
+
+## Text-Scan Service Matrix
+
+The text scan covered `web/backend/app` Python files at HEAD `18f5b43275bb`.
+
+| Seam | Canonical service file | Service LOC | Text-hit files | Route files | Service files | Current route/service surface |
+|---|---:|---:|---:|---:|---:|---|
+| `market_data_service_v2` | `web/backend/app/services/market_data_service_v2.py` | 668 | 3 | 2 | 1 | `market_v2.py` has direct calls across market-data endpoints; `dashboard_data_source.py` uses it for market overview cache/data |
+| `market_data_service` | `web/backend/app/services/market_data_service/get_market_data_service.py` | 33 | 8 | 3 | 5 | `market/market_data_request.py` already uses `Depends(get_market_data_service)`; package exports and adapter references also exist |
+| `data_service` | `web/backend/app/services/data_service.py` | 472 | 5 | 4 | 1 | indicator, strategy helper, backtest helper, and health/control-plane surfaces call or wrap `get_data_service()` |
+| `strategy_service` | `web/backend/app/services/strategy_service.py` | 461 | 5 | 1 | 3 | strategy route, strategy adapters, data adapters, and backtest task code all reference `get_strategy_service()` |
+| `tdx_service` | `web/backend/app/services/tdx_service.py` | 280 | 3 | 2 | 1 | `tdx.py` already uses `Depends(get_tdx_service)`; `dashboard_data_source.py` still uses live-market helper calls |
+| `enhanced_data_service` | `web/backend/app/services/data_service_enhanced.py` | 630 | 1 | 0 | 1 | exported singleton remains in service module; `v1/system/health.py` constructs `EnhancedDataService` through its own local helper rather than the exported getter |
+| `technical_analysis_service` | `web/backend/app/services/technical_analysis_service.py` | 751 | 1 | 0 | 1 | no route-surface consumer found by this scan; large service-internal seam only |
+
+The `market_data_service` row deliberately records both graph and text evidence. GitNexus reports `get_market_data_service` as LOW/0 upstream impact, while current text evidence shows active dependency-provider usage in `market/market_data_request.py`. Future design work must reconcile this graph/text mismatch before treating the getter as unused.
+
+## GitNexus Impact Spot Checks
+
+GitNexus impact was run against the current indexed repo for representative service accessors/classes.
+
+| Target | File | Risk | Impacted count | Direct callers | Processes affected | Modules affected | Design implication |
+|---|---|---:|---:|---:|---:|---:|---|
+| `get_market_data_service_v2` | `web/backend/app/services/market_data_service_v2.py` | CRITICAL | 18 | 15 | 6 | 2 | Direct route cluster; requires a separate provider-design packet before source edits |
+| `get_market_data_service` | `web/backend/app/services/market_data_service/get_market_data_service.py` | LOW | 0 | 0 | 0 | 0 | Graph/text mismatch; do not infer deletion or no-op status |
+| `get_data_service` | `web/backend/app/services/data_service.py` | CRITICAL | 5 | 3 | 7 | 2 | Indicator/backtest/strategy-data seam; not a route-only DI pilot |
+| `get_strategy_service` | `web/backend/app/services/strategy_service.py` | CRITICAL | 13 | 6 | 0 | 5 | Crosses route, adapter, data-adapter, and task surfaces; needs adapter/task seam design |
+| `get_tdx_service` | `web/backend/app/services/tdx_service.py` | CRITICAL | 6 | 2 | 5 | 1 | Live-market dashboard path and existing dependency-provider route path must be handled separately |
+| `get_enhanced_data_service` | `web/backend/app/services/data_service_enhanced.py` | LOW | 3 | 1 | 0 | 0 | Control-plane/system-health adjacent; do not mix with business route batches |
+| `TechnicalAnalysisService` | `web/backend/app/services/technical_analysis_service.py` | LOW | 0 | 0 | 0 | 0 | No route-surface consumer found; hold for service-internal test seam later |
+
+High/critical results are expected here because this packet samples broad seams. They are not implementation failures; they are why the next lane must stay design-first.
+
+## Design Classification
+
+### Market Data V2
+
+`market_data_service_v2` is the broadest current route-surface cluster in this scan. `market_v2.py` performs direct getter calls across fund-flow, ETF, LHB, sector fund flow, dividend, block-trade, and refresh-all endpoints. `dashboard_data_source.py` also uses the same service for market overview data and prewarm logic.
+
+Classification: future provider-design candidate, not an immediate source edit.
+
+### Market Data Package Getter
+
+`market_data_service` is already partially shaped like the route-level DI pattern used by earlier G2 lanes because `market/market_data_request.py` uses `Depends(get_market_data_service)`. It also appears in package exports and adapter/service references.
+
+Classification: provider standardization and graph/text reconciliation candidate.
+
+### TDX Live Market
+
+`tdx.py` already injects `TdxService` through `Depends(get_tdx_service)`, but `dashboard_data_source.py` still uses live-market helper flows. The dashboard path is tied to market-overview summary behavior and should not be folded into a generic service batch.
+
+Classification: separate live-market/control-plane-adjacent provider design.
+
+### Data Service
+
+`data_service` spans indicator cache, strategy indicator helpers, analysis/backtest helpers, and health/control-plane code. A direct route-level migration would mix API endpoint dependencies, strategy runtime helpers, and calculation/test-double concerns.
+
+Classification: data-provider/test-double interface design before implementation.
+
+### Strategy Service
+
+`strategy_service` spans `strategy_management` route code, strategy adapter modules, data adapter modules, and backtest task code. The direct route call count understates the seam because non-route consumers are part of the same lifecycle contract.
+
+Classification: adapter/task seam design before implementation.
+
+### Enhanced Data Service
+
+The exported `get_enhanced_data_service()` exists, but `v1/system/health.py` constructs `EnhancedDataService` through a local `_get_data_service()` helper. This is a control-plane/system-health concern rather than a normal business route provider candidate.
+
+Classification: control-plane provider design, not ordinary route-surface DI.
+
+### Technical Analysis Service
+
+No route-surface consumer was found by the scan. The service is large enough to deserve later service-internal seam work, but it is not the next route-level DI candidate.
+
+Classification: hold.
+
+## Decision
+
+No broad market/data/strategy source implementation is authorized by G2.24.
+
+No single mixed migration should be opened from this packet. The sampled seams cross different ownership and verification boundaries:
+
+- market route provider pattern
+- dashboard/live-market data path
+- indicator/backtest data-provider seam
+- strategy adapter/task seam
+- control-plane health/provider seam
+- service-internal technical-analysis seam
+
+The next recommended child lane is:
+
+`G2.25 market-data provider design packet`
+
+Scope of the recommended G2.25 packet:
+
+- governance and evidence only
+- reconcile `market_data_service` graph/text mismatch
+- decide whether `market_data_service` and `market_data_service_v2` should share one provider pattern or remain separate
+- list exact future route/function write candidates
+- define focused tests, rollback boundary, and GitNexus pre-edit gates
+- avoid source edits until the G2.25 packet is reviewed and a later implementation authorization explicitly opens code scope
+
+Future lanes after G2.25 should be separate:
+
+- TDX live-market provider design
+- data/indicator/backtest provider interface design
+- strategy adapter/task seam design
+- control-plane/system-health provider design
+- service-internal technical-analysis seam design
+
+## Verification Plan For This Packet
+
+This packet should be accepted only if:
+
+- markdown governance passes for this report and the steward tree
+- generated JSON evidence parses
+- mainline scope gate passes with only the allowed governance paths
+- git diff checks pass
+- source guard remains empty for `web/backend`, `src`, and `tests`
+- staged GitNexus detect-changes shows no runtime/source blast radius

--- a/governance/mainline/task-cards/pr-164.yaml
+++ b/governance/mainline/task-cards/pr-164.yaml
@@ -1,0 +1,102 @@
+version: "v0.2"
+
+task:
+  id: "pr-164"
+  title: "Record broad market data strategy service seam design"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-broad-service-seam-design"
+  objective: "decompose broad market/data/strategy service lifecycle DI seams before any further source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-broad-service-seam-design"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-broad-service-seam-design"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Design packet only; records current-head service seam evidence and future lane ordering without changing runtime code, tests, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/broad-service-seam-design-2026-05-23.json"
+    - "docs/reports/quality/backend-broad-service-seam-design-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-164.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, validation archive, or issue publication"
+  - "No issue label changes or ready-for-agent movement"
+  - "No broad market/data/strategy mixed implementation batch in this PR"
+  - "No compatibility wrapper, getter, provider, or route-surface cleanup in this PR"
+  - "No immediate G2.25 source implementation authorization in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-broad-service-seam-design-2026-05-23.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/broad-service-seam-design-2026-05-23.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-164.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the design-packet boundary"
+    - "If this PR opens a mixed market/data/strategy migration, it bypasses the design conclusion that seams must be split"
+    - "If G2.25 is treated as source authorization, it skips the required future market-data provider design packet"
+  rollback_plan: "revert this governance-only PR; previously merged service DI work remains unchanged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record broad market/data/strategy service seam evidence and next-lane decomposition"
+    modified_scope: "design report, generated JSON artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; all compatibility and service provider surfaces remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only design PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T12:01:41+08:00"
+    approval_note: "human maintainer approved continuing after PR #163; this packet records broad service seam design evidence only and does not authorize source edits"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record G2.24 broad market/data/strategy service seam design evidence
- add current-head JSON artifact and PR #164 mainline task card
- update the steward tree to select G2.25 market-data provider design before source edits

## Boundary
- governance/evidence only
- no backend source, tests, route, OpenAPI, OpenSpec, PM2, frontend, or issue-label changes
- no mixed market/data/strategy implementation authorization

## Verification
- markdown governance: 2 checked, 0 errors
- JSON parse: ok
- YAML parse: ok
- git diff --cached --check: ok
- GitNexus staged detect: low risk, 0 changed symbols, 0 affected processes
- post-commit mainline scope gate: pass=True