### PR TITLE
refactor(tdx): inject route provider dependency

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -718,14 +718,20 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 unrelated local `TdxDataService()` usage, and keeps
 │   │                 `get_tdx_service()` active with no source edits; G2.38
 │   │                 merged by PR `#178` at
-│   │                 `30c78a22dce5879396dfd5c7760cc61161377528`; G2.39 now
-│   │                 authorizes only a future `/api/v1/tdx` route-provider
+│   │                 `30c78a22dce5879396dfd5c7760cc61161377528`; G2.39
+│   │                 authorized only a future `/api/v1/tdx` route-provider
 │   │                 migration scope: `tdx_service.py`, `api/tdx.py`, focused
 │   │                 lifecycle DI tests, implementation evidence, and a future
-│   │                 task card; `get_tdx_service()` remains active
-│   └── Next gate: Human review of the G2.39 authorization packet; if accepted,
-│                  create a separate G2.40 implementation branch before source
-│                  edits
+│   │                 task card; `get_tdx_service()` remains active; G2.40 now
+│   │                 implements that scope by adding
+│   │                 `TDX_SERVICE_STATE_KEY` and
+│   │                 `get_tdx_service_dependency`, converting the five
+│   │                 `/api/v1/tdx` dependencies to the provider, keeping
+│   │                 OpenAPI paths at `500`, duplicate operation IDs at `0`,
+│   │                 and focused lifecycle DI tests at `4 passed`
+│   └── Next gate: Human review of the G2.40 implementation PR; if accepted,
+│                  merge and run a G2.41 closeout or current-head candidate
+│                  refresh before selecting the next service lifecycle DI lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -804,6 +810,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-di-candidate-refresh-after-tdx-helper-2026-05-23.md` | G | G2.37 candidate refresh reviewed and merged by PR `#177` at `f0f761ffb7d848b8e9a8e5a492ab82f763870086`: scans `152` service files and `18` candidate/signal files; records direct dashboard helper TDX getter calls at `0`, private `_get_tdx_service()` calls at `3`, `/api/tdx` `Depends(get_tdx_service)` sites at `5`, GitNexus spot checks for nine singleton getters, and no implementation lane selection | Superseded by G2.38 TDX route dependency consumer matrix |
 | `backend-tdx-route-dependency-consumer-matrix-2026-05-23.md` | G | G2.38 consumer matrix reviewed and merged by PR `#178` at `30c78a22dce5879396dfd5c7760cc61161377528`: OpenAPI paths=`500`, duplicate operation IDs=`0`, TDX paths=`7`; `/api/v1/tdx` has five active `Depends(get_tdx_service)` route consumers, `/api/ml/tdx` is unrelated local `TdxDataService()` usage, dashboard helper keeps `get_tdx_service` as default provider fallback, and `get_tdx_service()` must not be retired by this line | Superseded by G2.39 TDX route provider migration authorization |
 | `backend-tdx-route-provider-migration-authorization-2026-05-23.md` | G | G2.39 authorization prepared at current HEAD `30c78a22dce5879396dfd5c7760cc61161377528`: future implementation scope is limited to `tdx_service.py`, `api/tdx.py`, `web/backend/tests/test_tdx_service_lifecycle_di.py`, implementation evidence, and a future task card; it may add `TDX_SERVICE_STATE_KEY` and `get_tdx_service_dependency`, convert five `/api/v1/tdx` route dependencies, and must preserve `get_tdx_service()` compatibility fallback | Human review; if accepted, create G2.40 TDX route provider migration implementation branch before source edits |
+| `backend-tdx-route-provider-migration-implementation-2026-05-24.md` | G | G2.40 implementation prepared from G2.39 authorization at base `e4dc9088cabfb4dba756beb109294980c047c327`: adds `TDX_SERVICE_STATE_KEY` and `get_tdx_service_dependency(request)`, keeps `get_tdx_service()` as public fallback, converts exactly five `/api/v1/tdx` `Depends(get_tdx_service)` sites to `Depends(get_tdx_service_dependency)`, focused TDD ended at `4 passed`, ruff/black passed, `app.main` routes=`548`, OpenAPI paths=`500`, duplicate operation IDs=`0`, and TDX paths=`7` | Human review / PR merge decision; if accepted, run G2.41 closeout or current-head candidate refresh before selecting the next service lifecycle DI lane |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/tdx-route-provider-migration-implementation-2026-05-24.json
+++ b/.planning/codebase/generated/tdx-route-provider-migration-implementation-2026-05-24.json
@@ -1,0 +1,92 @@
+{
+  "artifact": "tdx-route-provider-migration-implementation",
+  "generated_at": "2026-05-24T00:34:22+08:00",
+  "workline": "G2.40",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "e4dc9088cabfb4dba756beb109294980c047c327",
+  "parent_authorization": {
+    "workline": "G2.39",
+    "pull_request": 179,
+    "merge_commit": "e4dc9088cabfb4dba756beb109294980c047c327"
+  },
+  "scope": {
+    "modified_source_files": [
+      "web/backend/app/services/tdx_service.py",
+      "web/backend/app/api/tdx.py"
+    ],
+    "modified_test_files": [
+      "web/backend/tests/test_tdx_service_lifecycle_di.py"
+    ],
+    "modified_governance_files": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      "docs/reports/quality/backend-tdx-route-provider-migration-implementation-2026-05-24.md",
+      "governance/mainline/task-cards/pr-180.yaml"
+    ],
+    "forbidden_paths_touched": []
+  },
+  "implementation": {
+    "state_key": "TDX_SERVICE_STATE_KEY",
+    "dependency_provider": "get_tdx_service_dependency",
+    "legacy_getter_retained": true,
+    "route_dependencies_converted": 5,
+    "route_paths_changed": false,
+    "response_models_changed": false,
+    "openapi_exposure_changed": false
+  },
+  "tdd": {
+    "red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tdx_service_lifecycle_di.py -q -n 0 --tb=short --no-cov",
+      "result": "3 failed, 1 passed",
+      "expected_failure_reason": "missing provider/state-key and old route dependency wiring"
+    },
+    "green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tdx_service_lifecycle_di.py -q -n 0 --tb=short --no-cov",
+      "result": "4 passed in 1.02s"
+    }
+  },
+  "guards": {
+    "dependency_counts": {
+      "api_depends_legacy": 0,
+      "api_depends_provider": 5,
+      "api_legacy_identifier_excluding_provider": 0,
+      "service_provider_def": 1,
+      "service_legacy_getter_def": 1,
+      "service_installer_def": 1,
+      "service_state_key_mentions": 4
+    },
+    "openapi_smoke": {
+      "routes_total": 548,
+      "openapi_paths_total": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "tdx_paths_count": 7,
+      "tdx_paths": [
+        "/api/ml/tdx/data",
+        "/api/ml/tdx/stocks/{market}",
+        "/api/v1/tdx/health",
+        "/api/v1/tdx/index/kline",
+        "/api/v1/tdx/index/quote/{symbol}",
+        "/api/v1/tdx/kline",
+        "/api/v1/tdx/quote/{symbol}"
+      ]
+    }
+  },
+  "verification": {
+    "focused_pytest": "passed",
+    "ruff_touched": "passed",
+    "black_check_touched": "passed",
+    "app_main_openapi_smoke": "passed",
+    "duplicate_operation_ids": 0,
+    "staged_gitnexus": {
+      "changed_files": 7,
+      "changed_symbols": 18,
+      "affected_count": 1,
+      "risk_level": "medium",
+      "affected_processes": [
+        "Prewarm_dashboard_market_overview_cache -> Warning"
+      ],
+      "high_or_critical": false
+    }
+  },
+  "next_gate": "human_review_then_merge_decision"
+}

--- a/docs/reports/quality/backend-tdx-route-provider-migration-implementation-2026-05-24.md
+++ b/docs/reports/quality/backend-tdx-route-provider-migration-implementation-2026-05-24.md
@@ -1,0 +1,144 @@
+# Backend TDX Route Provider Migration Implementation - 2026-05-24
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+- Workline: G2.40 TDX route provider migration implementation
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD: `e4dc9088cabfb4dba756beb109294980c047c327`
+- Parent approval: G2.39 authorization packet, PR `#179`
+- Scope: approved source implementation plus focused lifecycle DI tests and evidence
+
+## Decision Boundary
+
+This implementation applies the G2.39 authorization only.
+
+Implemented:
+
+- added `TDX_SERVICE_STATE_KEY = "tdx_service"`;
+- kept `get_tdx_service()` as the compatibility fallback getter;
+- updated `install_tdx_service(app, service=None)` to read/write the named app-state key;
+- added `get_tdx_service_dependency(request: Request) -> TdxService`;
+- converted exactly five `/api/v1/tdx` route handler dependencies from `Depends(get_tdx_service)` to `Depends(get_tdx_service_dependency)`;
+- added focused tests for provider fallback installation, explicit installer override, route dependency wiring, and injected route use.
+
+Not implemented:
+
+- no deletion or retirement of `get_tdx_service()`;
+- no changes to `dashboard_data_source.py`, `api/ml.py`, `main.py`, adapters, frontend, PM2, OpenSpec, issue labels, route paths, response models, or OpenAPI exposure;
+- no compatibility wrapper cleanup.
+
+## TDD Evidence
+
+RED command:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tdx_service_lifecycle_di.py -q -n 0 --tb=short --no-cov
+```
+
+RED result:
+
+- `3 failed, 1 passed`
+- expected failures: missing `get_tdx_service_dependency`, missing `TDX_SERVICE_STATE_KEY`, and route dependencies still pointing at `get_tdx_service`.
+
+GREEN command:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tdx_service_lifecycle_di.py -q -n 0 --tb=short --no-cov
+```
+
+GREEN result:
+
+- `4 passed in 1.02s`
+
+## Guard Evidence
+
+Text guard result:
+
+```json
+{
+  "api_depends_legacy": 0,
+  "api_depends_provider": 5,
+  "api_legacy_identifier_excluding_provider": 0,
+  "service_provider_def": 1,
+  "service_legacy_getter_def": 1,
+  "service_installer_def": 1,
+  "service_state_key_mentions": 4
+}
+```
+
+OpenAPI smoke result:
+
+```json
+{
+  "routes_total": 548,
+  "openapi_paths_total": 500,
+  "operation_ids": 536,
+  "duplicate_operation_ids": 0,
+  "tdx_paths_count": 7,
+  "tdx_paths": [
+    "/api/ml/tdx/data",
+    "/api/ml/tdx/stocks/{market}",
+    "/api/v1/tdx/health",
+    "/api/v1/tdx/index/kline",
+    "/api/v1/tdx/index/quote/{symbol}",
+    "/api/v1/tdx/kline",
+    "/api/v1/tdx/quote/{symbol}"
+  ]
+}
+```
+
+OpenAPI smoke notes:
+
+- `app.main` imported successfully.
+- The `Numba needs NumPy 2.2 or less. Got NumPy 2.4.` GPU warning is pre-existing fallback noise from optional GPU dependencies.
+- Socket.IO initialization log was emitted during import.
+
+## Static Verification
+
+Commands:
+
+```bash
+ruff check web/backend/app/services/tdx_service.py web/backend/app/api/tdx.py web/backend/tests/test_tdx_service_lifecycle_di.py
+black --check web/backend/app/services/tdx_service.py web/backend/app/api/tdx.py web/backend/tests/test_tdx_service_lifecycle_di.py
+```
+
+Results:
+
+- Ruff: `All checks passed!`
+- Black: `3 files would be left unchanged.`
+
+## GitNexus Pre-Edit Evidence
+
+Repository: `g2-40-tdx-route-provider-migration`
+
+- `impact(get_tdx_service, upstream, includeTests=true)`: LOW; direct dependency `install_tdx_service`; no affected execution flows or modules.
+- `impact(install_tdx_service, upstream, includeTests=true)`: LOW; no direct callers detected by graph.
+- `context(get_stock_quote, file_path=web/backend/app/api/tdx.py)`: route symbol located; outgoing `get_real_time_quote`; no incoming process participation.
+- `context(health_check, file_path=web/backend/app/api/tdx.py)`: route symbol located; outgoing `check_connection`; no incoming process participation.
+
+## GitNexus Staged Scope Evidence
+
+Command:
+
+```bash
+gitnexus detect-changes --scope staged
+```
+
+Result:
+
+- changed files: `7`
+- changed symbols: `18`
+- affected count: `1`
+- risk level: `medium`
+- affected process: `Prewarm_dashboard_market_overview_cache -> Warning`
+- no HIGH or CRITICAL risk verdict was reported.
+
+## Rollback
+
+Rollback is a single PR revert. Reverting restores the five route dependencies to `Depends(get_tdx_service)` and removes the new app-state dependency provider while preserving the pre-existing singleton fallback behavior.
+
+## Next Gate
+
+Human review of the implementation PR. If accepted and merged, run a G2.41 closeout or current-head candidate refresh before selecting the next service lifecycle DI lane.

--- a/governance/mainline/task-cards/pr-180.yaml
+++ b/governance/mainline/task-cards/pr-180.yaml
@@ -1,0 +1,125 @@
+version: "v0.2"
+
+task:
+  id: "pr-180"
+  title: "Implement TDX route provider migration"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-tdx-route-provider-migration-implementation"
+  objective: "implement the approved G2.40 TDX route dependency provider migration"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-tdx-route-provider-migration-implementation"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-tdx-route-provider-migration"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Route paths, response models, OpenAPI exposure, and product behavior remain unchanged; only the FastAPI service dependency provider is migrated"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/tdx-route-provider-migration-implementation-2026-05-24.json"
+    - "web/backend/app/services/tdx_service.py"
+    - "web/backend/app/api/tdx.py"
+    - "web/backend/tests/test_tdx_service_lifecycle_di.py"
+    - "docs/reports/quality/backend-tdx-route-provider-migration-implementation-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-180.yaml"
+  forbidden_paths:
+    - "web/backend/app/api/dashboard_data_source.py"
+    - "web/backend/app/api/ml.py"
+    - "web/backend/app/main.py"
+    - "web/backend/app/adapters/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No deletion, retirement, or behavior change for get_tdx_service()"
+  - "No dashboard_data_source.py, api/ml.py, main.py, adapter, frontend, PM2, OpenSpec, issue-label, route path, response model, or OpenAPI exposure changes"
+  - "No compatibility wrapper cleanup"
+  - "No broad service lifecycle DI candidate selection in this PR"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tdx_service_lifecycle_di.py -q -n 0 --tb=short --no-cov"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/tdx_service.py web/backend/app/api/tdx.py web/backend/tests/test_tdx_service_lifecycle_di.py"
+      required: true
+    - id: "black-check-touched"
+      command: "black --check web/backend/app/services/tdx_service.py web/backend/app/api/tdx.py web/backend/tests/test_tdx_service_lifecycle_di.py"
+      required: true
+    - id: "app-main-openapi-smoke"
+      command: "env POSTGRESQL_HOST=localhost POSTGRESQL_USER=test POSTGRESQL_PASSWORD=test JWT_SECRET_KEY=0123456789abcdef0123456789abcdef BACKEND_PORT=8888 BACKEND_BACKUP_PORT=8889 PYTHONPATH=web/backend python -c 'from collections import Counter; from app.main import app; schema=app.openapi(); ids=[spec.get(\"operationId\") for methods in schema.get(\"paths\", {}).values() for spec in methods.values() if isinstance(spec, dict) and spec.get(\"operationId\")]; counts=Counter(ids); print({\"routes_total\": len(app.routes), \"openapi_paths_total\": len(schema.get(\"paths\", {})), \"duplicate_operation_ids\": sum(1 for v in counts.values() if v > 1)})'"
+      required: true
+    - id: "dependency-count-guard"
+      command: "python - <<'PY'\nfrom pathlib import Path\napi = Path('web/backend/app/api/tdx.py').read_text()\nsvc = Path('web/backend/app/services/tdx_service.py').read_text()\nassert api.count('Depends(get_tdx_service)') == 0\nassert api.count('Depends(get_tdx_service_dependency)') == 5\nassert 'def get_tdx_service(' in svc\nassert 'def get_tdx_service_dependency(' in svc\nassert 'TDX_SERVICE_STATE_KEY' in svc\nprint('dependency-count-guard passed')\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-tdx-route-provider-migration-implementation-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/tdx-route-provider-migration-implementation-2026-05-24.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-180.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "gitnexus detect-changes --scope staged"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If a route dependency remains on get_tdx_service(), the public TDX routes are not migrated to app-state provider injection"
+    - "If get_tdx_service() is removed, dashboard helper fallback and external imports can break"
+    - "If dashboard_data_source.py, api/ml.py, main.py, adapters, OpenSpec, or frontend are edited, this PR exceeds the G2.39 authorization"
+  rollback_plan: "revert this PR to restore the five /api/v1/tdx route dependencies to get_tdx_service() and remove the new provider"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "implement approved TDX route provider migration"
+    modified_scope: "tdx_service.py, api/tdx.py, focused lifecycle DI tests, implementation report, JSON artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "get_tdx_service remains public fallback; five /api/v1/tdx dependencies now use get_tdx_service_dependency"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused pytest, ruff, black, app/OpenAPI smoke, dependency guard, mainline scope, staged GitNexus, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T00:34:22+08:00"
+    approval_note: "human maintainer approved continuing after G2.39 authorization; this PR implements only the approved TDX route provider migration scope"
+    secondary_approved: false

--- a/web/backend/app/api/tdx.py
+++ b/web/backend/app/api/tdx.py
@@ -23,7 +23,7 @@ from app.schemas.tdx_schemas import (
     RealTimeQuoteResponse,
     TdxHealthResponse,
 )
-from app.services.tdx_service import TdxService, get_tdx_service
+from app.services.tdx_service import TdxService, get_tdx_service_dependency
 
 router = APIRouter()
 
@@ -241,7 +241,7 @@ TDX_INDEX_KLINE_RESPONSES = {
 async def get_stock_quote(
     symbol: str = Path(..., description="6 位数字股票代码，例如 600519。"),
     current_user: User = Depends(get_current_active_user),
-    service: TdxService = Depends(get_tdx_service),
+    service: TdxService = Depends(get_tdx_service_dependency),
 ):
     """
     获取股票实时行情
@@ -297,7 +297,7 @@ async def get_stock_kline(
     end_date: Optional[str] = Query(None, description="结束日期 YYYY-MM-DD"),
     period: str = Query(default="1d", description="K线周期: 1m/5m/15m/30m/1h/1d"),
     current_user: User = Depends(get_current_active_user),
-    service: TdxService = Depends(get_tdx_service),
+    service: TdxService = Depends(get_tdx_service_dependency),
 ):
     """
     获取股票K线数据
@@ -383,7 +383,7 @@ async def get_stock_kline(
 async def get_index_quote(
     symbol: str = Path(..., description="6 位数字指数代码，例如 000001 或 399001。"),
     current_user: User = Depends(get_current_active_user),
-    service: TdxService = Depends(get_tdx_service),
+    service: TdxService = Depends(get_tdx_service_dependency),
 ):
     """
     获取指数实时行情
@@ -442,7 +442,7 @@ async def get_index_kline(
     end_date: Optional[str] = Query(None, description="结束日期 YYYY-MM-DD"),
     period: str = Query(default="1d", description="K线周期: 1m/5m/15m/30m/1h/1d"),
     current_user: User = Depends(get_current_active_user),
-    service: TdxService = Depends(get_tdx_service),
+    service: TdxService = Depends(get_tdx_service_dependency),
 ):
     """
     获取指数K线数据
@@ -511,7 +511,7 @@ async def get_index_kline(
     description="检查 TDX 服务的连接状态和服务端信息，用于后端运行状态探活与排障。",
     responses=TDX_HEALTH_RESPONSES,
 )
-async def health_check(service: TdxService = Depends(get_tdx_service)):
+async def health_check(service: TdxService = Depends(get_tdx_service_dependency)):
     """
     TDX服务健康检查
 

--- a/web/backend/app/services/tdx_service.py
+++ b/web/backend/app/services/tdx_service.py
@@ -9,6 +9,8 @@ import sys
 from datetime import datetime
 from typing import Any, Dict
 
+from fastapi import Request
+
 # 添加项目根目录到路径(web/backend -> mystocks_spec)
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
 sys.path.insert(0, project_root)
@@ -265,6 +267,8 @@ class TdxService:
 
 
 # 单例模式
+TDX_SERVICE_STATE_KEY = "tdx_service"
+
 _tdx_service_instance = None
 
 
@@ -281,8 +285,16 @@ def get_tdx_service() -> TdxService:
 
 def install_tdx_service(app: Any, service: TdxService | None = None) -> TdxService:
     """Install the TDX service on app.state while preserving the legacy fallback."""
-    selected_service = service or getattr(app.state, "tdx_service", None)
+    selected_service = service or getattr(app.state, TDX_SERVICE_STATE_KEY, None)
     if selected_service is None:
         selected_service = get_tdx_service()
-    app.state.tdx_service = selected_service
+    setattr(app.state, TDX_SERVICE_STATE_KEY, selected_service)
     return selected_service
+
+
+def get_tdx_service_dependency(request: Request) -> TdxService:
+    """FastAPI dependency provider backed by app.state."""
+    service = getattr(request.app.state, TDX_SERVICE_STATE_KEY, None)
+    if service is None:
+        service = install_tdx_service(request.app)
+    return service

--- a/web/backend/tests/test_tdx_service_lifecycle_di.py
+++ b/web/backend/tests/test_tdx_service_lifecycle_di.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from app.api import tdx as tdx_routes
+from app.services import tdx_service as tdx_service_module
+
+
+def test_tdx_service_dependency_installs_app_state_when_missing(monkeypatch):
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+    request = SimpleNamespace(app=fake_app)
+
+    monkeypatch.setattr(tdx_service_module, "get_tdx_service", lambda: fake_service)
+
+    assert tdx_service_module.get_tdx_service_dependency(request) is fake_service
+    assert getattr(fake_app.state, tdx_service_module.TDX_SERVICE_STATE_KEY) is fake_service
+
+
+def test_install_tdx_service_accepts_explicit_service():
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+
+    assert tdx_service_module.install_tdx_service(fake_app, fake_service) is fake_service
+    assert getattr(fake_app.state, tdx_service_module.TDX_SERVICE_STATE_KEY) is fake_service
+
+
+def test_tdx_routes_use_tdx_service_dependency_provider():
+    for function_name in [
+        "get_stock_quote",
+        "get_stock_kline",
+        "get_index_quote",
+        "get_index_kline",
+        "health_check",
+    ]:
+        signature = inspect.signature(getattr(tdx_routes, function_name))
+        service_parameter = signature.parameters["service"]
+        assert service_parameter.default.dependency is tdx_service_module.get_tdx_service_dependency
+
+
+@pytest.mark.asyncio
+async def test_tdx_health_check_uses_injected_tdx_service():
+    class FakeTdxService:
+        def __init__(self):
+            self.called = False
+
+        def check_connection(self):
+            self.called = True
+            return {
+                "status": "healthy",
+                "tdx_connected": True,
+                "timestamp": "2026-05-24 00:00:00",
+                "server_info": {"host": "fake"},
+            }
+
+    fake_service = FakeTdxService()
+
+    result = await tdx_routes.health_check(service=fake_service)
+
+    assert fake_service.called is True
+    assert result.status == "healthy"
+    assert result.tdx_connected is True
+    assert result.server_info == {"host": "fake"}


### PR DESCRIPTION
## Summary
- Implements the G2.39-approved TDX route provider migration only.
- Adds TDX_SERVICE_STATE_KEY and get_tdx_service_dependency(request), while keeping get_tdx_service() as the public compatibility fallback.
- Converts exactly five /api/v1/tdx route dependencies to Depends(get_tdx_service_dependency).
- Adds focused lifecycle DI tests and updates the steward tree, JSON artifact, implementation report, and task card.

## Verification
- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tdx_service_lifecycle_di.py -q -n 0 --tb=short --no-cov: 4 passed
- ruff check web/backend/app/services/tdx_service.py web/backend/app/api/tdx.py web/backend/tests/test_tdx_service_lifecycle_di.py: passed
- black --check web/backend/app/services/tdx_service.py web/backend/app/api/tdx.py web/backend/tests/test_tdx_service_lifecycle_di.py: passed
- app.main/OpenAPI smoke: routes_total=548, openapi_paths_total=500, duplicate_operation_ids=0, tdx_paths_count=7
- dependency guard: legacy route Depends=0, provider route Depends=5
- markdown governance: 2 checked files, 0 errors
- JSON parse: passed
- mainline scope gate: pass=True
- staged GitNexus detect_changes: risk_level=medium, affected_count=1, no HIGH/CRITICAL

## Boundary
No dashboard_data_source.py, api/ml.py, main.py, adapter, frontend, PM2, OpenSpec, issue-label, route path, response model, OpenAPI exposure, or get_tdx_service() retirement changes.