### PR TITLE
refactor(indicators): inject flat registry route provider

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -829,15 +829,21 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 OpenAPI paths=`500`, duplicate operation IDs=`0`, and no
 │   │                 source implementation target is authorized; PR `#193`
 │   │                 merged at
-│   │                 `ec3dc2920886eb24e963a33488bd2e945e98e6c9`; G2.53 now
+│   │                 `ec3dc2920886eb24e963a33488bd2e945e98e6c9`; G2.53
 │   │                 records the flat API registry consumer matrix: selected
 │   │                 indicator cache routes=`6`, direct registry route
 │   │                 consumers=`2`, service constructor consumer=`1`,
 │   │                 OpenAPI paths=`500`, duplicate operation IDs=`0`, and
-│   │                 collect-only checks=`16+112+29`
-│   └── Next gate: Human review of the G2.53 consumer matrix PR; if accepted,
-│                  create G2.54 flat API registry route-provider implementation
-│                  branch with TDD and pre-edit GitNexus checks
+│   │                 collect-only checks=`16+112+29`; PR `#194` merged at
+│   │                 `71510bb02a845ec529c8c04f3a7288ca86b87b9c`; G2.54 now
+│   │                 implements the flat API registry route provider:
+│   │                 provider surface=`3`, converted route handlers=`2`,
+│   │                 compatibility getter preserved, package registry and
+│   │                 `IndicatorCalculator` excluded, focused TDD=`2 passed`,
+│   │                 OpenAPI paths=`500`, duplicate operation IDs=`0`
+│   └── Next gate: Human review of the G2.54 implementation PR; if accepted,
+│                  run G2.55 closeout/current-head refresh before selecting
+│                  another service lifecycle DI lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -930,6 +936,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-di-candidate-refresh-after-market-data-provider-2026-05-24.md` | G | G2.51 candidate refresh prepared at current HEAD `047f483dd70a5234ca3a128342511a56779194d3`: records PR `#191` as `MERGED`, scans `152` service files and `219` API files, confirms provider functions=`8`, route provider dependency files=`11`, route provider dependency sites=`79`, route getter dependency sites=`270`, OpenAPI paths=`500`, duplicate operation IDs=`0`, `get_market_data_service` legacy route dependency sites=`0`, and classifies the remaining interesting seams: `get_indicator_registry` LOW/`4` as indicator-internal design, `get_data_service` CRITICAL/`5`, `get_strategy_service` CRITICAL/`13`, `get_kronos_client` CRITICAL/`3`, and route-local `get_technical_pattern_detection_service` as D2.1a historical provider surface; no next source implementation target is selected | Human review / PR merge decision; if accepted, choose a separate decision packet before any source edits |
 | `backend-indicator-registry-provider-design-2026-05-24.md` | G | G2.52 design packet prepared at current HEAD `363324bf31a89b797789403c55dbe3ca854bc7d6`: records PR `#192` as `MERGED`, confirms two same-name `get_indicator_registry()` surfaces, separates flat API registry `web/backend/app/services/indicator_registry.py` from package registry `web/backend/app/services/indicators/indicator_registry.py`, records flat API direct callers=`3`, package registry production callers=`3`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and selects no source implementation target; recommended next gate is G2.53 flat API registry consumer matrix / authorization candidate | Human review / PR merge decision; if accepted, create G2.53 flat API registry consumer matrix / authorization candidate before source edits |
 | `backend-flat-api-indicator-registry-consumer-matrix-2026-05-24.md` | G | G2.53 consumer matrix prepared at current HEAD `ec3dc2920886eb24e963a33488bd2e945e98e6c9`: records PR `#193` as `MERGED`, confirms the flat API registry singleton at `web/backend/app/services/indicator_registry.py`, identifies exactly two direct registry route consumers in `indicator_cache.py`, excludes `IndicatorCalculator.__init__` from the route-provider batch, keeps the package registry startup/jobs surface separate, records configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, selected indicator cache routes=`6`, and collect-only checks=`16+112+29` | Human review / PR merge decision; if accepted, create G2.54 flat API registry route-provider implementation branch before source edits |
+| `backend-flat-api-indicator-registry-route-provider-implementation-2026-05-24.md` | G | G2.54 implementation prepared at current HEAD `71510bb02a845ec529c8c04f3a7288ca86b87b9c`: records PR `#194` as `MERGED`, adds `INDICATOR_REGISTRY_STATE_KEY`, `install_indicator_registry`, and `get_indicator_registry_dependency`, preserves `get_indicator_registry()`, converts exactly two registry read handlers in `indicator_cache.py`, keeps `IndicatorCalculator.__init__` and package registry startup/jobs surfaces unchanged, verifies TDD red=`2 failed`, green=`2 passed`, touched ruff/black passed, v1 indicator OpenAPI doc test=`1 passed`, configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and records legacy `/api/indicators/*` path assertions in `test_indicators.py` as residual test debt | Human review / PR merge decision; if accepted, run G2.55 closeout/current-head refresh before selecting another service lifecycle DI lane |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/flat-api-indicator-registry-route-provider-implementation-2026-05-24.json
+++ b/.planning/codebase/generated/flat-api-indicator-registry-route-provider-implementation-2026-05-24.json
@@ -1,0 +1,117 @@
+{
+  "artifact": "flat-api-indicator-registry-route-provider-implementation",
+  "workline": "G2.54",
+  "generated_at": "2026-05-24T16:49:54+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "71510bb02a84",
+  "status": "ready_for_review",
+  "approval_chain": {
+    "g2_52_pr": 193,
+    "g2_52_merge_commit": "ec3dc2920886eb24e963a33488bd2e945e98e6c9",
+    "g2_53_pr": 194,
+    "g2_53_merge_commit": "71510bb02a845ec529c8c04f3a7288ca86b87b9c"
+  },
+  "pre_edit_gitnexus": {
+    "flat_registry_context": {
+      "symbol": "Function:web/backend/app/services/indicator_registry.py:get_indicator_registry",
+      "direct_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py:get_indicator_registry_endpoint",
+        "web/backend/app/api/indicators/indicator_cache.py:get_indicators_by_category",
+        "web/backend/app/services/indicator_calculator.py:__init__"
+      ]
+    },
+    "route_handler_impacts": [
+      {
+        "target": "get_indicator_registry_endpoint",
+        "file": "web/backend/app/api/indicators/indicator_cache.py",
+        "risk": "LOW",
+        "impacted_count": 0,
+        "processes_affected": 0
+      },
+      {
+        "target": "get_indicators_by_category",
+        "file": "web/backend/app/api/indicators/indicator_cache.py",
+        "risk": "LOW",
+        "impacted_count": 0,
+        "processes_affected": 0
+      }
+    ]
+  },
+  "implementation": {
+    "source_files": [
+      "web/backend/app/services/indicator_registry.py",
+      "web/backend/app/api/indicators/indicator_cache.py"
+    ],
+    "test_files": [
+      "web/backend/tests/test_indicator_registry_route_provider.py"
+    ],
+    "provider_surface": [
+      "INDICATOR_REGISTRY_STATE_KEY",
+      "install_indicator_registry",
+      "get_indicator_registry_dependency"
+    ],
+    "compatibility_preserved": [
+      "get_indicator_registry"
+    ],
+    "converted_route_handlers": [
+      "get_indicator_registry_endpoint",
+      "get_indicators_by_category"
+    ],
+    "excluded_surfaces": [
+      "IndicatorCalculator.__init__",
+      "web/backend/app/services/indicators/indicator_registry.py",
+      "web/backend/app/services/indicators/defaults.py",
+      "web/backend/app/services/indicators/talib_adapter.py",
+      "web/backend/app/services/indicators/jobs/**"
+    ]
+  },
+  "tdd": {
+    "red": {
+      "command": "pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --tb=short --no-cov",
+      "status": "failed_as_expected",
+      "failures": [
+        "assert dependency is not None",
+        "TypeError: get_indicator_registry_endpoint() got an unexpected keyword argument 'registry'"
+      ],
+      "summary": "2 failed in 1.77s"
+    },
+    "green": {
+      "command": "pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --tb=short --no-cov",
+      "status": "passed",
+      "summary": "2 passed in 1.60s"
+    }
+  },
+  "validation": {
+    "black_touched_files": "passed",
+    "ruff_touched_files": "passed",
+    "focused_route_provider_test": "2 passed in 1.68s",
+    "v1_indicator_openapi_doc_test": "1 passed in 10.62s",
+    "configured_app_openapi_smoke": {
+      "routes_total": 548,
+      "openapi_paths_total": 500,
+      "duplicate_operation_ids": 0,
+      "selected_indicator_cache_routes": 6
+    },
+    "staged_gitnexus_scope": {
+      "risk": "MEDIUM",
+      "changed_files": 7,
+      "changed_count": 22,
+      "affected_count": 2,
+      "affected_processes": [
+        "Calculate_indicators -> Warning",
+        "Calculate_indicators -> _dataframe_to_ohlcv_arrays"
+      ],
+      "manual_diff_review": "source hunks are bounded to indicator_cache import/signature/call-site changes, indicator_registry provider addition, and focused regression test; calculate handler body was not intentionally changed"
+    },
+    "known_existing_test_debt": {
+      "command": "pytest -o addopts= web/backend/tests/test_indicators.py -q --tb=short --no-cov",
+      "summary": "8 failed, 8 passed in 11.96s",
+      "reason": "legacy /api/indicators/* path assertions receive 404 while active routes are /api/v1/indicators/*"
+    }
+  },
+  "decision": {
+    "source_implementation_done": true,
+    "runtime_promotion_authorized": false,
+    "next_gate": "G2.55 closeout/current-head refresh after PR merge"
+  }
+}

--- a/docs/reports/quality/backend-flat-api-indicator-registry-route-provider-implementation-2026-05-24.md
+++ b/docs/reports/quality/backend-flat-api-indicator-registry-route-provider-implementation-2026-05-24.md
@@ -1,0 +1,210 @@
+# Backend Flat API IndicatorRegistry Route Provider Implementation - 2026-05-24
+
+> **历史实施说明**:
+> 本文件是历史实施记录，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.54 flat API `IndicatorRegistry` route-provider implementation
+after G2.53 consumer matrix.
+
+Base branch: `wip/root-dirty-20260403`
+Base HEAD: `71510bb02a84`
+Generated at: `2026-05-24T16:49:54+08:00`
+
+## Status
+
+`READY_FOR_REVIEW`.
+
+This implementation follows the G2.53 authorization candidate. It changes only
+the flat API registry provider surface, the two selected registry read route
+consumers, one focused regression test file, and governance records.
+
+## Human Approval Chain
+
+| Gate | State | Evidence |
+| --- | --- | --- |
+| G2.52 provider design | Accepted and merged | PR `#193`, merge commit `ec3dc2920886eb24e963a33488bd2e945e98e6c9` |
+| G2.53 consumer matrix | Accepted and merged | PR `#194`, merge commit `71510bb02a845ec529c8c04f3a7288ca86b87b9c` |
+| G2.54 implementation | Prepared for review | This report and PR task card `pr-195.yaml` |
+
+## Pre-Edit GitNexus Evidence
+
+Pre-edit graph checks were run before source changes.
+
+Flat registry getter:
+
+```text
+Function:web/backend/app/services/indicator_registry.py:get_indicator_registry
+direct callers:
+- get_indicator_registry_endpoint
+- get_indicators_by_category
+- IndicatorCalculator.__init__
+```
+
+Selected route handlers:
+
+```text
+get_indicator_registry_endpoint
+risk=LOW
+impacted_count=0
+direct=0
+processes_affected=0
+
+get_indicators_by_category
+risk=LOW
+impacted_count=0
+direct=0
+processes_affected=0
+```
+
+The generic same-name `get_indicator_registry` impact query still resolves to
+the package registry, so this implementation used exact context and caller
+evidence for the flat API registry surface.
+
+## Implementation Scope
+
+Modified source:
+
+- `web/backend/app/services/indicator_registry.py`
+- `web/backend/app/api/indicators/indicator_cache.py`
+
+Added test:
+
+- `web/backend/tests/test_indicator_registry_route_provider.py`
+
+Governance records:
+
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/flat-api-indicator-registry-route-provider-implementation-2026-05-24.json`
+- `docs/reports/quality/backend-flat-api-indicator-registry-route-provider-implementation-2026-05-24.md`
+- `governance/mainline/task-cards/pr-195.yaml`
+
+## Code Changes
+
+`web/backend/app/services/indicator_registry.py` now exposes an app-state-backed
+provider surface for the flat API registry:
+
+```text
+INDICATOR_REGISTRY_STATE_KEY = "indicator_registry"
+install_indicator_registry(app, registry=None)
+get_indicator_registry_dependency(request)
+```
+
+The existing compatibility getter remains intact:
+
+```text
+get_indicator_registry()
+```
+
+`web/backend/app/api/indicators/indicator_cache.py` now injects the provider into
+only the two selected read endpoints:
+
+```text
+GET /api/v1/indicators/registry
+GET /api/v1/indicators/registry/{category}
+```
+
+No calculate, batch, cache, `IndicatorCalculator`, package registry, TA-Lib
+adapter, defaults, or jobs code was changed.
+
+## TDD Evidence
+
+RED:
+
+```text
+pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --tb=short --no-cov
+2 failed in 1.77s
+
+Failure 1:
+assert dependency is not None
+
+Failure 2:
+TypeError: get_indicator_registry_endpoint() got an unexpected keyword argument 'registry'
+```
+
+GREEN:
+
+```text
+pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --tb=short --no-cov
+2 passed in 1.60s
+```
+
+The focused test verifies:
+
+- both registry read route handlers expose the FastAPI dependency provider;
+- both handlers accept an injected fake registry;
+- registry data still serializes through the existing response contract.
+
+## Validation
+
+Passed:
+
+```text
+black web/backend/app/services/indicator_registry.py \
+      web/backend/app/api/indicators/indicator_cache.py \
+      web/backend/tests/test_indicator_registry_route_provider.py
+
+ruff check web/backend/app/services/indicator_registry.py \
+           web/backend/app/api/indicators/indicator_cache.py \
+           web/backend/tests/test_indicator_registry_route_provider.py
+
+pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --tb=short --no-cov
+2 passed in 1.68s
+
+pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_v1_indicator_endpoints_have_examples_parameter_docs_and_descriptions -q --tb=short --no-cov
+1 passed in 10.62s
+
+configured app/OpenAPI smoke:
+routes_total=548
+openapi_paths_total=500
+duplicate_operation_ids=0
+selected_indicator_cache_routes=6
+```
+
+Staged GitNexus scope check:
+
+```text
+gitnexus_detect_changes(scope=staged)
+risk=MEDIUM
+changed_files=7
+changed_count=22
+affected_count=2
+affected_processes:
+- Calculate_indicators -> Warning
+- Calculate_indicators -> _dataframe_to_ohlcv_arrays
+```
+
+Manual staged diff review confirmed the actual source hunks are bounded to the
+`indicator_cache.py` import/signature/call-site changes, the
+`indicator_registry.py` provider addition, and the focused new regression test.
+The calculate-flow hits come from file-level parser attribution in
+`indicator_cache.py`; no calculate handler body was intentionally changed.
+
+Known existing test debt observed:
+
+```text
+pytest -o addopts= web/backend/tests/test_indicators.py -q --tb=short --no-cov
+8 failed, 8 passed in 11.96s
+```
+
+The failing assertions use legacy `/api/indicators/*` paths and receive `404`.
+The active route table exposes `/api/v1/indicators/*`. This was not introduced
+by G2.54 and is recorded here as residual test path debt, not an implementation
+regression.
+
+## Non-Goals Preserved
+
+- No package registry migration.
+- No `IndicatorCalculator.__init__` migration.
+- No route path, OpenAPI visibility, response model, or operation ID change.
+- No compatibility getter deletion.
+- No PM2 or runtime promotion.
+- No OpenSpec state movement.
+
+## Next Gate
+
+If accepted and merged, run a G2.55 closeout/current-head refresh before
+selecting another service lifecycle DI implementation lane. The closeout should
+verify that `indicator_cache.py` has zero direct route calls to
+`get_indicator_registry()` while `IndicatorCalculator` and the package registry
+remain intentionally outside this route-provider batch.

--- a/governance/mainline/task-cards/pr-195.yaml
+++ b/governance/mainline/task-cards/pr-195.yaml
@@ -1,0 +1,119 @@
+version: "v0.2"
+
+task:
+  id: "pr-195"
+  title: "Implement flat API IndicatorRegistry route provider"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-flat-api-indicator-registry-route-provider"
+  objective: "migrate selected flat API IndicatorRegistry read routes to an app-state-backed FastAPI dependency provider"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-flat-api-indicator-registry-route-provider"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-flat-api-indicator-registry-route-provider"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Route-provider migration preserves existing route paths, OpenAPI exposure, response models, operation IDs, and product surface while moving selected flat API IndicatorRegistry route dependencies to an app-state provider"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/flat-api-indicator-registry-route-provider-implementation-2026-05-24.json"
+    - "docs/reports/quality/backend-flat-api-indicator-registry-route-provider-implementation-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-195.yaml"
+    - "web/backend/app/services/indicator_registry.py"
+    - "web/backend/app/api/indicators/indicator_cache.py"
+    - "web/backend/tests/test_indicator_registry_route_provider.py"
+  forbidden_paths:
+    - "web/backend/app/services/indicator_calculator.py"
+    - "web/backend/app/services/indicators/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No package indicator registry startup/jobs migration"
+  - "No IndicatorCalculator migration"
+  - "No compatibility getter deletion"
+  - "No route path, OpenAPI visibility, response model, operation ID, generated client, or frontend change"
+  - "No PM2, runtime promotion, GitHub issue state, label, or OpenSpec state movement"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-flat-api-indicator-registry-route-provider-implementation-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/flat-api-indicator-registry-route-provider-implementation-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-195.yaml').read_text())\""
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/indicator_registry.py web/backend/app/api/indicators/indicator_cache.py web/backend/tests/test_indicator_registry_route_provider.py"
+      required: true
+    - id: "focused-route-provider-test"
+      command: "pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --tb=short --no-cov"
+      required: true
+    - id: "v1-indicator-openapi-doc-test"
+      command: "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_v1_indicator_endpoints_have_examples_parameter_docs_and_descriptions -q --tb=short --no-cov"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-195.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "gitnexus_detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If indicator_calculator.py or package registry files are changed, the PR exceeds the G2.54 authorization boundary"
+    - "If compatibility get_indicator_registry() is removed, service construction and legacy callers may break"
+    - "If route paths or response contracts change, frontend and OpenAPI consumers may regress"
+  rollback_plan: "revert this implementation PR; PR #194 remains the accepted consumer matrix unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "migrate selected flat API IndicatorRegistry read routes to an app-state-backed provider"
+    modified_scope: "flat registry service, indicator cache read routes, focused test, report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "compatibility getter preserved"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused route-provider or OpenAPI checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T16:38:58+08:00"
+    approval_note: "human maintainer approved continuing after PR #194 merge; this packet implements the bounded G2.54 flat API IndicatorRegistry route-provider scope"
+    secondary_approved: false

--- a/web/backend/app/api/indicators/indicator_cache.py
+++ b/web/backend/app/api/indicators/indicator_cache.py
@@ -39,7 +39,7 @@ from app.schemas.indicator_response import (
 )
 from app.services.data_service import InvalidDateRangeError, StockDataNotFoundError, get_data_service
 from app.services.indicator_calculator import IndicatorCalculationError, InsufficientDataError, get_indicator_calculator
-from app.services.indicator_registry import IndicatorCategory, get_indicator_registry
+from app.services.indicator_registry import IndicatorCategory, IndicatorRegistry, get_indicator_registry_dependency
 
 logger = structlog.get_logger()
 router = APIRouter()
@@ -63,6 +63,7 @@ IndicatorCache = _IndicatorCache
 RateLimiter = _RateLimiter
 IndicatorOptimizationRequest = _IndicatorOptimizationRequest
 
+
 @router.get(
     "/registry",
     response_model=UnifiedResponse[IndicatorRegistryResponse],
@@ -76,6 +77,7 @@ async def get_indicator_registry_endpoint(
     search: Optional[str] = Query(None, description="搜索指标名称或描述"),
     include_advanced: bool = Query(True, description="是否包含高级指标"),
     current_user: User = Depends(get_current_active_user),
+    registry: IndicatorRegistry = Depends(get_indicator_registry_dependency),
 ):
     """
     获取指标注册表 - Phase 4C Enhanced
@@ -83,7 +85,6 @@ async def get_indicator_registry_endpoint(
     返回所有可用的技术指标及其元数据，支持分类筛选和搜索
     """
     try:
-        registry = get_indicator_registry()
         all_indicators = registry.get_all_indicators()
 
         # 记录请求
@@ -195,7 +196,10 @@ async def get_indicator_registry_endpoint(
     description="返回指定指标分类下的元数据清单，便于前端按趋势、动量、波动率、成交量或 K 线形态组织指标选择面板。",
     responses=INDICATOR_CATEGORY_RESPONSES,
 )
-async def get_indicators_by_category(category: str = Path(..., description=INDICATOR_CATEGORY_PATH_DESCRIPTION)):
+async def get_indicators_by_category(
+    category: str = Path(..., description=INDICATOR_CATEGORY_PATH_DESCRIPTION),
+    registry: IndicatorRegistry = Depends(get_indicator_registry_dependency),
+):
     """
     获取指定分类的指标
 
@@ -210,7 +214,6 @@ async def get_indicators_by_category(category: str = Path(..., description=INDIC
                 detail=f"无效的指标分类: {category}. 有效分类: {[c.value for c in IndicatorCategory]}", field="category"
             )
 
-        registry = get_indicator_registry()
         indicators = registry.get_indicators_by_category(indicator_category)
 
         # 转换为响应格式

--- a/web/backend/app/services/indicator_registry.py
+++ b/web/backend/app/services/indicator_registry.py
@@ -6,6 +6,8 @@ Indicator Registry Service
 from enum import Enum
 from typing import Any, Dict, Optional
 
+from fastapi import Request
+
 
 class IndicatorCategory(str, Enum):
     """指标分类"""
@@ -625,7 +627,8 @@ class IndicatorRegistry:
 
 
 # 全局单例
-_indicator_registry = None
+_indicator_registry: Optional[IndicatorRegistry] = None
+INDICATOR_REGISTRY_STATE_KEY = "indicator_registry"
 
 
 def get_indicator_registry() -> IndicatorRegistry:
@@ -634,3 +637,18 @@ def get_indicator_registry() -> IndicatorRegistry:
     if _indicator_registry is None:
         _indicator_registry = IndicatorRegistry()
     return _indicator_registry
+
+
+def install_indicator_registry(app: Any, registry: IndicatorRegistry | None = None) -> IndicatorRegistry:
+    """Install the flat API indicator registry instance on FastAPI app.state."""
+    selected_registry = registry if registry is not None else get_indicator_registry()
+    setattr(app.state, INDICATOR_REGISTRY_STATE_KEY, selected_registry)
+    return selected_registry
+
+
+def get_indicator_registry_dependency(request: Request) -> IndicatorRegistry:
+    """FastAPI dependency provider for the flat API indicator registry."""
+    registry = getattr(request.app.state, INDICATOR_REGISTRY_STATE_KEY, None)
+    if registry is None:
+        registry = install_indicator_registry(request.app)
+    return registry

--- a/web/backend/tests/test_indicator_registry_route_provider.py
+++ b/web/backend/tests/test_indicator_registry_route_provider.py
@@ -1,0 +1,77 @@
+"""Regression tests for the flat API IndicatorRegistry route provider."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from types import SimpleNamespace
+
+from app.api.indicators import indicator_cache
+from app.services import indicator_registry as registry_module
+from app.services.indicator_registry import IndicatorCategory, PanelType
+
+
+class _FakeIndicatorRegistry:
+    def __init__(self) -> None:
+        self.calls: list[object] = []
+
+    def get_all_indicators(self) -> dict[str, dict[str, object]]:
+        self.calls.append("all")
+        return {"SMA": _indicator_metadata()}
+
+    def get_indicators_by_category(self, category: IndicatorCategory) -> dict[str, dict[str, object]]:
+        self.calls.append(("category", category))
+        return {"SMA": _indicator_metadata(category=category)}
+
+
+def _indicator_metadata(category: IndicatorCategory = IndicatorCategory.TREND) -> dict[str, object]:
+    return {
+        "full_name": "Simple Moving Average",
+        "chinese_name": "简单移动平均线",
+        "category": category,
+        "description": "Moving average test metadata",
+        "panel_type": PanelType.OVERLAY,
+        "parameters": [],
+        "outputs": [{"name": "sma", "description": "SMA value"}],
+        "reference_lines": None,
+        "min_data_points_formula": "timeperiod",
+    }
+
+
+def test_indicator_registry_routes_expose_app_state_dependency() -> None:
+    dependency = getattr(registry_module, "get_indicator_registry_dependency", None)
+
+    assert dependency is not None
+
+    for handler in (
+        indicator_cache.get_indicator_registry_endpoint,
+        indicator_cache.get_indicators_by_category,
+    ):
+        registry_parameter = inspect.signature(handler).parameters["registry"]
+        assert getattr(registry_parameter.default, "dependency", None) is dependency
+
+
+def test_indicator_registry_routes_accept_injected_registry() -> None:
+    registry = _FakeIndicatorRegistry()
+    user = SimpleNamespace(id="route-provider-test")
+
+    registry_response = asyncio.run(
+        indicator_cache.get_indicator_registry_endpoint(
+            category=None,
+            search=None,
+            include_advanced=True,
+            current_user=user,
+            registry=registry,
+        )
+    )
+    category_response = asyncio.run(
+        indicator_cache.get_indicators_by_category(
+            category="trend",
+            registry=registry,
+        )
+    )
+
+    assert registry.calls == ["all", ("category", IndicatorCategory.TREND)]
+    assert registry_response["data"]["total_count"] == 1
+    assert registry_response["data"]["indicators"][0]["abbreviation"] == "SMA"
+    assert category_response["data"][0]["abbreviation"] == "SMA"


### PR DESCRIPTION
## Summary
- Implement the G2.54 flat API IndicatorRegistry route-provider scope accepted by G2.53.
- Add app-state provider surface: INDICATOR_REGISTRY_STATE_KEY, install_indicator_registry, get_indicator_registry_dependency.
- Preserve compatibility getter get_indicator_registry().
- Convert exactly two registry read handlers in indicator_cache.py to Depends(get_indicator_registry_dependency).
- Keep IndicatorCalculator and package registry startup/jobs surfaces unchanged.
- Add focused TDD regression coverage and update steward tree/governance evidence.

## Verification
- Pre-edit GitNexus: selected route handlers LOW, impacted_count=0.
- TDD RED: 2 expected failures before implementation.
- TDD GREEN: test_indicator_registry_route_provider.py 2 passed.
- black touched files: passed.
- ruff touched files: passed.
- v1 indicator OpenAPI docs test: 1 passed.
- configured app/OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0.
- mainline scope gate: pass=true.
- git diff checks: passed.
- staged GitNexus detect_changes: MEDIUM, changed_files=7, changed_count=22, affected_count=2; report records manual diff review showing source hunks are bounded to the selected provider/import/signature/call-site changes.

## Known Existing Debt
- Full web/backend/tests/test_indicators.py currently reports 8 failed / 8 passed due legacy /api/indicators/* path assertions receiving 404 while active routes are /api/v1/indicators/*. This is recorded in the implementation report and is not introduced by this route-provider migration.
