### PR TITLE
docs(governance): select next service lifecycle candidate

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -774,11 +774,21 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 paths=`500`, duplicate operation IDs=`0`, completed
 │   │                 provider modules=`8`, route provider dependency
 │   │                 files=`11`, and route provider dependency sites=`72`;
-│   │                 no next implementation target is authorized
-│   └── Next gate: Human review of the G2.46 closeout/candidate refresh PR;
-│                  if accepted, create a separate G2.47 candidate selection and
-│                  usefulness/ownership triage packet before selecting another
-│                  service lifecycle DI lane
+│   │                 no next implementation target is authorized; PR `#186`
+│   │                 merged at
+│   │                 `e09e6db4a6a85dc392c20a737e729bb6f123804d`; G2.47 now
+│   │                 records current-head candidate selection: service files
+│   │                 scanned=`152`, API files scanned=`219`, provider
+│   │                 modules=`8`, route provider dependency sites=`72`,
+│   │                 route class dependency sites=`0`, route getter
+│   │                 dependency sites=`277`, and selected
+│   │                 `get_market_data_service` only as the next consumer
+│   │                 matrix / authorization candidate packet; broad or
+│   │                 external-client seams remain excluded
+│   └── Next gate: Human review of the G2.47 candidate-selection PR; if
+│                  accepted, create a separate G2.48
+│                  `get_market_data_service` route dependency consumer matrix /
+│                  route-provider authorization candidate before source edits
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -864,6 +874,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-advanced-analysis-route-provider-migration-authorization-2026-05-24.md` | G | G2.44 authorization prepared at current HEAD `1e137abb2a32b795c403a8a168a174ad86b7f693`: records PR `#183` as `MERGED`, confirms `advanced_analysis_api.py` has `14` class `Depends()` sites, preserves `get_advanced_analysis_service()` and module singleton compatibility, records GitNexus `AdvancedAnalysisService` upstream impact as LOW / `0`, and limits any future implementation to a separate G2.45 branch after human review | Human review / PR merge decision; if accepted, create G2.45 `AdvancedAnalysisService` route-provider implementation branch before source edits |
 | `backend-advanced-analysis-route-provider-migration-implementation-2026-05-24.md` | G | G2.45 implementation prepared from G2.44 authorization at base `22b617733e29c9a441e88cb1da2ce0a5d8be98cc`: adds `ADVANCED_ANALYSIS_SERVICE_STATE_KEY`, `install_advanced_analysis_service`, and `get_advanced_analysis_service_dependency`, preserves `get_advanced_analysis_service()` and module singleton compatibility, converts all `14` `advanced_analysis_api.py` service dependencies to the provider, focused TDD ended at `4 passed`, ruff/black passed, configured OpenAPI smoke reports routes=`548`, paths=`500`, duplicate operation IDs=`0`, and advanced paths=`14` | Human review / PR merge decision; if accepted, run G2.46 closeout/current-head candidate refresh before selecting the next service lifecycle DI lane |
 | `backend-advanced-analysis-route-provider-closeout-and-candidate-refresh-2026-05-24.md` | G | G2.46 closeout prepared at current HEAD `059638b573c6f2586537973e2a4b396f0ce156d7`: records PR `#185` as `MERGED`, confirms `AdvancedAnalysisService` route class dependency sites=`0`, provider sites=`14`, direct compatibility getter route calls=`0`, focused test result=`4 passed`, configured OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, advanced paths=`14`, completed provider modules=`8`, route provider dependency files=`11`, and route provider dependency sites=`72`; no next implementation target or compatibility getter retirement is authorized | Human review / PR merge decision; if accepted, create G2.47 candidate selection and usefulness/ownership triage packet before any source edits |
+| `backend-service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.md` | G | G2.47 candidate selection prepared at current HEAD `e09e6db4a6a85dc392c20a737e729bb6f123804d`: records PR `#186` as `MERGED`, scans `152` service files and `219` API files, confirms provider modules=`8`, route provider dependency sites=`72`, route class dependency sites=`0`, and classifies `get_market_data_service` as the next consumer matrix / authorization candidate packet while excluding `get_data_service`, `get_strategy_service`, and `get_kronos_client` from direct implementation | Human review / PR merge decision; if accepted, create G2.48 `get_market_data_service` route dependency consumer matrix / route-provider authorization candidate before any source edits |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.json
+++ b/.planning/codebase/generated/service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.json
@@ -1,0 +1,117 @@
+{
+  "artifact": "service-lifecycle-di-candidate-selection-after-advanced-analysis",
+  "status": "review-ready",
+  "created_at": "2026-05-24T10:34:00+08:00",
+  "worktree": ".worktrees/g2-47-service-lifecycle-candidate-selection",
+  "branch": "g2-47-service-lifecycle-candidate-selection",
+  "current_head": "e09e6db4a6a85dc392c20a737e729bb6f123804d",
+  "head_subject": "Merge pull request #186 from chengjon/g2-46-advanced-analysis-closeout-candidate-refresh",
+  "stale_if_head_mismatch": true,
+  "source_edits_authorized": false,
+  "implementation_target_selected": false,
+  "decision_packet_target_selected": true,
+  "openspec_changes_authorized": false,
+  "issue_label_changes_authorized": false,
+  "compatibility_retirement_authorized": false,
+  "pm2_execution_authorized": false,
+  "github_state": {
+    "pr_186": {
+      "state": "MERGED",
+      "url": "https://github.com/chengjon/mystocks/pull/186",
+      "merge_commit": "e09e6db4a6a85dc392c20a737e729bb6f123804d",
+      "merged_at": "2026-05-24T02:21:26Z"
+    },
+    "pr_187": {
+      "state": "MERGED",
+      "url": "https://github.com/chengjon/mystocks/pull/187",
+      "merge_commit": "02a4148c2b6edbb45dea6115a4ac9e57c4ba9b3e",
+      "merged_at": "2026-05-24T02:16:05Z"
+    },
+    "issue_79": {
+      "state": "OPEN",
+      "labels": [
+        "needs-triage"
+      ],
+      "url": "https://github.com/chengjon/mystocks/issues/79"
+    },
+    "issue_92": {
+      "state": "OPEN",
+      "labels": [
+        "enhancement",
+        "ready-for-human",
+        "ready-for-downstream"
+      ],
+      "url": "https://github.com/chengjon/mystocks/issues/92"
+    }
+  },
+  "scan_summary": {
+    "service_files_scanned": 152,
+    "api_files_scanned": 219,
+    "provider_modules_count": 8,
+    "route_provider_dependency_files": 11,
+    "route_provider_dependency_sites": 72,
+    "route_getter_dependency_files": 51,
+    "route_getter_dependency_sites": 277,
+    "route_class_dependency_files": 0,
+    "route_class_dependency_sites": 0,
+    "raw_direct_getter_call_files": 112,
+    "raw_direct_getter_call_sites": 707,
+    "getter_defs_count": 44
+  },
+  "completed_provider_modules": [
+    "web/backend/app/services/advanced_analysis_service.py",
+    "web/backend/app/services/announcement_service.py",
+    "web/backend/app/services/email_service.py",
+    "web/backend/app/services/market_data_service_v2.py",
+    "web/backend/app/services/stock_search_service/stock_search_service.py",
+    "web/backend/app/services/tdx_service.py",
+    "web/backend/app/services/tradingview_widget_service.py",
+    "web/backend/app/services/watchlist_service.py"
+  ],
+  "selected_next_decision_packet": {
+    "target": "get_market_data_service",
+    "target_file": "web/backend/app/services/market_data_service/get_market_data_service.py",
+    "consumer_surface": "web/backend/app/api/market/market_data_request.py",
+    "route_depends_sites": 7,
+    "source_implementation_authorized": false,
+    "recommended_next_gate": "G2.48 get_market_data_service route dependency consumer matrix / route-provider authorization candidate"
+  },
+  "candidate_classification": [
+    {
+      "candidate": "get_market_data_service",
+      "classification": "active-route-dependency-with-compatibility-surface",
+      "gitnexus_risk": "LOW",
+      "impacted_count": 0,
+      "disposition": "selected for next decision packet, not source implementation"
+    },
+    {
+      "candidate": "get_data_service",
+      "classification": "broad-data-seam",
+      "gitnexus_risk": "CRITICAL",
+      "impacted_count": 4,
+      "disposition": "excluded from immediate route-provider batch"
+    },
+    {
+      "candidate": "get_strategy_service",
+      "classification": "broad-strategy-seam",
+      "gitnexus_risk": "CRITICAL",
+      "impacted_count": 11,
+      "disposition": "excluded from immediate route-provider batch"
+    },
+    {
+      "candidate": "get_kronos_client",
+      "classification": "external-client-seam",
+      "gitnexus_risk": "CRITICAL",
+      "impacted_count": 3,
+      "disposition": "requires external-client provider gate"
+    },
+    {
+      "candidate": "get_indicator_registry",
+      "classification": "indicator-internal-registry-seam",
+      "gitnexus_risk": "LOW",
+      "impacted_count": 4,
+      "disposition": "requires dedicated indicator registry design before source edits"
+    }
+  ],
+  "next_gate": "Human review / PR merge decision; if accepted, create G2.48 get_market_data_service consumer matrix and route-provider authorization candidate before any source edits."
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.md
@@ -1,0 +1,142 @@
+# Backend Service Lifecycle DI Candidate Selection After AdvancedAnalysis - 2026-05-24
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Status: review-ready.
+
+Boundary note: this packet records a G2.47 current-head service lifecycle DI
+candidate selection only. It does not authorize backend source edits, test
+edits, route behavior changes, OpenAPI exposure changes, docs/API updates,
+generated client updates, frontend changes, PM2 execution, OpenSpec changes,
+issue-label changes, compatibility getter retirement, or movement of any issue
+to `ready-for-agent`.
+
+## Source Snapshot
+
+| Field | Value |
+|---|---|
+| Worktree | `.worktrees/g2-47-service-lifecycle-candidate-selection` |
+| Branch | `g2-47-service-lifecycle-candidate-selection` |
+| Current HEAD | `e09e6db4a6a85dc392c20a737e729bb6f123804d` |
+| HEAD subject | `Merge pull request #186 from chengjon/g2-46-advanced-analysis-closeout-candidate-refresh` |
+| Parent closeout PR | `#186`, `MERGED`, merge commit `e09e6db4a6a85dc392c20a737e729bb6f123804d` |
+| Steward-tree guide PR | `#187`, `MERGED`, merge commit `02a4148c2b6edbb45dea6115a4ac9e57c4ba9b3e` |
+| Issue `#79` state | `OPEN`, labels: `needs-triage` |
+| Issue `#92` state | `OPEN`, labels: `enhancement`, `ready-for-human`, `ready-for-downstream` |
+
+## Current-Head Scan Summary
+
+| Metric | Value | Interpretation |
+|---|---:|---|
+| Service files scanned | `152` | Same broad service surface as recent G2 refreshes. |
+| API files scanned | `219` | Route and API helper files included for dependency usage classification. |
+| Provider modules detected | `8` | Completed service provider seam count after G2.45/G2.46. |
+| Route provider dependency files | `11` | Route modules using `*_dependency` provider functions. |
+| Route provider dependency sites | `72` | Current provider-based route injection footprint. |
+| Route class `Depends()` files | `0` | No remaining `SomeService = Depends()` class injection pattern detected by this scan. |
+| Route class `Depends()` sites | `0` | Confirms the AdvancedAnalysis class-dependency surface stayed closed. |
+| Route getter dependency files | `51` | Mostly auth, DB, repository, and legacy dependency functions; not all are service lifecycle DI candidates. |
+| Route getter dependency sites | `277` | Requires classification before any candidate can become implementation work. |
+| Raw direct getter-call files | `112` | Noisy signal; includes helper methods and property-style getters that are not lifecycle singletons. |
+| Raw direct getter-call sites | `707` | Planning signal only; not a deletion or implementation backlog. |
+| Service getter definitions detected | `44` | Includes compatibility fallbacks, helpers, factories, and broad seams. |
+
+## Completed Provider Seams
+
+The scan detected these completed provider modules:
+
+| Service module | Provider seam | State key |
+|---|---|---|
+| `web/backend/app/services/advanced_analysis_service.py` | `install_advanced_analysis_service`, `get_advanced_analysis_service_dependency` | `ADVANCED_ANALYSIS_SERVICE_STATE_KEY` |
+| `web/backend/app/services/announcement_service.py` | `install_announcement_service`, `get_announcement_service_dependency` | `ANNOUNCEMENT_SERVICE_STATE_KEY` |
+| `web/backend/app/services/email_service.py` | `install_email_service`, `get_email_service_dependency` | `EMAIL_SERVICE_STATE_KEY` |
+| `web/backend/app/services/market_data_service_v2.py` | `install_market_data_service_v2`, `get_market_data_service_v2_dependency` | `MARKET_DATA_SERVICE_V2_STATE_KEY` |
+| `web/backend/app/services/stock_search_service/stock_search_service.py` | `install_stock_search_service`, `get_stock_search_service_dependency` | `STOCK_SEARCH_SERVICE_STATE_KEY` |
+| `web/backend/app/services/tdx_service.py` | `install_tdx_service`, `get_tdx_service_dependency` | `TDX_SERVICE_STATE_KEY` |
+| `web/backend/app/services/tradingview_widget_service.py` | `install_tradingview_service`, `get_tradingview_service_dependency` | `TRADINGVIEW_SERVICE_STATE_KEY` |
+| `web/backend/app/services/watchlist_service.py` | `install_watchlist_service`, `get_watchlist_service_dependency` | `WATCHLIST_SERVICE_STATE_KEY` |
+
+Completed provider modules remain closed/retained. Their compatibility getters
+must not be deleted from this packet.
+
+## Candidate Classification
+
+| Candidate | Evidence | GitNexus spot check | Classification | Disposition |
+|---|---|---|---|---|
+| `get_market_data_service` | `web/backend/app/api/market/market_data_request.py` has `7` `Depends(get_market_data_service)` route sites; tests already use dependency overrides; service package has direct getter and re-export; `market_data_adapter.py` also imports it as fallback | LOW / impacted count `0` for the indexed function | Active route dependency with compatibility and package-surface considerations | Select as next decision packet target: G2.48 consumer matrix / authorization candidate, not source edits in G2.47 |
+| `get_data_service` | Direct API callers in indicator and strategy surfaces | CRITICAL / impacted count `4`; affected modules include Indicators and Strategy | Broad data seam | Exclude from immediate service lifecycle DI batch; requires separate broad data-seam design |
+| `get_strategy_service` | Direct strategy-management, adapter, and task callers | CRITICAL / impacted count `11`; direct callers in strategy adapters, strategy management routes, and backtest tasks | Broad strategy seam | Exclude from immediate service lifecycle DI batch; requires separate strategy service design |
+| `get_kronos_client` | Three direct route calls in `web/backend/app/api/v1/analysis/kronos.py`; regression tests monkeypatch it | CRITICAL / impacted count `3`; affects Kronos prediction/encoding/status flows | External-client seam | Exclude from ordinary service lifecycle DI batch; requires external-client provider gate |
+| `get_indicator_registry` | Two direct calls in `indicator_cache.py`, internal indicator defaults/TALib jobs, many unit tests | LOW / impacted count `4`; affected modules Indicators and Jobs | Indicator-internal registry seam | Do not pick before a dedicated indicator registry/provider design; not a route-provider batch |
+| `get_current_user`, `get_current_active_user`, `get_db`, repository getters | Many `Depends(...)` sites | Not evaluated as service lifecycle DI targets | Auth/DB/repository dependency functions | Out of this lane |
+
+## Selected Next Gate
+
+G2.47 selects **a decision packet target**, not an implementation target:
+
+`get_market_data_service` should receive a G2.48 route dependency consumer matrix
+and route-provider authorization candidate packet.
+
+The G2.48 packet should answer:
+
+- Which exact public route handlers in `market/market_data_request.py` use
+  `Depends(get_market_data_service)`.
+- Whether a future provider seam belongs in
+  `web/backend/app/services/market_data_service/` or a narrower bridge module.
+- How to preserve `get_market_data_service()` compatibility for tests,
+  re-exports, and `market_data_adapter.py`.
+- Whether `web/backend/tests/test_market_api_integration.py` can be the focused
+  route dependency override test base.
+- Whether this package-level `MarketDataService` lane must stay separate from
+  `MarketDataServiceV2`.
+- Which route/OpenAPI smoke and route dependency count guards are required.
+
+## Non-Goals
+
+This packet does not authorize:
+
+- Adding `get_market_data_service_dependency`.
+- Rewiring `market/market_data_request.py`.
+- Removing or renaming `get_market_data_service`.
+- Consolidating `MarketDataService` and `MarketDataServiceV2`.
+- Changing route paths, response models, OpenAPI schema exposure, frontend code,
+  docs/API examples, generated clients, PM2 workflows, or OpenSpec state.
+- Moving issue `#79` or issue `#92` to `ready-for-agent`.
+
+## Decision
+
+G2.47 should be accepted as a candidate-selection packet if reviewers agree that:
+
+- G2.46 is closed after PR `#186` merge.
+- The next step is a `get_market_data_service` consumer matrix / authorization
+  candidate packet.
+- No new source implementation target is authorized yet.
+- Broad or external-client seams remain excluded from the ordinary route-provider
+  conveyor.
+
+## Verification Notes
+
+Fresh evidence used for this packet:
+
+```text
+service_files_scanned=152
+api_files_scanned=219
+provider_modules_count=8
+route_provider_dependency_sites=72
+route_class_dependency_sites=0
+route_getter_dependency_sites=277
+getter_defs_count=44
+```
+
+GitNexus spot checks:
+
+| Target | Risk | Impacted count | Notes |
+|---|---|---:|---|
+| `get_market_data_service` | LOW | `0` | Still needs consumer matrix because route dependency and fallback surfaces are active. |
+| `get_data_service` | CRITICAL | `4` | Broad data/indicator/strategy seam. |
+| `get_strategy_service` | CRITICAL | `11` | Broad strategy/adapters/tasks seam. |
+| `get_indicator_registry` | LOW | `4` | Indicator-internal registry/jobs seam. |
+| `get_kronos_client` | CRITICAL | `3` | External-client route seam. |

--- a/governance/mainline/task-cards/pr-188.yaml
+++ b/governance/mainline/task-cards/pr-188.yaml
@@ -1,0 +1,107 @@
+version: "v0.2"
+
+task:
+  id: "pr-188"
+  title: "Select next service lifecycle DI decision packet after AdvancedAnalysis"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-service-lifecycle-candidate-selection-after-advanced-analysis"
+  objective: "record the G2.47 current-head service lifecycle DI candidate selection after AdvancedAnalysis closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-candidate-selection-after-advanced-analysis"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-candidate-selection-after-advanced-analysis"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate-selection packet records governance evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-188.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, tests, generated clients, docs/API, OpenSpec, PM2, route, OpenAPI, or runtime behavior changes"
+  - "No GitHub issue state, label, or ready-for-agent movement"
+  - "No service lifecycle DI source implementation target authorization"
+  - "No compatibility getter, wrapper, or route cleanup authorization"
+  - "No MarketDataService and MarketDataServiceV2 consolidation"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-188.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-188.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "python -c \"print('staged-gitnexus-scope: docs-only candidate-selection packet; no source symbols changed')\""
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the candidate-selection-only boundary"
+    - "If this packet authorizes get_market_data_service source rewiring, it bypasses the required G2.48 consumer matrix / authorization gate"
+    - "If broad seams are selected for direct implementation, it contradicts this packet's candidate classification"
+  rollback_plan: "revert this governance-only PR; G2.46 closeout remains merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "select the next decision packet after AdvancedAnalysis route-provider closeout"
+    modified_scope: "candidate-selection report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only candidate-selection PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T10:34:00+08:00"
+    approval_note: "human maintainer approved continuing after PR #186 merge; this packet only records G2.47 candidate selection and next decision gate"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- Records G2.47 current-HEAD service lifecycle DI candidate selection after PR #186 AdvancedAnalysis closeout.
- Adds the generated provider/getter inventory snapshot and decision report.
- Updates the steward tree to select `get_market_data_service` only as the next consumer-matrix / authorization-candidate packet.
- Keeps broad seams (`get_data_service`, `get_strategy_service`) and external-client seams (`get_kronos_client`) out of immediate implementation.

## Boundary

This is governance-only. It does not authorize source edits, route dependency migrations, or provider implementation. The next executable step is a separate G2.48 decision/authorization packet for `get_market_data_service` consumer ownership.

## Verification

- `git diff --cached --check`
- `gitnexus_detect_changes(scope=staged)`: low risk, 4 changed files, 0 changed symbols, 0 affected processes
- `python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.md`: checked_files=2, errors=0
- `python -m json.tool .planning/codebase/generated/service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.json >/dev/null`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-188.yaml').read_text()); print('yaml-ok')"`
- `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-188.yaml`: pass=True
- `git diff HEAD~1..HEAD --check`
EOF 2>&1
