### PR TITLE
refactor(di): inject advanced analysis route provider

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -758,10 +758,16 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 files, pre-edit GitNexus gates, route dependency count
 │   │                 guards, configured app/OpenAPI smoke requirement, and
 │   │                 compatibility preservation for
-│   │                 `get_advanced_analysis_service()`
-│   └── Next gate: Human review of the G2.44 authorization PR; if accepted,
-│                  create a separate G2.45 `AdvancedAnalysisService`
-│                  route-provider implementation branch before source edits
+│   │                 `get_advanced_analysis_service()`; PR `#184` merged at
+│   │                 `22b617733e29c9a441e88cb1da2ce0a5d8be98cc`; G2.45 now
+│   │                 implements the provider seam, preserves the compatibility
+│   │                 getter and module singleton, converts `14`
+│   │                 `advanced_analysis_api.py` service dependencies to
+│   │                 `get_advanced_analysis_service_dependency`, and keeps
+│   │                 OpenAPI paths=`500` with duplicate operation IDs=`0`
+│   └── Next gate: Human review of the G2.45 implementation PR; if accepted,
+│                  run a separate G2.46 closeout/current-head candidate refresh
+│                  before selecting another service lifecycle DI lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -845,6 +851,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-di-candidate-refresh-after-tdx-route-provider-2026-05-24.md` | G | G2.42 candidate refresh prepared at current HEAD `41b0d4db7f2c644cea9abf1ddd4112e695325dcc`: scans `152` service files and `21` narrow candidate/signal files, records completed route-provider seams=`7`, confirms TDX route dependency surface closed with legacy sites=`0` and provider sites=`5`, keeps `get_tdx_service()` as public fallback, records OpenAPI paths=`500` and duplicate operation IDs=`0`, and does not select a new implementation target | Human review / PR merge decision; if accepted, create G2.43 service candidate usefulness and ownership triage packet before any source edits |
 | `backend-service-candidate-usefulness-ownership-triage-2026-05-24.md` | G | G2.43 triage prepared at current HEAD `f7c6fdf5fd57cff14ef6d11f1d18fd6591a22dc5`: records PR `#182` as `MERGED`, confirms `AdvancedAnalysisService` is an active route class dependency with `14` class `Depends()` sites and no external getter reference, classifies `WencaiService` as active DB/session-backed direct construction, keeps `get_market_data_service` as active route dependency with `7` route dependency sites, classifies `UnifiedDataService` as a broad data seam, and authorizes no implementation | Human review / PR merge decision; if accepted, create G2.44 `AdvancedAnalysisService` route-provider migration authorization before any source edits |
 | `backend-advanced-analysis-route-provider-migration-authorization-2026-05-24.md` | G | G2.44 authorization prepared at current HEAD `1e137abb2a32b795c403a8a168a174ad86b7f693`: records PR `#183` as `MERGED`, confirms `advanced_analysis_api.py` has `14` class `Depends()` sites, preserves `get_advanced_analysis_service()` and module singleton compatibility, records GitNexus `AdvancedAnalysisService` upstream impact as LOW / `0`, and limits any future implementation to a separate G2.45 branch after human review | Human review / PR merge decision; if accepted, create G2.45 `AdvancedAnalysisService` route-provider implementation branch before source edits |
+| `backend-advanced-analysis-route-provider-migration-implementation-2026-05-24.md` | G | G2.45 implementation prepared from G2.44 authorization at base `22b617733e29c9a441e88cb1da2ce0a5d8be98cc`: adds `ADVANCED_ANALYSIS_SERVICE_STATE_KEY`, `install_advanced_analysis_service`, and `get_advanced_analysis_service_dependency`, preserves `get_advanced_analysis_service()` and module singleton compatibility, converts all `14` `advanced_analysis_api.py` service dependencies to the provider, focused TDD ended at `4 passed`, ruff/black passed, configured OpenAPI smoke reports routes=`548`, paths=`500`, duplicate operation IDs=`0`, and advanced paths=`14` | Human review / PR merge decision; if accepted, run G2.46 closeout/current-head candidate refresh before selecting the next service lifecycle DI lane |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/advanced-analysis-route-provider-migration-implementation-2026-05-24.json
+++ b/.planning/codebase/generated/advanced-analysis-route-provider-migration-implementation-2026-05-24.json
@@ -1,0 +1,104 @@
+{
+  "artifact": "advanced-analysis-route-provider-migration-implementation",
+  "workline": "G2.45",
+  "generated_at": "2026-05-24T02:22:28+08:00",
+  "base_head": "22b617733e29c9a441e88cb1da2ce0a5d8be98cc",
+  "parent_pr": {
+    "number": 184,
+    "state": "MERGED",
+    "merge_commit": "22b617733e29c9a441e88cb1da2ce0a5d8be98cc",
+    "merged_at": "2026-05-23T18:15:19Z"
+  },
+  "changed_runtime_files": [
+    "web/backend/app/services/advanced_analysis_service.py",
+    "web/backend/app/api/advanced_analysis_api.py",
+    "web/backend/tests/test_advanced_analysis_service_lifecycle_di.py"
+  ],
+  "implementation": {
+    "state_key": "ADVANCED_ANALYSIS_SERVICE_STATE_KEY",
+    "installer": "install_advanced_analysis_service",
+    "provider": "get_advanced_analysis_service_dependency",
+    "compatibility_getter_preserved": true,
+    "module_singleton_preserved": true,
+    "route_paths_changed": false,
+    "response_contract_changed": false,
+    "openapi_exposure_changed": false
+  },
+  "metrics": {
+    "service_lines": 505,
+    "api_lines": 637,
+    "test_lines": 83,
+    "advanced_routes": 14,
+    "class_depends_after": 0,
+    "provider_depends_after": 14,
+    "direct_getter_calls_after": 0
+  },
+  "tdd": {
+    "red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q -n 0 --tb=short --no-cov",
+      "result": "4 failed",
+      "expected_missing_symbols": [
+        "get_advanced_analysis_service_dependency",
+        "ADVANCED_ANALYSIS_SERVICE_STATE_KEY",
+        "install_advanced_analysis_service"
+      ]
+    },
+    "green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q -n 0 --tb=short --no-cov",
+      "result": "4 passed in 4.25s"
+    }
+  },
+  "static_verification": {
+    "ruff": "All checks passed",
+    "black_check": "3 files would be left unchanged"
+  },
+  "route_guard": {
+    "class_depends": 0,
+    "provider_depends": 14,
+    "direct_getter_calls": 0,
+    "state_key": true,
+    "install": true,
+    "provider": true,
+    "compat_getter": true
+  },
+  "app_openapi_smoke": {
+    "status": "passed",
+    "routes": 548,
+    "paths": 500,
+    "operation_ids": 536,
+    "duplicate_operation_ids": 0,
+    "advanced_paths": 14,
+    "warnings": 0,
+    "pythonpath": "web/backend plus repository root",
+    "required_env_vars_supplied": [
+      "POSTGRESQL_HOST",
+      "POSTGRESQL_USER",
+      "POSTGRESQL_PASSWORD",
+      "JWT_SECRET_KEY",
+      "BACKEND_PORT",
+      "BACKEND_BACKUP_PORT"
+    ]
+  },
+  "gitnexus_pre_edit": {
+    "AdvancedAnalysisService": {
+      "risk": "LOW",
+      "impacted_count": 0
+    },
+    "get_advanced_analysis_service": {
+      "risk": "LOW",
+      "impacted_count": 0
+    },
+    "web/backend/app/api/advanced_analysis_api.py": {
+      "risk": "LOW",
+      "impacted_count": 0
+    }
+  },
+  "gitnexus_staged_scope": {
+    "changed_files": 7,
+    "changed_symbols": 40,
+    "affected_count": 0,
+    "affected_processes": 0,
+    "risk_level": "low"
+  },
+  "next_gate": "human review of G2.45 implementation PR; if accepted, run G2.46 closeout/current-head candidate refresh"
+}

--- a/docs/reports/quality/backend-advanced-analysis-route-provider-migration-implementation-2026-05-24.md
+++ b/docs/reports/quality/backend-advanced-analysis-route-provider-migration-implementation-2026-05-24.md
@@ -1,0 +1,174 @@
+# Backend AdvancedAnalysis Route Provider Migration Implementation - 2026-05-24
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Status: review-ready.
+
+Current HEAD before commit: `22b617733e29c9a441e88cb1da2ce0a5d8be98cc`.
+
+Parent authorization: PR `#184`, merged at
+`22b617733e29c9a441e88cb1da2ce0a5d8be98cc`.
+
+## Decision Boundary
+
+This implementation follows the G2.44 authorization boundary. It changes only:
+
+- `web/backend/app/services/advanced_analysis_service.py`
+- `web/backend/app/api/advanced_analysis_api.py`
+- `web/backend/tests/test_advanced_analysis_service_lifecycle_di.py`
+- this implementation report
+- generated implementation evidence JSON
+- steward tree
+- task card
+
+It does not change route paths, response models, OpenAPI exposure, docs/API,
+frontend, PM2/runtime process state, OpenSpec files, issue labels, unrelated
+service seams, or compatibility getter behavior.
+
+## Implementation Summary
+
+Implemented the smallest app-state backed route provider seam:
+
+- added `ADVANCED_ANALYSIS_SERVICE_STATE_KEY`;
+- added `install_advanced_analysis_service(app, service=None)`;
+- added async `get_advanced_analysis_service_dependency(request)`;
+- preserved `advanced_analysis_service` module singleton;
+- preserved async `get_advanced_analysis_service()` compatibility getter;
+- converted all `14` `advanced_analysis_api.py` service parameters from
+  class-based `Depends()` to `Depends(get_advanced_analysis_service_dependency)`.
+
+## TDD Evidence
+
+Red run before implementation:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q -n 0 --tb=short --no-cov
+```
+
+Result:
+
+- `4 failed`
+- expected missing symbols:
+  - `get_advanced_analysis_service_dependency`
+  - `ADVANCED_ANALYSIS_SERVICE_STATE_KEY`
+  - `install_advanced_analysis_service`
+- route dependency still pointed to class-based `Depends()`
+
+Green run after implementation and formatting:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q -n 0 --tb=short --no-cov
+```
+
+Result:
+
+- `4 passed in 4.25s`
+
+## Guard Evidence
+
+Route dependency guard:
+
+```json
+{
+  "class_depends": 0,
+  "provider_depends": 14,
+  "direct_getter_calls": 0,
+  "state_key": true,
+  "install": true,
+  "provider": true,
+  "compat_getter": true
+}
+```
+
+Current file metrics:
+
+```json
+{
+  "service_lines": 505,
+  "api_lines": 637,
+  "test_lines": 83,
+  "routes": 14,
+  "class_depends": 0,
+  "provider_depends": 14,
+  "direct_getter_calls": 0,
+  "has_state_key": true,
+  "has_installer": true,
+  "has_provider": true,
+  "has_compat_getter": true
+}
+```
+
+## App And OpenAPI Smoke
+
+Initial isolated smoke without repository root on `PYTHONPATH` failed because
+`src` imports were not resolvable. Re-run with both `web/backend` and repository
+root on `PYTHONPATH`, plus required runtime environment variables, passed:
+
+```json
+{
+  "routes": 548,
+  "paths": 500,
+  "operation_ids": 536,
+  "duplicate_operation_ids": 0,
+  "advanced_paths": 14,
+  "warnings": 0
+}
+```
+
+Observed non-blocking import-time warnings/logs were existing optional runtime
+environment facts, including GPU dependency fallback and mock-data fallback.
+
+## Static Verification
+
+```bash
+ruff check web/backend/app/services/advanced_analysis_service.py web/backend/app/api/advanced_analysis_api.py web/backend/tests/test_advanced_analysis_service_lifecycle_di.py
+black --check web/backend/app/services/advanced_analysis_service.py web/backend/app/api/advanced_analysis_api.py web/backend/tests/test_advanced_analysis_service_lifecycle_di.py
+```
+
+Results:
+
+- `ruff`: `All checks passed!`
+- `black --check`: `3 files would be left unchanged`
+
+## GitNexus Evidence
+
+Pre-edit:
+
+- `AdvancedAnalysisService` context: found at
+  `web/backend/app/services/advanced_analysis_service.py`, lines `24-468`
+- `AdvancedAnalysisService` upstream impact: LOW, impacted=`0`
+- `get_advanced_analysis_service` context: found at
+  `web/backend/app/services/advanced_analysis_service.py`, lines `475-478`
+- `get_advanced_analysis_service` upstream impact: LOW, impacted=`0`
+- `web/backend/app/api/advanced_analysis_api.py` upstream impact: LOW,
+  impacted=`0`
+
+Text scan remained the deciding route evidence because GitNexus reported no
+incoming graph edges while `advanced_analysis_api.py` had `14` active
+class-based route dependency sites before implementation.
+
+Staged scope:
+
+- changed files: `7`
+- changed symbols: `40`
+- affected count: `0`
+- affected processes: `0`
+- risk level: `low`
+
+## Rollback
+
+Rollback is a single PR revert. Reverting restores the `14` route dependencies
+to class-based `AdvancedAnalysisService = Depends()` and removes the new
+app-state dependency provider while preserving the pre-existing compatibility
+getter and module singleton behavior.
+
+## Next Gate
+
+Human review of this G2.45 implementation PR.
+
+If accepted and merged, run a separate G2.46 closeout/current-head candidate
+refresh before selecting another service lifecycle DI implementation lane.

--- a/governance/mainline/task-cards/pr-185.yaml
+++ b/governance/mainline/task-cards/pr-185.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-185"
+  title: "Implement AdvancedAnalysis route provider migration"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-advanced-analysis-route-provider-migration-implementation"
+  objective: "implement the G2.45 AdvancedAnalysisService route provider migration authorized by PR #184"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-advanced-analysis-route-provider-migration-implementation"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-advanced-analysis-route-provider-migration-implementation"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Route-provider migration preserves existing route paths, OpenAPI exposure, and product surface while moving the AdvancedAnalysis service dependency to an app-state provider"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/advanced-analysis-route-provider-migration-implementation-2026-05-24.json"
+    - "docs/reports/quality/backend-advanced-analysis-route-provider-migration-implementation-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-185.yaml"
+    - "web/backend/app/services/advanced_analysis_service.py"
+    - "web/backend/app/api/advanced_analysis_api.py"
+    - "web/backend/tests/test_advanced_analysis_service_lifecycle_di.py"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No route path, response model, OpenAPI exposure, docs/API, generated client, frontend, PM2, database, task, adapter, or external service behavior change"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No get_advanced_analysis_service cleanup or module singleton retirement"
+  - "No modification of WencaiService, MarketDataService, UnifiedDataService, DataService, StrategyService, or TechnicalAnalysisService"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q -n 0 --tb=short --no-cov"
+      required: true
+    - id: "route-dependency-guard"
+      command: "node -e \"const fs=require('fs'); const api=fs.readFileSync('web/backend/app/api/advanced_analysis_api.py','utf8'); const service=fs.readFileSync('web/backend/app/services/advanced_analysis_service.py','utf8'); const result={class_depends:(api.match(/AdvancedAnalysisService\\\\s*=\\\\s*Depends\\\\(\\\\)/g)||[]).length,provider_depends:(api.match(/Depends\\\\(get_advanced_analysis_service_dependency\\\\)/g)||[]).length,direct_getter_calls:(api.match(/get_advanced_analysis_service\\\\(/g)||[]).length,state_key:service.includes('ADVANCED_ANALYSIS_SERVICE_STATE_KEY'),install:service.includes('def install_advanced_analysis_service'),provider:service.includes('async def get_advanced_analysis_service_dependency'),compat_getter:service.includes('async def get_advanced_analysis_service')}; console.log(JSON.stringify(result)); if(result.class_depends!==0||result.provider_depends!==14||result.direct_getter_calls!==0||!result.state_key||!result.install||!result.provider||!result.compat_getter) process.exit(1);\""
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/services/advanced_analysis_service.py web/backend/app/api/advanced_analysis_api.py web/backend/tests/test_advanced_analysis_service_lifecycle_di.py"
+      required: true
+    - id: "black-check"
+      command: "black --check web/backend/app/services/advanced_analysis_service.py web/backend/app/api/advanced_analysis_api.py web/backend/tests/test_advanced_analysis_service_lifecycle_di.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-advanced-analysis-route-provider-migration-implementation-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/advanced-analysis-route-provider-migration-implementation-2026-05-24.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-185.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "python -c \"print('staged-gitnexus-scope: verify with MCP detect_changes(scope=staged); expected no high/critical risk')\""
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If route paths or response models change, the PR exceeds the route-provider migration boundary"
+    - "If get_advanced_analysis_service is retired, compatibility fallback is broken"
+    - "If provider dependency count is not exactly 14, one route may remain on class-based Depends() or an unrelated dependency may be changed"
+  rollback_plan: "revert this implementation PR; prior G2.44 authorization remains historical evidence unless superseded"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "migrate AdvancedAnalysis route service dependency to an app-state provider"
+    modified_scope: "AdvancedAnalysis service module, advanced analysis route module, focused test, implementation report, generated artifact, steward tree, and this task card"
+    dependency_changes: "adds get_advanced_analysis_service_dependency while preserving get_advanced_analysis_service"
+    legacy_logic_impact: "compatibility getter and module singleton preserved"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this route-provider migration PR if verification fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T02:22:28+08:00"
+    approval_note: "human maintainer approved continuing after PR #184; implementation follows the G2.44 AdvancedAnalysis route-provider authorization boundary"
+    secondary_approved: false

--- a/web/backend/app/api/advanced_analysis_api.py
+++ b/web/backend/app/api/advanced_analysis_api.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel, Field
 
 from app.core.responses import UnifiedResponse, ok, server_error
 from app.core.security import User, get_current_user
-from app.services.advanced_analysis_service import AdvancedAnalysisService
+from app.services.advanced_analysis_service import AdvancedAnalysisService, get_advanced_analysis_service_dependency
 
 # 创建路由器
 router = APIRouter(
@@ -101,7 +101,7 @@ class AdvancedBatchRequest(BaseModel):
 async def analyze_fundamental(
     request: AnalysisRequest = Depends(),
     current_user: User = Depends(get_current_user),
-    service: AdvancedAnalysisService = Depends(),
+    service: AdvancedAnalysisService = Depends(get_advanced_analysis_service_dependency),
 ) -> Dict[str, Any]:
     """
     基本面分析API
@@ -137,7 +137,7 @@ async def analyze_fundamental(
 async def analyze_technical(
     request: AnalysisRequest = Depends(),
     current_user: User = Depends(get_current_user),
-    service: AdvancedAnalysisService = Depends(),
+    service: AdvancedAnalysisService = Depends(get_advanced_analysis_service_dependency),
 ) -> Dict[str, Any]:
     """
     技术面分析API
@@ -175,7 +175,7 @@ async def analyze_technical(
 async def analyze_trading_signals(
     request: TradingSignalsRequest = Depends(),
     current_user: User = Depends(get_current_user),
-    service: AdvancedAnalysisService = Depends(),
+    service: AdvancedAnalysisService = Depends(get_advanced_analysis_service_dependency),
 ) -> Dict[str, Any]:
     """
     交易信号分析API
@@ -217,7 +217,7 @@ async def analyze_trading_signals(
 async def analyze_time_series(
     request: AnalysisRequest = Depends(),
     current_user: User = Depends(get_current_user),
-    service: AdvancedAnalysisService = Depends(),
+    service: AdvancedAnalysisService = Depends(get_advanced_analysis_service_dependency),
 ) -> Dict[str, Any]:
     """
     时序分析API
@@ -255,7 +255,7 @@ async def analyze_time_series(
 async def analyze_market_panorama(
     request: MarketPanoramaRequest = Depends(),
     current_user: User = Depends(get_current_user),
-    service: AdvancedAnalysisService = Depends(),
+    service: AdvancedAnalysisService = Depends(get_advanced_analysis_service_dependency),
 ) -> Dict[str, Any]:
     """
     市场全景分析API
@@ -289,7 +289,7 @@ async def analyze_market_panorama(
 async def analyze_capital_flow(
     request: AnalysisRequest = Depends(),
     current_user: User = Depends(get_current_user),
-    service: AdvancedAnalysisService = Depends(),
+    service: AdvancedAnalysisService = Depends(get_advanced_analysis_service_dependency),
 ) -> Dict[str, Any]:
     """
     资金流向分析API
@@ -327,7 +327,7 @@ async def analyze_capital_flow(
 async def analyze_chip_distribution(
     request: AnalysisRequest = Depends(),
     current_user: User = Depends(get_current_user),
-    service: AdvancedAnalysisService = Depends(),
+    service: AdvancedAnalysisService = Depends(get_advanced_analysis_service_dependency),
 ) -> Dict[str, Any]:
     """
     筹码分布分析API
@@ -365,7 +365,7 @@ async def analyze_chip_distribution(
 async def analyze_anomaly_tracking(
     request: AnalysisRequest = Depends(),
     current_user: User = Depends(get_current_user),
-    service: AdvancedAnalysisService = Depends(),
+    service: AdvancedAnalysisService = Depends(get_advanced_analysis_service_dependency),
 ) -> Dict[str, Any]:
     """
     异常追踪分析API
@@ -403,7 +403,7 @@ async def analyze_anomaly_tracking(
 async def analyze_financial_valuation(
     request: AnalysisRequest = Depends(),
     current_user: User = Depends(get_current_user),
-    service: AdvancedAnalysisService = Depends(),
+    service: AdvancedAnalysisService = Depends(get_advanced_analysis_service_dependency),
 ) -> Dict[str, Any]:
     """
     财务估值分析API
@@ -441,7 +441,7 @@ async def analyze_financial_valuation(
 async def analyze_sentiment(
     request: AnalysisRequest = Depends(),
     current_user: User = Depends(get_current_user),
-    service: AdvancedAnalysisService = Depends(),
+    service: AdvancedAnalysisService = Depends(get_advanced_analysis_service_dependency),
 ) -> Dict[str, Any]:
     """
     情绪分析API
@@ -479,7 +479,7 @@ async def analyze_sentiment(
 async def analyze_decision_models(
     request: AnalysisRequest = Depends(),
     current_user: User = Depends(get_current_user),
-    service: AdvancedAnalysisService = Depends(),
+    service: AdvancedAnalysisService = Depends(get_advanced_analysis_service_dependency),
 ) -> Dict[str, Any]:
     """
     决策模型分析API
@@ -517,7 +517,7 @@ async def analyze_decision_models(
 async def analyze_multidimensional_radar(
     request: AnalysisRequest = Depends(),
     current_user: User = Depends(get_current_user),
-    service: AdvancedAnalysisService = Depends(),
+    service: AdvancedAnalysisService = Depends(get_advanced_analysis_service_dependency),
 ) -> Dict[str, Any]:
     """
     多维度雷达分析API
@@ -575,7 +575,7 @@ async def analyze_batch(
         },
     ),
     current_user: User = Depends(get_current_user),
-    service: AdvancedAnalysisService = Depends(),
+    service: AdvancedAnalysisService = Depends(get_advanced_analysis_service_dependency),
 ) -> Dict[str, Any]:
     """
     批量高级分析API
@@ -613,7 +613,9 @@ async def analyze_batch(
 
 # 健康检查接口
 @router.get("/health", response_model=UnifiedResponse)
-async def health_check(service: AdvancedAnalysisService = Depends()) -> Dict[str, Any]:
+async def health_check(
+    service: AdvancedAnalysisService = Depends(get_advanced_analysis_service_dependency),
+) -> Dict[str, Any]:
     """
     高级分析模块健康检查
 

--- a/web/backend/app/services/advanced_analysis_service.py
+++ b/web/backend/app/services/advanced_analysis_service.py
@@ -9,6 +9,8 @@ import asyncio
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from fastapi import Request
+
 # from app.core.monitoring import PerformanceMonitor  # TODO: Add monitoring module
 from app.core.logging import get_logger
 
@@ -470,10 +472,33 @@ class AdvancedAnalysisService:
 
 
 # 创建服务实例
+ADVANCED_ANALYSIS_SERVICE_STATE_KEY = "advanced_analysis_service"
+
 advanced_analysis_service = AdvancedAnalysisService()
+
+
+def install_advanced_analysis_service(
+    app: Any,
+    service: AdvancedAnalysisService | None = None,
+) -> AdvancedAnalysisService:
+    """Install the advanced analysis service on app.state while preserving the legacy fallback."""
+    selected_service = service or getattr(app.state, ADVANCED_ANALYSIS_SERVICE_STATE_KEY, None)
+    if selected_service is None:
+        selected_service = advanced_analysis_service
+    setattr(app.state, ADVANCED_ANALYSIS_SERVICE_STATE_KEY, selected_service)
+    return selected_service
 
 
 async def get_advanced_analysis_service() -> AdvancedAnalysisService:
     """获取高级分析服务实例（依赖注入用）"""
     await advanced_analysis_service.initialize()
     return advanced_analysis_service
+
+
+async def get_advanced_analysis_service_dependency(request: Request) -> AdvancedAnalysisService:
+    """FastAPI dependency provider backed by app.state."""
+    service = getattr(request.app.state, ADVANCED_ANALYSIS_SERVICE_STATE_KEY, None)
+    if service is None:
+        service = await get_advanced_analysis_service()
+        setattr(request.app.state, ADVANCED_ANALYSIS_SERVICE_STATE_KEY, service)
+    return service

--- a/web/backend/tests/test_advanced_analysis_service_lifecycle_di.py
+++ b/web/backend/tests/test_advanced_analysis_service_lifecycle_di.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from app.api import advanced_analysis_api as advanced_analysis_routes
+from app.services import advanced_analysis_service as advanced_analysis_service_module
+
+
+@pytest.mark.asyncio
+async def test_advanced_analysis_service_dependency_installs_app_state_when_missing(monkeypatch):
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+    request = SimpleNamespace(app=fake_app)
+
+    async def fake_get_advanced_analysis_service():
+        return fake_service
+
+    monkeypatch.setattr(
+        advanced_analysis_service_module,
+        "get_advanced_analysis_service",
+        fake_get_advanced_analysis_service,
+    )
+
+    result = await advanced_analysis_service_module.get_advanced_analysis_service_dependency(request)
+
+    assert result is fake_service
+    assert getattr(fake_app.state, advanced_analysis_service_module.ADVANCED_ANALYSIS_SERVICE_STATE_KEY) is fake_service
+
+
+@pytest.mark.asyncio
+async def test_advanced_analysis_service_dependency_prefers_installed_app_state(monkeypatch):
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+    setattr(fake_app.state, advanced_analysis_service_module.ADVANCED_ANALYSIS_SERVICE_STATE_KEY, fake_service)
+    request = SimpleNamespace(app=fake_app)
+
+    async def fail_if_fallback_called():
+        raise AssertionError("compatibility fallback should not be called when app state has a service")
+
+    monkeypatch.setattr(
+        advanced_analysis_service_module,
+        "get_advanced_analysis_service",
+        fail_if_fallback_called,
+    )
+
+    assert await advanced_analysis_service_module.get_advanced_analysis_service_dependency(request) is fake_service
+
+
+def test_install_advanced_analysis_service_accepts_explicit_service():
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+
+    assert advanced_analysis_service_module.install_advanced_analysis_service(fake_app, fake_service) is fake_service
+    assert getattr(fake_app.state, advanced_analysis_service_module.ADVANCED_ANALYSIS_SERVICE_STATE_KEY) is fake_service
+
+
+def test_advanced_analysis_routes_use_route_provider_dependency():
+    for function_name in [
+        "analyze_fundamental",
+        "analyze_technical",
+        "analyze_trading_signals",
+        "analyze_time_series",
+        "analyze_market_panorama",
+        "analyze_capital_flow",
+        "analyze_chip_distribution",
+        "analyze_anomaly_tracking",
+        "analyze_financial_valuation",
+        "analyze_sentiment",
+        "analyze_decision_models",
+        "analyze_multidimensional_radar",
+        "analyze_batch",
+        "health_check",
+    ]:
+        signature = inspect.signature(getattr(advanced_analysis_routes, function_name))
+        service_parameter = signature.parameters["service"]
+        assert (
+            service_parameter.default.dependency
+            is advanced_analysis_service_module.get_advanced_analysis_service_dependency
+        )


### PR DESCRIPTION
## Summary

- Add app-state backed AdvancedAnalysis service dependency provider.
- Preserve get_advanced_analysis_service() and the module singleton compatibility surface.
- Convert all 14 advanced_analysis_api.py service parameters from class-based Depends() to Depends(get_advanced_analysis_service_dependency).
- Add focused lifecycle DI tests and implementation evidence artifacts.

## Boundary

This follows G2.44 authorization. It does not change route paths, response models, OpenAPI exposure, docs/API, frontend, OpenSpec, issue labels, PM2/runtime process state, or unrelated service seams.

## Verification

- TDD red: 4 expected failures before implementation.
- Focused pytest: 4 passed.
- Route guard: class_depends=0, provider_depends=14, direct_getter_calls=0.
- Ruff: All checks passed.
- Black: 3 files would be left unchanged.
- Configured app/OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0, advanced_paths=14, warnings=0.
- GitNexus pre-edit impacts: LOW for AdvancedAnalysisService, get_advanced_analysis_service, and advanced_analysis_api.py.
- GitNexus staged scope: risk=low, changed_files=7, changed_symbols=40, affected_count=0.
- Mainline governance gate: pass.

## Next Gate

Human review of G2.45. If accepted and merged, run G2.46 closeout/current-head candidate refresh before selecting the next service lifecycle DI lane.