### PR TITLE
docs(di): triage service candidate ownership

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -736,16 +736,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 dependency counts are legacy=`0` and provider=`5`, and
 │   │                 OpenAPI remains paths=`500` with duplicate operation
 │   │                 IDs=`0`; G2.41 merged by PR `#181` at
-│   │                 `41b0d4db7f2c644cea9abf1ddd4112e695325dcc`; G2.42 now
+│   │                 `41b0d4db7f2c644cea9abf1ddd4112e695325dcc`; G2.42
 │   │                 records the current-head candidate refresh: service files
 │   │                 scanned=`152`, narrow candidate/signal files=`21`,
 │   │                 completed route-provider seams=`7`, TDX legacy route
 │   │                 dependency sites=`0`, TDX provider sites=`5`, OpenAPI
-│   │                 paths=`500`, and duplicate operation IDs=`0`
-│   └── Next gate: Human review of the G2.42 candidate refresh PR; if accepted,
-│                  create a separate G2.43 service candidate usefulness and
-│                  ownership triage packet before selecting an implementation
-│                  lane
+│   │                 paths=`500`, and duplicate operation IDs=`0`; PR `#182`
+│   │                 merged at
+│   │                 `f7c6fdf5fd57cff14ef6d11f1d18fd6591a22dc5`; G2.43 now
+│   │                 records candidate usefulness and ownership triage:
+│   │                 `AdvancedAnalysisService` is an active route class
+│   │                 dependency with a definition-only compatibility getter,
+│   │                 `WencaiService` is an active DB/session-backed direct
+│   │                 constructor service, `get_market_data_service` remains an
+│   │                 active route dependency, and `UnifiedDataService` remains
+│   │                 a broad data seam; no implementation target is authorized
+│   └── Next gate: Human review of the G2.43 triage PR; if accepted, create a
+│                  separate G2.44 `AdvancedAnalysisService` route-provider
+│                  migration authorization packet before source edits
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -827,6 +835,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-tdx-route-provider-migration-implementation-2026-05-24.md` | G | G2.40 implementation prepared from G2.39 authorization at base `e4dc9088cabfb4dba756beb109294980c047c327`: adds `TDX_SERVICE_STATE_KEY` and `get_tdx_service_dependency(request)`, keeps `get_tdx_service()` as public fallback, converts exactly five `/api/v1/tdx` `Depends(get_tdx_service)` sites to `Depends(get_tdx_service_dependency)`, focused TDD ended at `4 passed`, ruff/black passed, `app.main` routes=`548`, OpenAPI paths=`500`, duplicate operation IDs=`0`, and TDX paths=`7` | Human review / PR merge decision; if accepted, run G2.41 closeout or current-head candidate refresh before selecting the next service lifecycle DI lane |
 | `backend-tdx-route-provider-migration-closeout-2026-05-24.md` | G | G2.41 closeout prepared at current HEAD `86b0ec43c037729b28df51c40484196175c96c6e`: records PR `#180` as `MERGED`, confirms focused TDX lifecycle DI tests `4 passed`, ruff/black passed, `tdx.py` legacy route dependency sites=`0`, provider sites=`5`, `get_tdx_service()` remains public fallback, `app.main` routes=`548`, OpenAPI paths=`500`, duplicate operation IDs=`0`, and no next service lifecycle DI candidate is selected | Human review / PR merge decision; if accepted, create G2.42 current-head candidate refresh before selecting the next service lifecycle DI lane |
 | `backend-service-lifecycle-di-candidate-refresh-after-tdx-route-provider-2026-05-24.md` | G | G2.42 candidate refresh prepared at current HEAD `41b0d4db7f2c644cea9abf1ddd4112e695325dcc`: scans `152` service files and `21` narrow candidate/signal files, records completed route-provider seams=`7`, confirms TDX route dependency surface closed with legacy sites=`0` and provider sites=`5`, keeps `get_tdx_service()` as public fallback, records OpenAPI paths=`500` and duplicate operation IDs=`0`, and does not select a new implementation target | Human review / PR merge decision; if accepted, create G2.43 service candidate usefulness and ownership triage packet before any source edits |
+| `backend-service-candidate-usefulness-ownership-triage-2026-05-24.md` | G | G2.43 triage prepared at current HEAD `f7c6fdf5fd57cff14ef6d11f1d18fd6591a22dc5`: records PR `#182` as `MERGED`, confirms `AdvancedAnalysisService` is an active route class dependency with `14` class `Depends()` sites and no external getter reference, classifies `WencaiService` as active DB/session-backed direct construction, keeps `get_market_data_service` as active route dependency with `7` route dependency sites, classifies `UnifiedDataService` as a broad data seam, and authorizes no implementation | Human review / PR merge decision; if accepted, create G2.44 `AdvancedAnalysisService` route-provider migration authorization before any source edits |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/service-candidate-usefulness-ownership-triage-2026-05-24.json
+++ b/.planning/codebase/generated/service-candidate-usefulness-ownership-triage-2026-05-24.json
@@ -1,0 +1,102 @@
+{
+  "artifact": "service-candidate-usefulness-ownership-triage",
+  "workline": "G2.43",
+  "generated_at": "2026-05-24T01:47:32+08:00",
+  "git_head": "f7c6fdf5fd57cff14ef6d11f1d18fd6591a22dc5",
+  "source_scope": "governance-only",
+  "parent_pr": {
+    "number": 182,
+    "state": "MERGED",
+    "merge_commit": "f7c6fdf5fd57cff14ef6d11f1d18fd6591a22dc5"
+  },
+  "github_state": {
+    "issue_79": {
+      "state": "OPEN",
+      "labels": [
+        "needs-triage"
+      ]
+    },
+    "issue_92": {
+      "state": "OPEN",
+      "labels": [
+        "enhancement",
+        "ready-for-human",
+        "ready-for-downstream"
+      ]
+    }
+  },
+  "candidate_disposition": [
+    {
+      "candidate": "AdvancedAnalysisService",
+      "service_file": "web/backend/app/services/advanced_analysis_service.py",
+      "service_file_lines": 480,
+      "route_file": "web/backend/app/api/advanced_analysis_api.py",
+      "route_count": 14,
+      "class_depends_count": 14,
+      "getter": "get_advanced_analysis_service",
+      "getter_external_active_references": 0,
+      "class_active_reference_files": [
+        "web/backend/app/api/advanced_analysis_api.py",
+        "web/backend/app/services/advanced_analysis_service.py"
+      ],
+      "disposition": "active-route-service-next-authorization-candidate",
+      "implementation_authorized": false,
+      "recommended_next_gate": "G2.44 AdvancedAnalysisService route-provider migration authorization"
+    },
+    {
+      "candidate": "WencaiService",
+      "service_file": "web/backend/app/services/wencai_service.py",
+      "service_file_lines": 430,
+      "route_file": "web/backend/app/api/wencai.py",
+      "route_count": 8,
+      "direct_constructor_count": 8,
+      "getter": "get_wencai_service",
+      "getter_external_active_references": 0,
+      "class_active_reference_files": [
+        "src/database/services/database_service.py",
+        "web/backend/app/api/wencai.py",
+        "web/backend/app/services/wencai_service.py",
+        "web/backend/app/tasks/wencai_tasks.py",
+        "web/backend/scripts/deploy_wencai.sh"
+      ],
+      "disposition": "active-db-session-backed-service-not-immediate-pilot",
+      "implementation_authorized": false
+    },
+    {
+      "candidate": "MarketDataService",
+      "service_file": "web/backend/app/services/market_data_service/get_market_data_service.py",
+      "service_file_lines": 33,
+      "route_file": "web/backend/app/api/market/market_data_request.py",
+      "route_count": 11,
+      "route_dependency_count": 7,
+      "getter": "get_market_data_service",
+      "disposition": "active-broad-market-data-route-dependency",
+      "implementation_authorized": false
+    },
+    {
+      "candidate": "UnifiedDataService",
+      "service_file": "web/backend/app/services/unified_data_service.py",
+      "service_file_lines": 613,
+      "route_file": "web/backend/app/api/industry_concept_analysis.py",
+      "route_count": 5,
+      "direct_constructor_count": 2,
+      "getter": "get_unified_data_service",
+      "disposition": "broad-data-seam-needs-separate-ownership-review",
+      "implementation_authorized": false
+    }
+  ],
+  "explicit_exclusions": [
+    "DataService",
+    "StrategyService",
+    "TechnicalAnalysisService"
+  ],
+  "non_goals": [
+    "no backend source changes",
+    "no backend test changes",
+    "no OpenSpec change or archive operation",
+    "no GitHub issue label changes",
+    "no compatibility getter cleanup",
+    "no implementation target authorization"
+  ],
+  "next_gate": "human review of G2.43; if accepted, create G2.44 AdvancedAnalysisService route-provider migration authorization before source edits"
+}

--- a/docs/reports/quality/backend-service-candidate-usefulness-ownership-triage-2026-05-24.md
+++ b/docs/reports/quality/backend-service-candidate-usefulness-ownership-triage-2026-05-24.md
@@ -1,0 +1,109 @@
+# Backend Service Candidate Usefulness And Ownership Triage - 2026-05-24
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: prepared for human review
+
+Scope: G2.43 decision-only packet after PR #182. This report records current
+HEAD evidence, candidate usefulness, ownership, and the next authorization gate.
+It does not authorize backend source edits, route changes, OpenSpec changes,
+issue label changes, compatibility getter cleanup, or implementation work.
+
+## Current State
+
+| Field | Value |
+|---|---|
+| Current HEAD | `f7c6fdf5fd57cff14ef6d11f1d18fd6591a22dc5` |
+| Parent PR | `#182` merged |
+| Parent issue | `#79` remains `OPEN` / `needs-triage` |
+| Parent decision context | `#92` remains `OPEN` / `enhancement`, `ready-for-human`, `ready-for-downstream` |
+| Workline | G2.43 service candidate usefulness and ownership triage |
+| Runtime/source scope | none |
+
+## Method
+
+The triage used current-head static evidence only:
+
+- active symbol reference scan for candidate getters/classes;
+- route-file dependency pattern scan;
+- prior G2.42 service lifecycle DI candidate refresh evidence;
+- current GitHub state for issue `#79`, issue `#92`, and PR `#182`.
+
+Because this is a decision-only governance packet, no `app.main` smoke,
+OpenAPI generation, pytest run, or source-code impact analysis is required here.
+Those gates belong to a later implementation authorization packet.
+
+## Candidate Disposition
+
+| Candidate | Current evidence | Disposition |
+|---|---|---|
+| `AdvancedAnalysisService` | `web/backend/app/services/advanced_analysis_service.py` has `480` lines. `get_advanced_analysis_service` has no active external reference outside its own definition. `AdvancedAnalysisService` has active route usage in `web/backend/app/api/advanced_analysis_api.py`; the route file has `14` routes and `14` class-based `Depends()` service parameters. | Active route service. Do not delete. Best next decision candidate for a separate G2.44 route-provider migration authorization packet. |
+| `WencaiService` | `web/backend/app/services/wencai_service.py` has `430` lines. `get_wencai_service` has no active external reference outside its own definition. `WencaiService` is active in `web/backend/app/api/wencai.py`, `web/backend/app/tasks/wencai_tasks.py`, `src/database/services/database_service.py`, and deployment script references; `web/backend/app/api/wencai.py` has `8` direct `WencaiService(db=db)` constructor sites. | Active DB/session-backed service. Do not treat as a singleton DI pilot. Do not clean up the getter without a later impact/test/route-contract packet. |
+| `get_market_data_service` / `MarketDataService` | `web/backend/app/services/market_data_service/get_market_data_service.py` is a `33` line active dependency module. `web/backend/app/api/market/market_data_request.py` has `11` routes and `7` `Depends(get_market_data_service)` sites. `MarketDataService` has broad service, route, test, and governance references. | Active broad market-data seam. Not a retirement candidate. Any future change needs a dedicated route/provider design packet, not a micro cleanup. |
+| `UnifiedDataService` | `web/backend/app/services/unified_data_service.py` has `613` lines. `get_unified_data_service` is used internally in the same module. `web/backend/app/api/industry_concept_analysis.py` has `5` routes and `2` direct `UnifiedDataService()` construction sites. | Broad data seam. Not a clean direct implementation target. Needs separate ownership/design review before source edits. |
+| `DataService`, `StrategyService`, `TechnicalAnalysisService` | These remain broad service seams with larger blast-radius risk and are not narrowed by the G2.42 refresh. | Explicitly excluded from immediate implementation selection in this packet. |
+
+## Decision
+
+Do not select an implementation target in G2.43.
+
+The next useful step is a separate G2.44 authorization packet for
+`AdvancedAnalysisService` route-provider migration. The authorization packet
+should decide whether to replace class-based route `Depends()` construction with
+an app-state/request-scoped provider while preserving route paths, response
+contracts, OpenAPI behavior, and any current test expectations.
+
+This report does not authorize that implementation. It only recommends the
+next packet.
+
+## Required Boundary For G2.44
+
+If G2.44 is opened, it must be a separate reviewable authorization packet before
+source edits. It should include:
+
+- allowed source scope, if any;
+- exact route handlers and dependency sites;
+- pre-edit GitNexus impact/context requirement;
+- focused pytest targets;
+- OpenAPI route/path/operation ID smoke;
+- compatibility fallback decision for `get_advanced_analysis_service`;
+- rollback plan;
+- explicit non-goals for `WencaiService`, `MarketDataService`,
+  `UnifiedDataService`, `DataService`, `StrategyService`, and
+  `TechnicalAnalysisService`.
+
+## Non-Goals
+
+- No backend source changes.
+- No backend test changes.
+- No OpenSpec change/spec/archive operation.
+- No GitHub issue label changes.
+- No compatibility getter cleanup or retirement.
+- No broad service lifecycle migration.
+- No route/OpenAPI contract modification.
+
+## Evidence Summary
+
+| Evidence | Result |
+|---|---|
+| Current HEAD | `f7c6fdf5fd57cff14ef6d11f1d18fd6591a22dc5` |
+| PR `#182` | `MERGED` |
+| `#79` | `OPEN`, `needs-triage` |
+| `#92` | `OPEN`, `enhancement`, `ready-for-human`, `ready-for-downstream` |
+| `get_advanced_analysis_service` | definition-only active reference |
+| `AdvancedAnalysisService` | active route class dependency in `advanced_analysis_api.py` |
+| `get_wencai_service` | definition-only active reference |
+| `WencaiService` | active DB/session-backed service with direct route constructors |
+| `get_market_data_service` | active route dependency, `7` route dependency sites |
+| `UnifiedDataService` | active broad data seam with direct route constructors |
+
+## Recommendation
+
+After human review of this packet, create G2.44:
+
+`AdvancedAnalysisService` route-provider migration authorization.
+
+Keep implementation locked until that packet is explicitly reviewed and
+approved.

--- a/governance/mainline/task-cards/pr-183.yaml
+++ b/governance/mainline/task-cards/pr-183.yaml
@@ -1,0 +1,102 @@
+version: "v0.2"
+
+task:
+  id: "pr-183"
+  title: "Triage service candidate usefulness and ownership"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-service-candidate-usefulness-ownership-triage"
+  objective: "record the G2.43 current-head service candidate usefulness and ownership triage after PR #182"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-candidate-usefulness-ownership-triage"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-candidate-usefulness-ownership-triage"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate usefulness and ownership triage records current-head evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-candidate-usefulness-ownership-triage-2026-05-24.json"
+    - "docs/reports/quality/backend-service-candidate-usefulness-ownership-triage-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-183.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No implementation target selection or source-edit authorization in this PR"
+  - "No compatibility getter cleanup, getter retirement, route provider implementation, or service consolidation in this PR"
+  - "No migration of WencaiService, MarketDataService, UnifiedDataService, DataService, StrategyService, or TechnicalAnalysisService"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-candidate-usefulness-ownership-triage-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-candidate-usefulness-ownership-triage-2026-05-24.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-183.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the triage boundary"
+    - "If this PR authorizes G2.44 implementation directly, it bypasses the separate authorization packet gate"
+    - "If definition-only getters are treated as deletion candidates here, active services can be misclassified"
+  rollback_plan: "revert this governance-only PR; PR #182 remains merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record current-head service candidate usefulness and ownership triage after PR #182"
+    modified_scope: "triage report, generated triage artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no compatibility getter is changed or retired"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only triage PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T01:47:32+08:00"
+    approval_note: "human maintainer approved continuing after PR #182; this triage only records candidate usefulness, ownership, and next-gate boundary"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- Add G2.43 service candidate usefulness and ownership triage report.
- Record current-head candidate dispositions after PR #182.
- Update the steward tree and add the mainline task card / generated JSON artifact.

## Decision Boundary

This PR is governance-only. It does not authorize backend source edits, route changes, OpenSpec changes, issue label movement, compatibility getter cleanup, or implementation work.

## Key Findings

- `AdvancedAnalysisService` is an active route class dependency with `14` class `Depends()` sites and no external getter reference.
- `WencaiService` is active DB/session-backed direct construction, not an immediate singleton DI pilot.
- `get_market_data_service` remains an active route dependency with `7` route dependency sites.
- `UnifiedDataService` remains a broad data seam.

## Next Gate

If accepted, create G2.44 `AdvancedAnalysisService` route-provider migration authorization before any source edits.

## Validation

- Markdown governance: 2 checked files, 0 errors.
- JSON parse: passed.
- Task card YAML parse: passed.
- Mainline scope gate: passed.
- `git diff --check HEAD~1..HEAD`: passed.
