### PR TITLE
docs: refresh service lifecycle DI candidates after MarketDataServiceV2

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -474,8 +474,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `.planning/codebase/generated/market-data-service-v2-route-provider-implementation-authorization-2026-05-23.json`,
 │   │   `backend-market-data-service-v2-route-provider-implementation-2026-05-23.md`,
 │   │   `backend-market-data-service-v2-route-provider-closeout-2026-05-23.md`,
-│   │   `.planning/codebase/generated/market-data-service-v2-route-provider-closeout-2026-05-23.json`
-│   ├── State: market-data-service-v2-route-provider-closeout-prepared-for-review
+│   │   `.planning/codebase/generated/market-data-service-v2-route-provider-closeout-2026-05-23.json`,
+│   │   `backend-service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.md`,
+│   │   `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.json`
+│   ├── State: service-lifecycle-di-candidate-refresh-after-market-data-v2-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -644,10 +646,19 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 route direct getter calls remain `0`, 13 route handlers
 │   │                 use the provider dependency, dashboard helper callers
 │   │                 remain `2`, and OpenAPI stays at paths=`500`,
-│   │                 `/api/v2/market` paths=`13`, duplicate operationIds=`0`
-│   └── Next gate: Human review of the G2.28 closeout packet; if accepted,
-│                  select any next service lifecycle DI lane only through a
-│                  separate evidence or authorization packet
+│   │                 `/api/v2/market` paths=`13`, duplicate operationIds=`0`;
+│   │                 PR `#168` merged at
+│   │                 `e79029ff99e8c3ee674d07efd8b1601e7deb32e0`; G2.29 now
+│   │                 refreshes current-head service lifecycle candidates,
+│   │                 records 152 service files, 20 narrow candidate files, 5
+│   │                 completed route-surface DI seams, and selects only a
+│   │                 future G2.30 `MarketDataServiceV2` compatibility getter /
+│   │                 dashboard helper consumer matrix packet before any source
+│   │                 edit
+│   └── Next gate: Human review of the G2.29 candidate-refresh packet; if
+│                  accepted, prepare G2.30 as a decision-only
+│                  `MarketDataServiceV2` compatibility getter / dashboard
+│                  helper consumer matrix packet
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -714,7 +725,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-market-data-provider-design-2026-05-23.md` | G | G2.25 design packet prepared at `f97ca070853`: `MarketDataService` and `MarketDataServiceV2` stay separate; `market_v2.py` is the recommended future route-provider authorization candidate; dashboard, adapter, and market-data package provider work stay in separate lanes | Human review; if accepted, create G2.26 `MarketDataServiceV2` route-provider implementation authorization before source edits |
 | `backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md` | G | G2.26 authorization packet prepared at `46507955f`: future source scope is limited to `market_data_service_v2.py`, `market_v2.py`, focused lifecycle tests, implementation evidence, and a future task card; dashboard, adapter, market-data package, service consolidation, route/OpenAPI, frontend, PM2, and OpenSpec work remain excluded | Human review; if accepted, create a separate implementation branch before source edits |
 | `backend-market-data-service-v2-route-provider-implementation-2026-05-23.md` | G | G2.27 implementation merged by PR `#167` at `8120f01a7022472b604f525ac9af2a517150c39b`: app-state provider seam added to `market_data_service_v2.py`, 13 `market_v2.py` route-local getter calls converted to injected `MarketDataServiceV2`, compatibility getter retained, and 2 dashboard helper callers intentionally left unchanged | Superseded by G2.28 closeout packet |
-| `backend-market-data-service-v2-route-provider-closeout-2026-05-23.md` | G | G2.28 closeout prepared at `8120f01a7022472b604f525ac9af2a517150c39b`: PR `#167` merge recorded, focused lifecycle DI test `4 passed`, ruff and black passed, `app.main` import passed, OpenAPI smoke reports paths=`500`, `/api/v2/market` paths=`13`, duplicate operationIds=`0`, `market_v2.py` direct route getter calls=`0`, and `dashboard_data_source.py` helper calls remain `2` | Human review; if accepted, select the next service lifecycle DI lane only through a separate evidence or authorization packet |
+| `backend-market-data-service-v2-route-provider-closeout-2026-05-23.md` | G | G2.28 closeout merged by PR `#168` at `e79029ff99e8c3ee674d07efd8b1601e7deb32e0`: PR `#167` merge recorded, focused lifecycle DI test `4 passed`, ruff and black passed, `app.main` import passed, OpenAPI smoke reports paths=`500`, `/api/v2/market` paths=`13`, duplicate operationIds=`0`, `market_v2.py` direct route getter calls=`0`, and `dashboard_data_source.py` helper calls remain `2` | Superseded by G2.29 candidate refresh packet |
+| `backend-service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.md` | G | G2.29 candidate refresh prepared at `e79029ff99e8`: scanned 152 service files, recorded 20 narrow candidate files, 5 completed route-surface DI seams, GitNexus `get_market_data_service_v2` remains CRITICAL because dashboard helper callers are active, and no direct implementation candidate is selected | Human review; if accepted, create G2.30 `MarketDataServiceV2` compatibility getter / dashboard helper consumer matrix packet before source edits |
 
 ## Completed And Reviewed Ledger
 
@@ -806,7 +818,8 @@ review, PR review, or OpenSpec archive review.
 | G2.25 market-data provider design | G/#79 | Decide the market-data provider seam before selecting an implementation authorization | Review-ready: PR `#164` merged at `f97ca070853a77afc80c226d53948e805ba33c8e`; `market_v2.py` has 13 direct `get_market_data_service_v2()` route calls, `dashboard_data_source.py` has 2 non-route helper calls, `market/market_data_request.py` already uses `Depends(get_market_data_service)` in 7 route handlers, and service consolidation is rejected | `docs/reports/quality/backend-market-data-provider-design-2026-05-23.md`; `.planning/codebase/generated/market-data-provider-design-2026-05-23.json` | Human review; if accepted, create G2.26 `MarketDataServiceV2` route-provider implementation authorization before source edits |
 | G2.26 MarketDataServiceV2 route-provider implementation authorization | G/#79 | Authorize exact future implementation boundary for `MarketDataServiceV2` route-provider DI | Review-ready: PR `#165` merged at `46507955f77a3166491bd4510c56ef034b6ff1cb`; GitNexus rates `get_market_data_service_v2` CRITICAL with 18 impacted symbols and 15 direct callers; future write scope is limited to `market_data_service_v2.py`, `market_v2.py`, focused lifecycle tests, implementation evidence, and a future task card; this packet performs no source edits | `docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md`; `.planning/codebase/generated/market-data-service-v2-route-provider-implementation-authorization-2026-05-23.json` | Human review; if accepted, create a separate implementation branch before source edits |
 | G2.27 MarketDataServiceV2 route-provider lifecycle DI | G/#79 | Implement the approved route-provider DI seam for `MarketDataServiceV2` | Merged by PR `#167` at `8120f01a7022472b604f525ac9af2a517150c39b`: `market_v2.py` route-local getter calls are now `0`, 13 route handlers accept injected `MarketDataServiceV2`, `get_market_data_service_v2()` remains as compatibility getter, and `dashboard_data_source.py` helper callers remain unchanged | `docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-2026-05-23.md`; focused lifecycle DI test file | Superseded by G2.28 closeout packet |
-| G2.28 MarketDataServiceV2 route-provider closeout | G/#79 | Record the PR `#167` merge result and post-merge route/OpenAPI stability | Review-ready: no backend source/test/runtime/OpenSpec/issue-label changes; post-merge scan shows `0` direct route getter calls in `market_v2.py`, 13 injected route params, and 2 dashboard helper compatibility calls unchanged; focused lifecycle DI test `4 passed`; ruff/black passed; `app.main` import passed; OpenAPI paths=`500`, `/api/v2/market` paths=`13`, duplicate operationIds=`0` | `docs/reports/quality/backend-market-data-service-v2-route-provider-closeout-2026-05-23.md`; `.planning/codebase/generated/market-data-service-v2-route-provider-closeout-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/167 | Human review of closeout; any next service lifecycle DI lane requires a separate evidence or authorization packet |
+| G2.28 MarketDataServiceV2 route-provider closeout | G/#79 | Record the PR `#167` merge result and post-merge route/OpenAPI stability | Reviewed and merged by PR `#168` at `e79029ff99e8c3ee674d07efd8b1601e7deb32e0`: no backend source/test/runtime/OpenSpec/issue-label changes; post-merge scan shows `0` direct route getter calls in `market_v2.py`, 13 injected route params, and 2 dashboard helper compatibility calls unchanged; focused lifecycle DI test `4 passed`; ruff/black passed; `app.main` import passed; OpenAPI paths=`500`, `/api/v2/market` paths=`13`, duplicate operationIds=`0` | `docs/reports/quality/backend-market-data-service-v2-route-provider-closeout-2026-05-23.md`; `.planning/codebase/generated/market-data-service-v2-route-provider-closeout-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/168 | Superseded by G2.29 candidate refresh packet |
+| G2.29 service lifecycle DI candidate refresh after MarketDataServiceV2 | G/#79 | Refresh current-head service lifecycle DI candidates after MarketDataServiceV2 route-provider closeout | Review-ready: service scan at `e79029ff99e8` covers 152 service files, records 20 narrow candidate files and 5 completed route-surface DI seams; `market_v2.py` direct getter calls remain `0`, `dashboard_data_source.py` helper getter calls remain `2`, GitNexus still rates `get_market_data_service_v2` CRITICAL, and no direct source implementation is authorized | `docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.md`; `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.json` | Human review; if accepted, create G2.30 `MarketDataServiceV2` compatibility getter / dashboard helper consumer matrix packet before source edits |
 
 ## OpenSpec Branch Register
 
@@ -888,7 +901,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review G2.28 `MarketDataServiceV2` route-provider closeout | Future service seam lane | PR `#167` merged; G2.28 closeout is review-ready with route direct getter calls `0`, 13 provider-injected `market_v2.py` handlers, compatibility getter retained, and dashboard helper callers unchanged |
+| P2 | Review G2.29 service lifecycle DI candidate refresh after `MarketDataServiceV2` | Future service seam lane | PR `#168` merged; G2.29 refresh is review-ready and selects only a future G2.30 `MarketDataServiceV2` compatibility getter / dashboard helper consumer matrix packet, with no source implementation authorized |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.json
+++ b/.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.json
@@ -1,0 +1,362 @@
+{
+  "artifact": "service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23",
+  "recorded_at": "2026-05-23T16:05:54+08:00",
+  "workline": "G2.29 current-head service lifecycle DI candidate refresh after MarketDataServiceV2",
+  "status": "candidate-refresh-prepared-for-review",
+  "current_head": "e79029ff99e8c3ee674d07efd8b1601e7deb32e0",
+  "remote_base": {
+    "branch": "origin/wip/root-dirty-20260403",
+    "head": "e79029ff99e8c3ee674d07efd8b1601e7deb32e0"
+  },
+  "stale_if_head_mismatch": true,
+  "target_pr": 169,
+  "parent_issue": {
+    "number": 92,
+    "state": "OPEN",
+    "labels": [
+      "enhancement",
+      "ready-for-human",
+      "ready-for-downstream"
+    ],
+    "url": "https://github.com/chengjon/mystocks/issues/92"
+  },
+  "service_lifecycle_issue": {
+    "number": 79,
+    "state": "OPEN",
+    "labels": [
+      "needs-triage"
+    ],
+    "url": "https://github.com/chengjon/mystocks/issues/79"
+  },
+  "merged_input": {
+    "pr_168": {
+      "state": "MERGED",
+      "merge_commit": "e79029ff99e8c3ee674d07efd8b1601e7deb32e0",
+      "merged_at": "2026-05-23T07:57:45Z"
+    }
+  },
+  "scan_summary": {
+    "service_py_files": 152,
+    "expanded_broad_heuristic_hit_files": 94,
+    "narrow_service_lifecycle_candidate_files": 20,
+    "bucket_counts": {
+      "completed-route-surface-di": 5,
+      "broad-market-data-strategy-seam": 9,
+      "hold-no-clear-active-route-surface": 2,
+      "process-runtime-singleton-or-streaming": 2,
+      "registry-integrated-seam": 1,
+      "reference-provider-pattern": 1
+    },
+    "scan_criteria": [
+      "Expanded broad heuristic counts service getter/provider/state-key/singleton signals and is not used as a backlog count by itself.",
+      "Narrow inventory includes service files with get_*service* functions, _instance = None, or service app-state provider/dependency patterns."
+    ]
+  },
+  "candidate_inventory": [
+    {
+      "file": "web/backend/app/services/__init__.py",
+      "getters_or_signals": [
+        "get_integrated_services",
+        "get_market_data_service",
+        "get_trading_data_service",
+        "get_analysis_data_service",
+        "get_data_api_service",
+        "get_database_service",
+        "get_websocket_service",
+        "get_cache_service"
+      ],
+      "api_hits": 8,
+      "test_hits": 11,
+      "non_route_service_hits": 6,
+      "bucket": "registry-integrated-seam"
+    },
+    {
+      "file": "web/backend/app/services/advanced_analysis_service.py",
+      "getters_or_signals": [
+        "get_advanced_analysis_service"
+      ],
+      "api_hits": 0,
+      "test_hits": 0,
+      "non_route_service_hits": 0,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/announcement_service.py",
+      "getters_or_signals": [
+        "get_announcement_service",
+        "get_announcement_service_dependency",
+        "install_announcement_service",
+        "ANNOUNCEMENT_SERVICE_STATE_KEY"
+      ],
+      "api_hits": 12,
+      "test_hits": 2,
+      "non_route_service_hits": 0,
+      "bucket": "completed-route-surface-di"
+    },
+    {
+      "file": "web/backend/app/services/data_service_enhanced.py",
+      "getters_or_signals": [
+        "get_service_health",
+        "get_enhanced_data_service"
+      ],
+      "api_hits": 1,
+      "test_hits": 0,
+      "non_route_service_hits": 0,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/data_service.py",
+      "getters_or_signals": [
+        "get_data_service"
+      ],
+      "api_hits": 5,
+      "test_hits": 6,
+      "non_route_service_hits": 0,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/email_notification_service.py",
+      "getters_or_signals": [
+        "get_email_service"
+      ],
+      "api_hits": 0,
+      "test_hits": 3,
+      "non_route_service_hits": 2,
+      "bucket": "hold-no-clear-active-route-surface"
+    },
+    {
+      "file": "web/backend/app/services/email_service.py",
+      "getters_or_signals": [
+        "get_email_service",
+        "get_email_service_dependency",
+        "install_email_service",
+        "EMAIL_SERVICE_STATE_KEY"
+      ],
+      "api_hits": 7,
+      "test_hits": 6,
+      "non_route_service_hits": 1,
+      "bucket": "completed-route-surface-di"
+    },
+    {
+      "file": "web/backend/app/services/market_data_service_v2.py",
+      "getters_or_signals": [
+        "get_market_data_service_v2",
+        "get_market_data_service_v2_dependency",
+        "install_market_data_service_v2",
+        "MARKET_DATA_SERVICE_V2_STATE_KEY"
+      ],
+      "api_hits": 17,
+      "test_hits": 3,
+      "non_route_service_hits": 0,
+      "bucket": "completed-route-surface-di"
+    },
+    {
+      "file": "web/backend/app/services/market_data_service/get_market_data_service.py",
+      "getters_or_signals": [
+        "get_market_data_service"
+      ],
+      "api_hits": 8,
+      "test_hits": 11,
+      "non_route_service_hits": 6,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/monitoring_service.py",
+      "getters_or_signals": [
+        "_instance = None"
+      ],
+      "api_hits": 0,
+      "test_hits": 0,
+      "non_route_service_hits": 0,
+      "bucket": "process-runtime-singleton-or-streaming"
+    },
+    {
+      "file": "web/backend/app/services/realtime_streaming_service.py",
+      "getters_or_signals": [
+        "get_streaming_service"
+      ],
+      "api_hits": 0,
+      "test_hits": 19,
+      "non_route_service_hits": 2,
+      "bucket": "process-runtime-singleton-or-streaming"
+    },
+    {
+      "file": "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "getters_or_signals": [
+        "get_stock_search_service",
+        "get_stock_search_service_dependency",
+        "install_stock_search_service",
+        "STOCK_SEARCH_SERVICE_STATE_KEY"
+      ],
+      "api_hits": 8,
+      "test_hits": 8,
+      "non_route_service_hits": 6,
+      "bucket": "completed-route-surface-di"
+    },
+    {
+      "file": "web/backend/app/services/strategy_service.py",
+      "getters_or_signals": [
+        "get_strategy_service",
+        "_instance = None"
+      ],
+      "api_hits": 4,
+      "test_hits": 1,
+      "non_route_service_hits": 4,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/tdx_service.py",
+      "getters_or_signals": [
+        "get_tdx_service",
+        "_instance = None"
+      ],
+      "api_hits": 9,
+      "test_hits": 0,
+      "non_route_service_hits": 0,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/technical_analysis_service.py",
+      "getters_or_signals": [
+        "_instance = None"
+      ],
+      "api_hits": 0,
+      "test_hits": 0,
+      "non_route_service_hits": 0,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/tradingview_widget_service.py",
+      "getters_or_signals": [
+        "get_tradingview_service",
+        "get_tradingview_service_dependency",
+        "install_tradingview_service",
+        "TRADINGVIEW_SERVICE_STATE_KEY"
+      ],
+      "api_hits": 7,
+      "test_hits": 9,
+      "non_route_service_hits": 0,
+      "bucket": "reference-provider-pattern"
+    },
+    {
+      "file": "web/backend/app/services/unified_data_service.py",
+      "getters_or_signals": [
+        "get_unified_data_service"
+      ],
+      "api_hits": 0,
+      "test_hits": 0,
+      "non_route_service_hits": 0,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/watchlist_service.py",
+      "getters_or_signals": [
+        "get_watchlist_service",
+        "get_watchlist_service_dependency",
+        "install_watchlist_service",
+        "WATCHLIST_SERVICE_STATE_KEY"
+      ],
+      "api_hits": 8,
+      "test_hits": 3,
+      "non_route_service_hits": 4,
+      "bucket": "completed-route-surface-di"
+    },
+    {
+      "file": "web/backend/app/services/websocket_service.py",
+      "getters_or_signals": [
+        "get_service_stats"
+      ],
+      "api_hits": 0,
+      "test_hits": 0,
+      "non_route_service_hits": 0,
+      "bucket": "broad-market-data-strategy-seam"
+    },
+    {
+      "file": "web/backend/app/services/wencai_service.py",
+      "getters_or_signals": [
+        "get_wencai_service"
+      ],
+      "api_hits": 0,
+      "test_hits": 0,
+      "non_route_service_hits": 0,
+      "bucket": "hold-no-clear-active-route-surface"
+    }
+  ],
+  "gitnexus_spot_checks": [
+    {
+      "target": "get_market_data_service_v2",
+      "risk": "CRITICAL",
+      "direct_impact": 15,
+      "processes_affected": 6,
+      "modules_affected": 2,
+      "interpretation": "route surface is migrated, but dashboard helper callers remain active and compatibility getter remains live"
+    },
+    {
+      "target": "get_data_service",
+      "risk": "CRITICAL",
+      "direct_impact": 3,
+      "processes_affected": 7,
+      "modules_affected": 2,
+      "interpretation": "indicator/strategy data seam needs design packet before edits"
+    },
+    {
+      "target": "get_wencai_service",
+      "risk": "LOW",
+      "direct_impact": 0,
+      "processes_affected": 0,
+      "modules_affected": 0,
+      "interpretation": "no active route/test surface found; not a route-surface DI pilot without ownership/usefulness decision"
+    },
+    {
+      "target": "get_unified_data_service",
+      "risk": "MEDIUM",
+      "direct_impact": 5,
+      "processes_affected": 0,
+      "modules_affected": 1,
+      "interpretation": "service-internal helper seam, not a route-provider migration candidate"
+    }
+  ],
+  "market_data_service_v2_reference_matrix": {
+    "web/backend/app/api/market_v2.py": {
+      "direct_getter_refs": 0,
+      "dependency_provider_refs": 14,
+      "installer_refs": 0,
+      "state_key_refs": 0,
+      "interpretation": "13 route params plus import; route surface migrated"
+    },
+    "web/backend/app/api/dashboard_data_source.py": {
+      "direct_getter_refs": 3,
+      "dependency_provider_refs": 0,
+      "installer_refs": 0,
+      "state_key_refs": 0,
+      "interpretation": "import plus 2 non-route helper calls intentionally unchanged"
+    },
+    "web/backend/app/services/market_data_service_v2.py": {
+      "direct_getter_refs": 2,
+      "dependency_provider_refs": 1,
+      "installer_refs": 2,
+      "state_key_refs": 3,
+      "interpretation": "service-owned provider and compatibility surface"
+    },
+    "web/backend/tests/test_market_data_service_v2_lifecycle_di.py": {
+      "direct_getter_refs": 1,
+      "dependency_provider_refs": 1,
+      "installer_refs": 1,
+      "state_key_refs": 2,
+      "interpretation": "focused compatibility/provider test coverage"
+    }
+  },
+  "decision": {
+    "direct_next_implementation_candidate_selected": false,
+    "selected_next_lane": "G2.30 MarketDataServiceV2 compatibility getter / dashboard helper consumer matrix packet",
+    "selected_next_lane_type": "decision-only",
+    "source_edits_authorized": false,
+    "rationale": [
+      "market/data/strategy/dashboard seams remain high-risk or broad",
+      "completed route-surface DI files still appear because compatibility getters and providers are retained intentionally",
+      "zero-route-hit getter files need ownership/usefulness decisions before route-provider work",
+      "the narrowest actionable follow-up is the MarketDataServiceV2 compatibility getter and dashboard helper boundary"
+    ]
+  },
+  "next_gate": "Human review of this G2.29 packet; if accepted, prepare G2.30 as a decision-only MarketDataServiceV2 compatibility getter / dashboard helper consumer matrix packet."
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.md
@@ -1,0 +1,206 @@
+# Backend Service Lifecycle DI Candidate Refresh After MarketDataServiceV2 - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: candidate-refresh-prepared-for-review
+- Workline: G2.29 current-head service lifecycle DI candidate refresh after
+  `MarketDataServiceV2`
+- Current HEAD: `e79029ff99e8c3ee674d07efd8b1601e7deb32e0`
+- Remote base: `origin/wip/root-dirty-20260403` at
+  `e79029ff99e8c3ee674d07efd8b1601e7deb32e0`
+- Parent issue: `#92` OPEN with `enhancement`, `ready-for-human`,
+  `ready-for-downstream`
+- Service lifecycle issue: `#79` OPEN with `needs-triage`
+- PR `#168`: MERGED at `2026-05-23T07:57:45Z`
+- Execution mode: governance/evidence only
+- Recorded at: `2026-05-23T16:05:54+08:00`
+
+Boundary note: this packet refreshes candidate evidence only. It does not
+authorize backend source edits, route edits, tests, OpenAPI changes, OpenSpec
+changes, issue label movement, `ready-for-agent` movement, PM2/runtime work, or
+a G2.30 implementation.
+
+## Governance Boundary
+
+This packet executes the current-head refresh requested by the G2.28 closeout.
+It does not authorize:
+
+- Backend source, test, route, OpenAPI, generated-client, frontend, PM2, or
+  runtime changes
+- OpenSpec change/spec creation, modification, validation archive, or issue
+  publication
+- GitHub issue label movement
+- Selecting a direct next service DI implementation candidate
+- Deleting, retiring, or modifying compatibility getters
+- Migrating `dashboard_data_source.py` helper callers
+
+## Input State
+
+PR `#168` merged the G2.28 closeout into `wip/root-dirty-20260403` at
+`e79029ff99e8c3ee674d07efd8b1601e7deb32e0`.
+
+The immediately preceding `MarketDataServiceV2` route-provider sequence is the
+relevant local context:
+
+- G2.26 authorized a narrow future write scope limited to
+  `market_data_service_v2.py`, `market_v2.py`, focused lifecycle tests,
+  implementation evidence, and a task card.
+- G2.27 implemented the route-provider seam.
+- G2.28 confirmed the merged result: `market_v2.py` has `0` direct route getter
+  calls, 13 provider-injected route handlers, and `dashboard_data_source.py`
+  still has two intentionally retained helper callers.
+
+## Current-Head Inventory
+
+The refresh scanned `web/backend/app/services/**/*.py` at HEAD `e79029ff99e8`.
+The scanner used two levels:
+
+- Expanded broad heuristic: files with service getter/provider/state-key/singleton
+  signals. This intentionally catches false positives and is not comparable to
+  the earlier G2.22 broad count, so it is not used as a backlog count.
+- Narrow service-lifecycle inventory: service files with `get_*service*`
+  functions, `_instance = None`, or service app-state provider/dependency
+  patterns. This is the candidate-selection input.
+
+Snapshot:
+
+| Metric | Value |
+|---|---:|
+| Service Python files scanned | 152 |
+| Expanded broad heuristic hit files | 94 |
+| Narrow service-lifecycle candidate files | 20 |
+
+Bucket counts for the narrow inventory:
+
+| Bucket | Count | Meaning |
+|---|---:|---|
+| completed-route-surface-di | 5 | Existing route-surface DI lanes already implemented or retained as reference |
+| broad-market-data-strategy-seam | 9 | Active market/data/strategy or broad service seams; not low-risk direct picks |
+| hold-no-clear-active-route-surface | 2 | No clear active route-surface candidate without more consumer proof |
+| process-runtime-singleton-or-streaming | 2 | Runtime/streaming/process-level behavior; do not batch as ordinary service DI |
+| registry-integrated-seam | 1 | Package registry/integrated service surface |
+| reference-provider-pattern | 1 | Reference provider pattern evidence |
+
+Narrow inventory:
+
+| File | Getter / signal | API hits | Test hits | Non-route service hits | Bucket |
+|---|---|---:|---:|---:|---|
+| `web/backend/app/services/__init__.py` | `get_integrated_services`, `get_market_data_service`, `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, `get_cache_service` | 8 | 11 | 6 | registry-integrated-seam |
+| `web/backend/app/services/advanced_analysis_service.py` | `get_advanced_analysis_service` | 0 | 0 | 0 | broad-market-data-strategy-seam |
+| `web/backend/app/services/announcement_service.py` | `get_announcement_service`, `get_announcement_service_dependency`, `install_announcement_service`, `ANNOUNCEMENT_SERVICE_STATE_KEY` | 12 | 2 | 0 | completed-route-surface-di |
+| `web/backend/app/services/data_service_enhanced.py` | `get_service_health`, `get_enhanced_data_service` | 1 | 0 | 0 | broad-market-data-strategy-seam |
+| `web/backend/app/services/data_service.py` | `get_data_service` | 5 | 6 | 0 | broad-market-data-strategy-seam |
+| `web/backend/app/services/email_notification_service.py` | `get_email_service` | 0 | 3 | 2 | hold-no-clear-active-route-surface |
+| `web/backend/app/services/email_service.py` | `get_email_service`, `get_email_service_dependency`, `install_email_service`, `EMAIL_SERVICE_STATE_KEY` | 7 | 6 | 1 | completed-route-surface-di |
+| `web/backend/app/services/market_data_service_v2.py` | `get_market_data_service_v2`, `get_market_data_service_v2_dependency`, `install_market_data_service_v2`, `MARKET_DATA_SERVICE_V2_STATE_KEY` | 17 | 3 | 0 | completed-route-surface-di |
+| `web/backend/app/services/market_data_service/get_market_data_service.py` | `get_market_data_service` | 8 | 11 | 6 | broad-market-data-strategy-seam |
+| `web/backend/app/services/monitoring_service.py` | `_instance = None` | 0 | 0 | 0 | process-runtime-singleton-or-streaming |
+| `web/backend/app/services/realtime_streaming_service.py` | `get_streaming_service` | 0 | 19 | 2 | process-runtime-singleton-or-streaming |
+| `web/backend/app/services/stock_search_service/stock_search_service.py` | `get_stock_search_service`, `get_stock_search_service_dependency`, `install_stock_search_service`, `STOCK_SEARCH_SERVICE_STATE_KEY` | 8 | 8 | 6 | completed-route-surface-di |
+| `web/backend/app/services/strategy_service.py` | `get_strategy_service`, `_instance = None` | 4 | 1 | 4 | broad-market-data-strategy-seam |
+| `web/backend/app/services/tdx_service.py` | `get_tdx_service`, `_instance = None` | 9 | 0 | 0 | broad-market-data-strategy-seam |
+| `web/backend/app/services/technical_analysis_service.py` | `_instance = None` | 0 | 0 | 0 | broad-market-data-strategy-seam |
+| `web/backend/app/services/tradingview_widget_service.py` | `get_tradingview_service`, `get_tradingview_service_dependency`, `install_tradingview_service`, `TRADINGVIEW_SERVICE_STATE_KEY` | 7 | 9 | 0 | reference-provider-pattern |
+| `web/backend/app/services/unified_data_service.py` | `get_unified_data_service` | 0 | 0 | 0 | broad-market-data-strategy-seam |
+| `web/backend/app/services/watchlist_service.py` | `get_watchlist_service`, `get_watchlist_service_dependency`, `install_watchlist_service`, `WATCHLIST_SERVICE_STATE_KEY` | 8 | 3 | 4 | completed-route-surface-di |
+| `web/backend/app/services/websocket_service.py` | `get_service_stats` | 0 | 0 | 0 | broad-market-data-strategy-seam |
+| `web/backend/app/services/wencai_service.py` | `get_wencai_service` | 0 | 0 | 0 | hold-no-clear-active-route-surface |
+
+## GitNexus Spot Checks
+
+GitNexus was used as risk evidence, not as the sole source of truth.
+
+| Target | GitNexus risk | Direct impact | Processes / modules | Current interpretation |
+|---|---:|---:|---|---|
+| `get_market_data_service_v2` | CRITICAL | 15 | 6 processes, 2 modules | Route surface is migrated, but dashboard helper callers remain active and the compatibility getter remains a live seam |
+| `get_data_service` | CRITICAL | 3 | 7 processes, 2 modules | Indicator/strategy data seam; needs design packet before edits |
+| `get_wencai_service` | LOW | 0 | 0 processes, 0 modules | No active route/test surface found; this is not a route-surface DI pilot without an ownership/usefulness decision |
+| `get_unified_data_service` | MEDIUM | 5 | 0 processes, 1 module | Service-internal helper seam, not a route-provider migration candidate |
+
+## MarketDataServiceV2 Compatibility Boundary
+
+Current text guard for the `MarketDataServiceV2` seam:
+
+| File | Direct compatibility getter refs | Dependency provider refs | Installer refs | State key refs | Interpretation |
+|---|---:|---:|---:|---:|---|
+| `web/backend/app/api/market_v2.py` | 0 | 14 | 0 | 0 | 13 route params plus import; route surface migrated |
+| `web/backend/app/api/dashboard_data_source.py` | 3 | 0 | 0 | 0 | import plus 2 non-route helper calls; intentionally unchanged |
+| `web/backend/app/services/market_data_service_v2.py` | 2 | 1 | 2 | 3 | service-owned provider and compatibility surface |
+| `web/backend/tests/test_market_data_service_v2_lifecycle_di.py` | 1 | 1 | 1 | 2 | focused compatibility/provider test coverage |
+
+This means route-surface DI migration is closed for `market_v2.py`, but the
+module-level compatibility getter is still an intentional surface until a later
+decision packet classifies dashboard helper, service-owned, and test references.
+
+## Decision
+
+No direct next service DI implementation candidate is selected by G2.29.
+
+Rationale:
+
+- The broad market/data/strategy/dashboard seams remain HIGH or CRITICAL by
+  GitNexus, or are text-scan active across API/test/non-route surfaces.
+- Completed route-surface DI files still appear in scans because their
+  compatibility getters and dependency providers are intentionally retained.
+- `get_wencai_service` and similar zero-route-hit files are not automatically
+  safe implementation candidates; they need ownership/usefulness decisions
+  before route-provider work.
+- The narrowest actionable follow-up after G2.28 is the
+  `MarketDataServiceV2` compatibility getter and dashboard helper consumer
+  boundary.
+
+Selected next lane:
+
+**G2.30 `MarketDataServiceV2` compatibility getter / dashboard helper consumer
+matrix packet.**
+
+This is a decision-only next lane. It should decide whether
+`get_market_data_service_v2()` remains:
+
+- active dashboard-helper compatibility,
+- test-only fallback,
+- package-internal fallback,
+- future dashboard provider migration candidate,
+- or future retire/delete candidate.
+
+## Required G2.30 Scope
+
+The G2.30 packet should:
+
+1. Enumerate all `MarketDataServiceV2` getter, dependency-provider, installer,
+   state-key, import, route, dashboard helper, and test references at current
+   HEAD.
+2. Separate route dependency-provider references from direct compatibility
+   getter calls.
+3. Classify the two `dashboard_data_source.py` helper callers as active
+   compatibility, future provider migration, or intentionally retained
+   non-route helper surface.
+4. Confirm `market_v2.py` stays at route direct getter calls=`0`.
+5. Decide whether a future implementation packet is warranted.
+6. If future implementation is warranted, require a separate authorization
+   packet with GitNexus impact, exact write scope, tests, rollback plan, and
+   forbidden scope.
+
+## Non-Goals
+
+- No backend source, test, route, OpenAPI, generated-client, frontend, PM2, or
+  runtime changes
+- No OpenSpec change or archive operation
+- No issue label movement or `ready-for-agent` movement
+- No dashboard helper migration
+- No compatibility getter deletion
+- No broad market/data/strategy seam implementation
+- No direct implementation selection for `wencai_service`,
+  `unified_data_service`, or `advanced_analysis_service`
+
+## Next Gate
+
+Human review of this G2.29 refresh packet.
+
+If accepted, prepare G2.30 as a decision-only `MarketDataServiceV2`
+compatibility getter / dashboard helper consumer matrix packet. Source edits
+remain locked until a later implementation authorization packet is approved.

--- a/governance/mainline/task-cards/pr-169.yaml
+++ b/governance/mainline/task-cards/pr-169.yaml
@@ -1,0 +1,101 @@
+version: "v0.2"
+
+task:
+  id: "pr-169"
+  title: "Refresh service lifecycle DI candidates after MarketDataServiceV2"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-service-lifecycle-di-candidate-refresh-after-market-data-v2"
+  objective: "record current-head service lifecycle DI candidate evidence after the MarketDataServiceV2 route-provider closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-di-candidate-refresh"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-di-candidate-refresh-after-market-data-v2"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate refresh records service lifecycle DI evidence and next decision gate only; no runtime entrypoint, route, OpenAPI behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-169.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No next service DI implementation authorization in this PR"
+  - "No dashboard helper migration, adapter migration, service consolidation, or compatibility getter cleanup in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-169.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the candidate-refresh boundary"
+    - "If this PR authorizes a direct implementation candidate, it bypasses the separate authorization gate"
+    - "If zero-route-hit getters are treated as implementation-ready, the plan may conflate ownership triage with route-provider migration"
+  rollback_plan: "revert this governance-only PR; PR #168 closeout and PR #167 implementation remain merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record current-head service lifecycle DI candidate evidence after MarketDataServiceV2 route-provider closeout"
+    modified_scope: "candidate refresh report, generated evidence artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; get_market_data_service_v2 remains compatibility getter and dashboard helper callers remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only candidate refresh PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T16:05:54+08:00"
+    approval_note: "human maintainer approved continuing after PR #168 closeout; this packet refreshes candidates and selects only a decision-only next lane"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records G2.29 current-head service lifecycle DI candidate refresh after PR #168 / MarketDataServiceV2 route-provider closeout
- adds structured evidence for 152 service files, 20 narrow candidate files, and 5 completed route-surface DI seams
- selects only a future G2.30 MarketDataServiceV2 compatibility getter / dashboard helper consumer matrix packet before any source edits

## Verification
- markdown governance: checked_files=2, errors=0
- JSON parse: passed
- YAML parse: passed
- git diff --check HEAD~1..HEAD: passed
- mainline scope gate: pass=True
- path guard: changed files exactly match pr-169 allowed paths
- GitNexus staged detect_changes before commit: low risk, changed_symbols=0, affected_processes=0

## Boundary
Governance-only candidate refresh. No backend source, tests, route behavior, OpenAPI schema, OpenSpec, PM2/runtime, frontend, docs/API, issue-label, compatibility getter cleanup, dashboard helper migration, or implementation authorization changes.