### PR TITLE
docs(governance): record flat API indicator registry consumer matrix

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -822,15 +822,22 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 duplicate operation IDs=`0`, and no ordinary
 │   │                 route-provider implementation target is selected; PR
 │   │                 `#192` merged at
-│   │                 `363324bf31a89b797789403c55dbe3ca854bc7d6`; G2.52 now
+│   │                 `363324bf31a89b797789403c55dbe3ca854bc7d6`; G2.52
 │   │                 records `IndicatorRegistry` provider design: two
 │   │                 same-name registry getters exist, flat API registry direct
 │   │                 callers=`3`, package registry production callers=`3`,
 │   │                 OpenAPI paths=`500`, duplicate operation IDs=`0`, and no
-│   │                 source implementation target is authorized
-│   └── Next gate: Human review of the G2.52 design PR; if accepted, create
-│                  G2.53 flat API registry consumer matrix / authorization
-│                  candidate before any source edits
+│   │                 source implementation target is authorized; PR `#193`
+│   │                 merged at
+│   │                 `ec3dc2920886eb24e963a33488bd2e945e98e6c9`; G2.53 now
+│   │                 records the flat API registry consumer matrix: selected
+│   │                 indicator cache routes=`6`, direct registry route
+│   │                 consumers=`2`, service constructor consumer=`1`,
+│   │                 OpenAPI paths=`500`, duplicate operation IDs=`0`, and
+│   │                 collect-only checks=`16+112+29`
+│   └── Next gate: Human review of the G2.53 consumer matrix PR; if accepted,
+│                  create G2.54 flat API registry route-provider implementation
+│                  branch with TDD and pre-edit GitNexus checks
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -922,6 +929,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-market-data-service-route-provider-closeout-2026-05-24.md` | G | G2.50 closeout prepared at current HEAD `33163197b59893372d5d1d68af53acbfbbb0f613`: records PR `#190` as `MERGED`, confirms `market_data_request.py` legacy dependency sites=`0`, provider dependency sites=`7`, provider import present=`true`, focused lifecycle tests=`5 passed`, market integration tests=`18 passed`, configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, provider functions=`8`, route provider dependency files=`11`, and route provider dependency sites=`79`; residual `get_market_data_service()` references remain compatibility or separate helper/fallback surfaces and are not deletion candidates | Human review / PR merge decision; if accepted, create a current-head candidate refresh before selecting the next service lifecycle DI implementation lane |
 | `backend-service-lifecycle-di-candidate-refresh-after-market-data-provider-2026-05-24.md` | G | G2.51 candidate refresh prepared at current HEAD `047f483dd70a5234ca3a128342511a56779194d3`: records PR `#191` as `MERGED`, scans `152` service files and `219` API files, confirms provider functions=`8`, route provider dependency files=`11`, route provider dependency sites=`79`, route getter dependency sites=`270`, OpenAPI paths=`500`, duplicate operation IDs=`0`, `get_market_data_service` legacy route dependency sites=`0`, and classifies the remaining interesting seams: `get_indicator_registry` LOW/`4` as indicator-internal design, `get_data_service` CRITICAL/`5`, `get_strategy_service` CRITICAL/`13`, `get_kronos_client` CRITICAL/`3`, and route-local `get_technical_pattern_detection_service` as D2.1a historical provider surface; no next source implementation target is selected | Human review / PR merge decision; if accepted, choose a separate decision packet before any source edits |
 | `backend-indicator-registry-provider-design-2026-05-24.md` | G | G2.52 design packet prepared at current HEAD `363324bf31a89b797789403c55dbe3ca854bc7d6`: records PR `#192` as `MERGED`, confirms two same-name `get_indicator_registry()` surfaces, separates flat API registry `web/backend/app/services/indicator_registry.py` from package registry `web/backend/app/services/indicators/indicator_registry.py`, records flat API direct callers=`3`, package registry production callers=`3`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and selects no source implementation target; recommended next gate is G2.53 flat API registry consumer matrix / authorization candidate | Human review / PR merge decision; if accepted, create G2.53 flat API registry consumer matrix / authorization candidate before source edits |
+| `backend-flat-api-indicator-registry-consumer-matrix-2026-05-24.md` | G | G2.53 consumer matrix prepared at current HEAD `ec3dc2920886eb24e963a33488bd2e945e98e6c9`: records PR `#193` as `MERGED`, confirms the flat API registry singleton at `web/backend/app/services/indicator_registry.py`, identifies exactly two direct registry route consumers in `indicator_cache.py`, excludes `IndicatorCalculator.__init__` from the route-provider batch, keeps the package registry startup/jobs surface separate, records configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, selected indicator cache routes=`6`, and collect-only checks=`16+112+29` | Human review / PR merge decision; if accepted, create G2.54 flat API registry route-provider implementation branch before source edits |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/flat-api-indicator-registry-consumer-matrix-2026-05-24.json
+++ b/.planning/codebase/generated/flat-api-indicator-registry-consumer-matrix-2026-05-24.json
@@ -1,0 +1,136 @@
+{
+  "artifact": "flat-api-indicator-registry-consumer-matrix",
+  "workline": "G2.53",
+  "generated_at": "2026-05-24T15:40:41+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "git_head": "ec3dc2920886",
+  "source_prerequisite": {
+    "g2_52_pr": 193,
+    "g2_52_state": "MERGED",
+    "g2_52_merge_commit": "ec3dc2920886eb24e963a33488bd2e945e98e6c9"
+  },
+  "status": "approve_with_guards_pending_human_review",
+  "runtime_scope": "governance_only_no_source_edits",
+  "flat_registry": {
+    "file": "web/backend/app/services/indicator_registry.py",
+    "getter": "get_indicator_registry",
+    "singleton_global_line": 628,
+    "getter_line": 631
+  },
+  "consumer_matrix": [
+    {
+      "consumer": "get_indicator_registry_endpoint",
+      "file": "web/backend/app/api/indicators/indicator_cache.py",
+      "line": 86,
+      "current_access": "get_indicator_registry()",
+      "route": "GET /api/v1/indicators/registry",
+      "future_migration": "candidate_route_dependency"
+    },
+    {
+      "consumer": "get_indicators_by_category",
+      "file": "web/backend/app/api/indicators/indicator_cache.py",
+      "line": 213,
+      "current_access": "get_indicator_registry()",
+      "route": "GET /api/v1/indicators/registry/{category}",
+      "future_migration": "candidate_route_dependency"
+    },
+    {
+      "consumer": "IndicatorCalculator.__init__",
+      "file": "web/backend/app/services/indicator_calculator.py",
+      "line": 43,
+      "current_access": "get_indicator_registry()",
+      "route": null,
+      "future_migration": "excluded_from_flat_api_route_provider_batch"
+    }
+  ],
+  "selected_indicator_cache_routes": [
+    {
+      "method": "GET",
+      "path": "/api/v1/indicators/registry",
+      "handler": "get_indicator_registry_endpoint",
+      "include_in_schema": true,
+      "direct_registry_consumer": true
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/indicators/registry/{category}",
+      "handler": "get_indicators_by_category",
+      "include_in_schema": true,
+      "direct_registry_consumer": true
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/indicators/calculate",
+      "handler": "calculate_indicators",
+      "include_in_schema": true,
+      "direct_registry_consumer": false
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/indicators/calculate/batch",
+      "handler": "calculate_indicators_batch",
+      "include_in_schema": true,
+      "direct_registry_consumer": false
+    },
+    {
+      "method": "GET",
+      "path": "/api/v1/indicators/cache/stats",
+      "handler": "get_cache_statistics",
+      "include_in_schema": true,
+      "direct_registry_consumer": false
+    },
+    {
+      "method": "POST",
+      "path": "/api/v1/indicators/cache/clear",
+      "handler": "clear_cache",
+      "include_in_schema": true,
+      "direct_registry_consumer": false
+    }
+  ],
+  "app_openapi_smoke": {
+    "routes_total": 548,
+    "openapi_paths_total": 500,
+    "duplicate_operation_ids": 0,
+    "selected_indicator_cache_routes": 6,
+    "selected_registry_route_consumers": 2,
+    "environment": "non_sensitive_placeholder_env"
+  },
+  "collection_checks": [
+    {
+      "command": "pytest -o addopts= web/backend/tests/test_indicators.py --collect-only -q --no-cov",
+      "status": "passed",
+      "collected": 16,
+      "duration_seconds": 11.2
+    },
+    {
+      "command": "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov",
+      "status": "passed",
+      "collected": 112,
+      "duration_seconds": 11.96
+    },
+    {
+      "command": "pytest -o addopts= web/backend/tests/unit/services/indicators/test_indicator_registry.py --collect-only -q --no-cov",
+      "status": "passed",
+      "collected": 29,
+      "duration_seconds": 1.31
+    }
+  ],
+  "future_implementation_allowed_paths": [
+    "web/backend/app/services/indicator_registry.py",
+    "web/backend/app/api/indicators/indicator_cache.py",
+    "focused indicator registry route and OpenAPI stability tests"
+  ],
+  "future_implementation_forbidden_paths": [
+    "web/backend/app/services/indicator_calculator.py",
+    "web/backend/app/services/indicators/indicator_registry.py",
+    "web/backend/app/services/indicators/defaults.py",
+    "web/backend/app/services/indicators/talib_adapter.py",
+    "web/backend/app/services/indicators/jobs/**"
+  ],
+  "decision": {
+    "g2_53_source_edits_authorized": false,
+    "future_g2_54_candidate_authorized_if_human_accepts_packet": true,
+    "future_candidate": "flat API registry route-provider implementation",
+    "required_next_gate": "human review then G2.54 implementation branch with TDD and pre-edit GitNexus checks"
+  }
+}

--- a/docs/reports/quality/backend-flat-api-indicator-registry-consumer-matrix-2026-05-24.md
+++ b/docs/reports/quality/backend-flat-api-indicator-registry-consumer-matrix-2026-05-24.md
@@ -1,0 +1,196 @@
+# Backend Flat API IndicatorRegistry Consumer Matrix - 2026-05-24
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.53 flat API registry consumer matrix / authorization candidate after
+G2.52 `IndicatorRegistry` provider design.
+
+Base branch: `wip/root-dirty-20260403`
+Current HEAD: `ec3dc2920886`
+Generated at: `2026-05-24T15:40:41+08:00`
+
+## Status
+
+`APPROVE_WITH_GUARDS` for a future implementation branch, pending human review of
+this packet.
+
+This packet is governance-only. It does not edit backend source, tests, API
+contracts, OpenAPI output, or runtime behavior.
+
+G2.52 is complete: PR `#193` was merged into `wip/root-dirty-20260403` at merge
+commit `ec3dc2920886eb24e963a33488bd2e945e98e6c9`.
+
+## Source Snapshot
+
+| Surface | File | Current role | G2.53 disposition |
+| --- | --- | --- | --- |
+| Flat API registry | `web/backend/app/services/indicator_registry.py` | API-facing TA-Lib metadata registry with module-level singleton fallback | Candidate for future app-state provider addition |
+| Indicator cache routes | `web/backend/app/api/indicators/indicator_cache.py` | Six `/api/v1/indicators/*` route handlers; two read endpoints call the flat registry directly | Candidate route consumer migration scope |
+| Indicator calculator | `web/backend/app/services/indicator_calculator.py` | Service constructor calls the flat registry getter | Excluded from route-provider implementation |
+| Package registry | `web/backend/app/services/indicators/indicator_registry.py` | Internal package registry for defaults, TA-Lib adapter, jobs, and unit tests | Excluded; requires separate startup/jobs design packet |
+
+The flat registry singleton remains:
+
+```text
+web/backend/app/services/indicator_registry.py:628 _indicator_registry = None
+web/backend/app/services/indicator_registry.py:631 def get_indicator_registry() -> IndicatorRegistry:
+web/backend/app/services/indicator_registry.py:633 global _indicator_registry
+web/backend/app/services/indicator_registry.py:634 if _indicator_registry is None:
+web/backend/app/services/indicator_registry.py:635 _indicator_registry = IndicatorRegistry()
+web/backend/app/services/indicator_registry.py:636 return _indicator_registry
+```
+
+## Consumer Matrix
+
+### Flat API Registry Consumers
+
+| Consumer | File | Current access | Migration decision |
+| --- | --- | --- | --- |
+| `get_indicator_registry_endpoint` | `web/backend/app/api/indicators/indicator_cache.py:86` | Calls `get_indicator_registry()` inside route handler | Future implementation may migrate to route dependency |
+| `get_indicators_by_category` | `web/backend/app/api/indicators/indicator_cache.py:213` | Calls `get_indicator_registry()` inside route handler | Future implementation may migrate to route dependency |
+| `IndicatorCalculator.__init__` | `web/backend/app/services/indicator_calculator.py:43` | Calls `get_indicator_registry()` during service construction | Keep untouched in the flat API route-provider batch |
+
+Import evidence:
+
+```text
+web/backend/app/api/indicators/indicator_cache.py:42
+from app.services.indicator_registry import IndicatorCategory, get_indicator_registry
+
+web/backend/app/services/indicator_calculator.py:20
+from .indicator_registry import get_indicator_registry
+```
+
+### Indicator Cache Route Inventory
+
+| Method | Path | Handler | Registry relationship |
+| --- | --- | --- | --- |
+| GET | `/api/v1/indicators/registry` | `get_indicator_registry_endpoint` | Direct flat registry consumer |
+| GET | `/api/v1/indicators/registry/{category}` | `get_indicators_by_category` | Direct flat registry consumer |
+| POST | `/api/v1/indicators/calculate` | `calculate_indicators` | Uses calculation flow; no direct registry getter call in route handler |
+| POST | `/api/v1/indicators/calculate/batch` | `calculate_indicators_batch` | Uses calculation flow; no direct registry getter call in route handler |
+| GET | `/api/v1/indicators/cache/stats` | `get_cache_statistics` | Cache/control behavior; no direct registry getter call |
+| POST | `/api/v1/indicators/cache/clear` | `clear_cache` | Cache/control behavior; no direct registry getter call |
+
+Only the first two route handlers are candidates for a route-provider
+implementation batch. The calculate and cache endpoints should remain out of the
+initial migration unless a later source-level review proves an additional route
+dependency is needed.
+
+## GitNexus Evidence
+
+GitNexus disambiguation confirms the flat API registry direct callers:
+
+```text
+get_indicator_registry_endpoint -> web/backend/app/api/indicators/indicator_cache.py
+get_indicators_by_category      -> web/backend/app/api/indicators/indicator_cache.py
+IndicatorCalculator.__init__    -> web/backend/app/services/indicator_calculator.py
+```
+
+The same-name package registry remains separate. A generic `impact` query on
+`get_indicator_registry` resolves to the package registry and reports LOW risk,
+impacted count `4`, and the `Run_daily_calculation -> Get_indicator_registry`
+process. That evidence must not be used to authorize edits to the flat API
+registry route handlers.
+
+## Runtime And Contract Evidence
+
+Configured app/OpenAPI smoke used non-sensitive placeholder environment
+variables only. It did not run PM2, connect intentionally to production
+resources, or authorize runtime promotion.
+
+```text
+routes_total=548
+openapi_paths_total=500
+duplicate_operation_ids=0
+selected_indicator_cache_routes=6
+selected_registry_route_consumers=2
+```
+
+Selected OpenAPI operations:
+
+```text
+GET  /api/v1/indicators/registry
+GET  /api/v1/indicators/registry/{category}
+POST /api/v1/indicators/calculate
+POST /api/v1/indicators/calculate/batch
+GET  /api/v1/indicators/cache/stats
+POST /api/v1/indicators/cache/clear
+```
+
+Targeted collection checks:
+
+```text
+pytest -o addopts= web/backend/tests/test_indicators.py --collect-only -q --no-cov
+16 tests collected in 11.20s
+
+pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov
+112 tests collected in 11.96s
+
+pytest -o addopts= web/backend/tests/unit/services/indicators/test_indicator_registry.py --collect-only -q --no-cov
+29 tests collected in 1.31s
+```
+
+## Authorization Candidate
+
+If this packet is accepted, a future implementation branch may be created for a
+narrow flat API registry route-provider migration.
+
+Allowed source scope for that future branch:
+
+- `web/backend/app/services/indicator_registry.py`
+- `web/backend/app/api/indicators/indicator_cache.py`
+- focused tests that directly cover indicator registry routes or app/OpenAPI
+  route contract stability
+
+Required implementation constraints:
+
+- Add an app-state provider surface for the flat API registry only, for example
+  `INDICATOR_REGISTRY_STATE_KEY`, `install_indicator_registry(app, registry=None)`,
+  and `get_indicator_registry_dependency(request)`.
+- Preserve `get_indicator_registry()` as a compatibility fallback.
+- Convert only the two direct registry route consumers in
+  `indicator_cache.py`.
+- Do not edit `IndicatorCalculator.__init__` in the same batch.
+- Do not edit `web/backend/app/services/indicators/indicator_registry.py`,
+  `defaults.py`, `talib_adapter.py`, or indicator jobs.
+- Do not merge the flat API registry and package registry surfaces.
+- Do not change route paths, response models, OpenAPI visibility, or operation
+  IDs.
+
+Required pre-edit gates for the future implementation branch:
+
+- Run GitNexus context for the exact flat registry getter and both selected
+  route handlers.
+- Run GitNexus impact or equivalent Cypher caller query before touching source.
+- If impact or caller inventory shows HIGH/CRITICAL risk, stop and return to
+  review.
+- Start from current `wip/root-dirty-20260403`, not from this governance branch
+  if it has become stale.
+
+## Non-Goals
+
+- No source implementation in G2.53.
+- No backend route, service, test, OpenAPI, PM2, or generated client edits.
+- No package registry startup/jobs design.
+- No compatibility getter deletion.
+- No route path or response contract change.
+- No GitHub issue label or OpenSpec state movement.
+
+## Decision
+
+G2.53 authorizes only a future reviewable implementation candidate, not source
+edits in this PR.
+
+The next safe implementation lane is a narrow flat API registry route-provider
+branch that touches the flat registry service and the two registry read
+endpoints only. The package registry and `IndicatorCalculator` remain explicit
+exclusions.
+
+## Next Gate
+
+If this packet is accepted, create G2.54 flat API registry route-provider
+implementation branch with TDD and pre-edit GitNexus checks. The G2.54 branch
+must carry its own task card and must not reuse this governance-only PR as
+implementation authorization beyond the bounded scope above.

--- a/governance/mainline/task-cards/pr-194.yaml
+++ b/governance/mainline/task-cards/pr-194.yaml
@@ -1,0 +1,108 @@
+version: "v0.2"
+
+task:
+  id: "pr-194"
+  title: "Record flat API IndicatorRegistry consumer matrix"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-flat-api-indicator-registry-consumer-matrix"
+  objective: "record flat API IndicatorRegistry route consumer matrix and future implementation authorization candidate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-flat-api-indicator-registry-consumer-matrix"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-flat-api-indicator-registry-consumer-matrix"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Consumer matrix and authorization candidate record governance evidence only and do not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/flat-api-indicator-registry-consumer-matrix-2026-05-24.json"
+    - "docs/reports/quality/backend-flat-api-indicator-registry-consumer-matrix-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-194.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, tests, generated clients, docs/API, OpenSpec, PM2, route, OpenAPI, or runtime behavior changes"
+  - "No GitHub issue state, label, or ready-for-agent movement"
+  - "No source implementation in this PR"
+  - "No compatibility getter cleanup authorization"
+  - "No package indicator registry startup/jobs design"
+  - "No IndicatorCalculator migration"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-flat-api-indicator-registry-consumer-matrix-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/flat-api-indicator-registry-consumer-matrix-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-194.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-194.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "python -c \"print('staged-gitnexus-scope: docs-only flat API IndicatorRegistry consumer matrix; no source symbols changed')\""
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the consumer-matrix boundary"
+    - "If package registry startup/jobs consumers are bundled into the future flat API implementation, the migration scope becomes unsafe"
+    - "If IndicatorCalculator is migrated with route consumers, service construction behavior may change outside the intended API route-provider batch"
+  rollback_plan: "revert this governance-only PR; PR #193 remains the accepted IndicatorRegistry provider design boundary unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record flat API IndicatorRegistry consumer matrix and future implementation candidate guards"
+    modified_scope: "consumer matrix report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only consumer matrix PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T15:31:11+08:00"
+    approval_note: "human maintainer approved continuing after PR #193 merge; this packet records G2.53 flat API IndicatorRegistry consumer matrix only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Add G2.53 governance-only flat API IndicatorRegistry consumer matrix.
- Record PR #193 as merged and current base head ec3dc2920886.
- Identify exactly two direct registry route consumers in indicator_cache.py.
- Exclude IndicatorCalculator and the package indicator registry startup/jobs surface from the route-provider batch.
- Record app/OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0.
- Record collect-only checks: test_indicators=16, test_health_route_conflicts=112, package registry tests=29.
- Preserve boundary: this PR authorizes no source edits; it only creates a future G2.54 candidate scope if accepted.

## Verification
- markdown governance gate: passed
- JSON parse: passed
- YAML parse: passed
- mainline scope gate: pass=true
- git diff --check: passed
- GitNexus staged detect_changes: LOW, changed_files=4, changed_count=0, affected_count=0
