### PR TITLE
docs: authorize market data service v2 provider lane

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -469,8 +469,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-broad-service-seam-design-2026-05-23.md`,
 │   │   `.planning/codebase/generated/broad-service-seam-design-2026-05-23.json`,
 │   │   `backend-market-data-provider-design-2026-05-23.md`,
-│   │   `.planning/codebase/generated/market-data-provider-design-2026-05-23.json`
-│   ├── State: market-data-provider-design-prepared-for-review
+│   │   `.planning/codebase/generated/market-data-provider-design-2026-05-23.json`,
+│   │   `backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md`,
+│   │   `.planning/codebase/generated/market-data-service-v2-route-provider-implementation-authorization-2026-05-23.json`
+│   ├── State: market-data-service-v2-route-provider-authorization-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -614,10 +616,20 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 accessor must not be conflated with the package getter;
 │   │                 G2.25 rejects service consolidation and selects a future
 │   │                 G2.26 `MarketDataServiceV2` route-provider implementation
-│   │                 authorization packet before source edits
-│   └── Next gate: Human review of the G2.25 design packet; if accepted, create
-│                  G2.26 `MarketDataServiceV2` route-provider implementation
-│                  authorization with exact write scope before any source edits
+│   │                 authorization packet before source edits; PR `#165`
+│   │                 merged at
+│   │                 `46507955f77a3166491bd4510c56ef034b6ff1cb`; G2.26 now
+│   │                 records exact future write scope for
+│   │                 `market_data_service_v2.py`, `market_v2.py`, focused
+│   │                 lifecycle tests, implementation evidence, and a future
+│   │                 task card, while explicitly excluding
+│   │                 `dashboard_data_source.py`, `market_data_adapter.py`, the
+│   │                 `market_data_service` package, services `__init__`,
+│   │                 service consolidation, and route/OpenAPI behavior changes;
+│   │                 no source edit is authorized in this packet
+│   └── Next gate: Human review of the G2.26 authorization packet; if accepted,
+│                  create a separate `MarketDataServiceV2` route-provider
+│                  implementation branch before source edits
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -682,6 +694,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md` | G | G2.23 consumer matrix prepared at `d186ce78ee0a`: route direct `get_stock_search_service()` calls remain `0`, route provider refs are `8`, package exports/tests still intentionally cover the compatibility getter, and cleanup implementation is not authorized | Human review; if accepted, retain the getter and create a separate broad market/data/strategy service seam design packet before source edits |
 | `backend-broad-service-seam-design-2026-05-23.md` | G | G2.24 design packet prepared at `18f5b43275bb`: broad market/data/strategy seams are split into separate future design lanes; market/data/strategy/tdx representative getters show CRITICAL impact except `get_market_data_service`, which has a graph/text mismatch; no source implementation is authorized | Human review; if accepted, create G2.25 market-data provider design packet before any market data service source edits |
 | `backend-market-data-provider-design-2026-05-23.md` | G | G2.25 design packet prepared at `f97ca070853`: `MarketDataService` and `MarketDataServiceV2` stay separate; `market_v2.py` is the recommended future route-provider authorization candidate; dashboard, adapter, and market-data package provider work stay in separate lanes | Human review; if accepted, create G2.26 `MarketDataServiceV2` route-provider implementation authorization before source edits |
+| `backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md` | G | G2.26 authorization packet prepared at `46507955f`: future source scope is limited to `market_data_service_v2.py`, `market_v2.py`, focused lifecycle tests, implementation evidence, and a future task card; dashboard, adapter, market-data package, service consolidation, route/OpenAPI, frontend, PM2, and OpenSpec work remain excluded | Human review; if accepted, create a separate implementation branch before source edits |
 
 ## Completed And Reviewed Ledger
 
@@ -771,6 +784,7 @@ review, PR review, or OpenSpec archive review.
 | G2.23 stock-search compatibility getter consumer matrix | G/#79 | Decide whether `get_stock_search_service()` cleanup is authorized after route-surface DI | Review-ready: route direct getter calls remain `0`; route provider refs are `8`; tests and package exports still intentionally cover compatibility getter, installer, state key, and provider behavior; no source/test/route cleanup implementation is authorized | `docs/reports/quality/backend-stock-search-compatibility-getter-consumer-matrix-2026-05-23.md`; `.planning/codebase/generated/stock-search-compatibility-getter-consumer-matrix-2026-05-23.json` | Human review; if accepted, retain the getter and open a separate broad service seam design packet before source edits |
 | G2.24 broad service seam design | G/#79 | Decompose broad market/data/strategy service seams before selecting another implementation lane | Review-ready: PR `#163` merged at `18f5b43275bbd1fc7f53c739063da37c6a753b11`; current-head text scan covers `market_data_service_v2`, `market_data_service`, `data_service`, `strategy_service`, `tdx_service`, `enhanced_data_service`, and `technical_analysis_service`; GitNexus spot checks classify most broad seams as CRITICAL and select no mixed implementation batch | `docs/reports/quality/backend-broad-service-seam-design-2026-05-23.md`; `.planning/codebase/generated/broad-service-seam-design-2026-05-23.json` | Human review; if accepted, create G2.25 market-data provider design packet before source edits |
 | G2.25 market-data provider design | G/#79 | Decide the market-data provider seam before selecting an implementation authorization | Review-ready: PR `#164` merged at `f97ca070853a77afc80c226d53948e805ba33c8e`; `market_v2.py` has 13 direct `get_market_data_service_v2()` route calls, `dashboard_data_source.py` has 2 non-route helper calls, `market/market_data_request.py` already uses `Depends(get_market_data_service)` in 7 route handlers, and service consolidation is rejected | `docs/reports/quality/backend-market-data-provider-design-2026-05-23.md`; `.planning/codebase/generated/market-data-provider-design-2026-05-23.json` | Human review; if accepted, create G2.26 `MarketDataServiceV2` route-provider implementation authorization before source edits |
+| G2.26 MarketDataServiceV2 route-provider implementation authorization | G/#79 | Authorize exact future implementation boundary for `MarketDataServiceV2` route-provider DI | Review-ready: PR `#165` merged at `46507955f77a3166491bd4510c56ef034b6ff1cb`; GitNexus rates `get_market_data_service_v2` CRITICAL with 18 impacted symbols and 15 direct callers; future write scope is limited to `market_data_service_v2.py`, `market_v2.py`, focused lifecycle tests, implementation evidence, and a future task card; this packet performs no source edits | `docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md`; `.planning/codebase/generated/market-data-service-v2-route-provider-implementation-authorization-2026-05-23.json` | Human review; if accepted, create a separate implementation branch before source edits |
 
 ## OpenSpec Branch Register
 
@@ -852,7 +866,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review G2.25 market-data provider design packet | Future service seam lane | PR `#164` merged; G2.25 is review-ready and selects a future G2.26 `MarketDataServiceV2` route-provider implementation authorization packet before source edits |
+| P2 | Review G2.26 `MarketDataServiceV2` route-provider authorization packet | Future service seam lane | PR `#165` merged; G2.26 is review-ready and defines the exact future route-provider implementation boundary before source edits |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/generated/market-data-service-v2-route-provider-implementation-authorization-2026-05-23.json
+++ b/.planning/codebase/generated/market-data-service-v2-route-provider-implementation-authorization-2026-05-23.json
@@ -1,0 +1,112 @@
+{
+  "artifact": "market-data-service-v2-route-provider-implementation-authorization",
+  "version": 1,
+  "recorded_at": "2026-05-23T13:59:20+08:00",
+  "status": "implementation-authorization-prepared-for-review",
+  "workline": "G2.26 MarketDataServiceV2 route-provider implementation authorization",
+  "current_head": "46507955f77a3166491bd4510c56ef034b6ff1cb",
+  "base_branch": "origin/wip/root-dirty-20260403",
+  "parent_pr": {
+    "number": 165,
+    "merged_at_commit": "46507955f77a3166491bd4510c56ef034b6ff1cb"
+  },
+  "parent_issues": {
+    "service_lifecycle_di": 79,
+    "downstream_decision": 92
+  },
+  "source_implementation_authorized_by_this_document": false,
+  "governance_boundary": {
+    "packet_type": "future implementation authorization request",
+    "this_pr_allows_source_edits": false,
+    "this_pr_allows_test_edits": false,
+    "this_pr_allows_openspec_edits": false,
+    "this_pr_allows_runtime_config_edits": false,
+    "this_pr_allows_issue_label_changes": false
+  },
+  "evidence_inputs": [
+    {
+      "type": "report",
+      "path": "docs/reports/quality/backend-broad-service-seam-design-2026-05-23.md",
+      "role": "decomposes broad service seam work before selecting implementation lanes"
+    },
+    {
+      "type": "report",
+      "path": "docs/reports/quality/backend-market-data-provider-design-2026-05-23.md",
+      "role": "selects MarketDataServiceV2 route-provider authorization as the next market-data lane"
+    },
+    {
+      "type": "json",
+      "path": ".planning/codebase/generated/market-data-provider-design-2026-05-23.json",
+      "role": "machine-readable G2.25 consumer and lane-ordering evidence"
+    },
+    {
+      "type": "code-pattern",
+      "path": "web/backend/app/services/email_service.py",
+      "role": "reference app-state installer plus dependency provider shape"
+    }
+  ],
+  "candidate_decision": {
+    "decision": "authorize a future MarketDataServiceV2 route-provider implementation lane after human approval",
+    "service_file": "web/backend/app/services/market_data_service_v2.py",
+    "route_file": "web/backend/app/api/market_v2.py",
+    "compatibility_getter_to_retain": "get_market_data_service_v2",
+    "service_consolidation_authorized": false
+  },
+  "gitnexus_snapshot": {
+    "target": "get_market_data_service_v2",
+    "file": "web/backend/app/services/market_data_service_v2.py",
+    "risk": "CRITICAL",
+    "impacted_count": 18,
+    "direct_callers": 15,
+    "processes_affected": 6,
+    "modules_affected": 2
+  },
+  "current_text_scan": {
+    "market_data_service_v2_loc": 668,
+    "singleton_variable_present": true,
+    "compatibility_getter_present": true,
+    "market_v2_route_local_getter_calls": 13,
+    "dashboard_data_source_getter_calls": 2
+  },
+  "future_allowed_write_scope": [
+    {
+      "path": "web/backend/app/services/market_data_service_v2.py",
+      "allowed_change": "add state key, installer, and FastAPI dependency provider while preserving compatibility getter fallback"
+    },
+    {
+      "path": "web/backend/app/api/market_v2.py",
+      "allowed_change": "convert only the 13 route-local get_market_data_service_v2 calls to injected MarketDataServiceV2 parameters"
+    },
+    {
+      "path": "web/backend/tests/test_market_data_service_v2_lifecycle_di.py",
+      "allowed_change": "focused lifecycle DI and route dependency override tests"
+    },
+    {
+      "path": "docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-2026-05-23.md",
+      "allowed_change": "future implementation evidence report"
+    },
+    {
+      "path": "governance/mainline/task-cards/pr-next.yaml",
+      "allowed_change": "future implementation task card with exact source/test/report paths"
+    }
+  ],
+  "explicit_exclusions": [
+    "web/backend/app/api/dashboard_data_source.py",
+    "web/backend/app/services/market_data_adapter.py",
+    "web/backend/app/services/market_data_service/**",
+    "web/backend/app/services/__init__.py",
+    "service consolidation between MarketDataService and MarketDataServiceV2",
+    "removing get_market_data_service_v2",
+    "route path, HTTP method, response model, response envelope, or OpenAPI schema exposure changes",
+    "docs/API, generated clients, frontend, PM2, runtime config, OpenSpec changes/specs, or GitHub issue labels"
+  ],
+  "future_required_gates": [
+    "GitNexus impact/context before editing symbols",
+    "failing focused lifecycle DI tests before implementation",
+    "focused pytest for lifecycle and representative route dependency behavior",
+    "ruff check on touched backend files",
+    "app.main import or targeted OpenAPI smoke if route signatures change",
+    "staged GitNexus detect_changes before commit"
+  ],
+  "next_gate": "Human review of this G2.26 authorization packet; if accepted, create a separate implementation branch before source edits"
+}

--- a/docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md
+++ b/docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md
@@ -1,0 +1,191 @@
+# Backend MarketDataServiceV2 Route Provider Implementation Authorization - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: implementation-authorization-prepared-for-review
+- Workline: G2.26 MarketDataServiceV2 route-provider implementation authorization
+- Recorded at: 2026-05-23T13:59:20+08:00
+- Current HEAD: `46507955f77a3166491bd4510c56ef034b6ff1cb`
+- Base branch: `origin/wip/root-dirty-20260403`
+- Parent PR: `#165`, merged at `46507955f77a3166491bd4510c56ef034b6ff1cb`
+- Parent issue: `#79`
+- Parent decision issue: `#92`
+- Source implementation authorized by this document: no
+
+## Governance Boundary
+
+This packet is an authorization request for a later implementation lane. It
+does not edit backend source, route handlers, tests, OpenSpec changes, runtime
+configuration, issue labels, or PM2/stateful gates.
+
+If approved, a future implementation PR may modify only the files listed in the
+allowed write scope below. Any dashboard, adapter, `MarketDataService` package,
+OpenAPI, frontend, generated-client, PM2, or service-consolidation work must be
+proposed as a separate lane.
+
+## Current Issue State
+
+| Item | State | Notes |
+|---|---|---|
+| Issue `#79` | `OPEN`, `needs-triage` | Parent service singleton lifecycle DI issue remains open. |
+| Issue `#92` | downstream decision accepted in this thread | Human maintainer accepted downstream split decisions; this packet remains decision/authorization only. |
+| G2.24 broad service seam design | PR `#164` merged at `f97ca070853a77afc80c226d53948e805ba33c8e` | Rejected a mixed broad implementation batch and selected a market-data design packet first. |
+| G2.25 market-data provider design | PR `#165` merged at `46507955f77a3166491bd4510c56ef034b6ff1cb` | Rejected service consolidation and selected this G2.26 authorization packet before source edits. |
+
+## Evidence Inputs
+
+| Evidence | Path / Source | Role |
+|---|---|---|
+| Broad service seam design | `docs/reports/quality/backend-broad-service-seam-design-2026-05-23.md` | Records that broad market/data/strategy seams are too large for one implementation batch. |
+| Market-data provider design | `docs/reports/quality/backend-market-data-provider-design-2026-05-23.md` | Selects `MarketDataServiceV2` route-provider authorization as the next market-data lane. |
+| Market-data provider JSON | `.planning/codebase/generated/market-data-provider-design-2026-05-23.json` | Machine-readable G2.25 consumer and lane-ordering evidence. |
+| Existing DI pattern evidence | `email_service.py`, `announcement_service.py`, `watchlist_service.py`, `stock_search_service` route-provider work | App-state provider plus compatibility getter fallback pattern to reuse. |
+| Route-provider reference pattern | `web/backend/app/services/email_service.py` | Uses `EMAIL_SERVICE_STATE_KEY`, `install_email_service(...)`, and `get_email_service_dependency(...)`. |
+| Current route scan | current HEAD `46507955f` | Confirms 13 direct `get_market_data_service_v2()` route-local calls in `market_v2.py`. |
+| GitNexus impact | `get_market_data_service_v2` | Confirms CRITICAL impact, 18 impacted symbols, 15 direct callers, 6 affected processes, and 2 affected modules. |
+
+## Candidate Decision
+
+Authorize a future `MarketDataServiceV2` route-provider implementation lane only
+after human approval of this packet.
+
+The future lane should standardize how `market_v2.py` route handlers obtain
+`MarketDataServiceV2`, while preserving the compatibility getter and leaving
+runtime behavior unchanged.
+
+Rationale:
+
+- G2.25 rejected consolidating `MarketDataService` and `MarketDataServiceV2`.
+- `market_v2.py` has a clear route-surface seam: 13 route-local calls to
+  `get_market_data_service_v2()`.
+- `dashboard_data_source.py` has 2 non-route helper/class consumers and should
+  not be mixed into a route-provider implementation batch.
+- `MarketDataService` package routes already use `Depends(get_market_data_service)`
+  in `market/market_data_request.py` and should stay in a separate lane.
+- GitNexus classifies the getter surface as CRITICAL, so the write scope must be
+  narrow and test-first.
+
+## GitNexus Pre-Edit Snapshot
+
+| Symbol | File | Risk | Impacted count | Direct callers | Processes affected | Disposition |
+|---|---|---:|---:|---:|---:|---|
+| `get_market_data_service_v2` | `web/backend/app/services/market_data_service_v2.py` | CRITICAL | 18 | 15 | 6 | Compatibility getter must remain; route call sites require deliberate migration. |
+
+Direct d=1 callers recorded by GitNexus:
+
+| Caller | File | Future disposition |
+|---|---|---|
+| `get_fund_flow` | `web/backend/app/api/market_v2.py` | Convert route-local getter call to an injected `MarketDataServiceV2`. |
+| `refresh_fund_flow` | `web/backend/app/api/market_v2.py` | Convert route-local getter call to an injected `MarketDataServiceV2`. |
+| `get_etf_list` | `web/backend/app/api/market_v2.py` | Convert route-local getter call to an injected `MarketDataServiceV2`. |
+| `refresh_etf_spot` | `web/backend/app/api/market_v2.py` | Convert route-local getter call to an injected `MarketDataServiceV2`. |
+| `get_lhb_detail` | `web/backend/app/api/market_v2.py` | Convert route-local getter call to an injected `MarketDataServiceV2`. |
+| `refresh_lhb_detail` | `web/backend/app/api/market_v2.py` | Convert route-local getter call to an injected `MarketDataServiceV2`. |
+| `get_sector_fund_flow` | `web/backend/app/api/market_v2.py` | Convert route-local getter call to an injected `MarketDataServiceV2`. |
+| `refresh_sector_fund_flow` | `web/backend/app/api/market_v2.py` | Convert route-local getter call to an injected `MarketDataServiceV2`. |
+| `get_stock_dividend` | `web/backend/app/api/market_v2.py` | Convert route-local getter call to an injected `MarketDataServiceV2`. |
+| `refresh_stock_dividend` | `web/backend/app/api/market_v2.py` | Convert route-local getter call to an injected `MarketDataServiceV2`. |
+| `get_stock_blocktrade` | `web/backend/app/api/market_v2.py` | Convert route-local getter call to an injected `MarketDataServiceV2`. |
+| `refresh_stock_blocktrade` | `web/backend/app/api/market_v2.py` | Convert route-local getter call to an injected `MarketDataServiceV2`. |
+| `refresh_all_market_data` | `web/backend/app/api/market_v2.py` | Convert route-local getter call to an injected `MarketDataServiceV2`. |
+| `_get_market_overview_data` | `web/backend/app/api/dashboard_data_source.py` | Excluded from first implementation scope; non-route helper/class consumer. |
+| `prewarm_dashboard_market_overview_cache` | `web/backend/app/api/dashboard_data_source.py` | Excluded from first implementation scope; non-route helper consumer. |
+
+## Current Text Scan
+
+| Surface | Current fact | Disposition |
+|---|---:|---|
+| `web/backend/app/services/market_data_service_v2.py` LOC | 668 | Large enough to keep implementation scope minimal. |
+| `_market_data_service_v2 = None` | present | Keep compatibility singleton fallback. |
+| `get_market_data_service_v2()` | present | Keep public compatibility getter. |
+| `market_v2.py` route-local getter calls | 13 | Future implementation target. |
+| `dashboard_data_source.py` getter calls | 2 | Excluded from first route-provider batch. |
+
+## Future Allowed Write Scope
+
+If this authorization packet is approved, a future implementation branch may
+modify only:
+
+| Path | Future allowed change |
+|---|---|
+| `web/backend/app/services/market_data_service_v2.py` | Add state key, installer, and FastAPI dependency provider; preserve `get_market_data_service_v2()` compatibility fallback. |
+| `web/backend/app/api/market_v2.py` | Convert only the 13 route-local `get_market_data_service_v2()` calls to injected `MarketDataServiceV2` parameters. |
+| `web/backend/tests/test_market_data_service_v2_lifecycle_di.py` or an equivalent focused test file | Cover provider install, app-state override, fallback behavior, route dependency override, and representative route call behavior. |
+| `docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-2026-05-23.md` | Record future implementation evidence and verification results. |
+| future PR task card | Bind the implementation PR to the authorized source/test/report paths. |
+
+## Future Implementation Shape
+
+The future implementation should follow the established app-state provider plus
+compatibility fallback shape:
+
+- keep `get_market_data_service_v2()` as the compatibility getter
+- add a stable state key, for example `MARKET_DATA_SERVICE_V2_STATE_KEY`
+- add `install_market_data_service_v2(app, service=None)` that stores the
+  selected service on `app.state`
+- add `get_market_data_service_v2_dependency(request: Request)` that reads from
+  `app.state` and falls back to the installer/getter when absent
+- inject `MarketDataServiceV2` into `market_v2.py` route handlers with
+  `Depends(get_market_data_service_v2_dependency)`
+- preserve existing route paths, HTTP methods, response envelopes, OpenAPI
+  operation IDs, validation behavior, and exception behavior
+
+## Explicit Non-Goals
+
+The future implementation lane must not:
+
+- modify `web/backend/app/api/dashboard_data_source.py`
+- modify `web/backend/app/services/market_data_adapter.py`
+- modify `web/backend/app/services/market_data_service/**`
+- modify `web/backend/app/services/__init__.py` integrated-services accessors
+- consolidate `MarketDataService` and `MarketDataServiceV2`
+- remove `get_market_data_service_v2()`
+- change route paths, HTTP methods, response models, response envelopes, or
+  OpenAPI schema exposure
+- change docs/API, generated clients, frontend code, PM2 scripts, runtime config,
+  OpenSpec changes/specs, or GitHub issue labels
+- expand into dashboard/source-factory provider design
+
+## Required Future Gates
+
+Before any future source implementation commit:
+
+1. Run GitNexus impact/context for `get_market_data_service_v2` and the selected
+   `market_v2.py` route symbols.
+2. Add failing focused tests for provider install/app-state override/fallback and
+   at least one route dependency override path.
+3. Implement the smallest route-provider seam that satisfies those tests.
+4. Run focused pytest for the new lifecycle test and any representative
+   `market_v2.py` route smoke chosen in the implementation packet.
+5. Run `ruff check` on touched backend source/test files.
+6. Run an `app.main` import or targeted OpenAPI smoke if route signatures change.
+7. Stage only the authorized paths and run GitNexus `detect_changes` on the staged
+   scope before committing.
+
+## Rollback Plan For Future Implementation
+
+If the future implementation causes regressions:
+
+- revert the future implementation PR
+- restore direct route-local getter calls in `market_v2.py`
+- remove the new route-provider dependency from route signatures
+- keep `get_market_data_service_v2()` compatibility getter available
+- keep this authorization packet as historical governance evidence unless the
+  decision itself is explicitly superseded
+
+## Review Checklist
+
+This packet should be accepted only if reviewers agree that:
+
+- `MarketDataServiceV2` route-provider DI is the next market-data implementation
+  candidate after G2.25
+- the first implementation scope is limited to `market_data_service_v2.py`,
+  `market_v2.py`, focused lifecycle tests, implementation evidence, and a future
+  task card
+- dashboard, adapter, `MarketDataService` package, OpenAPI, frontend, PM2, and
+  service-consolidation work remain out of scope
+- this PR does not itself authorize or perform source implementation

--- a/governance/mainline/task-cards/pr-166.yaml
+++ b/governance/mainline/task-cards/pr-166.yaml
@@ -1,0 +1,102 @@
+version: "v0.2"
+
+task:
+  id: "pr-166"
+  title: "Authorize market data service v2 route provider lane"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-market-data-service-v2-route-provider-authorization"
+  objective: "record the exact future implementation authorization boundary for MarketDataServiceV2 route-provider DI before any source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-market-data-service-v2-route-provider-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-market-data-service-v2-route-provider-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization packet only; records future MarketDataServiceV2 route-provider implementation scope without changing runtime code, tests, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/market-data-service-v2-route-provider-implementation-authorization-2026-05-23.json"
+    - "docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-166.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, validation archive, or issue publication"
+  - "No issue label changes or ready-for-agent movement"
+  - "No service consolidation between MarketDataService and MarketDataServiceV2"
+  - "No dashboard_data_source.py, market_data_adapter.py, market_data_service package, or services __init__ mutation in this PR"
+  - "No source implementation in this PR; this packet only requests review of a future implementation boundary"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/market-data-service-v2-route-provider-implementation-authorization-2026-05-23.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-166.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the authorization-packet boundary"
+    - "If this PR performs implementation, it bypasses the future implementation branch gate"
+    - "If this PR treats MarketDataService and MarketDataServiceV2 as one service, it contradicts G2.25 evidence"
+  rollback_plan: "revert this governance-only PR and restore the steward tree to G2.25 as the latest market-data service-seam evidence; do not touch runtime source while rolling back this packet"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record future MarketDataServiceV2 route-provider implementation authorization boundaries"
+    modified_scope: "authorization report, generated JSON artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; all service provider, route, compatibility getter, OpenAPI, and runtime surfaces remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only authorization PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T13:59:20+08:00"
+    approval_note: "human maintainer approved continuing after PR #165; this packet records future MarketDataServiceV2 route-provider implementation authorization only and does not authorize source edits"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- add G2.26 MarketDataServiceV2 route-provider implementation authorization packet
- add machine-readable authorization artifact and PR #166 governance task card
- update steward tree with G2.26 state, evidence mapping, ledger, and next gate

## Boundary
- governance-only packet
- no backend source, tests, OpenSpec, route behavior, OpenAPI, frontend, PM2, or issue-label changes
- does not authorize source implementation in this PR

## Verification
- markdown governance gate: 2 checked files, 0 errors
- JSON artifact parse: ok
- task card YAML parse: ok
- mainline scope gate: pass after commit
- git diff --check: pass
- source guard: 4 changed files, 0 source/test/OpenSpec paths
- GitNexus staged detect_changes: low risk, 0 changed symbols, 0 affected processes