### PR TITLE
docs(governance): close advanced analysis route provider refresh

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -764,10 +764,21 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 getter and module singleton, converts `14`
 │   │                 `advanced_analysis_api.py` service dependencies to
 │   │                 `get_advanced_analysis_service_dependency`, and keeps
-│   │                 OpenAPI paths=`500` with duplicate operation IDs=`0`
-│   └── Next gate: Human review of the G2.45 implementation PR; if accepted,
-│                  run a separate G2.46 closeout/current-head candidate refresh
-│                  before selecting another service lifecycle DI lane
+│   │                 OpenAPI paths=`500` with duplicate operation IDs=`0`;
+│   │                 PR `#185` merged at
+│   │                 `059638b573c6f2586537973e2a4b396f0ce156d7`; G2.46 now
+│   │                 records current-head closeout and candidate refresh:
+│   │                 `AdvancedAnalysisService` route class dependency sites=`0`,
+│   │                 provider sites=`14`, direct compatibility getter route
+│   │                 calls=`0`, focused test result=`4 passed`, OpenAPI
+│   │                 paths=`500`, duplicate operation IDs=`0`, completed
+│   │                 provider modules=`8`, route provider dependency
+│   │                 files=`11`, and route provider dependency sites=`72`;
+│   │                 no next implementation target is authorized
+│   └── Next gate: Human review of the G2.46 closeout/candidate refresh PR;
+│                  if accepted, create a separate G2.47 candidate selection and
+│                  usefulness/ownership triage packet before selecting another
+│                  service lifecycle DI lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -852,6 +863,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-candidate-usefulness-ownership-triage-2026-05-24.md` | G | G2.43 triage prepared at current HEAD `f7c6fdf5fd57cff14ef6d11f1d18fd6591a22dc5`: records PR `#182` as `MERGED`, confirms `AdvancedAnalysisService` is an active route class dependency with `14` class `Depends()` sites and no external getter reference, classifies `WencaiService` as active DB/session-backed direct construction, keeps `get_market_data_service` as active route dependency with `7` route dependency sites, classifies `UnifiedDataService` as a broad data seam, and authorizes no implementation | Human review / PR merge decision; if accepted, create G2.44 `AdvancedAnalysisService` route-provider migration authorization before any source edits |
 | `backend-advanced-analysis-route-provider-migration-authorization-2026-05-24.md` | G | G2.44 authorization prepared at current HEAD `1e137abb2a32b795c403a8a168a174ad86b7f693`: records PR `#183` as `MERGED`, confirms `advanced_analysis_api.py` has `14` class `Depends()` sites, preserves `get_advanced_analysis_service()` and module singleton compatibility, records GitNexus `AdvancedAnalysisService` upstream impact as LOW / `0`, and limits any future implementation to a separate G2.45 branch after human review | Human review / PR merge decision; if accepted, create G2.45 `AdvancedAnalysisService` route-provider implementation branch before source edits |
 | `backend-advanced-analysis-route-provider-migration-implementation-2026-05-24.md` | G | G2.45 implementation prepared from G2.44 authorization at base `22b617733e29c9a441e88cb1da2ce0a5d8be98cc`: adds `ADVANCED_ANALYSIS_SERVICE_STATE_KEY`, `install_advanced_analysis_service`, and `get_advanced_analysis_service_dependency`, preserves `get_advanced_analysis_service()` and module singleton compatibility, converts all `14` `advanced_analysis_api.py` service dependencies to the provider, focused TDD ended at `4 passed`, ruff/black passed, configured OpenAPI smoke reports routes=`548`, paths=`500`, duplicate operation IDs=`0`, and advanced paths=`14` | Human review / PR merge decision; if accepted, run G2.46 closeout/current-head candidate refresh before selecting the next service lifecycle DI lane |
+| `backend-advanced-analysis-route-provider-closeout-and-candidate-refresh-2026-05-24.md` | G | G2.46 closeout prepared at current HEAD `059638b573c6f2586537973e2a4b396f0ce156d7`: records PR `#185` as `MERGED`, confirms `AdvancedAnalysisService` route class dependency sites=`0`, provider sites=`14`, direct compatibility getter route calls=`0`, focused test result=`4 passed`, configured OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, advanced paths=`14`, completed provider modules=`8`, route provider dependency files=`11`, and route provider dependency sites=`72`; no next implementation target or compatibility getter retirement is authorized | Human review / PR merge decision; if accepted, create G2.47 candidate selection and usefulness/ownership triage packet before any source edits |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/advanced-analysis-route-provider-closeout-and-candidate-refresh-2026-05-24.json
+++ b/.planning/codebase/generated/advanced-analysis-route-provider-closeout-and-candidate-refresh-2026-05-24.json
@@ -1,0 +1,204 @@
+{
+  "artifact": "advanced-analysis-route-provider-closeout-and-candidate-refresh",
+  "status": "review-ready",
+  "created_at": "2026-05-24T03:02:17+08:00",
+  "worktree": ".worktrees/g2-46-advanced-analysis-closeout-candidate-refresh",
+  "branch": "g2-46-advanced-analysis-closeout-candidate-refresh",
+  "current_head": "059638b573c6f2586537973e2a4b396f0ce156d7",
+  "head_subject": "Merge pull request #185 from chengjon/g2-45-advanced-analysis-route-provider-migration",
+  "stale_if_head_mismatch": true,
+  "source_edits_authorized": false,
+  "openspec_changes_authorized": false,
+  "issue_label_changes_authorized": false,
+  "parent_pr": {
+    "number": 185,
+    "state": "MERGED",
+    "url": "https://github.com/chengjon/mystocks/pull/185",
+    "merge_commit": "059638b573c6f2586537973e2a4b396f0ce156d7"
+  },
+  "github_state": {
+    "issue_79": {
+      "state": "OPEN",
+      "labels": [
+        "needs-triage"
+      ],
+      "title": "Migrate service singletons to FastAPI Depends() lifecycle"
+    },
+    "issue_92": {
+      "state": "OPEN",
+      "labels": [
+        "enhancement",
+        "ready-for-human",
+        "ready-for-downstream"
+      ],
+      "title": "[Backend OpenSpec] Decide post-approval implementation plan"
+    }
+  },
+  "advanced_analysis_closeout": {
+    "focused_pytest": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q -n 0 --tb=short --no-cov",
+      "result": "4 passed in 4.04s"
+    },
+    "route_guard": {
+      "class_depends": 0,
+      "provider_depends": 14,
+      "direct_getter_calls": 0,
+      "state_key": true,
+      "install": true,
+      "provider": true,
+      "compat_getter": true
+    },
+    "configured_openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "advanced_paths": 14,
+      "warnings": 0
+    }
+  },
+  "current_head_refresh": {
+    "service_files_scanned": 152,
+    "provider_signal_files": 8,
+    "getter_signal_files": 24,
+    "route_provider_dependency_files": 11,
+    "route_provider_dependency_sites": 72,
+    "completed_provider_modules": [
+      {
+        "path": "web/backend/app/services/advanced_analysis_service.py",
+        "providers": [
+          "install_advanced_analysis_service",
+          "get_advanced_analysis_service_dependency"
+        ],
+        "state_key": "ADVANCED_ANALYSIS_SERVICE_STATE_KEY"
+      },
+      {
+        "path": "web/backend/app/services/announcement_service.py",
+        "providers": [
+          "install_announcement_service",
+          "get_announcement_service_dependency"
+        ],
+        "state_key": "ANNOUNCEMENT_SERVICE_STATE_KEY"
+      },
+      {
+        "path": "web/backend/app/services/email_service.py",
+        "providers": [
+          "install_email_service",
+          "get_email_service_dependency"
+        ],
+        "state_key": "EMAIL_SERVICE_STATE_KEY"
+      },
+      {
+        "path": "web/backend/app/services/market_data_service_v2.py",
+        "providers": [
+          "get_market_data_service_v2_dependency"
+        ],
+        "state_key": null
+      },
+      {
+        "path": "web/backend/app/services/stock_search_service/stock_search_service.py",
+        "providers": [
+          "install_stock_search_service",
+          "get_stock_search_service_dependency"
+        ],
+        "state_key": "STOCK_SEARCH_SERVICE_STATE_KEY"
+      },
+      {
+        "path": "web/backend/app/services/tdx_service.py",
+        "providers": [
+          "install_tdx_service",
+          "get_tdx_service_dependency"
+        ],
+        "state_key": "TDX_SERVICE_STATE_KEY"
+      },
+      {
+        "path": "web/backend/app/services/tradingview_widget_service.py",
+        "providers": [
+          "install_tradingview_service",
+          "get_tradingview_service_dependency"
+        ],
+        "state_key": "TRADINGVIEW_SERVICE_STATE_KEY"
+      },
+      {
+        "path": "web/backend/app/services/watchlist_service.py",
+        "providers": [
+          "install_watchlist_service",
+          "get_watchlist_service_dependency"
+        ],
+        "state_key": "WATCHLIST_SERVICE_STATE_KEY"
+      }
+    ],
+    "route_provider_dependency_usage": [
+      {
+        "route": "web/backend/app/api/advanced_analysis_api.py",
+        "sites": 14,
+        "provider": "get_advanced_analysis_service_dependency"
+      },
+      {
+        "route": "web/backend/app/api/announcement/routes.py",
+        "sites": 11,
+        "provider": "get_announcement_service_dependency"
+      },
+      {
+        "route": "web/backend/app/api/dashboard_data_source.py",
+        "sites": 1,
+        "provider": "get_market_data_service_v2_dependency"
+      },
+      {
+        "route": "web/backend/app/api/dashboard.py",
+        "sites": 3,
+        "provider": "get_data_source_dependency"
+      },
+      {
+        "route": "web/backend/app/api/market_v2.py",
+        "sites": 13,
+        "provider": "get_market_data_service_v2_dependency"
+      },
+      {
+        "route": "web/backend/app/api/market/market_data_request.py",
+        "sites": 1,
+        "provider": "get_stock_search_service_dependency"
+      },
+      {
+        "route": "web/backend/app/api/notification.py",
+        "sites": 6,
+        "provider": "get_email_service_dependency"
+      },
+      {
+        "route": "web/backend/app/api/stock_search/stock_search_result.py",
+        "sites": 5,
+        "provider": "get_stock_search_service_dependency"
+      },
+      {
+        "route": "web/backend/app/api/tdx.py",
+        "sites": 5,
+        "provider": "get_tdx_service_dependency"
+      },
+      {
+        "route": "web/backend/app/api/tradingview.py",
+        "sites": 6,
+        "provider": "get_tradingview_service_dependency"
+      },
+      {
+        "route": "web/backend/app/api/watchlist.py",
+        "sites": 7,
+        "provider": "get_watchlist_service_dependency"
+      }
+    ],
+    "broad_exclusions": [
+      "WencaiService",
+      "MarketDataService",
+      "UnifiedDataService",
+      "DataService",
+      "StrategyService",
+      "TechnicalAnalysisService"
+    ],
+    "getter_scan_caveat": "Getter external-reference scan is heuristic planning input only; governance/report references and compatibility re-exports must be filtered before retirement decisions."
+  },
+  "decision": {
+    "advanced_analysis_route_provider_closed": true,
+    "next_implementation_target_selected": false,
+    "compatibility_getter_retirement_authorized": false,
+    "recommended_next_gate": "G2.47 candidate selection and usefulness/ownership triage before any new service lifecycle DI source branch."
+  }
+}

--- a/docs/reports/quality/backend-advanced-analysis-route-provider-closeout-and-candidate-refresh-2026-05-24.md
+++ b/docs/reports/quality/backend-advanced-analysis-route-provider-closeout-and-candidate-refresh-2026-05-24.md
@@ -1,0 +1,168 @@
+# Backend AdvancedAnalysis Route Provider Closeout And Candidate Refresh - 2026-05-24
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Status: review-ready.
+
+Boundary note: this packet records closeout and candidate-refresh evidence only.
+It does not authorize backend source edits, test edits, route edits, OpenAPI
+behavior changes, docs/API changes, generated client updates, frontend changes,
+PM2 execution, OpenSpec changes, issue-label changes, compatibility getter
+retirement, or selection of a new implementation target.
+
+This report is a governance-only G2.46 closeout and current-head service lifecycle DI refresh after PR `#185` merged the G2.45 `AdvancedAnalysisService` route-provider migration.
+
+It does not authorize source edits, OpenSpec changes, issue-label changes, compatibility getter retirement, PM2 stateful gates, frontend changes, generated client updates, or selection of the next implementation lane.
+
+## Source Snapshot
+
+| Field | Value |
+|---|---|
+| Worktree | `.worktrees/g2-46-advanced-analysis-closeout-candidate-refresh` |
+| Branch | `g2-46-advanced-analysis-closeout-candidate-refresh` |
+| Current HEAD | `059638b573c6f2586537973e2a4b396f0ce156d7` |
+| HEAD subject | `Merge pull request #185 from chengjon/g2-45-advanced-analysis-route-provider-migration` |
+| Review timestamp | `2026-05-24T03:02:17+08:00` |
+| Parent PR | `#185` |
+| Parent PR state | `MERGED` |
+| Parent PR URL | `https://github.com/chengjon/mystocks/pull/185` |
+| Issue `#79` state | `OPEN`, labels: `needs-triage` |
+| Issue `#92` state | `OPEN`, labels: `enhancement`, `ready-for-human`, `ready-for-downstream` |
+
+## Closeout Evidence
+
+| Check | Result | Interpretation |
+|---|---:|---|
+| Focused lifecycle DI test | `4 passed in 4.04s` | `AdvancedAnalysisService` route-provider behavior remains covered by the focused test. |
+| `advanced_analysis_api.py` class `Depends()` sites | `0` | G2.45 route-level class injection surface is closed. |
+| `advanced_analysis_api.py` provider `Depends(get_advanced_analysis_service_dependency)` sites | `14` | All AdvancedAnalysis route dependencies now use the app-state provider seam. |
+| Direct route calls to `get_advanced_analysis_service()` | `0` | The route module no longer calls the compatibility getter directly. |
+| `ADVANCED_ANALYSIS_SERVICE_STATE_KEY` present | `true` | The service has an app-state lifecycle key. |
+| `install_advanced_analysis_service` present | `true` | Startup installation hook is present. |
+| `get_advanced_analysis_service_dependency` present | `true` | FastAPI dependency provider is present. |
+| `get_advanced_analysis_service()` compatibility getter present | `true` | Compatibility fallback remains intentionally preserved. |
+
+Configured app/OpenAPI smoke was run with the documented local environment overrides and produced:
+
+| Metric | Value |
+|---|---:|
+| FastAPI routes | `548` |
+| OpenAPI paths | `500` |
+| Operation IDs | `536` |
+| Duplicate operation IDs | `0` |
+| AdvancedAnalysis paths | `14` |
+| Captured warnings | `0` |
+
+## Current-Head Candidate Refresh
+
+The current-head refresh scanned service and route dependency files after PR `#185` merged. It is a planning/candidate signal refresh only, not deletion evidence and not implementation authorization.
+
+| Metric | Value |
+|---|---:|
+| Service files scanned | `152` |
+| Provider signal files | `8` |
+| Getter signal files | `24` |
+| Route provider dependency files | `11` |
+| Route provider dependency sites | `72` |
+
+Current completed route-provider modules:
+
+| Service module | Provider seam | State key |
+|---|---|---|
+| `web/backend/app/services/advanced_analysis_service.py` | `install_advanced_analysis_service`, `get_advanced_analysis_service_dependency` | `ADVANCED_ANALYSIS_SERVICE_STATE_KEY` |
+| `web/backend/app/services/announcement_service.py` | `install_announcement_service`, `get_announcement_service_dependency` | `ANNOUNCEMENT_SERVICE_STATE_KEY` |
+| `web/backend/app/services/email_service.py` | `install_email_service`, `get_email_service_dependency` | `EMAIL_SERVICE_STATE_KEY` |
+| `web/backend/app/services/market_data_service_v2.py` | `get_market_data_service_v2_dependency` | none detected |
+| `web/backend/app/services/stock_search_service/stock_search_service.py` | `install_stock_search_service`, `get_stock_search_service_dependency` | `STOCK_SEARCH_SERVICE_STATE_KEY` |
+| `web/backend/app/services/tdx_service.py` | `install_tdx_service`, `get_tdx_service_dependency` | `TDX_SERVICE_STATE_KEY` |
+| `web/backend/app/services/tradingview_widget_service.py` | `install_tradingview_service`, `get_tradingview_service_dependency` | `TRADINGVIEW_SERVICE_STATE_KEY` |
+| `web/backend/app/services/watchlist_service.py` | `install_watchlist_service`, `get_watchlist_service_dependency` | `WATCHLIST_SERVICE_STATE_KEY` |
+
+Current route provider dependency usage:
+
+| Route module | Sites | Provider dependency |
+|---|---:|---|
+| `web/backend/app/api/advanced_analysis_api.py` | `14` | `get_advanced_analysis_service_dependency` |
+| `web/backend/app/api/announcement/routes.py` | `11` | `get_announcement_service_dependency` |
+| `web/backend/app/api/dashboard_data_source.py` | `1` | `get_market_data_service_v2_dependency` |
+| `web/backend/app/api/dashboard.py` | `3` | `get_data_source_dependency` |
+| `web/backend/app/api/market_v2.py` | `13` | `get_market_data_service_v2_dependency` |
+| `web/backend/app/api/market/market_data_request.py` | `1` | `get_stock_search_service_dependency` |
+| `web/backend/app/api/notification.py` | `6` | `get_email_service_dependency` |
+| `web/backend/app/api/stock_search/stock_search_result.py` | `5` | `get_stock_search_service_dependency` |
+| `web/backend/app/api/tdx.py` | `5` | `get_tdx_service_dependency` |
+| `web/backend/app/api/tradingview.py` | `6` | `get_tradingview_service_dependency` |
+| `web/backend/app/api/watchlist.py` | `7` | `get_watchlist_service_dependency` |
+
+## Candidate Interpretation
+
+G2.45 is closed at the evidence level: the AdvancedAnalysis route module has no remaining class-based route dependency sites and still preserves the compatibility getter. This is the expected endpoint of the G2.44 authorization.
+
+The completed provider seam count is now `8` service modules, with `11` route modules and `72` route dependency sites using provider dependencies. This broadens the service lifecycle DI pattern, but it does not make any remaining getter safe to delete.
+
+The getter scan is intentionally treated as heuristic planning input. It can be polluted by governance artifacts, generated reports, and compatibility re-export modules. A compatibility getter with no active route call should still require a dedicated consumer matrix and retirement/retention decision before any implementation branch removes it.
+
+Broad seams remain excluded from direct pilot selection without a separate design packet:
+
+- `WencaiService`
+- `MarketDataService`
+- `UnifiedDataService`
+- `DataService`
+- `StrategyService`
+- `TechnicalAnalysisService`
+
+## Decision Boundary
+
+This packet records:
+
+- PR `#185` is merged.
+- `AdvancedAnalysisService` route-provider migration is closed at current HEAD `059638b573c6f2586537973e2a4b396f0ce156d7`.
+- Issue `#79` remains open and still needs triage for the broader service singleton lifecycle lane.
+- Issue `#92` remains open as a governance/downstream decision umbrella.
+- No next implementation target is selected.
+- No compatibility getter is approved for retirement.
+
+## Recommended Next Gate
+
+Run a separate G2.47 candidate selection and usefulness/ownership triage packet before any new service lifecycle DI source branch.
+
+The G2.47 packet should:
+
+- Regenerate a stricter current-head service getter/provider inventory.
+- Filter out governance/report references before interpreting external references.
+- Separate active route dependencies, compatibility fallbacks, factory helpers, process-level singletons, DB/session-backed services, and broad data seams.
+- Produce one of these outcomes: no next target, a decision-only authorization packet, or a human-reviewed implementation authorization for exactly one narrow target.
+
+## Verification Commands
+
+The focused checks used for this packet were:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q -n 0 --tb=short --no-cov
+```
+
+```bash
+POSTGRESQL_HOST=localhost POSTGRESQL_USER=mystocks POSTGRESQL_PASSWORD=mystocks JWT_SECRET_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef BACKEND_PORT=8020 BACKEND_BACKUP_PORT=8021 PYTHONPATH=web/backend:. python - <<'PY'
+import warnings
+from app.main import app
+with warnings.catch_warnings(record=True) as caught:
+    schema = app.openapi()
+operation_ids = []
+for path, methods in schema.get("paths", {}).items():
+    for method, operation in methods.items():
+        if isinstance(operation, dict) and operation.get("operationId"):
+            operation_ids.append(operation["operationId"])
+advanced_paths = [path for path in schema.get("paths", {}) if "advanced-analysis" in path]
+print({
+    "routes": len(app.routes),
+    "paths": len(schema.get("paths", {})),
+    "operation_ids": len(operation_ids),
+    "duplicate_operation_ids": len(operation_ids) - len(set(operation_ids)),
+    "advanced_paths": len(advanced_paths),
+    "warnings": len(caught),
+})
+PY
+```

--- a/governance/mainline/task-cards/pr-186.yaml
+++ b/governance/mainline/task-cards/pr-186.yaml
@@ -1,0 +1,105 @@
+version: "v0.2"
+
+task:
+  id: "pr-186"
+  title: "Close out AdvancedAnalysis route provider migration and refresh current-head candidates"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-advanced-analysis-route-provider-closeout-candidate-refresh"
+  objective: "record the G2.46 closeout evidence for PR #185 and refresh current-head service lifecycle DI candidate signals"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-advanced-analysis-route-provider-closeout-candidate-refresh"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-advanced-analysis-route-provider-closeout-candidate-refresh"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout and candidate refresh records governance evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/advanced-analysis-route-provider-closeout-and-candidate-refresh-2026-05-24.json"
+    - "docs/reports/quality/backend-advanced-analysis-route-provider-closeout-and-candidate-refresh-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-186.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No get_advanced_analysis_service cleanup or compatibility getter retirement"
+  - "No selection of a new service lifecycle DI implementation target"
+  - "No modification of WencaiService, MarketDataService, UnifiedDataService, DataService, StrategyService, or TechnicalAnalysisService"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-advanced-analysis-route-provider-closeout-and-candidate-refresh-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/advanced-analysis-route-provider-closeout-and-candidate-refresh-2026-05-24.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-186.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "python -c \"print('staged-gitnexus-scope: docs-only governance packet; no source symbols changed')\""
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the closeout-only boundary"
+    - "If this packet selects a next implementation target, it bypasses the required G2.47 candidate triage gate"
+    - "If this packet authorizes compatibility getter removal, it contradicts the G2.45 compatibility preservation boundary"
+  rollback_plan: "revert this governance-only PR; PR #185 remains merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record PR #185 closeout evidence and current-head service lifecycle DI candidate signals"
+    modified_scope: "closeout report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none in this PR"
+    legacy_logic_impact: "none; get_advanced_analysis_service remains preserved"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only closeout PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T03:02:17+08:00"
+    approval_note: "human maintainer approved continuing after PR #185 merge; this packet only records closeout and current-head candidate refresh evidence"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Record G2.46 closeout evidence after PR #185 merged the AdvancedAnalysis route-provider migration.
- Add current-head service lifecycle DI provider/candidate refresh metrics.
- Update the steward task tree and add the mainline task card for this governance-only packet.

## Verification
- python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-advanced-analysis-route-provider-closeout-and-candidate-refresh-2026-05-24.md
- python -m json.tool .planning/codebase/generated/advanced-analysis-route-provider-closeout-and-candidate-refresh-2026-05-24.json >/dev/null
- python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-186.yaml').read_text())"
- python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-186.yaml
- git diff HEAD~1..HEAD --check
- GitNexus detect_changes(scope=staged): changed_count=0, affected_count=0, risk=low

## Boundary
Governance-only closeout and candidate refresh. No backend source, tests, OpenSpec, issue label, PM2, frontend, or compatibility getter retirement changes.