### PR TITLE
docs(governance): design indicator registry provider boundary

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -820,11 +820,17 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 functions=`8`, route provider dependency sites=`79`,
 │   │                 route getter dependency sites=`270`, OpenAPI paths=`500`,
 │   │                 duplicate operation IDs=`0`, and no ordinary
-│   │                 route-provider implementation target is selected
-│   └── Next gate: Human review of the G2.51 candidate refresh PR; if accepted,
-│                  choose a separate decision packet for indicator registry,
-│                  technical-pattern route-local provider modernization, or
-│                  broad data/strategy seam design before source edits
+│   │                 route-provider implementation target is selected; PR
+│   │                 `#192` merged at
+│   │                 `363324bf31a89b797789403c55dbe3ca854bc7d6`; G2.52 now
+│   │                 records `IndicatorRegistry` provider design: two
+│   │                 same-name registry getters exist, flat API registry direct
+│   │                 callers=`3`, package registry production callers=`3`,
+│   │                 OpenAPI paths=`500`, duplicate operation IDs=`0`, and no
+│   │                 source implementation target is authorized
+│   └── Next gate: Human review of the G2.52 design PR; if accepted, create
+│                  G2.53 flat API registry consumer matrix / authorization
+│                  candidate before any source edits
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -915,6 +921,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-market-data-service-route-provider-implementation-2026-05-24.md` | G | G2.49 implementation prepared from G2.48 authorization at base `7daf74ce0c3210defc2ad283583a335037daa500`: adds `MARKET_DATA_SERVICE_STATE_KEY`, `install_market_data_service`, and `get_market_data_service_dependency`, preserves `get_market_data_service()` and package compatibility, converts exactly seven `/api/v1/market` route dependencies to the provider, keeps `market_data_adapter.py`, `services/__init__.py`, and `MarketDataServiceV2` unchanged, TDD red=`4 failed, 1 passed`, green=`5 passed`, market integration tests=`18 passed`, ruff/black passed, configured OpenAPI smoke reports routes=`548`, paths=`500`, duplicate operation IDs=`0`, selected market routes=`7` | Human review / PR merge decision; if accepted, run G2.50 closeout/current-head candidate refresh before selecting the next service lifecycle DI lane |
 | `backend-market-data-service-route-provider-closeout-2026-05-24.md` | G | G2.50 closeout prepared at current HEAD `33163197b59893372d5d1d68af53acbfbbb0f613`: records PR `#190` as `MERGED`, confirms `market_data_request.py` legacy dependency sites=`0`, provider dependency sites=`7`, provider import present=`true`, focused lifecycle tests=`5 passed`, market integration tests=`18 passed`, configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, provider functions=`8`, route provider dependency files=`11`, and route provider dependency sites=`79`; residual `get_market_data_service()` references remain compatibility or separate helper/fallback surfaces and are not deletion candidates | Human review / PR merge decision; if accepted, create a current-head candidate refresh before selecting the next service lifecycle DI implementation lane |
 | `backend-service-lifecycle-di-candidate-refresh-after-market-data-provider-2026-05-24.md` | G | G2.51 candidate refresh prepared at current HEAD `047f483dd70a5234ca3a128342511a56779194d3`: records PR `#191` as `MERGED`, scans `152` service files and `219` API files, confirms provider functions=`8`, route provider dependency files=`11`, route provider dependency sites=`79`, route getter dependency sites=`270`, OpenAPI paths=`500`, duplicate operation IDs=`0`, `get_market_data_service` legacy route dependency sites=`0`, and classifies the remaining interesting seams: `get_indicator_registry` LOW/`4` as indicator-internal design, `get_data_service` CRITICAL/`5`, `get_strategy_service` CRITICAL/`13`, `get_kronos_client` CRITICAL/`3`, and route-local `get_technical_pattern_detection_service` as D2.1a historical provider surface; no next source implementation target is selected | Human review / PR merge decision; if accepted, choose a separate decision packet before any source edits |
+| `backend-indicator-registry-provider-design-2026-05-24.md` | G | G2.52 design packet prepared at current HEAD `363324bf31a89b797789403c55dbe3ca854bc7d6`: records PR `#192` as `MERGED`, confirms two same-name `get_indicator_registry()` surfaces, separates flat API registry `web/backend/app/services/indicator_registry.py` from package registry `web/backend/app/services/indicators/indicator_registry.py`, records flat API direct callers=`3`, package registry production callers=`3`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and selects no source implementation target; recommended next gate is G2.53 flat API registry consumer matrix / authorization candidate | Human review / PR merge decision; if accepted, create G2.53 flat API registry consumer matrix / authorization candidate before source edits |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/indicator-registry-provider-design-2026-05-24.json
+++ b/.planning/codebase/generated/indicator-registry-provider-design-2026-05-24.json
@@ -1,0 +1,93 @@
+{
+  "artifact": "indicator-registry-provider-design-2026-05-24",
+  "created_at": "2026-05-24T14:10:00+08:00",
+  "workline": "G2.52",
+  "status": "design_packet_prepared",
+  "source_changes_authorized": false,
+  "base_branch": "wip/root-dirty-20260403",
+  "current_head": "363324bf31a89b797789403c55dbe3ca854bc7d6",
+  "head_subject": "Merge pull request #192 from chengjon/g2-51-service-lifecycle-candidate-refresh",
+  "parent_pr": {
+    "number": 192,
+    "state": "MERGED",
+    "merge_commit": "363324bf31a89b797789403c55dbe3ca854bc7d6",
+    "merged_at": "2026-05-24T06:01:41Z"
+  },
+  "design_finding": "two_same_name_indicator_registry_getters_with_different_ownership",
+  "surfaces": {
+    "flat_api_registry": {
+      "getter_file": "web/backend/app/services/indicator_registry.py",
+      "lines": 637,
+      "direct_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py:get_indicator_registry_endpoint",
+        "web/backend/app/api/indicators/indicator_cache.py:get_indicators_by_category",
+        "web/backend/app/services/indicator_calculator.py:__init__"
+      ],
+      "recommended_next_gate": "flat_api_registry_consumer_matrix_authorization_candidate"
+    },
+    "package_registry": {
+      "getter_file": "web/backend/app/services/indicators/indicator_registry.py",
+      "lines": 471,
+      "direct_callers": [
+        "web/backend/app/services/indicators/defaults.py:load_default_indicators",
+        "web/backend/app/services/indicators/talib_adapter.py:TalibGenericIndicator.__init__",
+        "web/backend/app/services/indicators/talib_adapter.py:register_all_talib_indicators"
+      ],
+      "classification": "indicator_internal_startup_jobs_surface",
+      "recommended_next_gate": "separate_startup_jobs_design_packet"
+    }
+  },
+  "relevant_file_counts": {
+    "web/backend/app/services/indicator_registry.py": {
+      "lines": 637,
+      "get_indicator_registry": 1,
+      "IndicatorRegistry": 3
+    },
+    "web/backend/app/services/indicators/indicator_registry.py": {
+      "lines": 471,
+      "get_indicator_registry": 1,
+      "IndicatorRegistry": 10
+    },
+    "web/backend/app/api/indicators/indicator_cache.py": {
+      "lines": 703,
+      "get_indicator_registry": 4,
+      "IndicatorRegistry": 3
+    },
+    "web/backend/app/services/indicator_calculator.py": {
+      "lines": 383,
+      "get_indicator_registry": 2
+    },
+    "web/backend/app/services/indicators/talib_adapter.py": {
+      "lines": 279,
+      "get_indicator_registry": 3,
+      "register_all_talib_indicators": 1
+    },
+    "web/backend/app/services/indicators/defaults.py": {
+      "lines": 121,
+      "get_indicator_registry": 2,
+      "load_default_indicators": 1,
+      "register_all_talib_indicators": 2
+    },
+    "web/backend/app/main.py": {
+      "lines": 901,
+      "load_default_indicators": 2
+    }
+  },
+  "openapi_smoke": {
+    "app_import": "ok",
+    "routes": 548,
+    "paths": 500,
+    "duplicate_operation_ids": 0,
+    "warnings": 121,
+    "environment": "non_sensitive_placeholder"
+  },
+  "gitnexus": {
+    "flat_api_registry_direct_callers": 3,
+    "package_registry_direct_production_callers": 3,
+    "package_registry_previous_risk": "LOW",
+    "package_registry_previous_impacted_count": 4,
+    "disambiguation_required": true
+  },
+  "decision": "no_source_implementation_target_selected",
+  "recommended_next_gate": "g2_53_flat_api_registry_consumer_matrix_authorization_candidate"
+}

--- a/docs/reports/quality/backend-indicator-registry-provider-design-2026-05-24.md
+++ b/docs/reports/quality/backend-indicator-registry-provider-design-2026-05-24.md
@@ -1,0 +1,137 @@
+# Backend IndicatorRegistry Provider Design - 2026-05-24
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为参考。
+
+## Status
+
+Status: review-ready.
+
+Workline: G2.52 `IndicatorRegistry` provider design packet after G2.51
+candidate refresh.
+
+This is a design and decision packet only. It does not authorize backend source
+edits, tests, OpenSpec changes, route changes, or the next implementation
+target.
+
+## Source Snapshot
+
+| Field | Value |
+|---|---|
+| Worktree | `.worktrees/g2-52-indicator-registry-provider-design` |
+| Branch | `g2-52-indicator-registry-provider-design` |
+| Current HEAD | `363324bf31a89b797789403c55dbe3ca854bc7d6` |
+| HEAD subject | `Merge pull request #192 from chengjon/g2-51-service-lifecycle-candidate-refresh` |
+| Parent refresh PR | `#192`, `MERGED`, merge commit `363324bf31a89b797789403c55dbe3ca854bc7d6` |
+| Parent issue | `#79` |
+| Parent decision issue | `#92` |
+
+## Design Finding
+
+`get_indicator_registry` is not a single implementation surface. The current
+codebase contains two same-name registry getters with different ownership:
+
+| Surface | Getter file | Primary callers | Role |
+|---|---|---|---|
+| Flat API registry | `web/backend/app/services/indicator_registry.py` | `indicator_cache.py`, `indicator_calculator.py` | API-facing TA-Lib metadata registry used by indicator endpoints and calculator construction. |
+| Package registry | `web/backend/app/services/indicators/indicator_registry.py` | `defaults.py`, `talib_adapter.py`, indicator jobs/tests | Internal indicator registry used by default indicator loading, TA-Lib registration, and jobs. |
+
+These two surfaces must not be merged or migrated in one ordinary
+route-provider batch. Treating them as one seam would mix route API behavior,
+startup/default registration, jobs, and tests.
+
+## Current Evidence
+
+| Evidence | Value |
+|---|---:|
+| Backend app files with indicator-registry-related hits | `12` |
+| Flat API registry lines | `637` |
+| Package registry lines | `471` |
+| `indicator_cache.py` lines | `703` |
+| `indicator_calculator.py` lines | `383` |
+| `talib_adapter.py` lines | `279` |
+| `defaults.py` lines | `121` |
+| `main.py` startup references to `load_default_indicators` | `2` |
+
+Configured app/OpenAPI smoke:
+
+| Field | Value |
+|---|---:|
+| Runtime routes | `548` |
+| OpenAPI paths | `500` |
+| Duplicate operation IDs | `0` |
+| Warnings captured | `121` |
+
+The OpenAPI path count is a current schema-exposure snapshot. It must not be
+treated as a permanent path-count baseline.
+
+## GitNexus Evidence
+
+GitNexus reports two distinct `get_indicator_registry` symbols:
+
+| Symbol | Direct callers | Notes |
+|---|---:|---|
+| `web/backend/app/services/indicator_registry.py:get_indicator_registry` | `3` | Called by `get_indicator_registry_endpoint`, `get_indicators_by_category`, and `IndicatorCalculator.__init__`. |
+| `web/backend/app/services/indicators/indicator_registry.py:get_indicator_registry` | `3` production callers plus tests | Called by `load_default_indicators`, `TalibGenericIndicator.__init__`, and `register_all_talib_indicators`; tests also depend on singleton behavior. |
+
+Previous G2.51 spot check for the package registry classified it as LOW /
+impacted count `4`, with Indicators and Jobs affected. That LOW rating does not
+make it an ordinary route-provider migration because startup and jobs are part
+of the surface.
+
+## Decision
+
+G2.52 selects no source implementation target.
+
+The next safe step is a narrower consumer matrix and authorization candidate for
+the flat API registry surface:
+
+- `web/backend/app/services/indicator_registry.py`
+- `web/backend/app/api/indicators/indicator_cache.py`
+- route endpoint callers in `indicator_cache.py`
+- existing `IndicatorCalculator.__init__` direct construction as an explicit
+  preserved/non-route surface
+
+The package registry surface must remain separate:
+
+- `web/backend/app/services/indicators/indicator_registry.py`
+- `web/backend/app/services/indicators/defaults.py`
+- `web/backend/app/services/indicators/talib_adapter.py`
+- `web/backend/app/services/indicators/jobs/daily_calculation.py`
+- startup loading from `web/backend/app/main.py`
+
+## Future Authorization Candidate
+
+If G2.52 is accepted, create a G2.53 flat API registry consumer matrix /
+authorization packet before any source edit. That packet should decide whether a
+future implementation may:
+
+- add `INDICATOR_REGISTRY_STATE_KEY`
+- add `install_indicator_registry(app, registry=None)`
+- add `get_indicator_registry_dependency(request)`
+- convert only the API endpoint consumers in `indicator_cache.py` to dependency
+  injection
+- preserve `get_indicator_registry()` as a compatibility fallback
+- leave `IndicatorCalculator.__init__` and the package registry untouched
+
+The package registry startup/jobs design should remain a separate future packet.
+It must not be bundled into the flat API registry route-provider authorization.
+
+## Non-Goals
+
+- No source implementation in G2.52.
+- No deletion or retirement of either `get_indicator_registry()` getter.
+- No merge between `app.services.indicator_registry` and
+  `app.services.indicators.indicator_registry`.
+- No startup/lifespan refactor.
+- No TA-Lib/default indicator registration changes.
+- No API response model, route path, or OpenAPI exposure change.
+- No test expectation changes.
+
+## Next Gate
+
+Human review / PR merge decision for this design packet.
+
+If accepted, create G2.53 flat API registry consumer matrix / authorization
+candidate before source edits. G2.53 should be evidence-only unless it is
+explicitly approved as an implementation authorization in a later PR.

--- a/governance/mainline/task-cards/pr-193.yaml
+++ b/governance/mainline/task-cards/pr-193.yaml
@@ -1,0 +1,108 @@
+version: "v0.2"
+
+task:
+  id: "pr-193"
+  title: "Design IndicatorRegistry provider boundary"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-indicator-registry-provider-design"
+  objective: "record IndicatorRegistry provider design boundary after G2.51 candidate refresh"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-indicator-registry-provider-design"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-indicator-registry-provider-design"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Design packet records governance evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/indicator-registry-provider-design-2026-05-24.json"
+    - "docs/reports/quality/backend-indicator-registry-provider-design-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-193.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, tests, generated clients, docs/API, OpenSpec, PM2, route, OpenAPI, or runtime behavior changes"
+  - "No GitHub issue state, label, or ready-for-agent movement"
+  - "No source implementation in this PR"
+  - "No next service lifecycle DI implementation target authorization"
+  - "No compatibility getter cleanup authorization"
+  - "No merge between flat API registry and package indicator registry"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-indicator-registry-provider-design-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/indicator-registry-provider-design-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-193.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-193.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "python -c \"print('staged-gitnexus-scope: docs-only IndicatorRegistry design packet; no source symbols changed')\""
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the design-only boundary"
+    - "If flat API registry and package registry are collapsed into one implementation lane, startup/jobs and route API behavior may be mixed"
+    - "If this packet authorizes source implementation, it bypasses the required separate consumer matrix and authorization gate"
+  rollback_plan: "revert this governance-only PR; PR #192 remains the current-head candidate refresh record unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record IndicatorRegistry provider design boundary and next evidence gate"
+    modified_scope: "design report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only design PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T14:01:41+08:00"
+    approval_note: "human maintainer approved continuing after PR #192 merge; this packet records G2.52 IndicatorRegistry provider design only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Add G2.52 governance-only design packet for IndicatorRegistry provider boundary.
- Record two distinct same-name get_indicator_registry() surfaces: flat API registry and package internal registry.
- Confirm flat API registry direct callers=3 and package registry production callers=3.
- Record app/OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0.
- Preserve boundary: no source implementation authorized by this packet.
- Recommend next gate: G2.53 flat API registry consumer matrix / authorization candidate.

## Verification
- markdown governance gate: 2 checked files, 0 errors
- JSON parse: indicator-registry-provider-design-2026-05-24.json ok
- YAML parse: governance/mainline/task-cards/pr-193.yaml ok
- mainline scope gate: pass=true
- git diff --check: passed
- GitNexus staged detect_changes: LOW, changed_files=4, changed_count=0, affected_count=0
