### PR TITLE
docs: classify MarketDataServiceV2 compatibility consumers

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -476,8 +476,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `backend-market-data-service-v2-route-provider-closeout-2026-05-23.md`,
 │   │   `.planning/codebase/generated/market-data-service-v2-route-provider-closeout-2026-05-23.json`,
 │   │   `backend-service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.md`,
-│   │   `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.json`
-│   ├── State: service-lifecycle-di-candidate-refresh-after-market-data-v2-prepared-for-review
+│   │   `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.json`,
+│   │   `backend-market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.md`,
+│   │   `.planning/codebase/generated/market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.json`
+│   ├── State: market-data-service-v2-consumer-matrix-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -654,11 +656,17 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 completed route-surface DI seams, and selects only a
 │   │                 future G2.30 `MarketDataServiceV2` compatibility getter /
 │   │                 dashboard helper consumer matrix packet before any source
-│   │                 edit
-│   └── Next gate: Human review of the G2.29 candidate-refresh packet; if
-│                  accepted, prepare G2.30 as a decision-only
-│                  `MarketDataServiceV2` compatibility getter / dashboard
-│                  helper consumer matrix packet
+│   │                 edit; PR `#169` merged at
+│   │                 `04e2f7038386dbea1b8fc8bdcb24dd91dc7e9bb1`; G2.30 now
+│   │                 classifies the `MarketDataServiceV2` compatibility getter
+│   │                 as active dashboard-helper compatibility surface, keeps
+│   │                 route direct getter calls at `0`, records 2 dashboard
+│   │                 helper calls, and selects only a future G2.31 dashboard
+│   │                 helper provider migration authorization packet before any
+│   │                 source edit
+│   └── Next gate: Human review of the G2.30 consumer matrix; if accepted,
+│                  prepare G2.31 dashboard helper provider migration
+│                  authorization before any source edits
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -726,7 +734,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md` | G | G2.26 authorization packet prepared at `46507955f`: future source scope is limited to `market_data_service_v2.py`, `market_v2.py`, focused lifecycle tests, implementation evidence, and a future task card; dashboard, adapter, market-data package, service consolidation, route/OpenAPI, frontend, PM2, and OpenSpec work remain excluded | Human review; if accepted, create a separate implementation branch before source edits |
 | `backend-market-data-service-v2-route-provider-implementation-2026-05-23.md` | G | G2.27 implementation merged by PR `#167` at `8120f01a7022472b604f525ac9af2a517150c39b`: app-state provider seam added to `market_data_service_v2.py`, 13 `market_v2.py` route-local getter calls converted to injected `MarketDataServiceV2`, compatibility getter retained, and 2 dashboard helper callers intentionally left unchanged | Superseded by G2.28 closeout packet |
 | `backend-market-data-service-v2-route-provider-closeout-2026-05-23.md` | G | G2.28 closeout merged by PR `#168` at `e79029ff99e8c3ee674d07efd8b1601e7deb32e0`: PR `#167` merge recorded, focused lifecycle DI test `4 passed`, ruff and black passed, `app.main` import passed, OpenAPI smoke reports paths=`500`, `/api/v2/market` paths=`13`, duplicate operationIds=`0`, `market_v2.py` direct route getter calls=`0`, and `dashboard_data_source.py` helper calls remain `2` | Superseded by G2.29 candidate refresh packet |
-| `backend-service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.md` | G | G2.29 candidate refresh prepared at `e79029ff99e8`: scanned 152 service files, recorded 20 narrow candidate files, 5 completed route-surface DI seams, GitNexus `get_market_data_service_v2` remains CRITICAL because dashboard helper callers are active, and no direct implementation candidate is selected | Human review; if accepted, create G2.30 `MarketDataServiceV2` compatibility getter / dashboard helper consumer matrix packet before source edits |
+| `backend-service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.md` | G | G2.29 candidate refresh merged by PR `#169` at `04e2f7038386dbea1b8fc8bdcb24dd91dc7e9bb1`: scanned 152 service files, recorded 20 narrow candidate files, 5 completed route-surface DI seams, GitNexus `get_market_data_service_v2` remains CRITICAL because dashboard helper callers are active, and no direct implementation candidate is selected | Superseded by G2.30 consumer matrix packet |
+| `backend-market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.md` | G | G2.30 consumer matrix prepared at `04e2f7038386`: `market_v2.py` route direct getter calls remain `0`, `dashboard_data_source.py` has import plus 2 non-route helper getter calls, the installer still uses the compatibility getter as fallback, GitNexus reports getter CRITICAL while provider/installer targets are not indexed, and no cleanup or dashboard helper migration implementation is authorized | Human review; if accepted, create G2.31 dashboard helper provider migration authorization before source edits |
 
 ## Completed And Reviewed Ledger
 
@@ -819,7 +828,8 @@ review, PR review, or OpenSpec archive review.
 | G2.26 MarketDataServiceV2 route-provider implementation authorization | G/#79 | Authorize exact future implementation boundary for `MarketDataServiceV2` route-provider DI | Review-ready: PR `#165` merged at `46507955f77a3166491bd4510c56ef034b6ff1cb`; GitNexus rates `get_market_data_service_v2` CRITICAL with 18 impacted symbols and 15 direct callers; future write scope is limited to `market_data_service_v2.py`, `market_v2.py`, focused lifecycle tests, implementation evidence, and a future task card; this packet performs no source edits | `docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-authorization-2026-05-23.md`; `.planning/codebase/generated/market-data-service-v2-route-provider-implementation-authorization-2026-05-23.json` | Human review; if accepted, create a separate implementation branch before source edits |
 | G2.27 MarketDataServiceV2 route-provider lifecycle DI | G/#79 | Implement the approved route-provider DI seam for `MarketDataServiceV2` | Merged by PR `#167` at `8120f01a7022472b604f525ac9af2a517150c39b`: `market_v2.py` route-local getter calls are now `0`, 13 route handlers accept injected `MarketDataServiceV2`, `get_market_data_service_v2()` remains as compatibility getter, and `dashboard_data_source.py` helper callers remain unchanged | `docs/reports/quality/backend-market-data-service-v2-route-provider-implementation-2026-05-23.md`; focused lifecycle DI test file | Superseded by G2.28 closeout packet |
 | G2.28 MarketDataServiceV2 route-provider closeout | G/#79 | Record the PR `#167` merge result and post-merge route/OpenAPI stability | Reviewed and merged by PR `#168` at `e79029ff99e8c3ee674d07efd8b1601e7deb32e0`: no backend source/test/runtime/OpenSpec/issue-label changes; post-merge scan shows `0` direct route getter calls in `market_v2.py`, 13 injected route params, and 2 dashboard helper compatibility calls unchanged; focused lifecycle DI test `4 passed`; ruff/black passed; `app.main` import passed; OpenAPI paths=`500`, `/api/v2/market` paths=`13`, duplicate operationIds=`0` | `docs/reports/quality/backend-market-data-service-v2-route-provider-closeout-2026-05-23.md`; `.planning/codebase/generated/market-data-service-v2-route-provider-closeout-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/168 | Superseded by G2.29 candidate refresh packet |
-| G2.29 service lifecycle DI candidate refresh after MarketDataServiceV2 | G/#79 | Refresh current-head service lifecycle DI candidates after MarketDataServiceV2 route-provider closeout | Review-ready: service scan at `e79029ff99e8` covers 152 service files, records 20 narrow candidate files and 5 completed route-surface DI seams; `market_v2.py` direct getter calls remain `0`, `dashboard_data_source.py` helper getter calls remain `2`, GitNexus still rates `get_market_data_service_v2` CRITICAL, and no direct source implementation is authorized | `docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.md`; `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.json` | Human review; if accepted, create G2.30 `MarketDataServiceV2` compatibility getter / dashboard helper consumer matrix packet before source edits |
+| G2.29 service lifecycle DI candidate refresh after MarketDataServiceV2 | G/#79 | Refresh current-head service lifecycle DI candidates after MarketDataServiceV2 route-provider closeout | Reviewed and merged by PR `#169` at `04e2f7038386dbea1b8fc8bdcb24dd91dc7e9bb1`: service scan covers 152 service files, records 20 narrow candidate files and 5 completed route-surface DI seams; `market_v2.py` direct getter calls remain `0`, `dashboard_data_source.py` helper getter calls remain `2`, GitNexus still rates `get_market_data_service_v2` CRITICAL, and no direct source implementation is authorized | `docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.md`; `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.json`; https://github.com/chengjon/mystocks/pull/169 | Superseded by G2.30 consumer matrix packet |
+| G2.30 MarketDataServiceV2 compatibility getter consumer matrix | G/#79 | Decide whether `get_market_data_service_v2()` cleanup is authorized after route-provider DI | Review-ready: route direct getter calls remain `0`; `market_v2.py` provider refs are `14`; `dashboard_data_source.py` has import plus two active non-route helper calls; tests cover provider/fallback behavior; `get_market_data_service_v2()` remains active dashboard-helper compatibility surface; no source/test/route cleanup implementation is authorized | `docs/reports/quality/backend-market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.md`; `.planning/codebase/generated/market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.json` | Human review; if accepted, create G2.31 dashboard helper provider migration authorization before source edits |
 
 ## OpenSpec Branch Register
 
@@ -901,7 +911,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Reconcile schema shim closure after runtime unblock | `sequence-backend-architecture-unblocks` then future schema branch | Complete; next gate is route/OpenAPI evidence refresh and later shim-retirement decision |
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
-| P2 | Review G2.29 service lifecycle DI candidate refresh after `MarketDataServiceV2` | Future service seam lane | PR `#168` merged; G2.29 refresh is review-ready and selects only a future G2.30 `MarketDataServiceV2` compatibility getter / dashboard helper consumer matrix packet, with no source implementation authorized |
+| P2 | Review G2.30 `MarketDataServiceV2` compatibility getter consumer matrix | Future service seam lane | PR `#169` merged; G2.30 matrix is review-ready and keeps `get_market_data_service_v2()` as active dashboard-helper compatibility surface while selecting only a future G2.31 dashboard helper provider migration authorization packet |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/generated/market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.json
+++ b/.planning/codebase/generated/market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.json
@@ -1,0 +1,161 @@
+{
+  "artifact": "market-data-service-v2-compatibility-getter-consumer-matrix",
+  "recorded_at": "2026-05-23T17:25:26+08:00",
+  "workline": "G2.30 MarketDataServiceV2 compatibility getter / dashboard helper consumer matrix",
+  "status": "consumer-matrix-prepared-for-review",
+  "current_head": "04e2f7038386dbea1b8fc8bdcb24dd91dc7e9bb1",
+  "parent_issue": {
+    "number": 92,
+    "state": "OPEN",
+    "labels": [
+      "enhancement",
+      "ready-for-human",
+      "ready-for-downstream"
+    ],
+    "url": "https://github.com/chengjon/mystocks/issues/92"
+  },
+  "service_lifecycle_issue": {
+    "number": 79,
+    "state": "OPEN",
+    "labels": [
+      "needs-triage"
+    ],
+    "url": "https://github.com/chengjon/mystocks/issues/79"
+  },
+  "merged_input": {
+    "pr_169": {
+      "state": "MERGED",
+      "merge_commit": "04e2f7038386dbea1b8fc8bdcb24dd91dc7e9bb1",
+      "merged_at": "2026-05-23T09:21:50Z"
+    }
+  },
+  "scan_tokens": [
+    "get_market_data_service_v2",
+    "get_market_data_service_v2_dependency",
+    "install_market_data_service_v2",
+    "MARKET_DATA_SERVICE_V2_STATE_KEY",
+    "MarketDataServiceV2"
+  ],
+  "consumer_summary": {
+    "route_files": {
+      "files_with_matches": 2,
+      "interpretation": "market_v2.py uses provider refs; dashboard_data_source.py still uses compatibility getter"
+    },
+    "service_files": {
+      "files_with_matches": 1,
+      "interpretation": "definition, installer, provider, state key, and compatibility getter surface"
+    },
+    "test_files": {
+      "files_with_matches": 3,
+      "interpretation": "provider lifecycle, runtime fallback, and file-level API integration references"
+    },
+    "governance_docs": {
+      "files_with_matches": 23,
+      "interpretation": "historical/planning evidence only; not runtime consumers"
+    }
+  },
+  "runtime_and_test_token_totals_excluding_governance": {
+    "get_market_data_service_v2": 6,
+    "get_market_data_service_v2_dependency": 16,
+    "install_market_data_service_v2": 3,
+    "MARKET_DATA_SERVICE_V2_STATE_KEY": 5,
+    "MarketDataServiceV2": 25
+  },
+  "route_and_api_consumers": [
+    {
+      "file": "web/backend/app/api/market_v2.py",
+      "consumers": [
+        "get_fund_flow",
+        "refresh_fund_flow",
+        "get_etf_list",
+        "refresh_etf_spot",
+        "get_lhb_detail",
+        "refresh_lhb_detail",
+        "get_sector_fund_flow",
+        "refresh_sector_fund_flow",
+        "get_stock_dividend",
+        "refresh_stock_dividend",
+        "get_stock_blocktrade",
+        "refresh_stock_blocktrade",
+        "refresh_all_market_data"
+      ],
+      "direct_compatibility_getter_calls": 0,
+      "dependency_provider_refs": 14,
+      "injected_route_params": 13,
+      "decision": "Keep provider refs; route-surface DI is complete"
+    },
+    {
+      "file": "web/backend/app/api/dashboard_data_source.py",
+      "consumers": [
+        "module import",
+        "_get_market_overview_data",
+        "prewarm_dashboard_market_overview_cache"
+      ],
+      "direct_compatibility_getter_calls": 2,
+      "direct_compatibility_getter_refs_including_import": 3,
+      "dependency_provider_refs": 0,
+      "decision": "Keep as active dashboard-helper compatibility surface until a separate provider-migration packet is approved"
+    }
+  ],
+  "service_surface": {
+    "file": "web/backend/app/services/market_data_service_v2.py",
+    "defines_class": true,
+    "defines_compatibility_getter": true,
+    "defines_dependency_provider": true,
+    "defines_installer": true,
+    "defines_state_key": true,
+    "installer_fallback_uses_getter": true,
+    "decision": "Keep all current symbols as active compatibility/provider surface"
+  },
+  "test_consumers": [
+    {
+      "file": "web/backend/tests/test_market_data_service_v2_lifecycle_di.py",
+      "role": "provider/installer lifecycle test; monkeypatches compatibility getter",
+      "direct_getter_calls": 1,
+      "decision": "Keep"
+    },
+    {
+      "file": "web/backend/tests/services/test_market_data_service_v2_runtime_fallback.py",
+      "role": "runtime fallback tests instantiate MarketDataServiceV2 directly",
+      "direct_getter_calls": 0,
+      "decision": "Keep"
+    },
+    {
+      "file": "tests/api/file_tests/test_market_v2_api.py",
+      "role": "file-level API integration test mention",
+      "direct_getter_calls": 0,
+      "decision": "Keep as historical/file-level test reference"
+    }
+  ],
+  "gitnexus_evidence": [
+    {
+      "target": "get_market_data_service_v2",
+      "result": "CRITICAL; direct impact 15; processes affected 6; modules affected 2",
+      "interpretation": "partly graph/text divergence for market_v2.py route callers, while dashboard helper calls remain real active compatibility consumers"
+    },
+    {
+      "target": "get_market_data_service_v2_dependency",
+      "result": "Target not found",
+      "interpretation": "post-DI provider symbol not exposed in current GitNexus index"
+    },
+    {
+      "target": "install_market_data_service_v2",
+      "result": "Target not found",
+      "interpretation": "post-DI installer symbol not exposed in current GitNexus index"
+    },
+    {
+      "target": "MarketDataServiceV2",
+      "result": "LOW; direct impact 0",
+      "interpretation": "class-level graph impact is not enough to justify deleting module-level compatibility functions"
+    }
+  ],
+  "decision": {
+    "compatibility_getter_status": "active dashboard-helper compatibility surface",
+    "cleanup_implementation_authorized": false,
+    "dashboard_helper_migration_authorized": false,
+    "selected_next_lane": "G2.31 MarketDataServiceV2 dashboard helper provider migration authorization packet",
+    "selected_next_lane_type": "future authorization packet",
+    "source_edits_authorized": false
+  },
+  "next_gate": "Human review of this G2.30 matrix; if accepted, prepare a separate G2.31 dashboard helper provider migration authorization packet before any source edits."
+}

--- a/docs/reports/quality/backend-market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.md
+++ b/docs/reports/quality/backend-market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.md
@@ -1,0 +1,195 @@
+# Backend MarketDataServiceV2 Compatibility Getter Consumer Matrix - 2026-05-23
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: consumer-matrix-prepared-for-review
+- Workline: G2.30 `MarketDataServiceV2` compatibility getter / dashboard
+  helper consumer matrix
+- Current HEAD: `04e2f7038386dbea1b8fc8bdcb24dd91dc7e9bb1`
+- Parent issue: `#92`
+- Service lifecycle issue: `#79`
+- PR `#169`: MERGED at `2026-05-23T09:21:50Z`
+- Execution mode: governance/evidence only
+- Recorded at: `2026-05-23T17:25:26+08:00`
+
+Boundary note: this packet classifies current `MarketDataServiceV2`
+compatibility getter consumers only. It does not authorize backend source edits,
+test edits, route edits, OpenAPI changes, OpenSpec changes, issue label
+movement, `ready-for-agent` movement, PM2/runtime work, dashboard helper
+migration, or compatibility getter deletion.
+
+## Governance Boundary
+
+This packet executes the G2.30 decision lane selected by G2.29. It is a
+consumer matrix and authorization decision, not an implementation branch. It
+does not create a source edit scope by itself.
+
+The packet answers one narrow question: whether
+`get_market_data_service_v2()` can be cleaned up after the `market_v2.py`
+route-surface DI migration.
+
+## Input State
+
+PR `#169` was merged at
+`04e2f7038386dbea1b8fc8bdcb24dd91dc7e9bb1`. That merge recorded:
+
+- 152 service Python files scanned.
+- 20 narrow service lifecycle candidate files.
+- 5 completed route-surface DI seams.
+- `market_v2.py` direct route getter calls remain `0`.
+- `dashboard_data_source.py` still has two non-route helper compatibility
+  calls.
+- No direct next source implementation candidate was selected.
+- This G2.30 consumer-matrix lane before any `MarketDataServiceV2`
+  compatibility getter or dashboard helper source edit.
+
+## Consumer Matrix Summary
+
+The scan looked for:
+
+- `get_market_data_service_v2`
+- `get_market_data_service_v2_dependency`
+- `install_market_data_service_v2`
+- `MARKET_DATA_SERVICE_V2_STATE_KEY`
+- `MarketDataServiceV2`
+
+Scope:
+
+| Area | Files with matches | Interpretation |
+|---|---:|---|
+| Route/API files | 2 | `market_v2.py` uses provider refs; `dashboard_data_source.py` still uses compatibility getter |
+| Service files | 1 | Definition, installer, provider, state key, and compatibility getter surface |
+| Test files | 3 | Provider lifecycle, runtime fallback, and file-level API integration references |
+| Governance docs | 23 | Historical/planning evidence only; not runtime consumers |
+
+Runtime and test token totals, excluding governance docs:
+
+| Token | Count | Meaning |
+|---|---:|---|
+| `get_market_data_service_v2` | 6 | Dashboard helper calls, service definition/fallback, and lifecycle test monkeypatch |
+| `get_market_data_service_v2_dependency` | 16 | Route provider refs, provider definition, and lifecycle test |
+| `install_market_data_service_v2` | 3 | Installer definition, provider fallback, and lifecycle test |
+| `MARKET_DATA_SERVICE_V2_STATE_KEY` | 5 | App-state key used by provider/tests |
+| `MarketDataServiceV2` | 25 | Route type annotations, service class, runtime fallback tests, and API integration mention |
+
+## Route And API Consumers
+
+| File | Consumers | Direct compatibility getter calls | Dependency provider refs | Decision |
+|---|---|---:|---:|---|
+| `web/backend/app/api/market_v2.py` | `get_fund_flow`, `refresh_fund_flow`, `get_etf_list`, `refresh_etf_spot`, `get_lhb_detail`, `refresh_lhb_detail`, `get_sector_fund_flow`, `refresh_sector_fund_flow`, `get_stock_dividend`, `refresh_stock_dividend`, `get_stock_blocktrade`, `refresh_stock_blocktrade`, `refresh_all_market_data` | 0 | 14 | Keep provider refs; route-surface DI is complete |
+| `web/backend/app/api/dashboard_data_source.py` | module import, `_get_market_overview_data`, `prewarm_dashboard_market_overview_cache` | 2 calls plus import | 0 | Keep as active dashboard-helper compatibility surface until a separate provider-migration packet is approved |
+
+Route conclusion: there are no direct route-local calls to
+`get_market_data_service_v2()` in `market_v2.py`. The route surface now depends
+on `get_market_data_service_v2_dependency`, which is the canonical DI provider
+for this lane. The dependency provider is not a cleanup target.
+
+Dashboard conclusion: the two `dashboard_data_source.py` helper calls are active
+non-route compatibility consumers. Treating them as cleanup leftovers would
+exceed the G2.27/G2.28 route-provider boundary.
+
+## Service Surface
+
+| File | Current role | Decision |
+|---|---|---|
+| `web/backend/app/services/market_data_service_v2.py` | Defines `MarketDataServiceV2`, module-level compatibility getter, app-state installer, app-state dependency provider, and state key | Keep all current symbols as active compatibility/provider surface |
+
+The module-level `get_market_data_service_v2()` is still used as the default
+fallback by `install_market_data_service_v2(app, service=None)`. Removing it
+would change the current app-state fallback behavior and would require a
+separate implementation authorization with route/dashboard/test updates.
+
+## Test Consumers
+
+| File | Current role | Direct getter calls | Decision |
+|---|---|---:|---|
+| `web/backend/tests/test_market_data_service_v2_lifecycle_di.py` | App-state provider/installer lifecycle test; monkeypatches `get_market_data_service_v2` and asserts provider/installer behavior | 1 monkeypatch | Keep; it proves fallback and explicit service injection |
+| `web/backend/tests/services/test_market_data_service_v2_runtime_fallback.py` | Runtime fallback tests instantiate `MarketDataServiceV2` directly | 0 | Keep; class-level service behavior coverage |
+| `tests/api/file_tests/test_market_v2_api.py` | File-level API integration test mention of `MarketDataServiceV2` | 0 | Historical/file-level test reference; no getter cleanup implication |
+
+## GitNexus Evidence
+
+| Target | Result | Interpretation |
+|---|---|---|
+| `get_market_data_service_v2` | CRITICAL; direct impact 15; processes affected 6; modules affected 2 | Graph still reports `market_v2.py` route callers plus dashboard helper callers; current text guard shows route direct calls are `0`, so this is partly graph/text divergence, while dashboard helper calls remain real active compatibility consumers |
+| `get_market_data_service_v2_dependency` | Target not found | GitNexus index does not yet expose this post-DI provider symbol; use text matrix until index refresh validates it |
+| `install_market_data_service_v2` | Target not found | GitNexus index does not yet expose this post-DI installer symbol; use text matrix until index refresh validates it |
+| `MarketDataServiceV2` | LOW; direct impact 0 | Class-level graph impact is not enough to justify deleting module-level compatibility functions |
+
+## Decision
+
+`get_market_data_service_v2()` remains **active dashboard-helper compatibility
+surface**.
+
+No `MarketDataServiceV2` compatibility getter cleanup implementation is
+authorized by this packet.
+
+Reasons:
+
+- `market_v2.py` has `0` direct `get_market_data_service_v2()` calls, so there
+  is no route-local cleanup left.
+- `market_v2.py` intentionally uses `get_market_data_service_v2_dependency`;
+  that provider is the canonical DI seam, not a legacy getter.
+- `dashboard_data_source.py` still has two active non-route helper calls.
+- Tests still validate the compatibility getter, installer, provider, and
+  app-state fallback behavior.
+- `install_market_data_service_v2(app, service=None)` currently uses
+  `get_market_data_service_v2()` as its default fallback.
+- GitNexus still reports `get_market_data_service_v2` as CRITICAL; this must not
+  be treated as deletion proof.
+
+Selected next lane:
+
+**G2.31 `MarketDataServiceV2` dashboard helper provider migration authorization
+packet.**
+
+This is a future authorization packet, not an implementation step in this PR.
+It should decide whether the two `dashboard_data_source.py` helper calls can be
+migrated to a provider/app-state seam without changing route behavior,
+OpenAPI schema, frontend contracts, or dashboard cache semantics.
+
+## Future Scope If Dashboard Helper Migration Is Requested
+
+Any future dashboard helper provider migration requires a separate
+implementation authorization after human review. Its candidate write scope must
+be explicit and should not include `market_v2.py` unless a future approved plan
+changes the provider strategy.
+
+Minimum future evidence before source edits:
+
+1. Fresh text matrix showing direct getter calls, provider references, installer
+   references, package exports, dashboard helper references, and tests.
+2. GitNexus index refresh or an explicit graph-staleness note.
+3. A decision on whether the compatibility getter is public API,
+   dashboard-helper fallback, test-only fallback, package-internal fallback, or
+   retirement candidate.
+4. Focused tests covering:
+   - `web/backend/tests/test_market_data_service_v2_lifecycle_di.py`
+   - `web/backend/tests/services/test_market_data_service_v2_runtime_fallback.py`
+   - dashboard data-source behavior for `_get_market_overview_data`
+   - dashboard prewarm behavior for `prewarm_dashboard_market_overview_cache`
+5. Rollback plan preserving `market_v2.py` route DI provider behavior and
+   dashboard cache/prewarm behavior.
+
+## Explicit Non-Goals
+
+- No backend source edits
+- No test edits
+- No route/OpenAPI/docs/API/generated client edits
+- No dashboard helper migration
+- No compatibility getter deletion, rename, or privatization
+- No issue label movement
+- No OpenSpec proposal creation or archive
+- No PM2/runtime verification
+
+## Next Gate
+
+Human review of this G2.30 matrix.
+
+If accepted, keep `get_market_data_service_v2()` as active dashboard-helper
+compatibility surface and prepare a separate G2.31 dashboard helper provider
+migration authorization packet before any source edits.

--- a/governance/mainline/task-cards/pr-170.yaml
+++ b/governance/mainline/task-cards/pr-170.yaml
@@ -1,0 +1,101 @@
+version: "v0.2"
+
+task:
+  id: "pr-170"
+  title: "Classify MarketDataServiceV2 compatibility getter consumers"
+  owner: "main"
+  created_at: "2026-05-23"
+
+mainline:
+  id: "L1-market-data-service-v2-compatibility-getter-consumer-matrix"
+  objective: "classify MarketDataServiceV2 compatibility getter and dashboard helper consumers after route-provider DI"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-market-data-service-v2-consumer-matrix"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-market-data-service-v2-consumer-matrix"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Consumer matrix records compatibility getter evidence and next decision gate only; no runtime entrypoint, route, OpenAPI behavior, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.json"
+    - "docs/reports/quality/backend-market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.md"
+    - "governance/mainline/task-cards/pr-170.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No dashboard helper migration implementation in this PR"
+  - "No compatibility getter deletion, rename, privatization, or cleanup implementation in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-170.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the consumer-matrix boundary"
+    - "If this PR authorizes dashboard helper migration implementation, it bypasses the separate authorization gate"
+    - "If the compatibility getter is deleted or privatized from this packet, dashboard helper and fallback behavior can break"
+  rollback_plan: "revert this governance-only PR; PR #169 candidate refresh and earlier MarketDataServiceV2 route-provider implementation remain merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "classify MarketDataServiceV2 compatibility getter and dashboard helper consumers"
+    modified_scope: "consumer matrix report, generated evidence artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; get_market_data_service_v2 remains active dashboard-helper compatibility surface"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only consumer matrix PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-23T17:25:26+08:00"
+    approval_note: "human maintainer approved continuing after PR #169; this packet classifies consumers and selects only a future authorization lane"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Add the G2.30 MarketDataServiceV2 compatibility getter and dashboard helper consumer matrix.
- Record that get_market_data_service_v2() remains an active dashboard-helper compatibility surface, with no cleanup/delete/privatize authorization in this PR.
- Update the codebase-map task tree and add the mainline task card for the next G2.31 authorization-only dashboard helper provider migration packet.

## Verification
- markdown governance gate: checked_files=2, errors=0
- JSON artifact parse: passed
- YAML task card parse: passed
- git diff --check HEAD~1..HEAD: passed
- mainline scope gate: pass=true for PR 170 task card
- path guard: exact governance/report/generated paths only
- GitNexus staged detect_changes: LOW risk, changed_symbols=0, affected_processes=0

## Boundary
- Governance and evidence only.
- Does not edit backend source, tests, route handlers, OpenAPI runtime, OpenSpec specs, PM2/frontend/docs/API, issue labels, or compatibility getter behavior.
- Does not authorize dashboard helper source migration; that remains a future G2.31 authorization packet.