### PR TITLE
refactor(di): inject market data service route provider

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -794,11 +794,21 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 `market_data_adapter.py` excluded, configured OpenAPI
 │   │                 smoke routes=`548`, paths=`500`, duplicate operation
 │   │                 IDs=`0`, and `test_market_api_integration.py`
-│   │                 result=`18 passed`
-│   └── Next gate: Human review of the G2.48 consumer-matrix /
-│                  authorization-candidate PR; if accepted, create a separate
-│                  G2.49 `get_market_data_service` route-provider
-│                  implementation branch before source edits
+│   │                 result=`18 passed`; PR `#189` merged at
+│   │                 `7daf74ce0c3210defc2ad283583a335037daa500`; G2.49 now
+│   │                 implements the provider seam, preserves
+│   │                 `get_market_data_service()`, converts exactly seven
+│   │                 `/api/v1/market` route dependencies to
+│   │                 `get_market_data_service_dependency`, leaves
+│   │                 `market_data_adapter.py` and
+│   │                 `web/backend/app/services/__init__.py` unchanged, and
+│   │                 records focused lifecycle tests=`5 passed`,
+│   │                 market integration tests=`18 passed`, route guard
+│   │                 old=`0` / new=`7`, OpenAPI paths=`500`, duplicate
+│   │                 operation IDs=`0`
+│   └── Next gate: Human review of the G2.49 implementation PR; if accepted,
+│                  run G2.50 closeout / current-head candidate refresh before
+│                  selecting another service lifecycle implementation lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -886,6 +896,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-advanced-analysis-route-provider-closeout-and-candidate-refresh-2026-05-24.md` | G | G2.46 closeout prepared at current HEAD `059638b573c6f2586537973e2a4b396f0ce156d7`: records PR `#185` as `MERGED`, confirms `AdvancedAnalysisService` route class dependency sites=`0`, provider sites=`14`, direct compatibility getter route calls=`0`, focused test result=`4 passed`, configured OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, advanced paths=`14`, completed provider modules=`8`, route provider dependency files=`11`, and route provider dependency sites=`72`; no next implementation target or compatibility getter retirement is authorized | Human review / PR merge decision; if accepted, create G2.47 candidate selection and usefulness/ownership triage packet before any source edits |
 | `backend-service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.md` | G | G2.47 candidate selection prepared at current HEAD `e09e6db4a6a85dc392c20a737e729bb6f123804d`: records PR `#186` as `MERGED`, scans `152` service files and `219` API files, confirms provider modules=`8`, route provider dependency sites=`72`, route class dependency sites=`0`, and classifies `get_market_data_service` as the next consumer matrix / authorization candidate packet while excluding `get_data_service`, `get_strategy_service`, and `get_kronos_client` from direct implementation | Human review / PR merge decision; if accepted, create G2.48 `get_market_data_service` route dependency consumer matrix / route-provider authorization candidate before any source edits |
 | `backend-market-data-service-route-dependency-consumer-matrix-2026-05-24.md` | G | G2.48 consumer matrix prepared at current HEAD `0dce9ca97cd043f898039176394eb5076c353cf5`: records PR `#188` as `MERGED`, confirms `get_market_data_service` GitNexus risk=`LOW` / impacted count=`0`, identifies exactly seven active `/api/v1/market` route handlers using `Depends(get_market_data_service)`, keeps the package compatibility getter and `market_data_adapter.py` fallback surface active, excludes `services/__init__.py` IntegratedServices accessor and `MarketDataServiceV2` consolidation, configured app/OpenAPI smoke reports routes=`548`, paths=`500`, duplicate operation IDs=`0`, and focused `test_market_api_integration.py` result=`18 passed` | Human review / PR merge decision; if accepted, create G2.49 `get_market_data_service` route-provider implementation branch before source edits |
+| `backend-market-data-service-route-provider-implementation-2026-05-24.md` | G | G2.49 implementation prepared from G2.48 authorization at base `7daf74ce0c3210defc2ad283583a335037daa500`: adds `MARKET_DATA_SERVICE_STATE_KEY`, `install_market_data_service`, and `get_market_data_service_dependency`, preserves `get_market_data_service()` and package compatibility, converts exactly seven `/api/v1/market` route dependencies to the provider, keeps `market_data_adapter.py`, `services/__init__.py`, and `MarketDataServiceV2` unchanged, TDD red=`4 failed, 1 passed`, green=`5 passed`, market integration tests=`18 passed`, ruff/black passed, configured OpenAPI smoke reports routes=`548`, paths=`500`, duplicate operation IDs=`0`, selected market routes=`7` | Human review / PR merge decision; if accepted, run G2.50 closeout/current-head candidate refresh before selecting the next service lifecycle DI lane |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/market-data-service-route-provider-implementation-2026-05-24.json
+++ b/.planning/codebase/generated/market-data-service-route-provider-implementation-2026-05-24.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": "1.0",
+  "workline": "G2.49",
+  "title": "MarketDataService route provider implementation",
+  "recorded_at": "2026-05-24T11:41:28+08:00",
+  "base_head": "7daf74ce0c3210defc2ad283583a335037daa500",
+  "base_branch": "origin/wip/root-dirty-20260403",
+  "parent_pr": {
+    "number": 189,
+    "state": "MERGED",
+    "merge_commit": "7daf74ce0c3210defc2ad283583a335037daa500"
+  },
+  "implementation": {
+    "state_key": "MARKET_DATA_SERVICE_STATE_KEY",
+    "installer": "install_market_data_service",
+    "provider": "get_market_data_service_dependency",
+    "compatibility_getter": "get_market_data_service",
+    "compatibility_getter_preserved": true,
+    "market_data_adapter_unchanged": true,
+    "services_init_integrated_accessor_unchanged": true,
+    "market_data_service_v2_unchanged": true
+  },
+  "changed_source_files": [
+    "web/backend/app/services/market_data_service/get_market_data_service.py",
+    "web/backend/app/services/market_data_service/__init__.py",
+    "web/backend/app/api/market/market_data_request.py"
+  ],
+  "changed_test_files": [
+    "web/backend/tests/test_market_data_service_lifecycle_di.py",
+    "web/backend/tests/test_market_api_integration.py"
+  ],
+  "route_dependency_surface": {
+    "old_dependency": "Depends(get_market_data_service)",
+    "new_dependency": "Depends(get_market_data_service_dependency)",
+    "old_depends_count": 0,
+    "new_depends_count": 7,
+    "routes": [
+      "POST /api/v1/market/fund-flow/refresh",
+      "GET /api/v1/market/etf/list",
+      "POST /api/v1/market/etf/refresh",
+      "GET /api/v1/market/chip-race",
+      "POST /api/v1/market/chip-race/refresh",
+      "GET /api/v1/market/lhb",
+      "POST /api/v1/market/lhb/refresh"
+    ]
+  },
+  "tdd": {
+    "red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_lifecycle_di.py -q --tb=short --no-cov",
+      "result": "4 failed, 1 passed in 2.16s"
+    },
+    "green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_lifecycle_di.py -q --tb=short --no-cov",
+      "result": "5 passed in 2.97s"
+    }
+  },
+  "verification": {
+    "market_api_integration": "18 passed in 15.41s",
+    "ruff": "All checks passed!",
+    "black_check": "5 files would be left unchanged",
+    "configured_openapi_smoke": {
+      "status": 0,
+      "app_import": "ok",
+      "routes": 548,
+      "paths": 500,
+      "duplicate_operation_ids": 0,
+      "selected_market_routes": 7
+    }
+  },
+  "gitnexus_pre_edit": {
+    "get_market_data_service": {
+      "risk": "LOW",
+      "impacted_count": 0
+    },
+    "market_data_request_file": {
+      "risk": "LOW",
+      "impacted_count": 3
+    }
+  },
+  "gitnexus_staged_detect_changes": {
+    "risk_level": "high",
+    "changed_files": 9,
+    "changed_count": 39,
+    "affected_count": 6,
+    "note": "High staged verdict is retained as review signal. Affected processes are reported through market_data_request.py file-level symbol mapping and get_kline_data flows, while the diff is limited to authorized provider import and seven route dependency parameters."
+  },
+  "next_gate": "G2.50 closeout / current-head candidate refresh before selecting another service lifecycle implementation lane"
+}

--- a/docs/reports/quality/backend-market-data-service-route-provider-implementation-2026-05-24.md
+++ b/docs/reports/quality/backend-market-data-service-route-provider-implementation-2026-05-24.md
@@ -1,0 +1,205 @@
+# Backend MarketDataService Route Provider Implementation - 2026-05-24
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为参考。
+
+## Status
+
+Status: review-ready.
+
+Workline: G2.49 `get_market_data_service` route-provider implementation.
+
+Recorded at: 2026-05-24T11:41:28+08:00.
+
+Base HEAD: `7daf74ce0c3210defc2ad283583a335037daa500`.
+
+Base branch: `origin/wip/root-dirty-20260403`.
+
+Parent PR: `#189`, merged at `7daf74ce0c3210defc2ad283583a335037daa500`.
+
+Parent issue: `#79`.
+
+Parent decision issue: `#92`.
+
+## Decision Boundary
+
+This implementation follows the G2.48 authorization boundary. It changes only:
+
+- `web/backend/app/services/market_data_service/get_market_data_service.py`
+- `web/backend/app/services/market_data_service/__init__.py`
+- `web/backend/app/api/market/market_data_request.py`
+- `web/backend/tests/test_market_data_service_lifecycle_di.py`
+- `web/backend/tests/test_market_api_integration.py`
+- this implementation report
+- generated implementation evidence JSON
+- steward tree
+- task card
+
+It does not change route paths, response models, OpenAPI exposure, docs/API,
+frontend, PM2/runtime process state, OpenSpec files, issue labels, unrelated
+service seams, `market_data_adapter.py`, `web/backend/app/services/__init__.py`,
+or `MarketDataServiceV2`.
+
+## Implementation Summary
+
+| Area | Change |
+|---|---|
+| Service provider | Added `MARKET_DATA_SERVICE_STATE_KEY`, `install_market_data_service(app, service=None)`, and `get_market_data_service_dependency(request)`. |
+| Compatibility getter | Preserved `get_market_data_service()` and its module-level fallback singleton. |
+| Package exports | Re-exported the state key, installer, provider dependency, and compatibility getter from `app.services.market_data_service`. |
+| Route dependencies | Converted exactly seven `/api/v1/market` route handler `service` parameters from `Depends(get_market_data_service)` to `Depends(get_market_data_service_dependency)`. |
+| Focused tests | Added lifecycle DI tests and updated the existing market API integration fixture to override the new provider dependency. |
+
+Converted route handlers:
+
+| Handler | Route | Result |
+|---|---|---|
+| `refresh_fund_flow` | `POST /api/v1/market/fund-flow/refresh` | Provider dependency |
+| `get_etf_list` | `GET /api/v1/market/etf/list` | Provider dependency |
+| `refresh_etf_data` | `POST /api/v1/market/etf/refresh` | Provider dependency |
+| `get_chip_race` | `GET /api/v1/market/chip-race` | Provider dependency |
+| `refresh_chip_race` | `POST /api/v1/market/chip-race/refresh` | Provider dependency |
+| `get_lhb_detail` | `GET /api/v1/market/lhb` | Provider dependency |
+| `refresh_lhb_detail` | `POST /api/v1/market/lhb/refresh` | Provider dependency |
+
+## TDD Evidence
+
+RED command:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_lifecycle_di.py -q --tb=short --no-cov
+```
+
+RED result:
+
+```text
+4 failed, 1 passed in 2.16s
+```
+
+Expected failing reasons:
+
+- package did not re-export `MARKET_DATA_SERVICE_STATE_KEY`
+- getter module did not define `install_market_data_service`
+- getter module did not define `get_market_data_service_dependency`
+- route handlers still depended on `get_market_data_service`
+
+GREEN command:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_lifecycle_di.py -q --tb=short --no-cov
+```
+
+GREEN result:
+
+```text
+5 passed in 2.97s
+```
+
+## Guard Evidence
+
+Route dependency guard:
+
+```text
+old_depends=0
+new_depends=7
+provider_import=true
+```
+
+This confirms the seven authorized route dependency parameters were migrated and
+no `Depends(get_market_data_service)` call remains in
+`market/market_data_request.py`.
+
+## Focused Integration Verification
+
+Command:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_api_integration.py -q --tb=short --no-cov
+```
+
+Result:
+
+```text
+18 passed in 15.41s
+```
+
+## App And OpenAPI Smoke
+
+The configured `app.main` / OpenAPI smoke used non-sensitive placeholder
+environment variables and produced:
+
+| Field | Value |
+|---|---:|
+| Runtime routes | `548` |
+| OpenAPI paths | `500` |
+| Duplicate operation IDs | `0` |
+| Selected `/api/v1/market` routes | `7` |
+
+The smoke exited with status `0`.
+
+## Static Verification
+
+Commands:
+
+```bash
+ruff check web/backend/app/services/market_data_service/get_market_data_service.py web/backend/app/services/market_data_service/__init__.py web/backend/app/api/market/market_data_request.py web/backend/tests/test_market_data_service_lifecycle_di.py web/backend/tests/test_market_api_integration.py
+black --check web/backend/app/services/market_data_service/get_market_data_service.py web/backend/app/services/market_data_service/__init__.py web/backend/app/api/market/market_data_request.py web/backend/tests/test_market_data_service_lifecycle_di.py web/backend/tests/test_market_api_integration.py
+```
+
+Results:
+
+- `ruff`: `All checks passed!`
+- `black --check`: `5 files would be left unchanged`
+
+## GitNexus Evidence
+
+Pre-edit GitNexus checks:
+
+| Target | Risk | Impacted count | Notes |
+|---|---|---:|---|
+| `get_market_data_service` | LOW | `0` | Package compatibility getter remains public. |
+| `web/backend/app/api/market/market_data_request.py` | LOW | `3` | Direct importer is package `api/market/__init__.py`; test imports are expected. |
+| selected route handlers | LOW / no process impact | `0` for unambiguous handlers | Some handler names are shared with mock modules, so file-level impact was used as the reliable route-surface guard. |
+
+Staged GitNexus detect changes:
+
+```text
+risk_level=high
+changed_files=9
+changed_count=39
+affected_count=6
+```
+
+The high staged verdict is retained as an explicit review signal. The affected
+processes are reported through `market_data_request.py` file-level symbol
+mapping and name `get_kline_data` flows even though this implementation changes
+only the authorized provider import and seven route dependency parameters in
+that file. The risk is therefore handled through the focused lifecycle test,
+market API integration test, route dependency count guard, ruff/black, and
+configured route/OpenAPI smoke rather than suppressed.
+
+## Compatibility Boundary
+
+The following compatibility surfaces are preserved:
+
+- `get_market_data_service()` remains public
+- package re-export remains public
+- `market_data_adapter.py` fallback surface remains unchanged
+- `web/backend/app/services/__init__.py` IntegratedServices accessor remains unchanged
+- `MarketDataServiceV2` remains separate
+
+## Rollback
+
+If this implementation causes a regression:
+
+1. Revert this implementation PR.
+2. The seven route handlers will return to `Depends(get_market_data_service)`.
+3. `get_market_data_service()` compatibility fallback remains available before,
+   during, and after rollback.
+4. The G2.48 consumer matrix remains historical authorization evidence unless
+   separately superseded.
+
+## Next Gate
+
+After review and merge, run a G2.50 closeout / current-head candidate refresh
+before selecting another service lifecycle implementation lane.

--- a/governance/mainline/task-cards/pr-190.yaml
+++ b/governance/mainline/task-cards/pr-190.yaml
@@ -1,0 +1,126 @@
+version: "v0.2"
+
+task:
+  id: "pr-190"
+  title: "Implement MarketDataService route provider migration"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-market-data-service-route-provider-implementation"
+  objective: "implement the G2.49 MarketDataService route provider migration authorized by PR #189"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-market-data-service-route-provider-implementation"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-market-data-service-route-provider-implementation"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Route-provider migration preserves existing route paths, OpenAPI exposure, and product surface while moving MarketDataService route dependencies to an app-state provider"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/market-data-service-route-provider-implementation-2026-05-24.json"
+    - "docs/reports/quality/backend-market-data-service-route-provider-implementation-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-190.yaml"
+    - "web/backend/app/services/market_data_service/get_market_data_service.py"
+    - "web/backend/app/services/market_data_service/__init__.py"
+    - "web/backend/app/api/market/market_data_request.py"
+    - "web/backend/tests/test_market_data_service_lifecycle_di.py"
+    - "web/backend/tests/test_market_api_integration.py"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No route path, response model, OpenAPI exposure, docs/API, generated client, frontend, PM2, database, task, adapter, or external service behavior change"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No get_market_data_service cleanup or compatibility getter retirement"
+  - "No MarketDataService and MarketDataServiceV2 consolidation"
+  - "No changes to market_data_adapter.py or web/backend/app/services/__init__.py"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_lifecycle_di.py -q --tb=short --no-cov"
+      required: true
+    - id: "integration-pytest"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_api_integration.py -q --tb=short --no-cov"
+      required: true
+    - id: "route-dependency-guard"
+      command: "python -c \"from pathlib import Path; route=Path('web/backend/app/api/market/market_data_request.py').read_text(); old=route.count('Depends(get_market_data_service)'); new=route.count('Depends(get_market_data_service_dependency)'); print({'old_depends': old, 'new_depends': new}); raise SystemExit(0 if old == 0 and new == 7 else 1)\""
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/services/market_data_service/get_market_data_service.py web/backend/app/services/market_data_service/__init__.py web/backend/app/api/market/market_data_request.py web/backend/tests/test_market_data_service_lifecycle_di.py web/backend/tests/test_market_api_integration.py"
+      required: true
+    - id: "black-check"
+      command: "black --check web/backend/app/services/market_data_service/get_market_data_service.py web/backend/app/services/market_data_service/__init__.py web/backend/app/api/market/market_data_request.py web/backend/tests/test_market_data_service_lifecycle_di.py web/backend/tests/test_market_api_integration.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-market-data-service-route-provider-implementation-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/market-data-service-route-provider-implementation-2026-05-24.json >/dev/null"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-190.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "python -c \"print('staged-gitnexus-scope: verify with MCP detect_changes(scope=staged); high verdict must be reviewed against authorized route-provider diff and recorded in implementation evidence')\""
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If route paths or response models change, the PR exceeds the route-provider migration boundary"
+    - "If get_market_data_service is retired, compatibility fallback is broken"
+    - "If provider dependency count is not exactly 7, one route may remain on the compatibility getter or an unrelated dependency may be changed"
+    - "If market_data_adapter.py or services/__init__.py changes, the PR exceeds the authorized scope"
+    - "GitNexus staged detect_changes reports high risk through market_data_request.py file-level mapping; reviewers must confirm the diff remains limited to the authorized provider import and seven route dependency parameters"
+  rollback_plan: "revert this implementation PR; prior G2.48 consumer matrix remains historical evidence unless superseded"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "migrate MarketDataService route dependencies to an app-state provider"
+    modified_scope: "MarketDataService getter package, market_data_request routes, focused tests, implementation report, generated artifact, steward tree, and this task card"
+    dependency_changes: "adds get_market_data_service_dependency while preserving get_market_data_service"
+    legacy_logic_impact: "compatibility getter and market_data_adapter fallback preserved"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this route-provider migration PR if verification fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T11:41:28+08:00"
+    approval_note: "human maintainer approved continuing after PR #189 merge; PR #189 authorized this exact route-provider implementation branch"
+    secondary_approved: false

--- a/web/backend/app/api/market/market_data_request.py
+++ b/web/backend/app/api/market/market_data_request.py
@@ -34,7 +34,7 @@ from app.schemas.market_schemas import (
     LongHuBangResponse,
     MessageResponse,
 )
-from app.services.market_data_service import MarketDataService, get_market_data_service
+from app.services.market_data_service import MarketDataService, get_market_data_service_dependency
 from app.services.stock_search_service import StockSearchService, get_stock_search_service_dependency
 
 router = APIRouter()
@@ -198,7 +198,7 @@ async def get_fund_flow(
 async def refresh_fund_flow(
     symbol: str = Query(..., description="股票代码", min_length=1, max_length=20, pattern=r"^[A-Z0-9.]+$"),
     timeframe: str = Query(default="1", description="时间维度", pattern=r"^[13510]$"),
-    service: MarketDataService = Depends(get_market_data_service),
+    service: MarketDataService = Depends(get_market_data_service_dependency),
 ):
     """
     从数据源刷新资金流向数据并保存到数据库
@@ -235,7 +235,7 @@ async def get_etf_list(
     category: Optional[str] = Query(None, description="ETF类型", pattern=r"^(股票|债券|商品|货币|QDII)$"),
     limit: int = Query(default=100, description="返回数量", ge=1, le=500),
     offset: int = Query(0, description="偏移量", ge=0, le=10000),
-    service: MarketDataService = Depends(get_market_data_service),
+    service: MarketDataService = Depends(get_market_data_service_dependency),
 ):
     """
     查询ETF实时行情数据（带缓存优化）
@@ -271,7 +271,7 @@ async def get_etf_list(
     responses=ETF_REFRESH_RESPONSES,
 )
 async def refresh_etf_data(
-    service: MarketDataService = Depends(get_market_data_service),
+    service: MarketDataService = Depends(get_market_data_service_dependency),
 ):
     """
     刷新全市场ETF实时数据
@@ -300,7 +300,7 @@ async def get_chip_race(
     trade_date: Optional[date] = Query(None, description="交易日期"),
     min_race_amount: Optional[float] = Query(None, ge=0, description="最小抢筹金额"),
     limit: int = Query(default=100, ge=1, le=500, description="返回记录数限制"),
-    service: MarketDataService = Depends(get_market_data_service),
+    service: MarketDataService = Depends(get_market_data_service_dependency),
 ):
     """
     查询竞价抢筹数据（带缓存优化）
@@ -328,7 +328,7 @@ async def get_chip_race(
 async def refresh_chip_race(
     race_type: str = Query(default="open", description="抢筹类型"),
     trade_date: Optional[str] = Query(None, description="交易日期 YYYY-MM-DD"),
-    service: MarketDataService = Depends(get_market_data_service),
+    service: MarketDataService = Depends(get_market_data_service_dependency),
 ):
     """
     刷新竞价抢筹数据
@@ -360,7 +360,7 @@ async def get_lhb_detail(
     end_date: Optional[date] = Query(None, description="结束日期"),
     min_net_amount: Optional[float] = Query(None, description="最小净买入额"),
     limit: int = Query(default=100, ge=1, le=500, description="返回记录数限制"),
-    service: MarketDataService = Depends(get_market_data_service),
+    service: MarketDataService = Depends(get_market_data_service_dependency),
 ):
     """
     查询龙虎榜详细数据（带缓存优化）
@@ -388,7 +388,7 @@ async def get_lhb_detail(
 )
 async def refresh_lhb_detail(
     trade_date: str = Query(..., description="交易日期 YYYY-MM-DD"),
-    service: MarketDataService = Depends(get_market_data_service),
+    service: MarketDataService = Depends(get_market_data_service_dependency),
 ):
     """
     刷新指定日期的龙虎榜数据

--- a/web/backend/app/services/market_data_service/__init__.py
+++ b/web/backend/app/services/market_data_service/__init__.py
@@ -1,5 +1,17 @@
 """market_data_service 拆分包"""
-from .market_data_service import MarketDataService  # noqa: F401
-from .get_market_data_service import get_market_data_service  # noqa: F401
 
-__all__ = ['MarketDataService', 'get_market_data_service']
+from .market_data_service import MarketDataService  # noqa: F401
+from .get_market_data_service import (  # noqa: F401
+    MARKET_DATA_SERVICE_STATE_KEY,
+    get_market_data_service,
+    get_market_data_service_dependency,
+    install_market_data_service,
+)
+
+__all__ = [
+    "MarketDataService",
+    "MARKET_DATA_SERVICE_STATE_KEY",
+    "get_market_data_service",
+    "get_market_data_service_dependency",
+    "install_market_data_service",
+]

--- a/web/backend/app/services/market_data_service/get_market_data_service.py
+++ b/web/backend/app/services/market_data_service/get_market_data_service.py
@@ -13,14 +13,17 @@
 """
 
 import logging
-from typing import Optional
+from typing import Any, Optional
 
+from fastapi import Request
 
 from .market_data_service import MarketDataService
 
 logger = logging.getLogger(__name__)
 
 _market_data_service: Optional[MarketDataService] = None
+MARKET_DATA_SERVICE_STATE_KEY = "market_data_service"
+
 
 def get_market_data_service() -> MarketDataService:
     """获取市场数据服务单例"""
@@ -30,3 +33,16 @@ def get_market_data_service() -> MarketDataService:
     return _market_data_service
 
 
+def install_market_data_service(app: Any, service: MarketDataService | None = None) -> MarketDataService:
+    """Install the market data service instance on FastAPI app.state."""
+    selected_service = service if service is not None else get_market_data_service()
+    setattr(app.state, MARKET_DATA_SERVICE_STATE_KEY, selected_service)
+    return selected_service
+
+
+def get_market_data_service_dependency(request: Request) -> MarketDataService:
+    """FastAPI dependency provider for the market data service."""
+    service = getattr(request.app.state, MARKET_DATA_SERVICE_STATE_KEY, None)
+    if service is None:
+        service = install_market_data_service(request.app)
+    return service

--- a/web/backend/tests/test_market_api_integration.py
+++ b/web/backend/tests/test_market_api_integration.py
@@ -28,7 +28,7 @@ from unittest.mock import Mock
 # 导入应用
 from app.main import app
 from app.core.security import User, get_current_user
-from app.services.market_data_service import get_market_data_service
+from app.services.market_data_service import get_market_data_service_dependency
 
 
 class _MockOverviewDataSourceFactory:
@@ -70,10 +70,11 @@ def mock_market_service():
 @pytest.fixture
 def client(mock_market_service, monkeypatch: pytest.MonkeyPatch):
     """提供测试客户端，使用dependency_overrides注入mock服务"""
+
     async def _get_data_source_factory():
         return _MockOverviewDataSourceFactory()
 
-    app.dependency_overrides[get_market_data_service] = lambda: mock_market_service
+    app.dependency_overrides[get_market_data_service_dependency] = lambda: mock_market_service
     app.dependency_overrides[get_current_user] = lambda: User(
         id=1,
         username="test-user",
@@ -163,9 +164,7 @@ class TestMarketOverview:
         assert "source" in data
         assert data["success"] is True
 
-    def test_overview_contains_required_fields(
-        self, client, mock_etf_data, mock_chip_race_data, mock_lhb_data
-    ):
+    def test_overview_contains_required_fields(self, client, mock_etf_data, mock_chip_race_data, mock_lhb_data):
         """测试市场概览包含必需字段"""
         response = client.get("/api/v1/data/markets/overview")
         data = response.json()

--- a/web/backend/tests/test_market_data_service_lifecycle_di.py
+++ b/web/backend/tests/test_market_data_service_lifecycle_di.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from app.api.market import market_data_request as market_routes
+from app.services import market_data_service
+
+
+ROUTE_HANDLER_NAMES = [
+    "refresh_fund_flow",
+    "get_etf_list",
+    "refresh_etf_data",
+    "get_chip_race",
+    "refresh_chip_race",
+    "get_lhb_detail",
+    "refresh_lhb_detail",
+]
+
+
+def test_market_data_service_package_reexports_provider_symbols():
+    for symbol_name in [
+        "MARKET_DATA_SERVICE_STATE_KEY",
+        "install_market_data_service",
+        "get_market_data_service_dependency",
+    ]:
+        assert hasattr(market_data_service, symbol_name)
+
+
+def test_market_data_service_dependency_installs_app_state_when_missing(monkeypatch):
+    getter_module = importlib.import_module("app.services.market_data_service.get_market_data_service")
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+    request = SimpleNamespace(app=fake_app)
+
+    monkeypatch.setattr(getter_module, "get_market_data_service", lambda: fake_service)
+
+    assert getter_module.get_market_data_service_dependency(request) is fake_service
+    assert getattr(fake_app.state, getter_module.MARKET_DATA_SERVICE_STATE_KEY) is fake_service
+
+
+def test_install_market_data_service_accepts_explicit_service():
+    getter_module = importlib.import_module("app.services.market_data_service.get_market_data_service")
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+
+    assert getter_module.install_market_data_service(fake_app, fake_service) is fake_service
+    assert getattr(fake_app.state, getter_module.MARKET_DATA_SERVICE_STATE_KEY) is fake_service
+
+
+def test_market_routes_use_market_data_service_dependency_provider():
+    getter_module = importlib.import_module("app.services.market_data_service.get_market_data_service")
+
+    for function_name in ROUTE_HANDLER_NAMES:
+        signature = inspect.signature(getattr(market_routes, function_name))
+        service_default = signature.parameters["service"].default
+
+        assert getattr(service_default, "dependency", None) is getter_module.get_market_data_service_dependency
+
+
+@pytest.mark.asyncio
+async def test_refresh_etf_data_uses_injected_market_data_service():
+    class FakeMarketDataService:
+        def __init__(self):
+            self.called = False
+
+        def fetch_and_save_etf_spot(self):
+            self.called = True
+            return {"success": True, "message": "ok"}
+
+    fake_service = FakeMarketDataService()
+
+    result = await market_routes.refresh_etf_data(service=fake_service)
+
+    assert result.message == "ok"
+    assert fake_service.called is True


### PR DESCRIPTION
## Summary
- Implements the G2.49 MarketDataService route-provider DI seam authorized by PR #189.
- Adds `MARKET_DATA_SERVICE_STATE_KEY`, `install_market_data_service()`, and `get_market_data_service_dependency()` while preserving the legacy `get_market_data_service()` compatibility getter.
- Converts exactly 7 `/api/v1/market` route dependencies to the request/app.state provider seam.

## Boundary
- Leaves `market_data_adapter.py`, `web/backend/app/services/__init__.py`, and `MarketDataServiceV2` unchanged.
- Does not change route paths, response models, OpenAPI schema policy, frontend code, docs/API examples, PM2 stateful gates, OpenSpec tasks, or issue labels.
- Keeps the existing route contract and compatibility surfaces intact.

## Verification
- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_lifecycle_di.py -q --tb=short --no-cov` -> 5 passed.
- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_api_integration.py -q --tb=short --no-cov` -> 18 passed.
- Route dependency guard -> `old_depends=0`, `new_depends=7`.
- OpenAPI smoke -> app import ok, routes=548, paths=500, duplicate_operation_ids=0, selected_market_routes=7.
- `ruff check` on touched Python files -> passed.
- `black --check` on touched Python files -> passed.
- Markdown governance and JSON/YAML parse checks -> passed.
- Mainline scope gate -> pass.
- `git diff HEAD~1..HEAD --check` -> passed.

## GitNexus review signal
- Pre-edit impact checks were LOW for the provider and route surface.
- Staged `gitnexus_detect_changes(scope=staged)` returned HIGH: changed_files=9, changed_count=39, affected_count=6.
- The HIGH signal is retained for reviewer attention; it comes from `market_data_request.py` file-level flow mapping while the actual diff is limited to the authorized provider import and 7 route dependency parameter changes.

## Evidence
- `docs/reports/quality/backend-market-data-service-route-provider-implementation-2026-05-24.md`
- `.planning/codebase/generated/market-data-service-route-provider-implementation-2026-05-24.json`
- `governance/mainline/task-cards/pr-190.yaml`