### PR TITLE
docs(di): refresh candidates after tdx provider

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -735,10 +735,17 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 focused TDX lifecycle DI tests are `4 passed`, route
 │   │                 dependency counts are legacy=`0` and provider=`5`, and
 │   │                 OpenAPI remains paths=`500` with duplicate operation
-│   │                 IDs=`0`
-│   └── Next gate: Human review of the G2.41 closeout PR; if accepted, create a
-│                  separate G2.42 current-head candidate refresh before
-│                  selecting the next service lifecycle DI lane
+│   │                 IDs=`0`; G2.41 merged by PR `#181` at
+│   │                 `41b0d4db7f2c644cea9abf1ddd4112e695325dcc`; G2.42 now
+│   │                 records the current-head candidate refresh: service files
+│   │                 scanned=`152`, narrow candidate/signal files=`21`,
+│   │                 completed route-provider seams=`7`, TDX legacy route
+│   │                 dependency sites=`0`, TDX provider sites=`5`, OpenAPI
+│   │                 paths=`500`, and duplicate operation IDs=`0`
+│   └── Next gate: Human review of the G2.42 candidate refresh PR; if accepted,
+│                  create a separate G2.43 service candidate usefulness and
+│                  ownership triage packet before selecting an implementation
+│                  lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -819,6 +826,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-tdx-route-provider-migration-authorization-2026-05-23.md` | G | G2.39 authorization prepared at current HEAD `30c78a22dce5879396dfd5c7760cc61161377528`: future implementation scope is limited to `tdx_service.py`, `api/tdx.py`, `web/backend/tests/test_tdx_service_lifecycle_di.py`, implementation evidence, and a future task card; it may add `TDX_SERVICE_STATE_KEY` and `get_tdx_service_dependency`, convert five `/api/v1/tdx` route dependencies, and must preserve `get_tdx_service()` compatibility fallback | Human review; if accepted, create G2.40 TDX route provider migration implementation branch before source edits |
 | `backend-tdx-route-provider-migration-implementation-2026-05-24.md` | G | G2.40 implementation prepared from G2.39 authorization at base `e4dc9088cabfb4dba756beb109294980c047c327`: adds `TDX_SERVICE_STATE_KEY` and `get_tdx_service_dependency(request)`, keeps `get_tdx_service()` as public fallback, converts exactly five `/api/v1/tdx` `Depends(get_tdx_service)` sites to `Depends(get_tdx_service_dependency)`, focused TDD ended at `4 passed`, ruff/black passed, `app.main` routes=`548`, OpenAPI paths=`500`, duplicate operation IDs=`0`, and TDX paths=`7` | Human review / PR merge decision; if accepted, run G2.41 closeout or current-head candidate refresh before selecting the next service lifecycle DI lane |
 | `backend-tdx-route-provider-migration-closeout-2026-05-24.md` | G | G2.41 closeout prepared at current HEAD `86b0ec43c037729b28df51c40484196175c96c6e`: records PR `#180` as `MERGED`, confirms focused TDX lifecycle DI tests `4 passed`, ruff/black passed, `tdx.py` legacy route dependency sites=`0`, provider sites=`5`, `get_tdx_service()` remains public fallback, `app.main` routes=`548`, OpenAPI paths=`500`, duplicate operation IDs=`0`, and no next service lifecycle DI candidate is selected | Human review / PR merge decision; if accepted, create G2.42 current-head candidate refresh before selecting the next service lifecycle DI lane |
+| `backend-service-lifecycle-di-candidate-refresh-after-tdx-route-provider-2026-05-24.md` | G | G2.42 candidate refresh prepared at current HEAD `41b0d4db7f2c644cea9abf1ddd4112e695325dcc`: scans `152` service files and `21` narrow candidate/signal files, records completed route-provider seams=`7`, confirms TDX route dependency surface closed with legacy sites=`0` and provider sites=`5`, keeps `get_tdx_service()` as public fallback, records OpenAPI paths=`500` and duplicate operation IDs=`0`, and does not select a new implementation target | Human review / PR merge decision; if accepted, create G2.43 service candidate usefulness and ownership triage packet before any source edits |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-tdx-route-provider-2026-05-24.json
+++ b/.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-tdx-route-provider-2026-05-24.json
@@ -1,0 +1,78 @@
+{
+  "artifact": "service-lifecycle-di-candidate-refresh-after-tdx-route-provider",
+  "generated_at": "2026-05-24T01:27:46+08:00",
+  "workline": "G2.42",
+  "current_head": "41b0d4db7f2c644cea9abf1ddd4112e695325dcc",
+  "parent": {
+    "pull_request": 181,
+    "state": "MERGED",
+    "merge_commit": "41b0d4db7f2c644cea9abf1ddd4112e695325dcc"
+  },
+  "scope": {
+    "governance_only": true,
+    "backend_source_changed": false,
+    "tests_changed": false,
+    "openapi_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "implementation_target_selected": false
+  },
+  "github_state": {
+    "issue_79": {
+      "state": "OPEN",
+      "labels": [
+        "needs-triage"
+      ]
+    },
+    "issue_92": {
+      "state": "OPEN",
+      "labels": [
+        "enhancement",
+        "ready-for-human",
+        "ready-for-downstream"
+      ]
+    }
+  },
+  "scan": {
+    "service_root": "web/backend/app/services",
+    "service_files_scanned": 152,
+    "narrow_candidate_files": 21,
+    "buckets": {
+      "completed-route-provider-seam": 7,
+      "route-surface-or-control-plane-review": 1,
+      "broad-data-or-strategy-seam": 4,
+      "process-runtime-singleton-or-streaming": 2,
+      "service-internal-or-test-surface": 2,
+      "registry-integrated-seam": 1,
+      "ownership-usefulness-decision-needed": 3,
+      "package-reexport-surface": 1
+    },
+    "direct_getter_matrix": {
+      "dashboard_data_source_direct_get_tdx_service_calls": 0,
+      "dashboard_data_source_private_get_tdx_service_calls": 3,
+      "tdx_py_depends_get_tdx_service": 0,
+      "tdx_py_depends_get_tdx_service_dependency": 5,
+      "tdx_py_direct_get_tdx_service_calls": 0,
+      "tdx_service_get_tdx_service_definitions": 1,
+      "tdx_service_get_tdx_service_dependency_definitions": 1,
+      "tdx_service_install_tdx_service_definitions": 1,
+      "market_v2_direct_get_market_data_service_v2_calls": 0,
+      "dashboard_data_source_direct_get_market_data_service_v2_calls": 0
+    }
+  },
+  "openapi_smoke": {
+    "routes_total": 548,
+    "openapi_paths_total": 500,
+    "operation_ids": 536,
+    "duplicate_operation_ids": 0,
+    "tdx_paths_count": 7
+  },
+  "decision": {
+    "next_gate": "G2.43 service candidate usefulness and ownership triage packet",
+    "do_not_retire_get_tdx_service": true,
+    "do_not_reopen_completed_route_provider_seams": true,
+    "do_not_move_issue_79_to_implementation_ready": true,
+    "do_not_create_or_modify_openspec_changes": true,
+    "do_not_select_next_service_implementation_target": true
+  }
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-tdx-route-provider-2026-05-24.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-tdx-route-provider-2026-05-24.md
@@ -1,0 +1,173 @@
+# Backend Service Lifecycle DI Candidate Refresh After TDX Route Provider - 2026-05-24
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Workline: G2.42 service lifecycle DI candidate refresh after TDX route
+  provider closeout
+- Status: review-ready
+- Current HEAD: `41b0d4db7f2c644cea9abf1ddd4112e695325dcc`
+- Parent PR: `#181`, merged at `41b0d4db7f2c644cea9abf1ddd4112e695325dcc`
+- Parent issue: `#79`
+- Scope: governance and evidence only
+
+Boundary note: this packet performs a current-head candidate refresh after the
+G2.40/G2.41 TDX route provider migration and closeout. It does not authorize
+backend source edits, tests, route changes, OpenAPI changes, PM2/runtime gate
+execution, OpenSpec archive actions, compatibility getter deletion, issue label
+movement, or a new implementation lane.
+
+## Why This Refresh Exists
+
+The steward tree gate after G2.41 says that after the TDX route provider
+migration is merged and closed out, the next step is a fresh current-head service
+lifecycle DI candidate refresh before selecting another source implementation
+lane.
+
+This refresh confirms the meaningful delta from G2.37:
+
+- `/api/v1/tdx` dependency sites moved from five `Depends(get_tdx_service)`
+  sites to five `Depends(get_tdx_service_dependency)` sites.
+- `tdx_service.py` now has the complete app-state route-provider seam:
+  `TDX_SERVICE_STATE_KEY`, `install_tdx_service(app, service=None)`,
+  `get_tdx_service_dependency(request)`, and the retained compatibility
+  fallback `get_tdx_service()`.
+- `get_tdx_service()` remains public and active as a compatibility fallback.
+- TDX route-provider migration is closed, but no compatibility getter retirement
+  is authorized.
+
+## Current GitHub State
+
+- Issue `#79`: `OPEN`, label `needs-triage`.
+- Issue `#92`: `OPEN`, labels `enhancement`, `ready-for-human`,
+  `ready-for-downstream`.
+
+No issue labels were changed by this refresh.
+
+## Scan Method
+
+- Service root: `web/backend/app/services`
+- Service files scanned: `152`
+- Narrow candidate criteria:
+  - `get_*service*`, `install_*service*`, or `get_service_*` functions
+  - `*_instance = None` or `_instance = None`
+  - `app.state.*service` references or explicit `SERVICE_STATE_KEY` usage
+- Reference surfaces:
+  - `web/backend/app/api`
+  - `web/backend/tests`
+  - other files under `web/backend/app/services`
+- Normalization rule:
+  - package `__init__.py` re-export surfaces are recorded separately from
+    route/provider implementation candidates;
+  - zero-reference service getters are not treated as implementation-ready
+    without an ownership/usefulness decision packet.
+
+## Scan Summary
+
+| Bucket | Count | Interpretation |
+|---|---:|---|
+| `completed-route-provider-seam` | 7 | Previously completed route/provider seams remain closed; TDX is now included here |
+| `route-surface-or-control-plane-review` | 1 | Route/control-plane adjacent candidate needs a separate decision packet |
+| `broad-data-or-strategy-seam` | 4 | Broad seams are not suitable direct pilots |
+| `process-runtime-singleton-or-streaming` | 2 | Runtime/streaming lifetime needs separate design |
+| `service-internal-or-test-surface` | 2 | Internal/test surfaces are not route-provider pilots |
+| `registry-integrated-seam` | 1 | Integrated registry remains a broad design seam |
+| `ownership-usefulness-decision-needed` | 3 | Zero/low-reference surfaces need usefulness and ownership triage before implementation |
+| `package-reexport-surface` | 1 | Package re-export surface is not an implementation candidate |
+
+Current narrow candidate/signal files: `21`.
+
+## Candidate Inventory
+
+| Service file | Bucket | API refs | Test refs | Service refs | Signals |
+|---|---|---:|---:|---:|---|
+| `web/backend/app/services/__init__.py` | `registry-integrated-seam` | 1 | 4 | 3 | `get_integrated_services`, `get_market_data_service`, `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, `get_cache_service` |
+| `web/backend/app/services/advanced_analysis_service.py` | `ownership-usefulness-decision-needed` | 0 | 0 | 0 | `get_advanced_analysis_service` |
+| `web/backend/app/services/announcement_service.py` | `completed-route-provider-seam` | 1 | 1 | 0 | `get_announcement_service`, `get_announcement_service_dependency`, `install_announcement_service`, app-state service |
+| `web/backend/app/services/data_service_enhanced.py` | `route-surface-or-control-plane-review` | 1 | 0 | 0 | `get_service_health`, `get_enhanced_data_service` |
+| `web/backend/app/services/data_service.py` | `broad-data-or-strategy-seam` | 2 | 2 | 0 | `get_data_service` |
+| `web/backend/app/services/email_notification_service.py` | `service-internal-or-test-surface` | 0 | 2 | 1 | `get_email_service` |
+| `web/backend/app/services/email_service.py` | `completed-route-provider-seam` | 1 | 2 | 1 | `get_email_service`, `get_email_service_dependency`, `install_email_service`, app-state service |
+| `web/backend/app/services/market_data_service_v2.py` | `completed-route-provider-seam` | 2 | 2 | 0 | `get_market_data_service_v2`, `get_market_data_service_v2_dependency`, `install_market_data_service_v2` |
+| `web/backend/app/services/market_data_service/get_market_data_service.py` | `ownership-usefulness-decision-needed` | 1 | 4 | 3 | `get_market_data_service` |
+| `web/backend/app/services/monitoring_service.py` | `service-internal-or-test-surface` | 0 | 0 | 0 | `_instance` |
+| `web/backend/app/services/realtime_streaming_service.py` | `process-runtime-singleton-or-streaming` | 0 | 2 | 1 | `get_streaming_service` |
+| `web/backend/app/services/stock_search_service/__init__.py` | `package-reexport-surface` | 0 | 0 | 0 | app-state service |
+| `web/backend/app/services/stock_search_service/stock_search_service.py` | `completed-route-provider-seam` | 2 | 4 | 1 | `get_stock_search_service`, `get_stock_search_service_dependency`, `install_stock_search_service`, app-state service |
+| `web/backend/app/services/strategy_service.py` | `broad-data-or-strategy-seam` | 1 | 1 | 2 | `get_strategy_service`, `_instance` |
+| `web/backend/app/services/tdx_service.py` | `completed-route-provider-seam` | 2 | 2 | 0 | `get_tdx_service`, `get_tdx_service_dependency`, `install_tdx_service`, `_instance`, app-state service |
+| `web/backend/app/services/technical_analysis_service.py` | `broad-data-or-strategy-seam` | 0 | 0 | 0 | `_instance` |
+| `web/backend/app/services/tradingview_widget_service.py` | `completed-route-provider-seam` | 1 | 1 | 0 | `get_tradingview_service`, `get_tradingview_service_dependency`, `install_tradingview_service`, app-state service |
+| `web/backend/app/services/unified_data_service.py` | `broad-data-or-strategy-seam` | 0 | 0 | 0 | `get_unified_data_service` |
+| `web/backend/app/services/watchlist_service.py` | `completed-route-provider-seam` | 1 | 2 | 2 | `get_watchlist_service`, `get_watchlist_service_dependency`, `install_watchlist_service`, app-state service |
+| `web/backend/app/services/websocket_service.py` | `process-runtime-singleton-or-streaming` | 0 | 0 | 0 | `get_service_stats` |
+| `web/backend/app/services/wencai_service.py` | `ownership-usefulness-decision-needed` | 0 | 0 | 0 | `get_wencai_service` |
+
+## Direct Getter Matrix
+
+| Surface | Count |
+|---|---:|
+| `dashboard_data_source.py` direct `get_tdx_service()` calls | 0 |
+| `dashboard_data_source.py` private `_get_tdx_service()` calls | 3 |
+| `tdx.py` `Depends(get_tdx_service)` sites | 0 |
+| `tdx.py` `Depends(get_tdx_service_dependency)` sites | 5 |
+| `tdx.py` direct `get_tdx_service()` calls | 0 |
+| `tdx_service.py` `get_tdx_service()` definitions | 1 |
+| `tdx_service.py` `get_tdx_service_dependency()` definitions | 1 |
+| `tdx_service.py` `install_tdx_service()` definitions | 1 |
+| `market_v2.py` direct `get_market_data_service_v2()` calls | 0 |
+| `dashboard_data_source.py` direct `get_market_data_service_v2()` calls | 0 |
+
+## OpenAPI Smoke
+
+The current-head `app.main` / OpenAPI smoke produced:
+
+| Field | Value |
+|---|---:|
+| Runtime routes | 548 |
+| OpenAPI paths | 500 |
+| Operation IDs | 536 |
+| Duplicate operation IDs | 0 |
+| TDX paths | 7 |
+
+The smoke emitted the known optional GPU dependency warning:
+`Numba needs NumPy 2.2 or less. Got NumPy 2.4.` The command still exited
+successfully and produced the expected route/OpenAPI results.
+
+## Interpretation
+
+G2.42 does not select a new implementation target.
+
+The strongest current-head delta is that the TDX route dependency surface is now
+closed and belongs in `completed-route-provider-seam`. The remaining candidate
+pool is not a clean direct implementation queue:
+
+- broad data/strategy seams remain too wide for direct migration;
+- runtime/streaming services need lifetime design before source edits;
+- zero-reference service getters need ownership/usefulness triage before being
+  promoted, retained, or deprecated;
+- package re-export surfaces are not service lifecycle migration targets.
+
+Recommended next gate:
+
+- Prepare a decision-only G2.43 service candidate usefulness and ownership
+  triage packet.
+- Scope it to zero/low-reference surfaces such as
+  `advanced_analysis_service.py`, `wencai_service.py`, and
+  `market_data_service/get_market_data_service.py`, plus any broad seam that
+  needs explicit exclusion.
+- Keep source edits locked until that triage packet is accepted and a separate
+  implementation authorization packet defines exact write scope.
+
+## Decision
+
+Record G2.42 as a current-head refresh only.
+
+- Do not retire `get_tdx_service()` from this packet.
+- Do not reopen the completed route-provider seams.
+- Do not move issue `#79` to implementation-ready state.
+- Do not create or modify OpenSpec changes from this packet.
+- Do not select the next service implementation target from this packet.

--- a/governance/mainline/task-cards/pr-182.yaml
+++ b/governance/mainline/task-cards/pr-182.yaml
@@ -1,0 +1,101 @@
+version: "v0.2"
+
+task:
+  id: "pr-182"
+  title: "Refresh service lifecycle DI candidates after TDX route provider"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-service-lifecycle-di-candidate-refresh-after-tdx-route-provider"
+  objective: "record the G2.42 current-head service lifecycle DI candidate refresh after PR #181"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-di-candidate-refresh-after-tdx-route-provider"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-di-candidate-refresh-after-tdx-route-provider"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate refresh records current-head evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-tdx-route-provider-2026-05-24.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-tdx-route-provider-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-182.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No implementation target selection in this PR"
+  - "No get_tdx_service cleanup, adapter refactor, service consolidation, or compatibility getter retirement in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-tdx-route-provider-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-tdx-route-provider-2026-05-24.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-182.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the candidate-refresh boundary"
+    - "If this PR selects or authorizes the next service candidate, it bypasses the separate-packet gate"
+    - "If get_tdx_service is treated as removable here, compatibility fallback can break"
+  rollback_plan: "revert this governance-only PR; PR #180 and PR #181 remain merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record current-head service lifecycle DI candidate state after TDX route provider closeout"
+    modified_scope: "candidate refresh report, generated refresh artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; get_tdx_service remains public fallback and no runtime source changes are made"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only refresh PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T01:27:46+08:00"
+    approval_note: "human maintainer approved continuing after PR #181; this candidate refresh only records current-head evidence and next-gate boundary"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Records PR #181 as merged at 41b0d4db7f2c644cea9abf1ddd4112e695325dcc.
- Refreshes current-head service lifecycle DI candidate evidence after TDX route provider closeout.
- Confirms TDX route dependency surface is closed: legacy route dependency sites=0, provider sites=5.
- Records 152 scanned service files, 21 narrow candidate/signal files, 7 completed route-provider seams, and no next implementation target selected.
- Updates steward tree, candidate refresh report, JSON artifact, and pr-182 task card only.

## Verification
- Issue #79: OPEN / needs-triage
- Issue #92: OPEN / enhancement, ready-for-human, ready-for-downstream
- app.main/OpenAPI smoke: routes_total=548, openapi_paths_total=500, operation_ids=536, duplicate_operation_ids=0, tdx_paths_count=7
- Markdown governance: 2 checked files, 0 errors
- JSON parse: passed
- YAML parse: passed
- Mainline scope gate after commit: pass=True
- git diff HEAD~1..HEAD --check: passed

## Boundary
Governance-only candidate refresh. No backend source, tests, OpenAPI, route path, response model, frontend, PM2, OpenSpec, issue-label, compatibility getter cleanup, or implementation target selection changes. Next recommended gate is G2.43 service candidate usefulness and ownership triage before any source edits.