### PR TITLE
docs: close out MarketDataServiceV2 route provider

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -472,8 +472,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `.planning/codebase/generated/market-data-provider-design-2026-05-23.json`,
 │   │   `backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md`,
 │   │   `.planning/codebase/generated/market-data-service-v2-route-provider-implementation-authorization-2026-05-23.json`,
-│   │   `backend-market-data-service-v2-route-provider-implementation-2026-05-23.md`
-│   ├── State: market-data-service-v2-route-provider-implementation-prepared-for-review
+│   │   `backend-market-data-service-v2-route-provider-implementation-2026-05-23.md`,
+│   │   `backend-market-data-service-v2-route-provider-closeout-2026-05-23.md`,
+│   │   `.planning/codebase/generated/market-data-service-v2-route-provider-closeout-2026-05-23.json`
+│   ├── State: market-data-service-v2-route-provider-closeout-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -635,10 +637,17 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 injecting `MarketDataServiceV2` into the 13 authorized
 │   │                 `market_v2.py` route handlers while preserving the
 │   │                 compatibility getter and leaving the 2
-│   │                 `dashboard_data_source.py` helper callers unchanged
-│   └── Next gate: Human review of the G2.27 implementation; if accepted and
-│                  merged, record a post-merge closeout packet before selecting
-│                  another service lifecycle DI lane
+│   │                 `dashboard_data_source.py` helper callers unchanged; PR
+│   │                 `#167` merged at
+│   │                 `8120f01a7022472b604f525ac9af2a517150c39b`; G2.28 now
+│   │                 records the post-merge closeout, confirms `market_v2.py`
+│   │                 route direct getter calls remain `0`, 13 route handlers
+│   │                 use the provider dependency, dashboard helper callers
+│   │                 remain `2`, and OpenAPI stays at paths=`500`,
+│   │                 `/api/v2/market` paths=`13`, duplicate operationIds=`0`
+│   └── Next gate: Human review of the G2.28 closeout packet; if accepted,
+│                  select any next service lifecycle DI lane only through a
+│                  separate evidence or authorization packet
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -704,7 +713,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-broad-service-seam-design-2026-05-23.md` | G | G2.24 design packet prepared at `18f5b43275bb`: broad market/data/strategy seams are split into separate future design lanes; market/data/strategy/tdx representative getters show CRITICAL impact except `get_market_data_service`, which has a graph/text mismatch; no source implementation is authorized | Human review; if accepted, create G2.25 market-data provider design packet before any market data service source edits |
 | `backend-market-data-provider-design-2026-05-23.md` | G | G2.25 design packet prepared at `f97ca070853`: `MarketDataService` and `MarketDataServiceV2` stay separate; `market_v2.py` is the recommended future route-provider authorization candidate; dashboard, adapter, and market-data package provider work stay in separate lanes | Human review; if accepted, create G2.26 `MarketDataServiceV2` route-provider implementation authorization before source edits |
 | `backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md` | G | G2.26 authorization packet prepared at `46507955f`: future source scope is limited to `market_data_service_v2.py`, `market_v2.py`, focused lifecycle tests, implementation evidence, and a future task card; dashboard, adapter, market-data package, service consolidation, route/OpenAPI, frontend, PM2, and OpenSpec work remain excluded | Human review; if accepted, create a separate implementation branch before source edits |
-| `backend-market-data-service-v2-route-provider-implementation-2026-05-23.md` | G | G2.27 implementation prepared at `76a1e271f`: app-state provider seam added to `market_data_service_v2.py`, 13 `market_v2.py` route-local getter calls converted to injected `MarketDataServiceV2`, compatibility getter retained, and 2 dashboard helper callers intentionally left unchanged | Human review; if accepted and merged, record post-merge closeout before selecting another service lifecycle DI lane |
+| `backend-market-data-service-v2-route-provider-implementation-2026-05-23.md` | G | G2.27 implementation merged by PR `#167` at `8120f01a7022472b604f525ac9af2a517150c39b`: app-state provider seam added to `market_data_service_v2.py`, 13 `market_v2.py` route-local getter calls converted to injected `MarketDataServiceV2`, compatibility getter retained, and 2 dashboard helper callers intentionally left unchanged | Superseded by G2.28 closeout packet |
+| `backend-market-data-service-v2-route-provider-closeout-2026-05-23.md` | G | G2.28 closeout prepared at `8120f01a7022472b604f525ac9af2a517150c39b`: PR `#167` merge recorded, focused lifecycle DI test `4 passed`, ruff and black passed, `app.main` import passed, OpenAPI smoke reports paths=`500`, `/api/v2/market` paths=`13`, duplicate operationIds=`0`, `market_v2.py` direct route getter calls=`0`, and `dashboard_data_source.py` helper calls remain `2` | Human review; if accepted, select the next service lifecycle DI lane only through a separate evidence or authorization packet |
 
 ## Completed And Reviewed Ledger
 
@@ -795,7 +805,8 @@ review, PR review, or OpenSpec archive review.
 | G2.24 broad service seam design | G/#79 | Decompose broad market/data/strategy service seams before selecting another implementation lane | Review-ready: PR `#163` merged at `18f5b43275bbd1fc7f53c739063da37c6a753b11`; current-head text scan covers `market_data_service_v2`, `market_data_service`, `data_service`, `strategy_service`, `tdx_service`, `enhanced_data_service`, and `technical_analysis_service`; GitNexus spot checks classify most broad seams as CRITICAL and select no mixed implementation batch | `docs/reports/quality/backend-broad-service-seam-design-2026-05-23.md`; `.planning/codebase/generated/broad-service-seam-design-2026-05-23.json` | Human review; if accepted, create G2.25 market-data provider design packet before source edits |
 | G2.25 market-data provider design | G/#79 | Decide the market-data provider seam before selecting an implementation authorization | Review-ready: PR `#164` merged at `f97ca070853a77afc80c226d53948e805ba33c8e`; `market_v2.py` has 13 direct `get_market_data_service_v2()` route calls, `dashboard_data_source.py` has 2 non-route helper calls, `market/market_data_request.py` already uses `Depends(get_market_data_service)` in 7 route handlers, and service consolidation is rejected | `docs/reports/quality/backend-market-data-provider-design-2026-05-23.md`; `.planning/codebase/generated/market-data-provider-design-2026-05-23.json` | Human review; if accepted, create G2.26 `MarketDataServiceV2` route-provider implementation authorization before source edits |
 | G2.26 MarketDataServiceV2 route-provider implementation authorization | G/#79 | Authorize exact future implementation boundary for `MarketDataServiceV2` route-provider DI | Review-ready: PR `#165` merged at `46507955f77a3166491bd4510c56ef034b6ff1cb`; GitNexus rates `get_market_data_service_v2` CRITICAL with 18 impacted symbols and 15 direct callers; future write scope is limited to `market_data_service_v2.py`, `market_v2.py`, focused lifecycle tests, implementation evidence, and a future task card; this packet performs no source edits | `docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md`; `.planning/codebase/generated/market-data-service-v2-route-provider-implementation-authorization-2026-05-23.json` | Human review; if accepted, create a separate implementation branch before source edits |
-| G2.27 MarketDataServiceV2 route-provider lifecycle DI | G/#79 | Implement the approved route-provider DI seam for `MarketDataServiceV2` | Review-ready: PR `#166` merged at `76a1e271fa602e692553acf2760f100ca88030aa`; `market_v2.py` route-local getter calls are now `0`, 13 route handlers accept injected `MarketDataServiceV2`, `get_market_data_service_v2()` remains as compatibility getter, and `dashboard_data_source.py` helper callers remain unchanged | `docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-2026-05-23.md`; focused lifecycle DI test file | Human review; if accepted and merged, record G2.28 post-merge closeout before selecting another service lifecycle DI lane |
+| G2.27 MarketDataServiceV2 route-provider lifecycle DI | G/#79 | Implement the approved route-provider DI seam for `MarketDataServiceV2` | Merged by PR `#167` at `8120f01a7022472b604f525ac9af2a517150c39b`: `market_v2.py` route-local getter calls are now `0`, 13 route handlers accept injected `MarketDataServiceV2`, `get_market_data_service_v2()` remains as compatibility getter, and `dashboard_data_source.py` helper callers remain unchanged | `docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-2026-05-23.md`; focused lifecycle DI test file | Superseded by G2.28 closeout packet |
+| G2.28 MarketDataServiceV2 route-provider closeout | G/#79 | Record the PR `#167` merge result and post-merge route/OpenAPI stability | Review-ready: no backend source/test/runtime/OpenSpec/issue-label changes; post-merge scan shows `0` direct route getter calls in `market_v2.py`, 13 injected route params, and 2 dashboard helper compatibility calls unchanged; focused lifecycle DI test `4 passed`; ruff/black passed; `app.main` import passed; OpenAPI paths=`500`, `/api/v2/market` paths=`13`, duplicate operationIds=`0` | `docs/reports/quality/backend-market-data-service-v2-route-provider-closeout-2026-05-23.md`; `.planning/codebase/generated/market-data-service-v2-route-provider-closeout-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/167 | Human review of closeout; any next service lifecycle DI lane requires a separate evidence or authorization packet |
 
 ## OpenSpec Branch Register
 
@@ -877,7 +888,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review G2.27 `MarketDataServiceV2` route-provider implementation | Future service seam lane | PR `#166` merged; G2.27 is review-ready with 13 `market_v2.py` route handlers injected and compatibility getter retained |
+| P2 | Review G2.28 `MarketDataServiceV2` route-provider closeout | Future service seam lane | PR `#167` merged; G2.28 closeout is review-ready with route direct getter calls `0`, 13 provider-injected `market_v2.py` handlers, compatibility getter retained, and dashboard helper callers unchanged |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/generated/market-data-service-v2-route-provider-closeout-2026-05-23.json
+++ b/.planning/codebase/generated/market-data-service-v2-route-provider-closeout-2026-05-23.json
@@ -1,0 +1,81 @@
+{
+  "artifact": "market-data-service-v2-route-provider-closeout",
+  "date": "2026-05-23",
+  "status": "closeout-prepared-for-review",
+  "workline": "G2.28 MarketDataServiceV2 route-provider closeout",
+  "parent_issue": 79,
+  "current_head": "8120f01a7022472b604f525ac9af2a517150c39b",
+  "recorded_at": "2026-05-23T15:38:42+08:00",
+  "implementation_pr": {
+    "number": 167,
+    "url": "https://github.com/chengjon/mystocks/pull/167",
+    "state": "MERGED",
+    "merge_commit": "8120f01a7022472b604f525ac9af2a517150c39b",
+    "merged_at": "2026-05-23T07:26:57Z"
+  },
+  "authorization_pr": {
+    "number": 166,
+    "url": "https://github.com/chengjon/mystocks/pull/166",
+    "merge_commit": "76a1e271fa602e692553acf2760f100ca88030aa"
+  },
+  "completed_scope": {
+    "service": "web/backend/app/services/market_data_service_v2.py",
+    "route_files": [
+      "web/backend/app/api/market_v2.py"
+    ],
+    "focused_test": "web/backend/tests/test_market_data_service_v2_lifecycle_di.py",
+    "compatibility_getter_preserved": "get_market_data_service_v2",
+    "excluded_compatibility_consumers": [
+      "web/backend/app/api/dashboard_data_source.py"
+    ]
+  },
+  "post_merge_route_surface_scan": {
+    "web/backend/app/api/market_v2.py": {
+      "direct_get_market_data_service_v2_calls": 0,
+      "injected_route_params": 13,
+      "dependency_references": 14
+    },
+    "web/backend/app/api/dashboard_data_source.py": {
+      "direct_get_market_data_service_v2_calls": 2,
+      "injected_route_params": 0,
+      "status": "intentionally_unchanged_non_route_helper_consumers"
+    }
+  },
+  "provider_seam_scan": {
+    "MARKET_DATA_SERVICE_V2_STATE_KEY": true,
+    "install_market_data_service_v2": true,
+    "get_market_data_service_v2_dependency": true,
+    "get_market_data_service_v2_compatibility_getter": true
+  },
+  "verification": {
+    "focused_pytest": "4 passed in 1.23s",
+    "ruff": "passed",
+    "black_check": "passed",
+    "app_main_import": "status=0, app-main-import-ok",
+    "openapi_smoke": {
+      "paths": 500,
+      "market_v2_prefix": "/api/v2/market",
+      "market_v2_paths": 13,
+      "duplicate_operation_ids": 0
+    }
+  },
+  "github_checks": {
+    "check_compliance": "SUCCESS",
+    "mainline_governance_gate": "SUCCESS",
+    "validate_api_contracts": "SUCCESS",
+    "generate_typescript_types": "SUCCESS",
+    "generate_contract_validation_report": "SUCCESS",
+    "detect_breaking_changes": "SUCCESS_OR_SKIPPED",
+    "weekly_full_scan": "SKIPPED"
+  },
+  "authorization_boundary": {
+    "no_source_edits_in_closeout": true,
+    "no_test_edits_in_closeout": true,
+    "no_next_candidate_selected": true,
+    "no_issue_label_changes": true,
+    "no_openspec_changes": true,
+    "no_runtime_or_pm2_changes": true,
+    "no_route_or_openapi_contract_changes": true
+  },
+  "next_gate": "Human review of closeout packet; any next service lifecycle DI lane requires a separate evidence or authorization packet."
+}

--- a/docs/reports/quality/backend-market-data-service-v2-route-provider-closeout-2026-05-23.md
+++ b/docs/reports/quality/backend-market-data-service-v2-route-provider-closeout-2026-05-23.md
@@ -1,0 +1,132 @@
+# Backend MarketDataServiceV2 Route-Provider Closeout - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: closeout-prepared-for-review
+- Workline: G2.28 `MarketDataServiceV2` route-provider closeout
+- Parent issue: `#79`
+- Implementation PR: https://github.com/chengjon/mystocks/pull/167
+- Implementation merge commit: `8120f01a7022472b604f525ac9af2a517150c39b`
+- Implementation PR merged at: `2026-05-23T07:26:57Z`
+- Authorization PR: https://github.com/chengjon/mystocks/pull/166
+- Authorization merge commit: `76a1e271fa602e692553acf2760f100ca88030aa`
+- Closeout branch: `g2-28-market-data-v2-route-provider-closeout`
+- Closeout HEAD: `8120f01a7022472b604f525ac9af2a517150c39b`
+- Recorded at: `2026-05-23T15:38:42+08:00`
+
+## Governance Boundary
+
+This closeout is governance bookkeeping only. It records the merged G2.27
+`MarketDataServiceV2` route-provider implementation and reruns post-merge
+verification from the clean closeout worktree.
+
+It does not authorize another service lifecycle DI candidate, dashboard helper
+migration, market-data adapter migration, service consolidation, route/OpenAPI
+contract changes, OpenSpec changes, issue label movement, PM2/runtime work,
+frontend work, docs/API changes, or additional source edits.
+
+## Completed Scope
+
+PR `#167` implemented the G2.26-authorized route-provider scope:
+
+- `web/backend/app/services/market_data_service_v2.py`
+  - added `MARKET_DATA_SERVICE_V2_STATE_KEY`
+  - added `install_market_data_service_v2(app, service=None)`
+  - added `get_market_data_service_v2_dependency(request)`
+  - retained `get_market_data_service_v2()` as the compatibility getter
+- `web/backend/app/api/market_v2.py`
+  - injected `MarketDataServiceV2` into all 13 route handlers
+  - removed route-body direct `get_market_data_service_v2()` calls from those
+    13 handlers
+- `web/backend/tests/test_market_data_service_v2_lifecycle_di.py`
+  - covers provider installation, request-state fallback, route signature
+    injection, and compatibility fallback
+- `docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-2026-05-23.md`
+  - records implementation evidence and rollback boundaries
+- `governance/mainline/task-cards/pr-167.yaml`
+  - records implementation scope and gates
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+  - records G2.27 as implementation prepared for review
+
+## Preserved Compatibility Boundary
+
+The implementation preserved `get_market_data_service_v2()` as the legacy
+compatibility getter. This is intentional because `dashboard_data_source.py`
+still has two non-route helper callers that were explicitly excluded from the
+route-provider implementation scope.
+
+Any dashboard helper migration, adapter migration, market-data package provider
+work, service consolidation, or compatibility getter cleanup must be routed
+through a separate packet with impact evidence, exact write scope, tests,
+rollback plan, and review gate.
+
+## Post-Merge Verification
+
+All commands below were run from the G2.28 closeout worktree at HEAD
+`8120f01a7022472b604f525ac9af2a517150c39b`.
+
+| Check | Result |
+|---|---|
+| Focused lifecycle DI test | `4 passed in 1.23s` |
+| `ruff check` on touched Python files | passed |
+| `black --check` on touched Python files | passed |
+| `app.main` import smoke | status `0`, `app-main-import-ok` |
+| OpenAPI smoke | paths=`500`, `/api/v2/market` paths=`13`, duplicate operationIds=`0` |
+| PR `#167` GitHub state | `MERGED` |
+
+GitHub PR `#167` checks:
+
+| Check | Result |
+|---|---|
+| `Validate API Contracts` | pass |
+| `Generate TypeScript Types` | pass |
+| `Detect Breaking Changes` | pass/skipped according to workflow matrix |
+| `Generate Contract Validation Report` | pass |
+| `Mainline Governance Gate` | pass |
+| `check-compliance` | pass |
+| weekly/notify jobs | skipped as expected |
+
+Post-merge route-surface scan:
+
+| File | Direct `get_market_data_service_v2()` calls | Injected route params | Notes |
+|---|---:|---:|---|
+| `web/backend/app/api/market_v2.py` | 0 | 13 | Approved route surface migrated |
+| `web/backend/app/api/dashboard_data_source.py` | 2 | 0 | Non-route helper compatibility callers intentionally unchanged |
+
+Provider seam scan:
+
+| Symbol or field | Present |
+|---|---|
+| `MARKET_DATA_SERVICE_V2_STATE_KEY` | yes |
+| `install_market_data_service_v2` | yes |
+| `get_market_data_service_v2_dependency` | yes |
+| `get_market_data_service_v2` compatibility getter | yes |
+
+## Current State After Merge
+
+- `MarketDataServiceV2` now has a merged route-provider lifecycle DI seam for
+  the `market_v2.py` route surface.
+- All 13 `market_v2.py` routes receive `MarketDataServiceV2` through the
+  provider dependency.
+- Direct route-body calls to `get_market_data_service_v2()` in `market_v2.py`
+  are now `0`.
+- `dashboard_data_source.py` retains its two compatibility helper calls by
+  design.
+- The OpenAPI schema remains stable at `500` paths with `13` `/api/v2/market`
+  paths and `0` duplicate operationIds.
+- Issue `#79` remains the parent service lifecycle DI issue and should not be
+  moved to implementation-ready state by this closeout.
+- No next service lifecycle DI candidate is selected by this closeout.
+
+## Next Gate
+
+Human review of this closeout packet.
+
+If accepted, select the next service lifecycle DI lane only through a separate
+evidence or authorization packet. That packet must define the exact target,
+impact evidence, write scope, tests, rollback plan, and forbidden scope before
+any source edit.

--- a/governance/mainline/task-cards/pr-168.yaml
+++ b/governance/mainline/task-cards/pr-168.yaml
@@ -1,0 +1,101 @@
+version: "v0.2"
+
+task:
+  id: "pr-168"
+  title: "Close out MarketDataServiceV2 route-provider lifecycle DI"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-market-data-service-v2-route-provider-closeout"
+  objective: "record the G2.27 MarketDataServiceV2 route-provider merge result and closeout boundary"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-market-data-service-v2-route-provider-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-market-data-service-v2-route-provider-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout records already-merged PR #167 and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/market-data-service-v2-route-provider-closeout-2026-05-23.json"
+    - "docs/reports/quality/backend-market-data-service-v2-route-provider-closeout-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-168.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No next service DI candidate selection in this PR"
+  - "No dashboard helper migration, adapter migration, service consolidation, or compatibility getter cleanup in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-market-data-service-v2-route-provider-closeout-2026-05-23.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/market-data-service-v2-route-provider-closeout-2026-05-23.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-168.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the closeout boundary"
+    - "If this PR selects or authorizes the next service candidate, it bypasses the separate-packet gate"
+    - "If dashboard helper calls are treated as route-surface leftovers, future cleanup could exceed the approved G2.27 boundary"
+  rollback_plan: "revert this governance-only PR; PR #167 implementation remains merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record the merged G2.27 MarketDataServiceV2 route-provider lifecycle DI implementation"
+    modified_scope: "closeout report, generated closeout artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; get_market_data_service_v2 remains compatibility getter and dashboard helper callers remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only closeout PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T15:38:42+08:00"
+    approval_note: "human maintainer approved continuing after PR #167 review; this closeout only records the merged implementation and next-gate boundary"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records G2.28 closeout for the merged MarketDataServiceV2 route-provider lifecycle DI work from PR #167
- adds a structured closeout artifact and mainline task card for PR #168
- updates the steward tree so G2.27 is superseded by the G2.28 closeout packet

## Verification
- focused lifecycle DI test: 4 passed
- ruff check on touched implementation files: passed
- black --check on touched implementation files: passed
- app.main import smoke: status 0, app-main-import-ok
- OpenAPI smoke: paths=500, /api/v2/market paths=13, duplicate operationIds=0
- markdown governance: checked_files=2, errors=0
- JSON parse: passed
- mainline scope gate: pass=True
- git diff --check HEAD~1..HEAD: passed
- GitNexus staged detect_changes before commit: low risk, changed_symbols=0, affected_processes=0

## Boundary
Governance-only closeout. No backend source, tests, route behavior, OpenAPI schema, OpenSpec, PM2/runtime, frontend, docs/API, issue-label, or next-candidate authorization changes.