### PR TITLE
docs(governance): map market data service consumers

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -784,11 +784,21 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 dependency sites=`277`, and selected
 │   │                 `get_market_data_service` only as the next consumer
 │   │                 matrix / authorization candidate packet; broad or
-│   │                 external-client seams remain excluded
-│   └── Next gate: Human review of the G2.47 candidate-selection PR; if
-│                  accepted, create a separate G2.48
-│                  `get_market_data_service` route dependency consumer matrix /
-│                  route-provider authorization candidate before source edits
+│   │                 external-client seams remain excluded; PR `#188` merged
+│   │                 at
+│   │                 `0dce9ca97cd043f898039176394eb5076c353cf5`; G2.48 now
+│   │                 records the exact `get_market_data_service` route
+│   │                 dependency consumer matrix: seven `/api/v1/market`
+│   │                 route handlers in `market/market_data_request.py`,
+│   │                 package-level compatibility getter retained,
+│   │                 `market_data_adapter.py` excluded, configured OpenAPI
+│   │                 smoke routes=`548`, paths=`500`, duplicate operation
+│   │                 IDs=`0`, and `test_market_api_integration.py`
+│   │                 result=`18 passed`
+│   └── Next gate: Human review of the G2.48 consumer-matrix /
+│                  authorization-candidate PR; if accepted, create a separate
+│                  G2.49 `get_market_data_service` route-provider
+│                  implementation branch before source edits
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -875,6 +885,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-advanced-analysis-route-provider-migration-implementation-2026-05-24.md` | G | G2.45 implementation prepared from G2.44 authorization at base `22b617733e29c9a441e88cb1da2ce0a5d8be98cc`: adds `ADVANCED_ANALYSIS_SERVICE_STATE_KEY`, `install_advanced_analysis_service`, and `get_advanced_analysis_service_dependency`, preserves `get_advanced_analysis_service()` and module singleton compatibility, converts all `14` `advanced_analysis_api.py` service dependencies to the provider, focused TDD ended at `4 passed`, ruff/black passed, configured OpenAPI smoke reports routes=`548`, paths=`500`, duplicate operation IDs=`0`, and advanced paths=`14` | Human review / PR merge decision; if accepted, run G2.46 closeout/current-head candidate refresh before selecting the next service lifecycle DI lane |
 | `backend-advanced-analysis-route-provider-closeout-and-candidate-refresh-2026-05-24.md` | G | G2.46 closeout prepared at current HEAD `059638b573c6f2586537973e2a4b396f0ce156d7`: records PR `#185` as `MERGED`, confirms `AdvancedAnalysisService` route class dependency sites=`0`, provider sites=`14`, direct compatibility getter route calls=`0`, focused test result=`4 passed`, configured OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, advanced paths=`14`, completed provider modules=`8`, route provider dependency files=`11`, and route provider dependency sites=`72`; no next implementation target or compatibility getter retirement is authorized | Human review / PR merge decision; if accepted, create G2.47 candidate selection and usefulness/ownership triage packet before any source edits |
 | `backend-service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.md` | G | G2.47 candidate selection prepared at current HEAD `e09e6db4a6a85dc392c20a737e729bb6f123804d`: records PR `#186` as `MERGED`, scans `152` service files and `219` API files, confirms provider modules=`8`, route provider dependency sites=`72`, route class dependency sites=`0`, and classifies `get_market_data_service` as the next consumer matrix / authorization candidate packet while excluding `get_data_service`, `get_strategy_service`, and `get_kronos_client` from direct implementation | Human review / PR merge decision; if accepted, create G2.48 `get_market_data_service` route dependency consumer matrix / route-provider authorization candidate before any source edits |
+| `backend-market-data-service-route-dependency-consumer-matrix-2026-05-24.md` | G | G2.48 consumer matrix prepared at current HEAD `0dce9ca97cd043f898039176394eb5076c353cf5`: records PR `#188` as `MERGED`, confirms `get_market_data_service` GitNexus risk=`LOW` / impacted count=`0`, identifies exactly seven active `/api/v1/market` route handlers using `Depends(get_market_data_service)`, keeps the package compatibility getter and `market_data_adapter.py` fallback surface active, excludes `services/__init__.py` IntegratedServices accessor and `MarketDataServiceV2` consolidation, configured app/OpenAPI smoke reports routes=`548`, paths=`500`, duplicate operation IDs=`0`, and focused `test_market_api_integration.py` result=`18 passed` | Human review / PR merge decision; if accepted, create G2.49 `get_market_data_service` route-provider implementation branch before source edits |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/market-data-service-route-dependency-consumer-matrix-2026-05-24.json
+++ b/.planning/codebase/generated/market-data-service-route-dependency-consumer-matrix-2026-05-24.json
@@ -1,0 +1,164 @@
+{
+  "schema_version": "1.0",
+  "workline": "G2.48",
+  "title": "MarketDataService route dependency consumer matrix",
+  "recorded_at": "2026-05-24T10:47:51+08:00",
+  "current_head": "0dce9ca97cd043f898039176394eb5076c353cf5",
+  "base_branch": "origin/wip/root-dirty-20260403",
+  "parent_pr": {
+    "number": 188,
+    "state": "MERGED",
+    "merge_commit": "0dce9ca97cd043f898039176394eb5076c353cf5"
+  },
+  "candidate": {
+    "symbol": "get_market_data_service",
+    "file": "web/backend/app/services/market_data_service/get_market_data_service.py",
+    "classification": "active-route-dependency-with-compatibility-fallback",
+    "source_implementation_authorized_by_this_packet_alone": false
+  },
+  "gitnexus": {
+    "target": "Function:web/backend/app/services/market_data_service/get_market_data_service.py:get_market_data_service",
+    "risk": "LOW",
+    "impacted_count": 0,
+    "direct": 0,
+    "processes_affected": 0,
+    "modules_affected": 0,
+    "note": "Graph impact is low, but current-head text and route scans show active FastAPI dependency consumers."
+  },
+  "route_dependency_surface": {
+    "route_file": "web/backend/app/api/market/market_data_request.py",
+    "mount_prefix": "/api/v1/market",
+    "dependency": "Depends(get_market_data_service)",
+    "site_count": 7,
+    "routes": [
+      {
+        "method": "POST",
+        "full_path": "/api/v1/market/fund-flow/refresh",
+        "handler": "refresh_fund_flow",
+        "handler_line": 198,
+        "dependency_line": 201
+      },
+      {
+        "method": "GET",
+        "full_path": "/api/v1/market/etf/list",
+        "handler": "get_etf_list",
+        "handler_line": 231,
+        "dependency_line": 238
+      },
+      {
+        "method": "POST",
+        "full_path": "/api/v1/market/etf/refresh",
+        "handler": "refresh_etf_data",
+        "handler_line": 273,
+        "dependency_line": 274
+      },
+      {
+        "method": "GET",
+        "full_path": "/api/v1/market/chip-race",
+        "handler": "get_chip_race",
+        "handler_line": 298,
+        "dependency_line": 303
+      },
+      {
+        "method": "POST",
+        "full_path": "/api/v1/market/chip-race/refresh",
+        "handler": "refresh_chip_race",
+        "handler_line": 328,
+        "dependency_line": 331
+      },
+      {
+        "method": "GET",
+        "full_path": "/api/v1/market/lhb",
+        "handler": "get_lhb_detail",
+        "handler_line": 357,
+        "dependency_line": 363
+      },
+      {
+        "method": "POST",
+        "full_path": "/api/v1/market/lhb/refresh",
+        "handler": "refresh_lhb_detail",
+        "handler_line": 389,
+        "dependency_line": 391
+      }
+    ]
+  },
+  "compatibility_surfaces": [
+    {
+      "path": "web/backend/app/services/market_data_service/get_market_data_service.py",
+      "role": "package-level compatibility getter",
+      "future_disposition": "preserve getter and add app-state provider only after approval"
+    },
+    {
+      "path": "web/backend/app/services/market_data_service/__init__.py",
+      "role": "package re-export",
+      "future_disposition": "re-export future provider symbols if approved"
+    },
+    {
+      "path": "web/backend/app/services/__init__.py",
+      "role": "separate IntegratedServices accessor with same function name",
+      "future_disposition": "exclude from this lane"
+    },
+    {
+      "path": "web/backend/app/services/market_data_adapter.py",
+      "role": "non-route fallback import of package getter",
+      "future_disposition": "exclude from this route-provider lane; compatibility getter remains public"
+    },
+    {
+      "path": "web/backend/tests/test_market_api_integration.py",
+      "role": "existing dependency override test base",
+      "future_disposition": "use or extend for route dependency override coverage"
+    }
+  ],
+  "reference_scan": {
+    "python_reference_files": 14,
+    "python_reference_count": 52,
+    "import_sites": [
+      "web/backend/app/services/market_data_service/__init__.py:3",
+      "web/backend/app/services/market_data_adapter.py:64",
+      "web/backend/app/api/market/market_data_request.py:37",
+      "web/backend/tests/test_market_api_integration.py:31"
+    ],
+    "override_sites": [
+      "web/backend/tests/test_market_api_integration.py:76"
+    ]
+  },
+  "configured_smoke": {
+    "environment": "non-sensitive placeholder env for route/OpenAPI smoke only",
+    "app_import": "ok",
+    "route_count": 548,
+    "openapi_paths": 500,
+    "duplicate_operation_ids": 0,
+    "selected_market_routes": 7
+  },
+  "focused_tests": {
+    "collect_only": {
+      "command": "pytest -o addopts= web/backend/tests/test_market_api_integration.py --collect-only -q --no-cov",
+      "result": "18 tests collected"
+    },
+    "test_run": {
+      "command": "pytest -o addopts= web/backend/tests/test_market_api_integration.py -q --tb=short --no-cov",
+      "result": "18 passed in 13.95s"
+    }
+  },
+  "future_allowed_write_scope_if_approved": [
+    "web/backend/app/services/market_data_service/get_market_data_service.py",
+    "web/backend/app/services/market_data_service/__init__.py",
+    "web/backend/app/api/market/market_data_request.py",
+    "web/backend/tests/test_market_data_service_lifecycle_di.py",
+    "web/backend/tests/test_market_api_integration.py",
+    "docs/reports/quality/backend-market-data-service-route-provider-implementation-2026-05-24.md",
+    "governance/mainline/task-cards/pr-190.yaml"
+  ],
+  "explicit_non_goals": [
+    "No source edits in this packet",
+    "No MarketDataService and MarketDataServiceV2 consolidation",
+    "No changes to market_data_adapter.py",
+    "No changes to web/backend/app/services/__init__.py",
+    "No compatibility getter cleanup",
+    "No route path, OpenAPI exposure, frontend, docs/API, PM2, OpenSpec, or GitHub issue label changes"
+  ],
+  "decision": {
+    "recommendation": "approve a separate implementation branch that converts exactly seven market_data_request.py route dependency parameters to a future get_market_data_service_dependency provider while preserving get_market_data_service compatibility fallback",
+    "next_gate": "human review of G2.48; if accepted, create G2.49 source implementation branch"
+  }
+}

--- a/docs/reports/quality/backend-market-data-service-route-dependency-consumer-matrix-2026-05-24.md
+++ b/docs/reports/quality/backend-market-data-service-route-dependency-consumer-matrix-2026-05-24.md
@@ -1,0 +1,202 @@
+# Backend MarketDataService Route Dependency Consumer Matrix - 2026-05-24
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为参考。
+
+## Status
+
+Status: review-ready.
+
+Workline: G2.48 `get_market_data_service` route dependency consumer matrix and route-provider authorization candidate.
+
+Recorded at: 2026-05-24T10:47:51+08:00.
+
+Current HEAD: `0dce9ca97cd043f898039176394eb5076c353cf5`.
+
+Base branch: `origin/wip/root-dirty-20260403`.
+
+Parent PR: `#188`, merged at `0dce9ca97cd043f898039176394eb5076c353cf5`.
+
+Parent issue: `#79`.
+
+Parent decision issue: `#92`.
+
+Source implementation authorized by this document alone: no.
+
+## Governance Boundary
+
+Boundary note: this packet records a route dependency consumer matrix and a
+future implementation authorization candidate only. It does not edit backend
+source, tests, route behavior, OpenAPI exposure, docs/API examples, generated
+clients, frontend code, PM2/stateful gates, OpenSpec changes, issue labels, or
+runtime configuration.
+
+If a human reviewer approves this packet, a later implementation lane may use
+the future write scope below. Until that explicit approval exists, this packet is
+evidence and planning only.
+
+## Parent State
+
+| Item | State | Notes |
+|---|---|---|
+| PR `#188` | `MERGED` at `0dce9ca97cd043f898039176394eb5076c353cf5` | G2.47 selected `get_market_data_service` as the next consumer matrix / authorization candidate packet. |
+| Issue `#79` | `OPEN`, `needs-triage` | Parent service singleton lifecycle DI issue remains open. |
+| Issue `#92` | Parent decision context retained | This packet stays within the accepted downstream governance conveyor. |
+| Completed provider modules | `8` | Existing route-provider seams remain closed and their compatibility getters must not be retired here. |
+
+## Evidence Inputs
+
+| Evidence | Path / Source | Role |
+|---|---|---|
+| G2.47 candidate selection | `docs/reports/quality/backend-service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.md` | Selected `get_market_data_service` as the next consumer matrix target. |
+| Generated G2.48 evidence | `.planning/codebase/generated/market-data-service-route-dependency-consumer-matrix-2026-05-24.json` | Machine-readable current-head consumer matrix and smoke results. |
+| Route consumer file | `web/backend/app/api/market/market_data_request.py` | Contains the active `Depends(get_market_data_service)` route dependency surface. |
+| Service getter package | `web/backend/app/services/market_data_service/` | Owns the package-level `MarketDataService` and `get_market_data_service()` surface. |
+| Focused test base | `web/backend/tests/test_market_api_integration.py` | Already overrides `get_market_data_service` through `app.dependency_overrides`. |
+
+## GitNexus Snapshot
+
+GitNexus target:
+
+| Symbol | File | Risk | Impacted count | Processes affected | Disposition |
+|---|---|---:|---:|---:|---|
+| `get_market_data_service` | `web/backend/app/services/market_data_service/get_market_data_service.py` | LOW | `0` | `0` | Route dependency surface still requires a route/provider authorization packet because text consumers are active. |
+
+The indexed graph does not capture the seven FastAPI dependency call sites as
+direct symbol callers, so this packet uses both GitNexus and current-head text /
+route scans. This is a graph/text mismatch, not proof that the surface is unused.
+
+## Route Dependency Consumer Matrix
+
+The active route dependency surface is exactly seven public route handlers in
+`web/backend/app/api/market/market_data_request.py`.
+
+| Method | Full path | Handler | Handler line | Dependency line | Current dependency |
+|---|---|---|---:|---:|---|
+| POST | `/api/v1/market/fund-flow/refresh` | `refresh_fund_flow` | `198` | `201` | `Depends(get_market_data_service)` |
+| GET | `/api/v1/market/etf/list` | `get_etf_list` | `231` | `238` | `Depends(get_market_data_service)` |
+| POST | `/api/v1/market/etf/refresh` | `refresh_etf_data` | `273` | `274` | `Depends(get_market_data_service)` |
+| GET | `/api/v1/market/chip-race` | `get_chip_race` | `298` | `303` | `Depends(get_market_data_service)` |
+| POST | `/api/v1/market/chip-race/refresh` | `refresh_chip_race` | `328` | `331` | `Depends(get_market_data_service)` |
+| GET | `/api/v1/market/lhb` | `get_lhb_detail` | `357` | `363` | `Depends(get_market_data_service)` |
+| POST | `/api/v1/market/lhb/refresh` | `refresh_lhb_detail` | `389` | `391` | `Depends(get_market_data_service)` |
+
+These routes are mounted through `VERSION_MAPPING["market"]["prefix"]` as
+`/api/v1/market`. The future route-provider migration must preserve the method,
+path, response model, response envelope, validation behavior, OpenAPI
+operation IDs, and error behavior for each row.
+
+## Compatibility And Package Surfaces
+
+| Surface | Current evidence | Future disposition |
+|---|---|---|
+| `web/backend/app/services/market_data_service/get_market_data_service.py` | Defines module-level `_market_data_service` and `get_market_data_service()` only. No app-state installer/provider exists. | Add provider seam here in a later approved implementation lane. Preserve `get_market_data_service()` as compatibility fallback. |
+| `web/backend/app/services/market_data_service/__init__.py` | Re-exports `MarketDataService` and `get_market_data_service`. | Re-export the future installer/provider/state key if implementation is approved. |
+| `web/backend/app/services/__init__.py` | Defines a separate IntegratedServices accessor also named `get_market_data_service()`. | Do not modify in this lane; it is not the route import target. |
+| `web/backend/app/services/market_data_adapter.py` | Imports `get_market_data_service` from the package and uses it as a fallback. | Keep out of the route-provider migration; the compatibility getter must remain. |
+| `web/backend/tests/test_market_api_integration.py` | Uses `app.dependency_overrides[get_market_data_service]` in the `client` fixture. | Use as focused route override base; future implementation should update/extend tests for the provider dependency. |
+| `MarketDataServiceV2` lane | Already has `install_market_data_service_v2()` and `get_market_data_service_v2_dependency()`. | Keep separate; do not consolidate V1 package service and V2 service in this lane. |
+
+## Candidate Decision
+
+This packet recommends approving a separate implementation branch that migrates
+only the seven `market/market_data_request.py` route dependency parameters from
+the compatibility getter to an app-state provider dependency.
+
+The compatibility getter should remain public because non-route fallback
+surfaces and tests still depend on it.
+
+## Future Allowed Write Scope
+
+If this packet is approved, the next implementation branch should be limited to:
+
+| Path | Future allowed change |
+|---|---|
+| `web/backend/app/services/market_data_service/get_market_data_service.py` | Add a stable state key, `install_market_data_service(app, service=None)`, and `get_market_data_service_dependency(request)` while preserving `get_market_data_service()`. |
+| `web/backend/app/services/market_data_service/__init__.py` | Re-export the future provider, installer, and state key. |
+| `web/backend/app/api/market/market_data_request.py` | Convert only the seven route dependency parameters listed in the matrix to `Depends(get_market_data_service_dependency)`. |
+| `web/backend/tests/test_market_data_service_lifecycle_di.py` or equivalent focused test file | Cover provider install, app-state override, fallback behavior, dependency override, and representative market route behavior. |
+| `web/backend/tests/test_market_api_integration.py` | Update only if needed to keep the existing route override fixture aligned with the new provider dependency. |
+| future implementation evidence report | Record implementation evidence and verification results. |
+| future PR task card | Bind the implementation PR to the authorized source/test/report paths. |
+
+## Future Implementation Shape
+
+The future implementation should follow the established app-state provider plus
+compatibility fallback pattern:
+
+- keep `get_market_data_service()` as the compatibility getter
+- add a stable state key, for example `MARKET_DATA_SERVICE_STATE_KEY`
+- add `install_market_data_service(app, service=None)` that stores the selected
+  service on `app.state`
+- add `get_market_data_service_dependency(request: Request)` that reads from
+  `app.state` and falls back to installer/getter when absent
+- inject `MarketDataService` into the seven listed route handlers with
+  `Depends(get_market_data_service_dependency)`
+- preserve existing route paths, HTTP methods, response envelopes, OpenAPI
+  operation IDs, validation behavior, and exception behavior
+
+## Explicit Non-Goals
+
+This packet and the future implementation lane must not:
+
+- modify `web/backend/app/services/market_data_adapter.py`
+- modify `web/backend/app/services/__init__.py`
+- consolidate `MarketDataService` and `MarketDataServiceV2`
+- remove, rename, or deprecate `get_market_data_service()`
+- change route paths, HTTP methods, response models, response envelopes, or
+  OpenAPI schema exposure
+- change docs/API examples, generated clients, frontend code, PM2 scripts,
+  runtime configuration, OpenSpec changes/specs, or GitHub issue labels
+- expand into dashboard, V2 market data, data-service, strategy-service, or
+  external-client seams
+- authorize compatibility getter cleanup
+
+## Required Future Gates
+
+Before any future source implementation commit:
+
+1. Run GitNexus impact/context for `get_market_data_service` and the selected
+   route handlers.
+2. Add failing focused tests for provider install/app-state override/fallback and
+   at least one route dependency override path.
+3. Implement the smallest provider seam that satisfies those tests.
+4. Run the focused lifecycle DI test and `web/backend/tests/test_market_api_integration.py`.
+5. Run `ruff check` on touched backend source/test files.
+6. Run configured app/OpenAPI smoke and confirm route count, OpenAPI path count,
+   duplicate operation IDs, and the seven selected market route paths.
+7. Stage only the authorized paths and run GitNexus `detect_changes` on staged
+   scope before committing.
+
+## Rollback Plan For Future Implementation
+
+If the future implementation causes regressions:
+
+- revert the implementation PR
+- keep this consumer matrix packet as historical evidence
+- preserve `get_market_data_service()` compatibility behavior
+- do not delete route consumers, tests, or package re-exports during rollback
+
+## Verification Notes
+
+Fresh current-head evidence used for this packet:
+
+```text
+current_head=0dce9ca97cd043f898039176394eb5076c353cf5
+route_dependency_sites=7
+reference_files=14
+reference_count=52
+gitnexus_get_market_data_service_risk=LOW
+gitnexus_impacted_count=0
+configured_app_import=ok
+configured_route_count=548
+configured_openapi_paths=500
+configured_duplicate_operation_ids=0
+selected_market_routes=7
+test_market_api_integration_collect_only=18 collected
+test_market_api_integration=18 passed
+```
+
+The configured app/OpenAPI smoke used non-sensitive placeholder environment
+variables only. It did not read production secrets, run PM2, connect to a live
+database intentionally, or authorize runtime promotion.

--- a/governance/mainline/task-cards/pr-189.yaml
+++ b/governance/mainline/task-cards/pr-189.yaml
@@ -1,0 +1,107 @@
+version: "v0.2"
+
+task:
+  id: "pr-189"
+  title: "Record MarketDataService route dependency consumer matrix"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-market-data-service-route-dependency-consumer-matrix"
+  objective: "record the G2.48 get_market_data_service consumer matrix and route-provider authorization candidate before source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-market-data-service-route-dependency-consumer-matrix"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-market-data-service-route-dependency-consumer-matrix"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Consumer-matrix packet records governance evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/market-data-service-route-dependency-consumer-matrix-2026-05-24.json"
+    - "docs/reports/quality/backend-market-data-service-route-dependency-consumer-matrix-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-189.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, tests, generated clients, docs/API, OpenSpec, PM2, route, OpenAPI, or runtime behavior changes"
+  - "No GitHub issue state, label, or ready-for-agent movement"
+  - "No source implementation in this PR"
+  - "No compatibility getter cleanup authorization"
+  - "No MarketDataService and MarketDataServiceV2 consolidation"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-market-data-service-route-dependency-consumer-matrix-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/market-data-service-route-dependency-consumer-matrix-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-189.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-189.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "python -c \"print('staged-gitnexus-scope: docs-only consumer-matrix packet; no source symbols changed')\""
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the consumer-matrix-only boundary"
+    - "If this packet rewires route dependencies, it bypasses the required separate implementation branch"
+    - "If compatibility getter cleanup is authorized here, it contradicts the active fallback and test surfaces"
+  rollback_plan: "revert this governance-only PR; G2.47 candidate selection remains merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record the get_market_data_service route dependency consumer matrix and future authorization candidate"
+    modified_scope: "consumer matrix report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only consumer matrix PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T10:47:51+08:00"
+    approval_note: "human maintainer approved continuing after PR #188 merge; this packet records G2.48 consumer matrix and a future authorization candidate only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- Records G2.48 `get_market_data_service` route dependency consumer matrix after PR #188 merge.
- Confirms exactly seven active `/api/v1/market` route handlers still use `Depends(get_market_data_service)` in `market/market_data_request.py`.
- Identifies compatibility surfaces that must stay active: package getter, package re-export, `market_data_adapter.py` fallback, and existing test override behavior.
- Prepares a future route-provider implementation authorization candidate only; this PR does not edit backend source or tests.

## Boundary

Governance-only. No source edits, no route behavior changes, no OpenAPI exposure changes, no compatibility getter cleanup, no issue label movement, and no `MarketDataService` / `MarketDataServiceV2` consolidation.

If accepted, the next lane is G2.49: a separate implementation branch that may add `install_market_data_service`, `get_market_data_service_dependency`, and convert exactly the seven listed route dependency parameters under the allowed write scope.

## Verification

- GitNexus `get_market_data_service` impact: LOW, impacted_count=0
- GitNexus staged detect_changes: low risk, 4 changed files, 0 changed symbols, 0 affected processes
- Markdown governance: checked_files=2, errors=0
- JSON parse: ok
- YAML parse: ok
- Mainline scope gate: pass=True
- `git diff HEAD~1..HEAD --check`: clean
- Configured app/OpenAPI smoke with placeholder env: app_import=ok, routes=548, paths=500, duplicate_operation_ids=0, selected_market_routes=7
- Focused pytest: `web/backend/tests/test_market_api_integration.py` 18 passed
EOF 2>&1
