### PR TITLE
refactor: inject market data service v2 routes

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -471,8 +471,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-market-data-provider-design-2026-05-23.md`,
 │   │   `.planning/codebase/generated/market-data-provider-design-2026-05-23.json`,
 │   │   `backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md`,
-│   │   `.planning/codebase/generated/market-data-service-v2-route-provider-implementation-authorization-2026-05-23.json`
-│   ├── State: market-data-service-v2-route-provider-authorization-prepared-for-review
+│   │   `.planning/codebase/generated/market-data-service-v2-route-provider-implementation-authorization-2026-05-23.json`,
+│   │   `backend-market-data-service-v2-route-provider-implementation-2026-05-23.md`
+│   ├── State: market-data-service-v2-route-provider-implementation-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -626,10 +627,18 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 `dashboard_data_source.py`, `market_data_adapter.py`, the
 │   │                 `market_data_service` package, services `__init__`,
 │   │                 service consolidation, and route/OpenAPI behavior changes;
-│   │                 no source edit is authorized in this packet
-│   └── Next gate: Human review of the G2.26 authorization packet; if accepted,
-│                  create a separate `MarketDataServiceV2` route-provider
-│                  implementation branch before source edits
+│   │                 no source edit is authorized in this packet; PR `#166`
+│   │                 merged at
+│   │                 `76a1e271fa602e692553acf2760f100ca88030aa`; G2.27 now
+│   │                 implements the approved route-provider seam by adding an
+│   │                 app-state provider to `market_data_service_v2.py` and
+│   │                 injecting `MarketDataServiceV2` into the 13 authorized
+│   │                 `market_v2.py` route handlers while preserving the
+│   │                 compatibility getter and leaving the 2
+│   │                 `dashboard_data_source.py` helper callers unchanged
+│   └── Next gate: Human review of the G2.27 implementation; if accepted and
+│                  merged, record a post-merge closeout packet before selecting
+│                  another service lifecycle DI lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -695,6 +704,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-broad-service-seam-design-2026-05-23.md` | G | G2.24 design packet prepared at `18f5b43275bb`: broad market/data/strategy seams are split into separate future design lanes; market/data/strategy/tdx representative getters show CRITICAL impact except `get_market_data_service`, which has a graph/text mismatch; no source implementation is authorized | Human review; if accepted, create G2.25 market-data provider design packet before any market data service source edits |
 | `backend-market-data-provider-design-2026-05-23.md` | G | G2.25 design packet prepared at `f97ca070853`: `MarketDataService` and `MarketDataServiceV2` stay separate; `market_v2.py` is the recommended future route-provider authorization candidate; dashboard, adapter, and market-data package provider work stay in separate lanes | Human review; if accepted, create G2.26 `MarketDataServiceV2` route-provider implementation authorization before source edits |
 | `backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md` | G | G2.26 authorization packet prepared at `46507955f`: future source scope is limited to `market_data_service_v2.py`, `market_v2.py`, focused lifecycle tests, implementation evidence, and a future task card; dashboard, adapter, market-data package, service consolidation, route/OpenAPI, frontend, PM2, and OpenSpec work remain excluded | Human review; if accepted, create a separate implementation branch before source edits |
+| `backend-market-data-service-v2-route-provider-implementation-2026-05-23.md` | G | G2.27 implementation prepared at `76a1e271f`: app-state provider seam added to `market_data_service_v2.py`, 13 `market_v2.py` route-local getter calls converted to injected `MarketDataServiceV2`, compatibility getter retained, and 2 dashboard helper callers intentionally left unchanged | Human review; if accepted and merged, record post-merge closeout before selecting another service lifecycle DI lane |
 
 ## Completed And Reviewed Ledger
 
@@ -785,6 +795,7 @@ review, PR review, or OpenSpec archive review.
 | G2.24 broad service seam design | G/#79 | Decompose broad market/data/strategy service seams before selecting another implementation lane | Review-ready: PR `#163` merged at `18f5b43275bbd1fc7f53c739063da37c6a753b11`; current-head text scan covers `market_data_service_v2`, `market_data_service`, `data_service`, `strategy_service`, `tdx_service`, `enhanced_data_service`, and `technical_analysis_service`; GitNexus spot checks classify most broad seams as CRITICAL and select no mixed implementation batch | `docs/reports/quality/backend-broad-service-seam-design-2026-05-23.md`; `.planning/codebase/generated/broad-service-seam-design-2026-05-23.json` | Human review; if accepted, create G2.25 market-data provider design packet before source edits |
 | G2.25 market-data provider design | G/#79 | Decide the market-data provider seam before selecting an implementation authorization | Review-ready: PR `#164` merged at `f97ca070853a77afc80c226d53948e805ba33c8e`; `market_v2.py` has 13 direct `get_market_data_service_v2()` route calls, `dashboard_data_source.py` has 2 non-route helper calls, `market/market_data_request.py` already uses `Depends(get_market_data_service)` in 7 route handlers, and service consolidation is rejected | `docs/reports/quality/backend-market-data-provider-design-2026-05-23.md`; `.planning/codebase/generated/market-data-provider-design-2026-05-23.json` | Human review; if accepted, create G2.26 `MarketDataServiceV2` route-provider implementation authorization before source edits |
 | G2.26 MarketDataServiceV2 route-provider implementation authorization | G/#79 | Authorize exact future implementation boundary for `MarketDataServiceV2` route-provider DI | Review-ready: PR `#165` merged at `46507955f77a3166491bd4510c56ef034b6ff1cb`; GitNexus rates `get_market_data_service_v2` CRITICAL with 18 impacted symbols and 15 direct callers; future write scope is limited to `market_data_service_v2.py`, `market_v2.py`, focused lifecycle tests, implementation evidence, and a future task card; this packet performs no source edits | `docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md`; `.planning/codebase/generated/market-data-service-v2-route-provider-implementation-authorization-2026-05-23.json` | Human review; if accepted, create a separate implementation branch before source edits |
+| G2.27 MarketDataServiceV2 route-provider lifecycle DI | G/#79 | Implement the approved route-provider DI seam for `MarketDataServiceV2` | Review-ready: PR `#166` merged at `76a1e271fa602e692553acf2760f100ca88030aa`; `market_v2.py` route-local getter calls are now `0`, 13 route handlers accept injected `MarketDataServiceV2`, `get_market_data_service_v2()` remains as compatibility getter, and `dashboard_data_source.py` helper callers remain unchanged | `docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-2026-05-23.md`; focused lifecycle DI test file | Human review; if accepted and merged, record G2.28 post-merge closeout before selecting another service lifecycle DI lane |
 
 ## OpenSpec Branch Register
 
@@ -866,7 +877,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review G2.26 `MarketDataServiceV2` route-provider authorization packet | Future service seam lane | PR `#165` merged; G2.26 is review-ready and defines the exact future route-provider implementation boundary before source edits |
+| P2 | Review G2.27 `MarketDataServiceV2` route-provider implementation | Future service seam lane | PR `#166` merged; G2.27 is review-ready with 13 `market_v2.py` route handlers injected and compatibility getter retained |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-2026-05-23.md
+++ b/docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-2026-05-23.md
@@ -1,0 +1,135 @@
+# Backend MarketDataServiceV2 Route Provider Implementation - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: implementation-prepared-for-review
+- Workline: G2.27 MarketDataServiceV2 route-provider lifecycle DI
+- Recorded at: 2026-05-23T14:53:05+08:00
+- Base HEAD: `76a1e271fa602e692553acf2760f100ca88030aa`
+- Parent authorization: `backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md`
+- Parent authorization PR: `#166`, merged at `76a1e271fa602e692553acf2760f100ca88030aa`
+- Parent issue: `#79`
+- Parent decision issue: `#92`
+
+## Governance Boundary
+
+This implementation follows the G2.26 authorization packet. It changes only the
+approved `MarketDataServiceV2` service seam, the approved `market_v2.py` route
+surface, one focused lifecycle DI test file, this evidence report, the steward
+tree, and this PR task card.
+
+It does not change `dashboard_data_source.py`, `market_data_adapter.py`, the
+`market_data_service` package, services `__init__`, route paths, HTTP methods,
+response models, OpenAPI schema exposure, docs/API examples, frontend code,
+PM2/stateful gates, OpenSpec changes/specs, issue labels, or service
+consolidation.
+
+## Implementation Summary
+
+| Area | Change |
+|---|---|
+| Service seam | Added `MARKET_DATA_SERVICE_V2_STATE_KEY`, `install_market_data_service_v2`, and `get_market_data_service_v2_dependency`. |
+| Compatibility | Preserved `get_market_data_service_v2()` as the fallback singleton getter. |
+| Route surface | Converted the 13 approved `market_v2.py` route-local getter calls to injected `MarketDataServiceV2` parameters. |
+| Exclusions | Left the 2 `dashboard_data_source.py` helper/class getter calls unchanged. |
+| Tests | Added focused lifecycle DI tests for provider install, explicit install, route signatures, and injected ETF refresh behavior. |
+
+## GitNexus Pre-Edit Evidence
+
+| Symbol / file | Risk | Impacted count | Direct callers | Processes affected | Action |
+|---|---:|---:|---:|---:|---|
+| `get_market_data_service_v2` | CRITICAL | 18 | 15 | 6 | Preserved as compatibility fallback; only the 13 authorized `market_v2.py` route callers were migrated. |
+| `web/backend/app/api/market_v2.py` | LOW | 0 | 0 | 0 | Allowed route-surface target for dependency injection. |
+
+The CRITICAL getter-level risk was handled by preserving the compatibility
+getter and excluding the two `dashboard_data_source.py` helper callers from this
+route-provider implementation.
+
+## Route Consumer Closure
+
+| Function | Previous access | New access |
+|---|---|---|
+| `get_fund_flow` | `get_market_data_service_v2()` | `service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)` |
+| `refresh_fund_flow` | `get_market_data_service_v2()` | `service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)` |
+| `get_etf_list` | `get_market_data_service_v2()` | `service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)` |
+| `refresh_etf_spot` | `get_market_data_service_v2()` | `service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)` |
+| `get_lhb_detail` | `get_market_data_service_v2()` | `service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)` |
+| `refresh_lhb_detail` | `get_market_data_service_v2()` | `service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)` |
+| `get_sector_fund_flow` | `get_market_data_service_v2()` | `service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)` |
+| `refresh_sector_fund_flow` | `get_market_data_service_v2()` | `service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)` |
+| `get_stock_dividend` | `get_market_data_service_v2()` | `service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)` |
+| `refresh_stock_dividend` | `get_market_data_service_v2()` | `service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)` |
+| `get_stock_blocktrade` | `get_market_data_service_v2()` | `service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)` |
+| `refresh_stock_blocktrade` | `get_market_data_service_v2()` | `service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)` |
+| `refresh_all_market_data` | `get_market_data_service_v2()` | `service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)` |
+
+Current scan result:
+
+- approved `market_v2.py` route signatures with `service`: `13`
+- approved `market_v2.py` route-local `get_market_data_service_v2()` calls: `0`
+- excluded `dashboard_data_source.py` helper/class getter calls: `2`, unchanged
+
+## TDD Evidence
+
+RED:
+
+```text
+env PYTHONPATH=web/backend pytest -q -o addopts= web/backend/tests/test_market_data_service_v2_lifecycle_di.py --no-cov --tb=short
+FFFF
+```
+
+Failures were the intended missing behavior:
+
+- missing `get_market_data_service_v2_dependency`
+- missing `install_market_data_service_v2`
+- missing `service` parameters on `market_v2.py` route handlers
+- `refresh_etf_spot()` rejected an injected service argument
+
+GREEN:
+
+```text
+env PYTHONPATH=web/backend pytest -q -o addopts= web/backend/tests/test_market_data_service_v2_lifecycle_di.py --no-cov --tb=short
+4 passed in 1.31s
+```
+
+## Verification Snapshot
+
+| Gate | Command | Result |
+|---|---|---|
+| Focused lifecycle DI tests | `env PYTHONPATH=web/backend pytest -q -o addopts= web/backend/tests/test_market_data_service_v2_lifecycle_di.py --no-cov --tb=short` | `4 passed` |
+| Ruff touched files | `ruff check web/backend/app/services/market_data_service_v2.py web/backend/app/api/market_v2.py web/backend/tests/test_market_data_service_v2_lifecycle_di.py` | passed |
+| Black check touched files | `black --check web/backend/app/services/market_data_service_v2.py web/backend/app/api/market_v2.py web/backend/tests/test_market_data_service_v2_lifecycle_di.py` | passed |
+| App import smoke | minimal test env plus `python -c "import app.main"` | `app-main-import-ok` |
+| OpenAPI targeted smoke | minimal test env plus `app.openapi()` | `paths=500`, `market_v2_paths=13`, `duplicate_operation_ids=0` |
+| Staged GitNexus detect changes | `detect_changes(scope="staged")` | medium risk, 6 changed files, 1 affected process: `Refresh_all_market_data -> Rename` |
+
+Notes:
+
+- An initial `app.main` import without required environment variables failed on
+  existing environment validation. The quiet import smoke above supplied the
+  required minimal test environment and passed.
+- OpenSpec was inspected for active context; this implementation does not modify
+  OpenSpec changes or specs.
+
+## Rollback Plan
+
+If this implementation causes regressions:
+
+- revert this PR
+- restore the 13 `market_v2.py` route functions to direct
+  `get_market_data_service_v2()` calls
+- remove `MARKET_DATA_SERVICE_V2_STATE_KEY`, `install_market_data_service_v2`,
+  and `get_market_data_service_v2_dependency`
+- remove the focused lifecycle DI test file
+- keep G2.26 authorization evidence as historical decision input unless it is
+  explicitly superseded
+
+## Next Gate
+
+Human review of this G2.27 implementation. If accepted and merged, run a
+post-merge closeout packet that records final route-surface scan, PR number,
+merge commit, and whether another service lifecycle DI lane should be selected.

--- a/governance/mainline/task-cards/pr-167.yaml
+++ b/governance/mainline/task-cards/pr-167.yaml
@@ -1,0 +1,129 @@
+version: "v0.2"
+
+task:
+  id: "pr-167"
+  title: "Implement market data service v2 route provider DI"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-market-data-service-v2-route-provider-implementation"
+  objective: "implement the approved MarketDataServiceV2 route-provider DI seam without changing route behavior"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-market-data-service-v2-route-provider-implementation"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-market-data-service-v2-route-provider-implementation"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Route-provider DI only; route paths, response contracts, OpenAPI exposure, frontend, docs/API, PM2, and OpenSpec remain unchanged"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - "web/backend/app/services/market_data_service_v2.py"
+    - "web/backend/app/api/market_v2.py"
+    - "web/backend/tests/test_market_data_service_v2_lifecycle_di.py"
+    - "docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-167.yaml"
+  forbidden_paths:
+    - "web/backend/app/api/dashboard_data_source.py"
+    - "web/backend/app/services/market_data_adapter.py"
+    - "web/backend/app/services/market_data_service/**"
+    - "web/backend/app/services/__init__.py"
+    - "web/backend/app/services/email_service.py"
+    - "web/backend/app/services/announcement_service.py"
+    - "web/backend/app/services/watchlist_service.py"
+    - "web/backend/app/services/stock_search_service/**"
+    - "web/backend/app/services/strategy_service.py"
+    - "web/backend/app/services/tdx_service.py"
+    - "web/backend/app/services/data_service.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No dashboard_data_source.py, market_data_adapter.py, market_data_service package, or services __init__ changes"
+  - "No service consolidation between MarketDataService and MarketDataServiceV2"
+  - "No route path, HTTP method, response model, response envelope, or OpenAPI schema exposure change"
+  - "No docs/API, generated client, frontend, PM2, runtime config, OpenSpec, or issue-label change"
+  - "No removal of get_market_data_service_v2 compatibility getter"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -q -o addopts= web/backend/tests/test_market_data_service_v2_lifecycle_di.py --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/market_data_service_v2.py web/backend/app/api/market_v2.py web/backend/tests/test_market_data_service_v2_lifecycle_di.py"
+      required: true
+    - id: "black-check-touched"
+      command: "black --check web/backend/app/services/market_data_service_v2.py web/backend/app/api/market_v2.py web/backend/tests/test_market_data_service_v2_lifecycle_di.py"
+      required: true
+    - id: "app-main-import"
+      command: "env PYTHONPATH=web/backend TESTING=true DEVELOPMENT_MODE=true POSTGRESQL_HOST=localhost POSTGRESQL_PORT=5432 POSTGRESQL_USER=test POSTGRESQL_PASSWORD=test POSTGRESQL_DATABASE=test JWT_SECRET_KEY=0123456789abcdef0123456789abcdef BACKEND_PORT=8020 BACKEND_BACKUP_PORT=8021 python -c 'import app.main; print(\"app-main-import-ok\")'"
+      required: true
+    - id: "openapi-smoke"
+      command: "env PYTHONPATH=web/backend TESTING=true DEVELOPMENT_MODE=true POSTGRESQL_HOST=localhost POSTGRESQL_PORT=5432 POSTGRESQL_USER=test POSTGRESQL_PASSWORD=test POSTGRESQL_DATABASE=test JWT_SECRET_KEY=0123456789abcdef0123456789abcdef BACKEND_PORT=8020 BACKEND_BACKUP_PORT=8021 python -c 'from app.main import app; schema=app.openapi(); print(len(schema.get(\"paths\", {})))'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-2026-05-23.md"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-167.yaml"
+      required: true
+    - id: "staged-gitnexus"
+      command: "gitnexus_detect_changes(scope=staged)"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If dashboard, adapter, market-data package, route/OpenAPI, or frontend paths are edited, the PR exceeds the G2.26 authorization boundary"
+    - "If get_market_data_service_v2 is removed, compatibility callers outside market_v2.py can break"
+    - "If route paths or response contracts change, this PR becomes route/OpenAPI governance work instead of lifecycle DI work"
+  rollback_plan: "revert this PR; restore the 13 market_v2.py route functions to direct get_market_data_service_v2() calls; remove the MarketDataServiceV2 dependency provider and focused lifecycle DI test as one unit"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "implement approved MarketDataServiceV2 route-provider lifecycle DI"
+    modified_scope: "market_data_service_v2.py, market_v2.py, focused tests, implementation report, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "get_market_data_service_v2 remains as compatibility getter; 13 market_v2 route-local callers now use injected MarketDataServiceV2"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, ruff, black check, app/OpenAPI smoke, mainline scope, staged GitNexus, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T14:53:05+08:00"
+    approval_note: "human maintainer approved continuing after G2.26 authorization; this PR implements only the approved MarketDataServiceV2 route-provider DI scope"
+    secondary_approved: false

--- a/web/backend/app/api/market_v2.py
+++ b/web/backend/app/api/market_v2.py
@@ -14,10 +14,10 @@
 from datetime import date, datetime
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.openapi_config import COMMON_RESPONSES
-from app.services.market_data_service_v2 import get_market_data_service_v2
+from app.services.market_data_service_v2 import MarketDataServiceV2, get_market_data_service_v2_dependency
 
 MARKET_V2_ROUTE_RESPONSES = {
     500: COMMON_RESPONSES[500],
@@ -63,7 +63,13 @@ SECTOR_FLOW_REFRESH_RESPONSES = {
     **MARKET_V2_REFRESH_BASE_RESPONSES,
     **_success_response_spec(
         "行业/概念资金流向刷新结果",
-        {"success": True, "message": "板块资金流向刷新完成", "sector_type": "行业", "timeframe": "今日", "updated_count": 128},
+        {
+            "success": True,
+            "message": "板块资金流向刷新完成",
+            "sector_type": "行业",
+            "timeframe": "今日",
+            "updated_count": 128,
+        },
     ),
 }
 
@@ -260,6 +266,7 @@ async def get_fund_flow(
     timeframe: str = Query(default="1", description="时间维度: 1/3/5/10天"),
     start_date: Optional[date] = Query(None, description="开始日期"),
     end_date: Optional[date] = Query(None, description="结束日期"),
+    service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency),
 ):
     """
     查询个股资金流向历史数据
@@ -270,7 +277,6 @@ async def get_fund_flow(
         start_date/end_date: 时间范围筛选
     """
     try:
-        service = get_market_data_service_v2()
         results = service.query_fund_flow(symbol, timeframe, start_date, end_date)
         return {"success": True, "data": results, "count": len(results)}
     except Exception as e:
@@ -281,6 +287,7 @@ async def get_fund_flow(
 async def refresh_fund_flow(
     symbol: Optional[str] = Query(None, description="股票代码，不传则刷新全市场"),
     timeframe: str = Query(default="今日", description="时间维度: 今日/3日/5日/10日"),
+    service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency),
 ):
     """
     从东方财富刷新资金流向数据
@@ -288,7 +295,6 @@ async def refresh_fund_flow(
     不传symbol则刷新全市场数据（约4000+只股票）
     """
     try:
-        service = get_market_data_service_v2()
         result = service.fetch_and_save_fund_flow(symbol, timeframe)
         return result
     except Exception as e:
@@ -303,6 +309,7 @@ async def get_etf_list(
     symbol: Optional[str] = Query(None, description="ETF代码"),
     keyword: Optional[str] = Query(None, description="关键词搜索"),
     limit: int = Query(default=50, ge=1, le=500, description="返回数量"),
+    service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency),
 ):
     """
     查询ETF实时行情数据
@@ -310,7 +317,6 @@ async def get_etf_list(
     支持按代码精确查询或按关键词模糊搜索
     """
     try:
-        service = get_market_data_service_v2()
         results = service.query_etf_spot(symbol, keyword, limit)
         return {"success": True, "data": results, "count": len(results)}
     except Exception as e:
@@ -323,12 +329,11 @@ async def get_etf_list(
     description="从东方财富拉取并落库全市场 ETF 行情数据，适用于定时同步任务或手工补数场景。",
     responses=ETF_REFRESH_RESPONSES,
 )
-async def refresh_etf_spot():
+async def refresh_etf_spot(service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)):
     """
     从东方财富刷新全市场ETF数据
     """
     try:
-        service = get_market_data_service_v2()
         result = service.fetch_and_save_etf_spot()
         return result
     except Exception as e:
@@ -345,6 +350,7 @@ async def get_lhb_detail(
     end_date: Optional[date] = Query(None, description="结束日期"),
     min_net_amount: Optional[float] = Query(None, description="最小净买入额(元)"),
     limit: int = Query(default=100, ge=1, le=500, description="返回数量"),
+    service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency),
 ):
     """
     查询龙虎榜详细数据
@@ -352,7 +358,6 @@ async def get_lhb_detail(
     支持按股票代码、日期范围、净买入额筛选
     """
     try:
-        service = get_market_data_service_v2()
         results = service.query_lhb_detail(symbol, start_date, end_date, min_net_amount, limit)
         return {"success": True, "data": results, "count": len(results)}
     except Exception as e:
@@ -365,12 +370,14 @@ async def get_lhb_detail(
     description="按指定交易日从东方财富同步龙虎榜明细数据，适用于 A 股盘后榜单补齐和复盘分析。",
     responses=LHB_REFRESH_RESPONSES,
 )
-async def refresh_lhb_detail(trade_date: str = Query(..., description="交易日期 (YYYY-MM-DD)")):
+async def refresh_lhb_detail(
+    trade_date: str = Query(..., description="交易日期 (YYYY-MM-DD)"),
+    service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency),
+):
     """
     从东方财富刷新指定日期的龙虎榜数据
     """
     try:
-        service = get_market_data_service_v2()
         result = service.fetch_and_save_lhb_detail(trade_date)
         return result
     except Exception as e:
@@ -385,6 +392,7 @@ async def get_sector_fund_flow(
     sector_type: str = Query(default="行业", description="板块类型: 行业/概念/地域"),
     timeframe: str = Query(default="今日", description="时间维度: 今日/3日/5日/10日"),
     limit: int = Query(default=100, ge=1, le=500, description="返回数量"),
+    service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency),
 ):
     """
     查询行业/概念板块资金流向
@@ -394,7 +402,6 @@ async def get_sector_fund_flow(
         timeframe: 今日、3日、5日或10日
     """
     try:
-        service = get_market_data_service_v2()
         results = service.query_sector_fund_flow(sector_type, timeframe, limit)
         return {"success": True, "data": results, "count": len(results)}
     except Exception as e:
@@ -410,12 +417,12 @@ async def get_sector_fund_flow(
 async def refresh_sector_fund_flow(
     sector_type: str = Query(default="行业", description="板块类型: 行业/概念/地域"),
     timeframe: str = Query(default="今日", description="时间维度: 今日/3日/5日/10日"),
+    service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency),
 ):
     """
     从东方财富刷新行业/概念资金流向数据
     """
     try:
-        service = get_market_data_service_v2()
         result = service.fetch_and_save_sector_fund_flow(sector_type, timeframe)
         return result
     except Exception as e:
@@ -429,6 +436,7 @@ async def refresh_sector_fund_flow(
 async def get_stock_dividend(
     symbol: str = Query(..., description="股票代码"),
     limit: int = Query(default=50, ge=1, le=200, description="返回数量"),
+    service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency),
 ):
     """
     查询股票分红配送历史记录
@@ -437,7 +445,6 @@ async def get_stock_dividend(
         symbol: 股票代码 (如: 600519)
     """
     try:
-        service = get_market_data_service_v2()
         results = service.query_stock_dividend(symbol, limit)
         return {"success": True, "data": results, "count": len(results)}
     except Exception as e:
@@ -450,12 +457,14 @@ async def get_stock_dividend(
     description="按股票代码从东方财富同步分红配送历史记录，适用于个股权益事件校准和补录。",
     responses=DIVIDEND_REFRESH_RESPONSES,
 )
-async def refresh_stock_dividend(symbol: str = Query(..., description="股票代码")):
+async def refresh_stock_dividend(
+    symbol: str = Query(..., description="股票代码"),
+    service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency),
+):
     """
     从东方财富刷新股票分红配送数据
     """
     try:
-        service = get_market_data_service_v2()
         result = service.fetch_and_save_stock_dividend(symbol)
         return result
     except Exception as e:
@@ -471,6 +480,7 @@ async def get_stock_blocktrade(
     start_date: Optional[date] = Query(None, description="开始日期"),
     end_date: Optional[date] = Query(None, description="结束日期"),
     limit: int = Query(default=100, ge=1, le=500, description="返回数量"),
+    service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency),
 ):
     """
     查询股票大宗交易记录
@@ -480,7 +490,6 @@ async def get_stock_blocktrade(
         start_date/end_date: 日期范围 (可选)
     """
     try:
-        service = get_market_data_service_v2()
         results = service.query_blocktrade(symbol, start_date, end_date, limit)
         return {"success": True, "data": results, "count": len(results)}
     except Exception as e:
@@ -494,13 +503,13 @@ async def get_stock_blocktrade(
     responses=BLOCKTRADE_REFRESH_RESPONSES,
 )
 async def refresh_stock_blocktrade(
-    trade_date: Optional[str] = Query(None, description="交易日期 (YYYY-MM-DD)，不传则获取最新")
+    trade_date: Optional[str] = Query(None, description="交易日期 (YYYY-MM-DD)，不传则获取最新"),
+    service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency),
 ):
     """
     从东方财富刷新大宗交易数据
     """
     try:
-        service = get_market_data_service_v2()
         result = service.fetch_and_save_blocktrade(trade_date)
         return result
     except Exception as e:
@@ -511,7 +520,7 @@ async def refresh_stock_blocktrade(
 
 
 @router.post("/refresh-all", summary="批量刷新所有市场数据", responses=REFRESH_ALL_RESPONSES)
-async def refresh_all_market_data():
+async def refresh_all_market_data(service: MarketDataServiceV2 = Depends(get_market_data_service_v2_dependency)):
     """
     一键刷新所有市场数据（用于定时任务）
 
@@ -524,7 +533,6 @@ async def refresh_all_market_data():
     - 当日大宗交易
     """
     try:
-        service = get_market_data_service_v2()
         results = {}
 
         # 1. 刷新资金流向

--- a/web/backend/app/services/market_data_service_v2.py
+++ b/web/backend/app/services/market_data_service_v2.py
@@ -14,6 +14,7 @@ import os
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 
+from fastapi import Request
 import pandas as pd
 from sqlalchemy import and_, create_engine, or_
 from sqlalchemy.orm import sessionmaker
@@ -55,8 +56,7 @@ class MarketDataServiceV2:
 
     def _runtime_fallback_enabled(self) -> bool:
         return (
-            os.getenv("TESTING", "false").lower() == "true"
-            or os.getenv("DEVELOPMENT_MODE", "false").lower() == "true"
+            os.getenv("TESTING", "false").lower() == "true" or os.getenv("DEVELOPMENT_MODE", "false").lower() == "true"
         )
 
     def _build_sector_fund_flow_runtime_rows(
@@ -657,6 +657,7 @@ class MarketDataServiceV2:
 
 # 全局单例
 _market_data_service_v2 = None
+MARKET_DATA_SERVICE_V2_STATE_KEY = "market_data_service_v2"
 
 
 def get_market_data_service_v2() -> MarketDataServiceV2:
@@ -665,3 +666,18 @@ def get_market_data_service_v2() -> MarketDataServiceV2:
     if _market_data_service_v2 is None:
         _market_data_service_v2 = MarketDataServiceV2()
     return _market_data_service_v2
+
+
+def install_market_data_service_v2(app: Any, service: MarketDataServiceV2 | None = None) -> MarketDataServiceV2:
+    """Install the market data service V2 instance on FastAPI app.state."""
+    selected_service = service if service is not None else get_market_data_service_v2()
+    setattr(app.state, MARKET_DATA_SERVICE_V2_STATE_KEY, selected_service)
+    return selected_service
+
+
+def get_market_data_service_v2_dependency(request: Request) -> MarketDataServiceV2:
+    """FastAPI dependency provider for the market data service V2."""
+    service = getattr(request.app.state, MARKET_DATA_SERVICE_V2_STATE_KEY, None)
+    if service is None:
+        service = install_market_data_service_v2(request.app)
+    return service

--- a/web/backend/tests/test_market_data_service_v2_lifecycle_di.py
+++ b/web/backend/tests/test_market_data_service_v2_lifecycle_di.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from app.api import market_v2 as market_v2_routes
+from app.services import market_data_service_v2
+
+
+def test_market_data_service_v2_dependency_installs_app_state_when_missing(monkeypatch):
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+    request = SimpleNamespace(app=fake_app)
+
+    monkeypatch.setattr(market_data_service_v2, "get_market_data_service_v2", lambda: fake_service)
+
+    assert market_data_service_v2.get_market_data_service_v2_dependency(request) is fake_service
+    assert getattr(fake_app.state, market_data_service_v2.MARKET_DATA_SERVICE_V2_STATE_KEY) is fake_service
+
+
+def test_install_market_data_service_v2_accepts_explicit_service():
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+
+    assert market_data_service_v2.install_market_data_service_v2(fake_app, fake_service) is fake_service
+    assert getattr(fake_app.state, market_data_service_v2.MARKET_DATA_SERVICE_V2_STATE_KEY) is fake_service
+
+
+def test_market_v2_routes_accept_injected_market_data_service_v2():
+    for function_name in [
+        "get_fund_flow",
+        "refresh_fund_flow",
+        "get_etf_list",
+        "refresh_etf_spot",
+        "get_lhb_detail",
+        "refresh_lhb_detail",
+        "get_sector_fund_flow",
+        "refresh_sector_fund_flow",
+        "get_stock_dividend",
+        "refresh_stock_dividend",
+        "get_stock_blocktrade",
+        "refresh_stock_blocktrade",
+        "refresh_all_market_data",
+    ]:
+        signature = inspect.signature(getattr(market_v2_routes, function_name))
+        assert "service" in signature.parameters
+
+
+@pytest.mark.asyncio
+async def test_refresh_etf_spot_uses_injected_market_data_service_v2():
+    class FakeMarketDataServiceV2:
+        def __init__(self):
+            self.called = False
+
+        def fetch_and_save_etf_spot(self):
+            self.called = True
+            return {"success": True, "message": "ok"}
+
+    fake_service = FakeMarketDataServiceV2()
+
+    result = await market_v2_routes.refresh_etf_spot(service=fake_service)
+
+    assert result == {"success": True, "message": "ok"}
+    assert fake_service.called is True


### PR DESCRIPTION
## Summary
- add MarketDataServiceV2 app-state installer and FastAPI dependency provider while preserving the compatibility getter
- inject MarketDataServiceV2 into the 13 authorized market_v2.py route handlers
- add focused lifecycle DI tests, implementation evidence report, PR #167 task card, and steward-tree progress update

## Boundary
- follows G2.26 authorization from PR #166
- no dashboard_data_source.py, market_data_adapter.py, market_data_service package, services __init__, frontend, docs/API, PM2, OpenSpec, or issue-label changes
- no route path, HTTP method, response contract, or OpenAPI exposure changes

## Verification
- TDD RED: focused test failed with missing provider/installer/service parameters
- focused pytest: 4 passed
- ruff touched files: passed
- black --check touched files: passed
- app.main import smoke with minimal test env: app-main-import-ok
- OpenAPI smoke: paths=500, market_v2_paths=13, duplicate_operation_ids=0
- route scan: market_v2 direct getter calls=0; dashboard helper getter calls=2 unchanged
- markdown governance: 2 checked files, 0 errors
- mainline scope gate: pass after commit
- GitNexus staged detect_changes: medium, 6 changed files, 1 affected process