### PR TITLE
docs(tdx): close out route provider migration

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -728,10 +728,17 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 `get_tdx_service_dependency`, converting the five
 │   │                 `/api/v1/tdx` dependencies to the provider, keeping
 │   │                 OpenAPI paths at `500`, duplicate operation IDs at `0`,
-│   │                 and focused lifecycle DI tests at `4 passed`
-│   └── Next gate: Human review of the G2.40 implementation PR; if accepted,
-│                  merge and run a G2.41 closeout or current-head candidate
-│                  refresh before selecting the next service lifecycle DI lane
+│   │                 and focused lifecycle DI tests at `4 passed`; G2.40
+│   │                 merged by PR `#180` at
+│   │                 `86b0ec43c037729b28df51c40484196175c96c6e`; G2.41 now
+│   │                 records the post-merge closeout: PR `#180` is `MERGED`,
+│   │                 focused TDX lifecycle DI tests are `4 passed`, route
+│   │                 dependency counts are legacy=`0` and provider=`5`, and
+│   │                 OpenAPI remains paths=`500` with duplicate operation
+│   │                 IDs=`0`
+│   └── Next gate: Human review of the G2.41 closeout PR; if accepted, create a
+│                  separate G2.42 current-head candidate refresh before
+│                  selecting the next service lifecycle DI lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -811,6 +818,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-tdx-route-dependency-consumer-matrix-2026-05-23.md` | G | G2.38 consumer matrix reviewed and merged by PR `#178` at `30c78a22dce5879396dfd5c7760cc61161377528`: OpenAPI paths=`500`, duplicate operation IDs=`0`, TDX paths=`7`; `/api/v1/tdx` has five active `Depends(get_tdx_service)` route consumers, `/api/ml/tdx` is unrelated local `TdxDataService()` usage, dashboard helper keeps `get_tdx_service` as default provider fallback, and `get_tdx_service()` must not be retired by this line | Superseded by G2.39 TDX route provider migration authorization |
 | `backend-tdx-route-provider-migration-authorization-2026-05-23.md` | G | G2.39 authorization prepared at current HEAD `30c78a22dce5879396dfd5c7760cc61161377528`: future implementation scope is limited to `tdx_service.py`, `api/tdx.py`, `web/backend/tests/test_tdx_service_lifecycle_di.py`, implementation evidence, and a future task card; it may add `TDX_SERVICE_STATE_KEY` and `get_tdx_service_dependency`, convert five `/api/v1/tdx` route dependencies, and must preserve `get_tdx_service()` compatibility fallback | Human review; if accepted, create G2.40 TDX route provider migration implementation branch before source edits |
 | `backend-tdx-route-provider-migration-implementation-2026-05-24.md` | G | G2.40 implementation prepared from G2.39 authorization at base `e4dc9088cabfb4dba756beb109294980c047c327`: adds `TDX_SERVICE_STATE_KEY` and `get_tdx_service_dependency(request)`, keeps `get_tdx_service()` as public fallback, converts exactly five `/api/v1/tdx` `Depends(get_tdx_service)` sites to `Depends(get_tdx_service_dependency)`, focused TDD ended at `4 passed`, ruff/black passed, `app.main` routes=`548`, OpenAPI paths=`500`, duplicate operation IDs=`0`, and TDX paths=`7` | Human review / PR merge decision; if accepted, run G2.41 closeout or current-head candidate refresh before selecting the next service lifecycle DI lane |
+| `backend-tdx-route-provider-migration-closeout-2026-05-24.md` | G | G2.41 closeout prepared at current HEAD `86b0ec43c037729b28df51c40484196175c96c6e`: records PR `#180` as `MERGED`, confirms focused TDX lifecycle DI tests `4 passed`, ruff/black passed, `tdx.py` legacy route dependency sites=`0`, provider sites=`5`, `get_tdx_service()` remains public fallback, `app.main` routes=`548`, OpenAPI paths=`500`, duplicate operation IDs=`0`, and no next service lifecycle DI candidate is selected | Human review / PR merge decision; if accepted, create G2.42 current-head candidate refresh before selecting the next service lifecycle DI lane |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/tdx-route-provider-migration-closeout-2026-05-24.json
+++ b/.planning/codebase/generated/tdx-route-provider-migration-closeout-2026-05-24.json
@@ -1,0 +1,60 @@
+{
+  "artifact": "tdx-route-provider-migration-closeout",
+  "generated_at": "2026-05-24T01:11:51+08:00",
+  "workline": "G2.41",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_head": "86b0ec43c037729b28df51c40484196175c96c6e",
+  "closed_implementation": {
+    "workline": "G2.40",
+    "pull_request": 180,
+    "state": "MERGED",
+    "merged_at": "2026-05-23T17:08:53Z",
+    "merge_commit": "86b0ec43c037729b28df51c40484196175c96c6e",
+    "url": "https://github.com/chengjon/mystocks/pull/180"
+  },
+  "scope": {
+    "governance_only": true,
+    "backend_source_changed": false,
+    "tests_changed": false,
+    "openapi_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false
+  },
+  "post_merge_verification": {
+    "focused_pytest": "4 passed in 1.09s",
+    "ruff_touched": "All checks passed!",
+    "black_check_touched": "3 files would be left unchanged",
+    "dependency_guard": {
+      "api_depends_legacy": 0,
+      "api_depends_provider": 5,
+      "api_legacy_identifier_excluding_provider": 0,
+      "service_provider_def": 1,
+      "service_legacy_getter_def": 1,
+      "service_installer_def": 1,
+      "service_state_key_mentions": 4
+    },
+    "openapi_smoke": {
+      "routes_total": 548,
+      "openapi_paths_total": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "tdx_paths_count": 7,
+      "tdx_paths": [
+        "/api/ml/tdx/data",
+        "/api/ml/tdx/stocks/{market}",
+        "/api/v1/tdx/health",
+        "/api/v1/tdx/index/kline",
+        "/api/v1/tdx/index/quote/{symbol}",
+        "/api/v1/tdx/kline",
+        "/api/v1/tdx/quote/{symbol}"
+      ]
+    }
+  },
+  "current_state": {
+    "tdx_route_provider_migrated": true,
+    "legacy_get_tdx_service_retained": true,
+    "legacy_getter_retirement_authorized": false,
+    "next_service_lifecycle_candidate_selected": false
+  },
+  "next_gate": "human_review_then_g2_42_current_head_candidate_refresh"
+}

--- a/docs/reports/quality/backend-tdx-route-provider-migration-closeout-2026-05-24.md
+++ b/docs/reports/quality/backend-tdx-route-provider-migration-closeout-2026-05-24.md
@@ -1,0 +1,77 @@
+# Backend TDX Route Provider Migration Closeout - 2026-05-24
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Workline: G2.41 TDX route provider migration closeout
+- Base branch: `wip/root-dirty-20260403`
+- Current HEAD: `86b0ec43c037729b28df51c40484196175c96c6e`
+- Closed implementation PR: `#180`
+- PR state: `MERGED`
+- Merge timestamp: `2026-05-23T17:08:53Z`
+- Merge commit: `86b0ec43c037729b28df51c40484196175c96c6e`
+- Scope: governance-only closeout for the already-merged G2.40 implementation
+
+## Closeout Scope
+
+This packet records the already-merged G2.40 implementation result. It does not
+edit backend source, tests, route contracts, OpenAPI schema exposure, frontend,
+PM2/runtime configuration, OpenSpec artifacts, issue labels, or docs/API files.
+
+The implementation branch completed the approved TDX route provider migration:
+
+- `tdx_service.py` exposes `TDX_SERVICE_STATE_KEY = "tdx_service"`.
+- `tdx_service.py` exposes `get_tdx_service_dependency(request)`.
+- `get_tdx_service()` remains public and active as the compatibility fallback.
+- `install_tdx_service(app, service=None)` reads and writes the named app-state
+  key.
+- exactly five `/api/v1/tdx` route dependencies now use
+  `Depends(get_tdx_service_dependency)`.
+- `/api/ml/tdx` remains unrelated local `TdxDataService()` usage.
+
+## Post-Merge Verification
+
+All commands below were run from the G2.41 closeout worktree at HEAD
+`86b0ec43c037729b28df51c40484196175c96c6e`.
+
+| Check | Result |
+|---|---|
+| PR state | PR `#180` is `MERGED` |
+| Merge commit | `86b0ec43c037729b28df51c40484196175c96c6e` |
+| Focused TDX lifecycle DI pytest | `4 passed in 1.09s` |
+| Ruff touched files | `All checks passed!` |
+| Black touched files | `3 files would be left unchanged` |
+| `tdx.py` `Depends(get_tdx_service)` sites | `0` |
+| `tdx.py` `Depends(get_tdx_service_dependency)` sites | `5` |
+| `tdx_service.py` `get_tdx_service_dependency()` definitions | `1` |
+| `tdx_service.py` `get_tdx_service()` definitions | `1` |
+| `tdx_service.py` `install_tdx_service()` definitions | `1` |
+| `tdx_service.py` `TDX_SERVICE_STATE_KEY` mentions | `4` |
+| `app.main` import / OpenAPI smoke | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, TDX paths=`7` |
+
+The `app.main` and OpenAPI smoke emitted existing import-time service logs and
+the known optional GPU dependency warning:
+`Numba needs NumPy 2.2 or less. Got NumPy 2.4.` The smoke command still exited
+successfully and produced the expected route/OpenAPI results.
+
+## Current State After Merge
+
+- The public `/api/v1/tdx` route handlers are provider-fed through FastAPI
+  dependency injection.
+- The TDX route dependency seam now matches the app-state installer pattern used
+  by the earlier dashboard helper migration.
+- `get_tdx_service()` remains intentionally active as compatibility fallback.
+- There is no current authorization to retire `get_tdx_service()`.
+- OpenAPI remains stable at `500` paths with `0` duplicate operation IDs.
+- Issue `#79` remains the parent service lifecycle DI issue and should not be
+  moved to implementation-ready state by this closeout.
+- No next service lifecycle DI candidate is selected by this closeout.
+
+## Next Gate
+
+Human review of this closeout packet. If accepted and merged, create a separate
+G2.42 current-head service lifecycle DI candidate refresh before selecting the
+next implementation lane.

--- a/governance/mainline/task-cards/pr-181.yaml
+++ b/governance/mainline/task-cards/pr-181.yaml
@@ -1,0 +1,101 @@
+version: "v0.2"
+
+task:
+  id: "pr-181"
+  title: "Close out TDX route provider migration"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-tdx-route-provider-migration-closeout"
+  objective: "record the G2.40 TDX route provider merge result and closeout boundary"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-tdx-route-provider-migration-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-tdx-route-provider-migration-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout records already-merged PR #180 and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/tdx-route-provider-migration-closeout-2026-05-24.json"
+    - "docs/reports/quality/backend-tdx-route-provider-migration-closeout-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-181.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No next service DI candidate selection in this PR"
+  - "No get_tdx_service retirement, adapter refactor, service consolidation, or compatibility cleanup in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-tdx-route-provider-migration-closeout-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/tdx-route-provider-migration-closeout-2026-05-24.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-181.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the closeout boundary"
+    - "If this PR selects or authorizes the next service candidate, it bypasses the separate refresh gate"
+    - "If get_tdx_service is treated as removable here, compatibility fallback can break"
+  rollback_plan: "revert this governance-only PR; PR #180 implementation remains merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record the merged G2.40 TDX route provider migration"
+    modified_scope: "closeout report, generated closeout artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; get_tdx_service remains public fallback and no runtime source changes are made"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only closeout PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T01:11:51+08:00"
+    approval_note: "human maintainer approved continuing after PR #180; this closeout only records the merged implementation and next-gate boundary"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Records PR #180 as merged at 86b0ec43c037729b28df51c40484196175c96c6e.
- Captures post-merge TDX route provider state: legacy route dependency count is 0 and provider route dependency count is 5.
- Updates the steward tree, closeout report, JSON artifact, and pr-181 task card only.

## Verification
- PR #180 state: MERGED
- Focused TDX lifecycle DI pytest: 4 passed
- Ruff touched files: passed
- Black touched files: passed
- app.main/OpenAPI smoke: routes_total=548, openapi_paths_total=500, duplicate_operation_ids=0, tdx_paths_count=7
- Markdown governance: 2 checked files, 0 errors
- JSON parse: passed
- YAML parse: passed
- Mainline scope gate after closeout commit: pass=True
- git diff HEAD~1..HEAD --check: passed

## Boundary
Governance-only closeout. No backend source, tests, OpenAPI, route path, response model, frontend, PM2, OpenSpec, issue-label, or compatibility getter cleanup changes. No next service lifecycle DI candidate is selected here.