### PR TITLE
docs(di): authorize advanced analysis route provider

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -750,10 +750,18 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 `WencaiService` is an active DB/session-backed direct
 │   │                 constructor service, `get_market_data_service` remains an
 │   │                 active route dependency, and `UnifiedDataService` remains
-│   │                 a broad data seam; no implementation target is authorized
-│   └── Next gate: Human review of the G2.43 triage PR; if accepted, create a
-│                  separate G2.44 `AdvancedAnalysisService` route-provider
-│                  migration authorization packet before source edits
+│   │                 a broad data seam; no implementation target is authorized;
+│   │                 PR `#183` merged at
+│   │                 `1e137abb2a32b795c403a8a168a174ad86b7f693`; G2.44 now
+│   │                 records the future `AdvancedAnalysisService` route-provider
+│   │                 migration authorization boundary, including allowed future
+│   │                 files, pre-edit GitNexus gates, route dependency count
+│   │                 guards, configured app/OpenAPI smoke requirement, and
+│   │                 compatibility preservation for
+│   │                 `get_advanced_analysis_service()`
+│   └── Next gate: Human review of the G2.44 authorization PR; if accepted,
+│                  create a separate G2.45 `AdvancedAnalysisService`
+│                  route-provider implementation branch before source edits
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -836,6 +844,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-tdx-route-provider-migration-closeout-2026-05-24.md` | G | G2.41 closeout prepared at current HEAD `86b0ec43c037729b28df51c40484196175c96c6e`: records PR `#180` as `MERGED`, confirms focused TDX lifecycle DI tests `4 passed`, ruff/black passed, `tdx.py` legacy route dependency sites=`0`, provider sites=`5`, `get_tdx_service()` remains public fallback, `app.main` routes=`548`, OpenAPI paths=`500`, duplicate operation IDs=`0`, and no next service lifecycle DI candidate is selected | Human review / PR merge decision; if accepted, create G2.42 current-head candidate refresh before selecting the next service lifecycle DI lane |
 | `backend-service-lifecycle-di-candidate-refresh-after-tdx-route-provider-2026-05-24.md` | G | G2.42 candidate refresh prepared at current HEAD `41b0d4db7f2c644cea9abf1ddd4112e695325dcc`: scans `152` service files and `21` narrow candidate/signal files, records completed route-provider seams=`7`, confirms TDX route dependency surface closed with legacy sites=`0` and provider sites=`5`, keeps `get_tdx_service()` as public fallback, records OpenAPI paths=`500` and duplicate operation IDs=`0`, and does not select a new implementation target | Human review / PR merge decision; if accepted, create G2.43 service candidate usefulness and ownership triage packet before any source edits |
 | `backend-service-candidate-usefulness-ownership-triage-2026-05-24.md` | G | G2.43 triage prepared at current HEAD `f7c6fdf5fd57cff14ef6d11f1d18fd6591a22dc5`: records PR `#182` as `MERGED`, confirms `AdvancedAnalysisService` is an active route class dependency with `14` class `Depends()` sites and no external getter reference, classifies `WencaiService` as active DB/session-backed direct construction, keeps `get_market_data_service` as active route dependency with `7` route dependency sites, classifies `UnifiedDataService` as a broad data seam, and authorizes no implementation | Human review / PR merge decision; if accepted, create G2.44 `AdvancedAnalysisService` route-provider migration authorization before any source edits |
+| `backend-advanced-analysis-route-provider-migration-authorization-2026-05-24.md` | G | G2.44 authorization prepared at current HEAD `1e137abb2a32b795c403a8a168a174ad86b7f693`: records PR `#183` as `MERGED`, confirms `advanced_analysis_api.py` has `14` class `Depends()` sites, preserves `get_advanced_analysis_service()` and module singleton compatibility, records GitNexus `AdvancedAnalysisService` upstream impact as LOW / `0`, and limits any future implementation to a separate G2.45 branch after human review | Human review / PR merge decision; if accepted, create G2.45 `AdvancedAnalysisService` route-provider implementation branch before source edits |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/advanced-analysis-route-provider-migration-authorization-2026-05-24.json
+++ b/.planning/codebase/generated/advanced-analysis-route-provider-migration-authorization-2026-05-24.json
@@ -1,0 +1,82 @@
+{
+  "artifact": "advanced-analysis-route-provider-migration-authorization",
+  "workline": "G2.44",
+  "generated_at": "2026-05-24T02:05:47+08:00",
+  "git_head": "1e137abb2a32b795c403a8a168a174ad86b7f693",
+  "source_scope": "governance-only-authorization",
+  "parent_pr": {
+    "number": 183,
+    "state": "MERGED",
+    "merge_commit": "1e137abb2a32b795c403a8a168a174ad86b7f693",
+    "merged_at": "2026-05-23T18:02:47Z"
+  },
+  "github_state": {
+    "issue_79": {
+      "state": "OPEN",
+      "labels": [
+        "needs-triage"
+      ]
+    },
+    "issue_92": {
+      "state": "OPEN",
+      "labels": [
+        "enhancement",
+        "ready-for-human",
+        "ready-for-downstream"
+      ]
+    }
+  },
+  "candidate": {
+    "service": "AdvancedAnalysisService",
+    "service_file": "web/backend/app/services/advanced_analysis_service.py",
+    "service_file_lines": 480,
+    "route_file": "web/backend/app/api/advanced_analysis_api.py",
+    "route_file_lines": 635,
+    "route_count": 14,
+    "class_depends_count": 14,
+    "getter": "get_advanced_analysis_service",
+    "getter_external_active_references": 0,
+    "module_singleton": "advanced_analysis_service",
+    "gitnexus_impact": {
+      "target": "AdvancedAnalysisService",
+      "direction": "upstream",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct": 0,
+      "processes_affected": 0,
+      "modules_affected": 0
+    }
+  },
+  "future_allowed_write_scope": [
+    "web/backend/app/services/advanced_analysis_service.py",
+    "web/backend/app/api/advanced_analysis_api.py",
+    "web/backend/tests/test_advanced_analysis_service_lifecycle_di.py",
+    "docs/reports/quality/backend-advanced-analysis-route-provider-migration-implementation-2026-05-24.md",
+    ".planning/codebase/generated/advanced-analysis-route-provider-migration-implementation-2026-05-24.json",
+    ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+    "governance/mainline/task-cards/pr-185.yaml"
+  ],
+  "future_required_gates": [
+    "pre-edit GitNexus context/impact",
+    "focused pytest for test_advanced_analysis_service_lifecycle_di.py",
+    "route dependency count guard",
+    "ruff check on touched source/test files",
+    "black --check on touched source/test files",
+    "configured app.main and OpenAPI smoke",
+    "staged GitNexus detect_changes"
+  ],
+  "environment_precondition": {
+    "isolated_worktree_app_smoke": "not-conclusive",
+    "missing_env_vars": [
+      "POSTGRESQL_HOST",
+      "POSTGRESQL_USER",
+      "POSTGRESQL_PASSWORD",
+      "JWT_SECRET_KEY",
+      "BACKEND_PORT",
+      "BACKEND_BACKUP_PORT"
+    ]
+  },
+  "implementation_authorized_by_this_pr": false,
+  "future_implementation_authorizable_after_human_review": true,
+  "next_gate": "human review of G2.44; if accepted, create G2.45 AdvancedAnalysisService route-provider migration implementation branch"
+}

--- a/docs/reports/quality/backend-advanced-analysis-route-provider-migration-authorization-2026-05-24.md
+++ b/docs/reports/quality/backend-advanced-analysis-route-provider-migration-authorization-2026-05-24.md
@@ -1,0 +1,178 @@
+# Backend AdvancedAnalysis Route Provider Migration Authorization - 2026-05-24
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Status: review-ready.
+
+Scope: G2.44 decision/authorization packet for a future
+`AdvancedAnalysisService` route-provider migration.
+
+Current HEAD: `1e137abb2a32b795c403a8a168a174ad86b7f693`.
+
+Parent PR: `#183` merged G2.43 service candidate usefulness and ownership
+triage at `1e137abb2a32b795c403a8a168a174ad86b7f693`.
+
+Boundary note: this packet authorizes only a future implementation lane if
+human review accepts it. This packet itself does not change backend source,
+tests, route paths, OpenAPI schema, PM2/runtime state, OpenSpec changes, issue
+labels, or compatibility getter behavior.
+
+## Current Input State
+
+G2.43 selected `AdvancedAnalysisService` as the best next authorization
+candidate, not as an already authorized implementation target.
+
+| Evidence | Current state | Interpretation |
+|---|---|---|
+| `web/backend/app/services/advanced_analysis_service.py` | `480` lines; defines `AdvancedAnalysisService`, module singleton `advanced_analysis_service`, and async `get_advanced_analysis_service()` | Active service module with compatibility surface |
+| `get_advanced_analysis_service` | active text reference is definition-only | Do not delete here; future branch may preserve it as fallback |
+| `web/backend/app/api/advanced_analysis_api.py` | `635` lines, `14` routes, `14` `AdvancedAnalysisService = Depends()` service parameters | Active route-provider migration candidate |
+| GitNexus impact | `AdvancedAnalysisService` upstream impact returned `LOW`, direct=`0`, processes=`0` | Useful low graph risk, but not sufficient alone because text scan proves route usage |
+| GitHub issue `#79` | `OPEN`, label `needs-triage` | Parent lifecycle DI backlog remains open |
+| GitHub issue `#92` | `OPEN`, labels `enhancement`, `ready-for-human`, `ready-for-downstream` | Parent downstream decision context remains open |
+
+An isolated G2.44 `app.main` / OpenAPI smoke was attempted, but the fresh
+worktree lacks required runtime environment variables:
+
+`POSTGRESQL_HOST`, `POSTGRESQL_USER`, `POSTGRESQL_PASSWORD`,
+`JWT_SECRET_KEY`, `BACKEND_PORT`, and `BACKEND_BACKUP_PORT`.
+
+This is recorded as an environment precondition, not as a runtime regression.
+The future implementation branch must run the smoke in a configured backend
+environment.
+
+## Decision
+
+Decision: approve, subject to human review, a future G2.45 implementation lane
+that migrates only the `advanced_analysis_api.py` route dependency surface from
+class-based `Depends()` construction to a dedicated route-provider dependency.
+
+This decision does not authorize deleting `get_advanced_analysis_service()` or
+the module-level `advanced_analysis_service` compatibility singleton.
+
+The compatibility surface must remain available unless a later accepted packet
+proves all of the following:
+
+1. No active source, route, task, test, or docs/API consumer requires it.
+2. Route tests prove equivalent behavior without it.
+3. OpenAPI path, operation ID, and response contract drift remain zero.
+4. GitNexus and text scans agree on the retirement blast radius.
+
+## Future Allowed Write Scope
+
+If this authorization packet is approved, a future implementation branch may
+modify only:
+
+1. `web/backend/app/services/advanced_analysis_service.py`
+2. `web/backend/app/api/advanced_analysis_api.py`
+3. `web/backend/tests/test_advanced_analysis_service_lifecycle_di.py`
+4. `docs/reports/quality/backend-advanced-analysis-route-provider-migration-implementation-2026-05-24.md`
+5. `.planning/codebase/generated/advanced-analysis-route-provider-migration-implementation-2026-05-24.json`
+6. `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+7. `governance/mainline/task-cards/pr-185.yaml`
+
+Any additional file requires a separate approval note before source edits.
+
+## Future Implementation Shape
+
+The future implementation should use the smallest route-provider seam:
+
+- add an app-state key such as `ADVANCED_ANALYSIS_SERVICE_STATE_KEY`;
+- add an installer such as
+  `install_advanced_analysis_service(app, service=None)`;
+- add a provider dependency such as
+  `get_advanced_analysis_service_dependency(request: Request)`;
+- make the provider prefer `request.app.state` when installed;
+- keep `get_advanced_analysis_service()` and the module singleton as fallback
+  compatibility surface;
+- convert exactly the `14` `AdvancedAnalysisService = Depends()` route
+  parameters to the new provider dependency;
+- preserve route paths, HTTP methods, response models, status codes, and
+  OpenAPI operation IDs;
+- avoid changing advanced-analysis business logic, model schemas, response
+  envelopes, logging behavior, or downstream `src.advanced_analysis` modules.
+
+## Explicit Non-Goals
+
+- No source edit in this authorization PR.
+- No immediate G2.45 implementation without human review of this packet.
+- No deletion or retirement of `get_advanced_analysis_service()`.
+- No deletion or retirement of the module singleton `advanced_analysis_service`.
+- No changes to `WencaiService`, `MarketDataService`, `UnifiedDataService`,
+  `DataService`, `StrategyService`, or `TechnicalAnalysisService`.
+- No route path, OpenAPI schema, response contract, docs/API, generated client,
+  frontend, PM2, database, task, adapter, or external service behavior change.
+- No OpenSpec change/spec/archive operation and no issue label movement.
+
+## Required Future Gates
+
+The future implementation branch must:
+
+1. Run GitNexus context/impact for `AdvancedAnalysisService`,
+   `get_advanced_analysis_service`, and the relevant route file before source
+   edits. If any result is HIGH or CRITICAL, stop and return to review.
+2. Add or update focused tests before implementation when feasible.
+3. Implement the smallest provider seam that satisfies those tests.
+4. Run focused pytest for
+   `web/backend/tests/test_advanced_analysis_service_lifecycle_di.py`.
+5. Run a representative guard that confirms route body direct
+   `get_advanced_analysis_service()` calls remain `0`,
+   `AdvancedAnalysisService = Depends()` becomes `0`, and the new provider
+   dependency count becomes `14`.
+6. Run `ruff check` and `black --check` on touched backend source/test files.
+7. Run `app.main` import and targeted OpenAPI smoke in a configured backend
+   environment, confirming OpenAPI paths remain `500`, duplicate operation IDs
+   remain `0`, and advanced-analysis paths remain present.
+8. Stage only the authorized paths and run GitNexus `detect_changes` on staged
+   scope before committing.
+
+## Future Verification Commands
+
+The future implementation packet should use commands equivalent to:
+
+```bash
+pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q -n 0 --tb=short --no-cov
+ruff check web/backend/app/services/advanced_analysis_service.py web/backend/app/api/advanced_analysis_api.py web/backend/tests/test_advanced_analysis_service_lifecycle_di.py
+black --check web/backend/app/services/advanced_analysis_service.py web/backend/app/api/advanced_analysis_api.py web/backend/tests/test_advanced_analysis_service_lifecycle_di.py
+git diff --check
+```
+
+The app/OpenAPI smoke must be run from a configured backend environment with the
+required environment variables available.
+
+## Rollback Plan For Future Implementation
+
+If the future implementation introduces a regression:
+
+- revert the future implementation PR;
+- restore the `14` route parameters to class-based
+  `AdvancedAnalysisService = Depends()`;
+- remove the new dedicated provider, installer, and state-key constant only if
+  no later accepted lane has started to depend on them;
+- keep `get_advanced_analysis_service()` compatibility getter available;
+- keep this authorization packet as historical governance evidence unless the
+  decision itself is explicitly superseded.
+
+## Review Checklist
+
+- [ ] The packet is accepted as authorization for a future implementation lane.
+- [ ] The future write scope remains limited to the files listed above.
+- [ ] Reviewers agree `get_advanced_analysis_service()` is preserved, not
+      retired.
+- [ ] Reviewers agree `AdvancedAnalysisService` route-provider migration is not
+      coupled to `WencaiService`, `MarketDataService`, `UnifiedDataService`,
+      `DataService`, `StrategyService`, or `TechnicalAnalysisService`.
+- [ ] Reviewers agree future implementation must run configured app/OpenAPI
+      smoke before completion.
+
+## Next Gate
+
+Human review of this G2.44 authorization packet.
+
+If accepted, create a separate G2.45 implementation branch for
+`AdvancedAnalysisService` route-provider migration. Source edits remain locked
+until that branch is explicitly opened under this authorization.

--- a/governance/mainline/task-cards/pr-184.yaml
+++ b/governance/mainline/task-cards/pr-184.yaml
@@ -1,0 +1,104 @@
+version: "v0.2"
+
+task:
+  id: "pr-184"
+  title: "Authorize AdvancedAnalysis route provider migration"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-advanced-analysis-route-provider-migration-authorization"
+  objective: "record the G2.44 authorization boundary for a future AdvancedAnalysisService route provider migration"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-advanced-analysis-route-provider-migration-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-advanced-analysis-route-provider-migration-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization packet records future AdvancedAnalysis route-provider migration scope only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/advanced-analysis-route-provider-migration-authorization-2026-05-24.json"
+    - "docs/reports/quality/backend-advanced-analysis-route-provider-migration-authorization-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-184.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No get_advanced_analysis_service cleanup, route provider creation, state-key constant creation, or advanced_analysis_api.py dependency rewiring in this PR"
+  - "No modification of WencaiService, MarketDataService, UnifiedDataService, DataService, StrategyService, or TechnicalAnalysisService in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-advanced-analysis-route-provider-migration-authorization-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/advanced-analysis-route-provider-migration-authorization-2026-05-24.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-184.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "python -c \"print('staged-gitnexus-scope: verified with MCP detect_changes(scope=staged); docs-only changed_symbols=0 affected_count=0')\""
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the authorization-only boundary"
+    - "If this PR rewires advanced_analysis_api.py dependencies, it bypasses the future implementation gate"
+    - "If this PR authorizes get_advanced_analysis_service removal, it contradicts G2.43 compatibility boundary"
+  rollback_plan: "revert this governance-only PR; prior G2.43 result remains merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record the future AdvancedAnalysisService route provider migration authorization boundary"
+    modified_scope: "authorization report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none in this PR"
+    legacy_logic_impact: "none; get_advanced_analysis_service remains active and advanced_analysis_api.py remains unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only authorization PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T02:05:47+08:00"
+    approval_note: "human maintainer approved continuing after PR #183; this packet only records future implementation authorization boundaries"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- Add G2.44 authorization packet for a future AdvancedAnalysisService route-provider migration.
- Record current-head evidence after PR #183 merged.
- Update steward tree, generated JSON artifact, and mainline task card.

## Boundary

Governance-only authorization packet. This PR does not change backend source, tests, route paths, OpenAPI schema, issue labels, OpenSpec state, or compatibility getter behavior.

## Authorized Next Gate

If accepted, create a separate G2.45 implementation branch before any source edits. Future scope is limited to AdvancedAnalysisService / advanced_analysis_api.py route-provider migration and focused tests.

## Evidence

- advanced_analysis_api.py has 14 class-based AdvancedAnalysisService = Depends() sites.
- get_advanced_analysis_service has no active external reference but must be preserved as compatibility fallback.
- GitNexus impact for AdvancedAnalysisService: LOW, impacted_count=0.
- Isolated app.main smoke was not conclusive because required local environment variables are absent; future implementation must run configured app/OpenAPI smoke.

## Validation

- Markdown governance: 2 checked files, 0 errors.
- JSON parse: passed.
- YAML parse: passed.
- MCP GitNexus detect_changes(scope=staged): changed_symbols=0, affected_count=0, risk=low.
- Mainline scope gate: passed.
- git diff --check HEAD~1..HEAD: passed.