### PR TITLE
docs(governance): close out market data service provider

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -805,10 +805,18 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 records focused lifecycle tests=`5 passed`,
 │   │                 market integration tests=`18 passed`, route guard
 │   │                 old=`0` / new=`7`, OpenAPI paths=`500`, duplicate
-│   │                 operation IDs=`0`
-│   └── Next gate: Human review of the G2.49 implementation PR; if accepted,
-│                  run G2.50 closeout / current-head candidate refresh before
-│                  selecting another service lifecycle implementation lane
+│   │                 operation IDs=`0`; PR `#190` merged at
+│   │                 `33163197b59893372d5d1d68af53acbfbbb0f613`; G2.50
+│   │                 now records current-head closeout: legacy market route
+│   │                 dependency sites=`0`, provider sites=`7`, provider
+│   │                 import present=`true`, focused lifecycle tests=`5
+│   │                 passed`, market integration tests=`18 passed`, OpenAPI
+│   │                 paths=`500`, duplicate operation IDs=`0`, route
+│   │                 provider dependency files=`11`, and route provider
+│   │                 dependency sites=`79`
+│   └── Next gate: Human review of the G2.50 closeout PR; if accepted,
+│                  create a current-head candidate refresh before selecting
+│                  another service lifecycle implementation lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -897,6 +905,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-di-candidate-selection-after-advanced-analysis-2026-05-24.md` | G | G2.47 candidate selection prepared at current HEAD `e09e6db4a6a85dc392c20a737e729bb6f123804d`: records PR `#186` as `MERGED`, scans `152` service files and `219` API files, confirms provider modules=`8`, route provider dependency sites=`72`, route class dependency sites=`0`, and classifies `get_market_data_service` as the next consumer matrix / authorization candidate packet while excluding `get_data_service`, `get_strategy_service`, and `get_kronos_client` from direct implementation | Human review / PR merge decision; if accepted, create G2.48 `get_market_data_service` route dependency consumer matrix / route-provider authorization candidate before any source edits |
 | `backend-market-data-service-route-dependency-consumer-matrix-2026-05-24.md` | G | G2.48 consumer matrix prepared at current HEAD `0dce9ca97cd043f898039176394eb5076c353cf5`: records PR `#188` as `MERGED`, confirms `get_market_data_service` GitNexus risk=`LOW` / impacted count=`0`, identifies exactly seven active `/api/v1/market` route handlers using `Depends(get_market_data_service)`, keeps the package compatibility getter and `market_data_adapter.py` fallback surface active, excludes `services/__init__.py` IntegratedServices accessor and `MarketDataServiceV2` consolidation, configured app/OpenAPI smoke reports routes=`548`, paths=`500`, duplicate operation IDs=`0`, and focused `test_market_api_integration.py` result=`18 passed` | Human review / PR merge decision; if accepted, create G2.49 `get_market_data_service` route-provider implementation branch before source edits |
 | `backend-market-data-service-route-provider-implementation-2026-05-24.md` | G | G2.49 implementation prepared from G2.48 authorization at base `7daf74ce0c3210defc2ad283583a335037daa500`: adds `MARKET_DATA_SERVICE_STATE_KEY`, `install_market_data_service`, and `get_market_data_service_dependency`, preserves `get_market_data_service()` and package compatibility, converts exactly seven `/api/v1/market` route dependencies to the provider, keeps `market_data_adapter.py`, `services/__init__.py`, and `MarketDataServiceV2` unchanged, TDD red=`4 failed, 1 passed`, green=`5 passed`, market integration tests=`18 passed`, ruff/black passed, configured OpenAPI smoke reports routes=`548`, paths=`500`, duplicate operation IDs=`0`, selected market routes=`7` | Human review / PR merge decision; if accepted, run G2.50 closeout/current-head candidate refresh before selecting the next service lifecycle DI lane |
+| `backend-market-data-service-route-provider-closeout-2026-05-24.md` | G | G2.50 closeout prepared at current HEAD `33163197b59893372d5d1d68af53acbfbbb0f613`: records PR `#190` as `MERGED`, confirms `market_data_request.py` legacy dependency sites=`0`, provider dependency sites=`7`, provider import present=`true`, focused lifecycle tests=`5 passed`, market integration tests=`18 passed`, configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, provider functions=`8`, route provider dependency files=`11`, and route provider dependency sites=`79`; residual `get_market_data_service()` references remain compatibility or separate helper/fallback surfaces and are not deletion candidates | Human review / PR merge decision; if accepted, create a current-head candidate refresh before selecting the next service lifecycle DI implementation lane |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/market-data-service-route-provider-closeout-2026-05-24.json
+++ b/.planning/codebase/generated/market-data-service-route-provider-closeout-2026-05-24.json
@@ -1,0 +1,79 @@
+{
+  "artifact": "market-data-service-route-provider-closeout-2026-05-24",
+  "created_at": "2026-05-24T12:30:00+08:00",
+  "workline": "G2.50",
+  "status": "closeout_prepared",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_head": "33163197b59893372d5d1d68af53acbfbbb0f613",
+  "parent_prs": {
+    "g2_48": {
+      "pr": 189,
+      "state": "MERGED",
+      "merge_commit": "7daf74ce0c3210defc2ad283583a335037daa500"
+    },
+    "g2_49": {
+      "pr": 190,
+      "state": "MERGED",
+      "merged_at": "2026-05-24T04:13:57Z",
+      "merge_commit": "33163197b59893372d5d1d68af53acbfbbb0f613",
+      "implementation_commit": "f9a945b624a2f6915b5ea60acf6dbad6f1f61403"
+    }
+  },
+  "route_dependency_guard": {
+    "file": "web/backend/app/api/market/market_data_request.py",
+    "old_depends": 0,
+    "new_depends": 7,
+    "provider_import": true
+  },
+  "provider_inventory": {
+    "service_provider_files": 8,
+    "provider_functions": 8,
+    "provider_function_names": [
+      "get_announcement_service_dependency",
+      "get_email_service_dependency",
+      "get_market_data_service_dependency",
+      "get_market_data_service_v2_dependency",
+      "get_stock_search_service_dependency",
+      "get_tdx_service_dependency",
+      "get_tradingview_service_dependency",
+      "get_watchlist_service_dependency"
+    ],
+    "route_provider_dependency_files": 11,
+    "route_provider_dependency_sites": 79
+  },
+  "openapi_smoke": {
+    "app_import": "ok",
+    "routes": 548,
+    "paths": 500,
+    "duplicate_operation_ids": 0,
+    "selected_market_schema_paths": 13,
+    "warnings": 121,
+    "environment": "non_sensitive_placeholder"
+  },
+  "focused_tests": {
+    "web/backend/tests/test_market_data_service_lifecycle_di.py": "5 passed in 2.35s",
+    "web/backend/tests/test_market_api_integration.py": "18 passed in 16.52s"
+  },
+  "compatibility_surfaces_preserved": [
+    "get_market_data_service()",
+    "app.services.market_data_service package exports",
+    "web/backend/app/services/market_data_adapter.py",
+    "web/backend/app/services/__init__.py",
+    "MarketDataServiceV2"
+  ],
+  "residual_non_route_references": [
+    "web/backend/app/services/market_data_service/get_market_data_service.py",
+    "web/backend/app/services/__init__.py",
+    "web/backend/app/services/market_data_adapter.py",
+    "web/backend/app/api/dashboard_data_source.py"
+  ],
+  "gitnexus_review_signal": {
+    "g2_49_staged_detect_changes": "HIGH",
+    "changed_files": 9,
+    "changed_count": 39,
+    "affected_count": 6,
+    "closeout_disposition": "recorded_and_reviewed_as_file_level_flow_mapping_signal"
+  },
+  "next_gate": "current_head_candidate_refresh_before_selecting_next_service_lifecycle_di_implementation_lane",
+  "source_changes_authorized": false
+}

--- a/docs/reports/quality/backend-market-data-service-route-provider-closeout-2026-05-24.md
+++ b/docs/reports/quality/backend-market-data-service-route-provider-closeout-2026-05-24.md
@@ -1,0 +1,150 @@
+# Backend MarketDataService Route Provider Closeout - 2026-05-24
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为参考。
+
+## Status
+
+Status: closeout packet prepared.
+
+Workline: G2.50 `MarketDataService` route-provider closeout after PR `#190`
+merge.
+
+This is a governance and evidence closeout packet only. It records the
+post-merge state of the G2.49 implementation and does not authorize another
+source implementation lane.
+
+## Governance Boundary
+
+Allowed scope:
+
+- record PR `#190` merge status
+- record current-head route dependency and OpenAPI evidence
+- update the steward tree and evidence ledger
+- create a path-limited mainline task card for this closeout packet
+
+Out of scope:
+
+- backend source changes
+- route path or response model changes
+- `market_data_adapter.py` fallback changes
+- `web/backend/app/services/__init__.py` IntegratedServices changes
+- `MarketDataServiceV2` consolidation
+- frontend, docs/API, PM2, OpenSpec task, or issue-label changes
+- selecting or authorizing the next service lifecycle implementation target
+
+## Parent State
+
+| Item | State | Notes |
+|---|---|---|
+| PR `#189` | `MERGED` at `7daf74ce0c3210defc2ad283583a335037daa500` | G2.48 consumer matrix and implementation authorization candidate. |
+| PR `#190` | `MERGED` at `33163197b59893372d5d1d68af53acbfbbb0f613` | G2.49 route-provider implementation merged on `2026-05-24T04:13:57Z`. |
+| Implementation commit | `f9a945b624a2f6915b5ea60acf6dbad6f1f61403` | Adds the provider seam and converts the authorized route dependencies. |
+| Closeout HEAD | `33163197b59893372d5d1d68af53acbfbbb0f613` | Current `origin/wip/root-dirty-20260403` at closeout preparation. |
+
+## Evidence Inputs
+
+| Evidence | Path / Source | Notes |
+|---|---|---|
+| G2.48 authorization | `docs/reports/quality/backend-market-data-service-route-dependency-consumer-matrix-2026-05-24.md` | Identified exactly seven `/api/v1/market` route dependencies as the authorized migration surface. |
+| G2.49 implementation report | `docs/reports/quality/backend-market-data-service-route-provider-implementation-2026-05-24.md` | Records TDD, implementation scope, GitNexus review signal, and local verification. |
+| G2.49 generated evidence | `.planning/codebase/generated/market-data-service-route-provider-implementation-2026-05-24.json` | Machine-readable implementation evidence. |
+| G2.49 task card | `governance/mainline/task-cards/pr-190.yaml` | Mainline scope and acceptance gates for PR `#190`. |
+| PR merge metadata | GitHub PR `#190` | `state=MERGED`, merge commit `33163197b59893372d5d1d68af53acbfbbb0f613`. |
+
+## Closeout Findings
+
+The G2.49 implementation is now part of the target branch. Current-head checks
+confirm the authorized route dependency surface is closed:
+
+| Check | Value |
+|---|---:|
+| `Depends(get_market_data_service)` in `market_data_request.py` | `0` |
+| `Depends(get_market_data_service_dependency)` in `market_data_request.py` | `7` |
+| Provider import present in `market_data_request.py` | `true` |
+| Service provider files under `web/backend/app/services` | `8` |
+| Provider dependency functions under `web/backend/app/services` | `8` |
+| API files with provider dependency usage | `11` |
+| API provider dependency sites | `79` |
+
+Current provider dependency functions:
+
+- `get_announcement_service_dependency`
+- `get_email_service_dependency`
+- `get_market_data_service_dependency`
+- `get_market_data_service_v2_dependency`
+- `get_stock_search_service_dependency`
+- `get_tdx_service_dependency`
+- `get_tradingview_service_dependency`
+- `get_watchlist_service_dependency`
+
+## Compatibility Boundary
+
+The following surfaces remain intentionally preserved:
+
+- `get_market_data_service()` remains public compatibility fallback.
+- `app.services.market_data_service` package exports the compatibility getter
+  and provider dependency.
+- `market_data_adapter.py` fallback surface remains unchanged.
+- `web/backend/app/services/__init__.py` IntegratedServices accessor remains
+  unchanged.
+- `MarketDataServiceV2` remains a separate service lane.
+
+Residual non-route references to `get_market_data_service()` are not deletion
+candidates in this closeout:
+
+- `web/backend/app/services/market_data_service/get_market_data_service.py`
+- `web/backend/app/services/__init__.py`
+- `web/backend/app/services/market_data_adapter.py`
+- `web/backend/app/api/dashboard_data_source.py`
+
+These references are either compatibility surfaces or separate route/helper
+lanes. They must not be collapsed into the G2.49/G2.50 route-provider closure.
+
+## Verification
+
+| Gate | Result |
+|---|---|
+| PR `#190` metadata | `state=MERGED`, merge commit `33163197b59893372d5d1d68af53acbfbbb0f613`. |
+| PR `#190` checks before merge | No failed check; checks were `pass` or `skipping`. |
+| Focused lifecycle DI test | `5 passed in 2.35s`. |
+| Market API integration test | `18 passed in 16.52s`. |
+| Route dependency guard | `old_depends=0`, `new_depends=7`, `provider_import=true`. |
+| Configured app/OpenAPI smoke | `app_import=ok`, routes=`548`, paths=`500`, duplicate operation IDs=`0`, selected `/api/v1/market` schema paths=`13`. |
+
+The OpenAPI smoke used non-sensitive placeholder environment variables. It
+captures the current schema exposure snapshot and must not be treated as a
+permanent path-count baseline.
+
+## GitNexus Review Signal
+
+G2.49 staged `gitnexus_detect_changes(scope=staged)` returned `HIGH`
+(`changed_files=9`, `changed_count=39`, `affected_count=6`). That signal was
+kept in the implementation report and PR body for reviewer attention.
+
+The HIGH signal is closed as reviewed evidence for this route-provider lane, not
+as a suppressed warning. It came from `market_data_request.py` file-level flow
+mapping while the accepted diff remained limited to the authorized provider
+import and seven route dependency parameter changes.
+
+## Decision
+
+G2.49 is closed as merged and verified for the authorized `/api/v1/market`
+route-provider surface.
+
+This closeout does not authorize the next source implementation. The next
+service lifecycle step should be a current-head candidate refresh / selection
+packet, starting from merge commit
+`33163197b59893372d5d1d68af53acbfbbb0f613`.
+
+## Next Gate
+
+Prepare a new current-head candidate refresh before selecting another service
+lifecycle DI lane. That packet must:
+
+- start from the post-PR `#190` head
+- keep already preserved compatibility surfaces out of deletion scope
+- distinguish route-provider candidates from dashboard/helper/fallback callers
+- avoid broad external-client, DB/session-backed, cache/task-running, and
+  process-level singleton seams unless explicitly authorized
+- require a separate implementation authorization before any source edits

--- a/governance/mainline/task-cards/pr-191.yaml
+++ b/governance/mainline/task-cards/pr-191.yaml
@@ -1,0 +1,110 @@
+version: "v0.2"
+
+task:
+  id: "pr-191"
+  title: "Close out MarketDataService route provider migration"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-market-data-service-route-provider-closeout"
+  objective: "record post-merge closeout for the G2.49 MarketDataService route-provider implementation"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-market-data-service-route-provider-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-market-data-service-route-provider-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout packet records post-merge governance evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/market-data-service-route-provider-closeout-2026-05-24.json"
+    - "docs/reports/quality/backend-market-data-service-route-provider-closeout-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-191.yaml"
+  forbidden_paths:
+    - "web/backend/app/**"
+    - "web/backend/tests/**"
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, tests, generated clients, docs/API, OpenSpec, PM2, route, OpenAPI, or runtime behavior changes"
+  - "No GitHub issue state, label, or ready-for-agent movement"
+  - "No source implementation in this PR"
+  - "No compatibility getter cleanup authorization"
+  - "No MarketDataService and MarketDataServiceV2 consolidation"
+  - "No next service lifecycle DI implementation target selection"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-market-data-service-route-provider-closeout-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/market-data-service-route-provider-closeout-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nfrom pathlib import Path\nwith Path('governance/mainline/task-cards/pr-191.yaml').open() as fh:\n    yaml.safe_load(fh)\nprint('yaml-ok')\nPY"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-191.yaml"
+      required: true
+    - id: "no-source-diff"
+      command: "python - <<'PY'\nimport subprocess, sys\nchanged = subprocess.check_output(['git', 'diff', '--cached', '--name-only'], text=True).splitlines()\nblocked = [p for p in changed if p.startswith(('web/backend/app/', 'web/backend/tests/', 'web/frontend/', 'src/', 'tests/', 'openspec/'))]\nprint({'changed': changed, 'blocked': blocked})\nsys.exit(1 if blocked else 0)\nPY"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record post-merge closeout for the MarketDataService route-provider migration"
+    modified_scope: "steward tree, closeout report, generated closeout artifact, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; compatibility surfaces remain documented as preserved"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance closeout PR if the recorded merge or evidence state is incorrect"
+
+risk_and_rollback:
+  risks:
+    - "If source files change, the closeout exceeds its governance-only boundary"
+    - "If residual compatibility references are treated as deletion candidates, the next lane may collapse separate surfaces"
+    - "If the next implementation target is selected here, this packet bypasses the required candidate-refresh gate"
+  rollback_plan: "revert this closeout PR; PR #190 remains the source implementation merge record"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T12:13:57+08:00"
+    approval_note: "human maintainer approved continuing after PR #190 merge; this packet records G2.50 closeout evidence only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Records G2.50 closeout after PR #190 merged the MarketDataService route-provider implementation.
- Updates the steward tree and evidence ledger with current-head route dependency, OpenAPI, provider inventory, and compatibility-boundary facts.
- Adds a generated closeout artifact and mainline task card for this governance-only packet.

## Boundary
- Governance-only closeout: no backend source, frontend, tests, docs/API, OpenSpec, PM2, route, OpenAPI, or issue-label changes.
- Does not authorize the next service lifecycle DI implementation target.
- Keeps residual `get_market_data_service()` references classified as compatibility, fallback, or separate helper surfaces; they are not deletion candidates in this packet.

## Current-head evidence
- PR #190 is merged at `33163197b59893372d5d1d68af53acbfbbb0f613`.
- Route guard: `Depends(get_market_data_service)=0`, `Depends(get_market_data_service_dependency)=7`, provider import present.
- Focused lifecycle DI test: 5 passed.
- Market API integration test: 18 passed.
- App/OpenAPI smoke: app import ok, routes=548, paths=500, duplicate_operation_ids=0.
- Provider inventory: 8 provider functions, 11 API files with provider dependency usage, 79 provider dependency sites.

## Verification
- Markdown governance: 2 checked files, 0 errors.
- JSON parse: passed.
- YAML parse: passed.
- Mainline scope gate against base `33163197b59893372d5d1d68af53acbfbbb0f613`: pass=True.
- `git diff HEAD~1..HEAD --check`: passed.
- GitNexus staged detect_changes: LOW, changed_files=4, changed_count=0, affected_count=0.

## Next gate
After this closeout is reviewed and accepted, create a current-head candidate refresh before selecting another service lifecycle DI implementation lane.