### PR TITLE
docs: record market data provider design

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -467,8 +467,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md`,
 │   │   `.planning/codebase/generated/stock-search-compatibility-getter-consumer-matrix-2026-05-23.json`,
 │   │   `backend-broad-service-seam-design-2026-05-23.md`,
-│   │   `.planning/codebase/generated/broad-service-seam-design-2026-05-23.json`
-│   ├── State: broad-service-seam-design-prepared-for-review
+│   │   `.planning/codebase/generated/broad-service-seam-design-2026-05-23.json`,
+│   │   `backend-market-data-provider-design-2026-05-23.md`,
+│   │   `.planning/codebase/generated/market-data-provider-design-2026-05-23.json`
+│   ├── State: market-data-provider-design-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -600,11 +602,22 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 `get_strategy_service`, and `get_tdx_service`, records the
 │   │                 `get_market_data_service` graph/text mismatch, rejects a
 │   │                 mixed implementation batch, and selects a future G2.25
-│   │                 market-data provider design packet before any source edit
-│   └── Next gate: Human review of the G2.24 design packet; if accepted, create
-│                  a separate G2.25 market-data provider design packet before
-│                  any `market_data_service` or `market_data_service_v2`
-│                  source edits
+│   │                 market-data provider design packet before any source edit;
+│   │                 PR `#164` merged at
+│   │                 `f97ca070853a77afc80c226d53948e805ba33c8e`; G2.25 now
+│   │                 records that `market_v2.py` has 13 direct
+│   │                 `get_market_data_service_v2()` route calls,
+│   │                 `dashboard_data_source.py` has 2 non-route helper calls,
+│   │                 `market/market_data_request.py` already uses
+│   │                 `Depends(get_market_data_service)` in 7 route handlers,
+│   │                 and the `app.services.__init__` integrated-services
+│   │                 accessor must not be conflated with the package getter;
+│   │                 G2.25 rejects service consolidation and selects a future
+│   │                 G2.26 `MarketDataServiceV2` route-provider implementation
+│   │                 authorization packet before source edits
+│   └── Next gate: Human review of the G2.25 design packet; if accepted, create
+│                  G2.26 `MarketDataServiceV2` route-provider implementation
+│                  authorization with exact write scope before any source edits
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -668,6 +681,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md` | G | G2.22 current-head refresh merged by PR `#162` at `d186ce78ee0ad4017b36e3788a54533ce3a972df`: scanned 152 service Python files, recorded 42 broad heuristic hit files and 17 narrow service-lifecycle candidate files, found no safe direct next route-surface implementation candidate, and selected future G2.23 `stock_search_service` compatibility getter cleanup authorization / consumer-matrix packet | Superseded by G2.23 consumer matrix |
 | `backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md` | G | G2.23 consumer matrix prepared at `d186ce78ee0a`: route direct `get_stock_search_service()` calls remain `0`, route provider refs are `8`, package exports/tests still intentionally cover the compatibility getter, and cleanup implementation is not authorized | Human review; if accepted, retain the getter and create a separate broad market/data/strategy service seam design packet before source edits |
 | `backend-broad-service-seam-design-2026-05-23.md` | G | G2.24 design packet prepared at `18f5b43275bb`: broad market/data/strategy seams are split into separate future design lanes; market/data/strategy/tdx representative getters show CRITICAL impact except `get_market_data_service`, which has a graph/text mismatch; no source implementation is authorized | Human review; if accepted, create G2.25 market-data provider design packet before any market data service source edits |
+| `backend-market-data-provider-design-2026-05-23.md` | G | G2.25 design packet prepared at `f97ca070853`: `MarketDataService` and `MarketDataServiceV2` stay separate; `market_v2.py` is the recommended future route-provider authorization candidate; dashboard, adapter, and market-data package provider work stay in separate lanes | Human review; if accepted, create G2.26 `MarketDataServiceV2` route-provider implementation authorization before source edits |
 
 ## Completed And Reviewed Ledger
 
@@ -756,6 +770,7 @@ review, PR review, or OpenSpec archive review.
 | G2.22 service lifecycle DI candidate refresh after stock-search | G/#79 | Refresh current-head service lifecycle candidates after stock-search route-surface DI | Reviewed and merged by PR `#162` at `d186ce78ee0ad4017b36e3788a54533ce3a972df`: scanned 152 service files, recorded 42 broad heuristic hit files and 17 narrow candidate files, selected G2.23 stock-search compatibility getter consumer matrix, and kept source edits locked | `docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.md`; `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/162 | Superseded by G2.23 consumer matrix |
 | G2.23 stock-search compatibility getter consumer matrix | G/#79 | Decide whether `get_stock_search_service()` cleanup is authorized after route-surface DI | Review-ready: route direct getter calls remain `0`; route provider refs are `8`; tests and package exports still intentionally cover compatibility getter, installer, state key, and provider behavior; no source/test/route cleanup implementation is authorized | `docs/reports/quality/backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md`; `.planning/codebase/generated/stock-search-compatibility-getter-consumer-matrix-2026-05-23.json` | Human review; if accepted, retain the getter and open a separate broad service seam design packet before source edits |
 | G2.24 broad service seam design | G/#79 | Decompose broad market/data/strategy service seams before selecting another implementation lane | Review-ready: PR `#163` merged at `18f5b43275bbd1fc7f53c739063da37c6a753b11`; current-head text scan covers `market_data_service_v2`, `market_data_service`, `data_service`, `strategy_service`, `tdx_service`, `enhanced_data_service`, and `technical_analysis_service`; GitNexus spot checks classify most broad seams as CRITICAL and select no mixed implementation batch | `docs/reports/quality/backend-broad-service-seam-design-2026-05-23.md`; `.planning/codebase/generated/broad-service-seam-design-2026-05-23.json` | Human review; if accepted, create G2.25 market-data provider design packet before source edits |
+| G2.25 market-data provider design | G/#79 | Decide the market-data provider seam before selecting an implementation authorization | Review-ready: PR `#164` merged at `f97ca070853a77afc80c226d53948e805ba33c8e`; `market_v2.py` has 13 direct `get_market_data_service_v2()` route calls, `dashboard_data_source.py` has 2 non-route helper calls, `market/market_data_request.py` already uses `Depends(get_market_data_service)` in 7 route handlers, and service consolidation is rejected | `docs/reports/quality/backend-market-data-provider-design-2026-05-23.md`; `.planning/codebase/generated/market-data-provider-design-2026-05-23.json` | Human review; if accepted, create G2.26 `MarketDataServiceV2` route-provider implementation authorization before source edits |
 
 ## OpenSpec Branch Register
 
@@ -837,7 +852,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review G2.24 broad service seam design packet | Future service seam lane | PR `#163` merged; G2.24 is review-ready and selects a future G2.25 market-data provider design packet before any market/data/strategy source edits |
+| P2 | Review G2.25 market-data provider design packet | Future service seam lane | PR `#164` merged; G2.25 is review-ready and selects a future G2.26 `MarketDataServiceV2` route-provider implementation authorization packet before source edits |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/generated/market-data-provider-design-2026-05-23.json
+++ b/.planning/codebase/generated/market-data-provider-design-2026-05-23.json
@@ -1,0 +1,167 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-05-23T13:18:48+08:00",
+  "workline": "G2.25 market-data provider design",
+  "status": "design-packet-prepared-for-review",
+  "base_head": "f97ca070853a77afc80c226d53948e805ba33c8e",
+  "branch": "g2-25-market-data-provider-design",
+  "parent_pr": 164,
+  "parent_pr_merge_commit": "f97ca070853a77afc80c226d53948e805ba33c8e",
+  "governance_boundary": {
+    "source_edits_authorized": false,
+    "test_edits_authorized": false,
+    "route_edits_authorized": false,
+    "openapi_edits_authorized": false,
+    "openspec_edits_authorized": false,
+    "issue_label_changes_authorized": false,
+    "service_consolidation_authorized": false,
+    "implementation_batch_authorized": false
+  },
+  "provider_surfaces": [
+    {
+      "id": "market_data_service_v2",
+      "service_file": "web/backend/app/services/market_data_service_v2.py",
+      "service_loc": 668,
+      "class": "MarketDataServiceV2",
+      "getter": "get_market_data_service_v2",
+      "state": "_market_data_service_v2",
+      "constructor_dependencies": [
+        "database engine/sessionmaker",
+        "eastmoney adapter via get_eastmoney_adapter"
+      ],
+      "route_consumers": [
+        {
+          "file": "web/backend/app/api/market_v2.py",
+          "direct_getter_calls": 13,
+          "functions": [
+            "get_fund_flow",
+            "refresh_fund_flow",
+            "get_etf_list",
+            "refresh_etf_spot",
+            "get_lhb_detail",
+            "refresh_lhb_detail",
+            "get_sector_fund_flow",
+            "refresh_sector_fund_flow",
+            "get_stock_dividend",
+            "refresh_stock_dividend",
+            "get_stock_blocktrade",
+            "refresh_stock_blocktrade",
+            "refresh_all_market_data"
+          ]
+        }
+      ],
+      "non_route_consumers": [
+        {
+          "file": "web/backend/app/api/dashboard_data_source.py",
+          "functions": [
+            "RealBusinessDataSource._get_market_overview_data",
+            "prewarm_dashboard_market_overview_cache"
+          ]
+        }
+      ],
+      "gitnexus": {
+        "risk": "CRITICAL",
+        "impacted_count": 18,
+        "direct": 15,
+        "processes_affected": 6,
+        "modules_affected": 2
+      },
+      "decision": "future route-provider candidate, not immediate source edit"
+    },
+    {
+      "id": "market_data_service_package",
+      "service_file": "web/backend/app/services/market_data_service/get_market_data_service.py",
+      "service_loc": 33,
+      "class": "MarketDataService",
+      "getter": "get_market_data_service",
+      "state": "_market_data_service",
+      "implementation_files": [
+        {
+          "file": "web/backend/app/services/market_data_service/market_data_service_methods/part1.py",
+          "loc": 669,
+          "class": "MarketDataServiceCoreMixin"
+        },
+        {
+          "file": "web/backend/app/services/market_data_service/market_data_service_methods/part2.py",
+          "loc": 135,
+          "class": "MarketDataServiceFetchAndSaveMixin"
+        },
+        {
+          "file": "web/backend/app/services/market_data_service/market_data_service_methods/part3.py",
+          "loc": 43,
+          "class": "MarketDataServiceChipRaceQueryMixin"
+        }
+      ],
+      "constructor_dependencies": [
+        "database engine/sessionmaker",
+        "akshare extension adapter",
+        "tqlex adapter",
+        "cache integration"
+      ],
+      "route_consumers": [
+        {
+          "file": "web/backend/app/api/market/market_data_request.py",
+          "pattern": "Depends(get_market_data_service)",
+          "functions": [
+            "refresh_fund_flow",
+            "get_etf_list",
+            "refresh_etf_data",
+            "get_chip_race",
+            "refresh_chip_race",
+            "get_lhb_detail",
+            "refresh_lhb_detail"
+          ]
+        }
+      ],
+      "service_layer_consumers": [
+        "web/backend/app/services/market_data_adapter.py::_get_market_service"
+      ],
+      "gitnexus": {
+        "risk": "LOW",
+        "impacted_count": 0,
+        "direct": 0,
+        "processes_affected": 0,
+        "modules_affected": 0,
+        "note": "Graph impact undercounts FastAPI dependency-parameter references; text scan records active route usage."
+      },
+      "decision": "keep as separate provider normalization candidate, not the next implementation target"
+    },
+    {
+      "id": "integrated_services_market_data_accessor",
+      "file": "web/backend/app/services/__init__.py",
+      "function": "get_market_data_service",
+      "consumer_scan_result": "no direct text import consumers found in web/backend/app",
+      "decision": "do not conflate with package getter"
+    }
+  ],
+  "design_decision": {
+    "consolidate_market_data_service_classes": false,
+    "standardize_access_shape_only": true,
+    "recommended_next_lane": "G2.26 MarketDataServiceV2 route-provider implementation authorization",
+    "recommended_future_candidate_scope": [
+      "web/backend/app/services/market_data_service_v2.py",
+      "web/backend/app/api/market_v2.py",
+      "focused market-v2 route dependency override tests",
+      "implementation evidence report",
+      "PR task card"
+    ],
+    "first_authorization_exclusions": [
+      "web/backend/app/api/dashboard_data_source.py",
+      "web/backend/app/services/market_data_adapter.py",
+      "web/backend/app/services/market_data_service/**",
+      "route path changes",
+      "OpenAPI schema exposure changes",
+      "service consolidation",
+      "docs/API changes",
+      "generated client changes",
+      "frontend changes",
+      "PM2/runtime changes"
+    ]
+  },
+  "future_lanes": [
+    "dashboard market overview/source-factory provider design",
+    "MarketDataService package provider/app-state normalization",
+    "market_data_adapter.py helper seam",
+    "legacy route/API ownership reconciliation between market v1 and v2"
+  ]
+}

--- a/docs/reports/quality/backend-market-data-provider-design-2026-05-23.md
+++ b/docs/reports/quality/backend-market-data-provider-design-2026-05-23.md
@@ -1,0 +1,213 @@
+# Backend Market Data Provider Design Packet
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Date: 2026-05-23
+
+Status: design-packet-prepared-for-review
+
+Workline: G2.25 market-data provider design
+
+Base HEAD: `f97ca070853a77afc80c226d53948e805ba33c8e`
+
+Parent evidence: PR `#164` merged the G2.24 broad service seam design packet at `f97ca070853a77afc80c226d53948e805ba33c8e`.
+
+Boundary note: this packet classifies current market-data provider seams only. It
+does not authorize backend source edits, test edits, route edits, OpenAPI
+changes, OpenSpec changes, issue label movement, `ready-for-agent` movement,
+PM2/runtime work, service consolidation, or a market-data implementation batch.
+
+## Governance Boundary
+
+This packet is evidence and design routing only. It exists because G2.24 found
+that broad market/data/strategy service seams are too large to migrate as one
+batch.
+
+This packet does not authorize:
+
+- backend source, route, test, OpenAPI, response-contract, PM2, or runtime changes
+- OpenSpec proposal/spec creation or archive work
+- issue label movement or ready-for-agent changes
+- service consolidation between `MarketDataService` and `MarketDataServiceV2`
+- dashboard/source-factory refactoring
+- market-data adapter refactoring
+- compatibility getter deletion, privatization, or rename
+
+## Current-Head Evidence
+
+Generated at: 2026-05-23T13:18:48+08:00
+
+Current checkout:
+
+- branch: `g2-25-market-data-provider-design`
+- base branch: `origin/wip/root-dirty-20260403`
+- HEAD: `f97ca0708 Merge pull request #164 from chengjon/g2-24-broad-service-seam-design`
+- source guard before packet: no staged or unstaged source/test changes
+
+## Provider Surfaces
+
+| Surface | File | Current pattern | Consumers | Design classification |
+|---|---|---|---|---|
+| `MarketDataServiceV2` | `web/backend/app/services/market_data_service_v2.py` | module singleton `_market_data_service_v2` plus `get_market_data_service_v2()` | `market_v2.py` route functions and `dashboard_data_source.py` helper/class methods | Future route-provider candidate, but only after a separate implementation authorization |
+| `MarketDataService` package getter | `web/backend/app/services/market_data_service/get_market_data_service.py` | module singleton `_market_data_service` plus `get_market_data_service()` | `market/market_data_request.py` FastAPI dependency parameters and `market_data_adapter.py` direct helper | Already partially route-DI-shaped; not the next implementation target |
+| Integrated services accessor | `web/backend/app/services/__init__.py` | `get_integrated_services().market_data_service` accessor | no current direct text import consumers found | Do not conflate with the package getter |
+| Dashboard market overview | `web/backend/app/api/dashboard_data_source.py` | class/helper methods call `get_market_data_service_v2()` directly | `RealBusinessDataSource._get_market_overview_data()` and `prewarm_dashboard_market_overview_cache()` | Separate dashboard/source-factory design, not ordinary route-provider DI |
+| Market data adapter | `web/backend/app/services/market_data_adapter.py` | `_get_market_service()` calls package `get_market_data_service()` | service adapter internals | Separate adapter helper design, not route-surface DI |
+
+## Current Consumers
+
+### `MarketDataServiceV2`
+
+`web/backend/app/services/market_data_service_v2.py` has 668 lines. The
+constructor creates a database engine/sessionmaker and initializes the Eastmoney
+adapter via `get_eastmoney_adapter()`.
+
+Direct singleton getter:
+
+- `_market_data_service_v2 = None`
+- `get_market_data_service_v2() -> MarketDataServiceV2`
+
+Route-surface consumers in `web/backend/app/api/market_v2.py`:
+
+| Function | Current service method |
+|---|---|
+| `get_fund_flow` | `query_fund_flow` |
+| `refresh_fund_flow` | `fetch_and_save_fund_flow` |
+| `get_etf_list` | `query_etf_spot` |
+| `refresh_etf_spot` | `fetch_and_save_etf_spot` |
+| `get_lhb_detail` | `query_lhb_detail` |
+| `refresh_lhb_detail` | `fetch_and_save_lhb_detail` |
+| `get_sector_fund_flow` | `query_sector_fund_flow` |
+| `refresh_sector_fund_flow` | `fetch_and_save_sector_fund_flow` |
+| `get_stock_dividend` | `query_stock_dividend` |
+| `refresh_stock_dividend` | `fetch_and_save_stock_dividend` |
+| `get_stock_blocktrade` | `query_blocktrade` |
+| `refresh_stock_blocktrade` | `fetch_and_save_blocktrade` |
+| `refresh_all_market_data` | `fetch_and_save_fund_flow`, `fetch_and_save_etf_spot`, `fetch_and_save_sector_fund_flow`, `fetch_and_save_lhb_detail`, `fetch_and_save_blocktrade` |
+
+Non-route helper consumers in `web/backend/app/api/dashboard_data_source.py`:
+
+- `RealBusinessDataSource._get_market_overview_data()`
+- `prewarm_dashboard_market_overview_cache()`
+
+These dashboard consumers are intentionally not part of the recommended first
+implementation authorization because they are not ordinary FastAPI route
+dependency parameters.
+
+### `MarketDataService`
+
+`web/backend/app/services/market_data_service/get_market_data_service.py` has 33
+lines and returns the package `MarketDataService` singleton. The concrete class
+is assembled through `market_data_service_methods` mixins:
+
+- `part1.py`: 669 lines, `MarketDataServiceCoreMixin`
+- `part2.py`: 135 lines, `MarketDataServiceFetchAndSaveMixin`
+- `part3.py`: 43 lines, `MarketDataServiceChipRaceQueryMixin`
+
+The core mixin constructor creates a database engine/sessionmaker, initializes
+Akshare and TQLEX adapters, and initializes cache integration.
+
+Route consumers in `web/backend/app/api/market/market_data_request.py` already
+use `Depends(get_market_data_service)`:
+
+| Function | Current service method |
+|---|---|
+| `refresh_fund_flow` | `fetch_and_save_fund_flow` |
+| `get_etf_list` | `query_etf_spot` |
+| `refresh_etf_data` | `fetch_and_save_etf_spot` |
+| `get_chip_race` | `query_chip_race` |
+| `refresh_chip_race` | `fetch_and_save_chip_race` |
+| `get_lhb_detail` | `query_lhb_detail` |
+| `refresh_lhb_detail` | `fetch_and_save_lhb_detail` |
+
+Additional service-layer consumer:
+
+- `web/backend/app/services/market_data_adapter.py::_get_market_service()`
+
+## GitNexus Evidence
+
+| Target | Risk | Impacted count | Direct callers | Processes affected | Modules affected | Notes |
+|---|---:|---:|---:|---:|---:|---|
+| `get_market_data_service_v2` | CRITICAL | 18 | 15 | 6 | 2 | GitNexus and text scan agree this is a broad route/dashboard surface |
+| `get_market_data_service` | LOW | 0 | 0 | 0 | 0 | GitNexus undercounts FastAPI dependency-parameter consumers; text scan is authoritative for current active route usage |
+
+GitNexus context for `get_market_data_service` is ambiguous:
+
+- `web/backend/app/services/market_data_service/get_market_data_service.py:get_market_data_service`
+- `web/backend/app/services/__init__.py:get_market_data_service`
+
+The integrated-services accessor in `web/backend/app/services/__init__.py` has no
+current direct text import consumers in `web/backend/app`. It must not be
+conflated with the package getter imported by `market/market_data_request.py`.
+
+## Design Decision
+
+Do not consolidate `MarketDataService` and `MarketDataServiceV2`.
+
+Reasons:
+
+- They have different construction dependencies.
+- They expose overlapping but not identical method surfaces.
+- They are tied to different API ownership surfaces: `/api/v1/market` versus `/api/v2/market`.
+- `market_data_request.py` already uses FastAPI dependency parameters, while `market_v2.py` still uses direct singleton calls.
+- Dashboard market overview uses `MarketDataServiceV2` from helper/class methods, not from normal route dependency injection.
+
+The provider-governance target is standardizing access shape, not merging service
+classes.
+
+## Recommended Next Lane
+
+Create a separate `G2.26 MarketDataServiceV2 route-provider implementation authorization` packet.
+
+That future authorization packet should be governance-only and should decide the
+exact code scope before implementation. The recommended candidate scope is:
+
+- `web/backend/app/services/market_data_service_v2.py`
+- `web/backend/app/api/market_v2.py`
+- a focused market-v2 route dependency override test file
+- implementation evidence report
+- PR task card
+
+Recommended future behavior, if authorized later:
+
+- keep `get_market_data_service_v2()` as compatibility fallback
+- add a state key, installer, and FastAPI dependency provider following the
+  route-level pattern already used by the stock-search lane
+- inject `MarketDataServiceV2` into `market_v2.py` route handlers through
+  `Depends(...)`
+- leave route paths, response shape, OpenAPI operation IDs, and service methods
+  unchanged
+
+Explicit exclusions for the first implementation authorization:
+
+- no `dashboard_data_source.py` mutation
+- no `market_data_adapter.py` mutation
+- no `market_data_service` package/provider rewrite
+- no service consolidation
+- no route path or OpenAPI schema exposure change
+- no docs/API/generated-client/frontend/PM2 changes
+
+## Future Separate Lanes
+
+After the `MarketDataServiceV2` route-provider authorization and implementation
+are reviewed, separate packets may be considered for:
+
+- dashboard market overview/source-factory provider design
+- `MarketDataService` package provider/app-state normalization
+- `market_data_adapter.py` helper seam
+- legacy route/API ownership reconciliation between market v1 and v2
+
+None of those are authorized by this packet.
+
+## Verification Plan For This Packet
+
+This packet should be accepted only if:
+
+- markdown governance passes for this report and the steward tree
+- generated JSON evidence parses
+- mainline scope gate passes with only the allowed governance paths
+- git diff checks pass
+- source guard remains empty for `web/backend`, `web/frontend`, `src`, `tests`, and `openspec`
+- staged GitNexus detect-changes shows no runtime/source blast radius

--- a/governance/mainline/task-cards/pr-165.yaml
+++ b/governance/mainline/task-cards/pr-165.yaml
@@ -1,0 +1,102 @@
+version: "v0.2"
+
+task:
+  id: "pr-165"
+  title: "Record market data provider design"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-market-data-provider-design"
+  objective: "decide the market-data provider seam before any market data service source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-market-data-provider-design"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-market-data-provider-design"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Design packet only; records current-head market-data provider evidence and future lane ordering without changing runtime code, tests, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/market-data-provider-design-2026-05-23.json"
+    - "docs/reports/quality/backend-market-data-provider-design-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-165.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, validation archive, or issue publication"
+  - "No issue label changes or ready-for-agent movement"
+  - "No service consolidation between MarketDataService and MarketDataServiceV2"
+  - "No dashboard_data_source.py, market_data_adapter.py, or market_data_service package mutation in this PR"
+  - "No immediate G2.26 source implementation authorization in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-market-data-provider-design-2026-05-23.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/market-data-provider-design-2026-05-23.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-165.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the design-packet boundary"
+    - "If this PR authorizes source implementation, it bypasses the future G2.26 authorization gate"
+    - "If this PR treats MarketDataService and MarketDataServiceV2 as one class, it contradicts the provider-design evidence"
+  rollback_plan: "revert this governance-only PR; previously merged service DI work remains unchanged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record market-data provider evidence and next-lane decomposition"
+    modified_scope: "design report, generated JSON artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; all service provider, route, and compatibility surfaces remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only design PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T13:18:48+08:00"
+    approval_note: "human maintainer approved continuing after PR #164; this packet records market-data provider design evidence only and does not authorize source edits"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record G2.25 market-data provider design evidence
- split MarketDataService and MarketDataServiceV2 into separate future lanes instead of consolidating them
- select a future G2.26 MarketDataServiceV2 route-provider implementation authorization packet before source edits

## Boundary
- governance/evidence only
- no backend source, tests, route, OpenAPI, OpenSpec, PM2, frontend, or issue-label changes
- no service consolidation or market-data implementation authorization

## Verification
- markdown governance: 2 checked, 0 errors
- JSON parse: ok
- YAML parse: ok
- git diff --cached --check: ok
- GitNexus staged detect: low risk, 0 changed symbols, 0 affected processes
- post-commit mainline scope gate: pass=True