### PR TITLE
docs(governance): close out indicator registry route provider

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -835,15 +835,21 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 consumers=`2`, service constructor consumer=`1`,
 │   │                 OpenAPI paths=`500`, duplicate operation IDs=`0`, and
 │   │                 collect-only checks=`16+112+29`; PR `#194` merged at
-│   │                 `71510bb02a845ec529c8c04f3a7288ca86b87b9c`; G2.54 now
+│   │                 `71510bb02a845ec529c8c04f3a7288ca86b87b9c`; G2.54
 │   │                 implements the flat API registry route provider:
 │   │                 provider surface=`3`, converted route handlers=`2`,
 │   │                 compatibility getter preserved, package registry and
 │   │                 `IndicatorCalculator` excluded, focused TDD=`2 passed`,
-│   │                 OpenAPI paths=`500`, duplicate operation IDs=`0`
-│   └── Next gate: Human review of the G2.54 implementation PR; if accepted,
-│                  run G2.55 closeout/current-head refresh before selecting
-│                  another service lifecycle DI lane
+│   │                 OpenAPI paths=`500`, duplicate operation IDs=`0`; PR
+│   │                 `#195` merged at
+│   │                 `5b12a3c08cac3558c56af615ff14c05913d96f72`; G2.55 now
+│   │                 records closeout evidence: route direct getter refs=`0`,
+│   │                 provider dependency route sites=`2`, focused tests=`2+1`
+│   │                 passed, OpenAPI paths=`500`, duplicate operation IDs=`0`,
+│   │                 GitNexus index stale for new provider symbols
+│   └── Next gate: Human review of the G2.55 closeout PR; if accepted, refresh
+│                  GitNexus or explicitly discount stale graph output before
+│                  selecting another service lifecycle DI lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -937,6 +943,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-indicator-registry-provider-design-2026-05-24.md` | G | G2.52 design packet prepared at current HEAD `363324bf31a89b797789403c55dbe3ca854bc7d6`: records PR `#192` as `MERGED`, confirms two same-name `get_indicator_registry()` surfaces, separates flat API registry `web/backend/app/services/indicator_registry.py` from package registry `web/backend/app/services/indicators/indicator_registry.py`, records flat API direct callers=`3`, package registry production callers=`3`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and selects no source implementation target; recommended next gate is G2.53 flat API registry consumer matrix / authorization candidate | Human review / PR merge decision; if accepted, create G2.53 flat API registry consumer matrix / authorization candidate before source edits |
 | `backend-flat-api-indicator-registry-consumer-matrix-2026-05-24.md` | G | G2.53 consumer matrix prepared at current HEAD `ec3dc2920886eb24e963a33488bd2e945e98e6c9`: records PR `#193` as `MERGED`, confirms the flat API registry singleton at `web/backend/app/services/indicator_registry.py`, identifies exactly two direct registry route consumers in `indicator_cache.py`, excludes `IndicatorCalculator.__init__` from the route-provider batch, keeps the package registry startup/jobs surface separate, records configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, selected indicator cache routes=`6`, and collect-only checks=`16+112+29` | Human review / PR merge decision; if accepted, create G2.54 flat API registry route-provider implementation branch before source edits |
 | `backend-flat-api-indicator-registry-route-provider-implementation-2026-05-24.md` | G | G2.54 implementation prepared at current HEAD `71510bb02a845ec529c8c04f3a7288ca86b87b9c`: records PR `#194` as `MERGED`, adds `INDICATOR_REGISTRY_STATE_KEY`, `install_indicator_registry`, and `get_indicator_registry_dependency`, preserves `get_indicator_registry()`, converts exactly two registry read handlers in `indicator_cache.py`, keeps `IndicatorCalculator.__init__` and package registry startup/jobs surfaces unchanged, verifies TDD red=`2 failed`, green=`2 passed`, touched ruff/black passed, v1 indicator OpenAPI doc test=`1 passed`, configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and records legacy `/api/indicators/*` path assertions in `test_indicators.py` as residual test debt | Human review / PR merge decision; if accepted, run G2.55 closeout/current-head refresh before selecting another service lifecycle DI lane |
+| `backend-flat-api-indicator-registry-route-provider-closeout-2026-05-24.md` | G | G2.55 closeout prepared at current HEAD `5b12a3c08cac3558c56af615ff14c05913d96f72`: records PR `#195` as `MERGED`, confirms flat API registry provider surface remains present, route direct `get_indicator_registry()` references under `web/backend/app/api`=`0`, provider dependency route sites=`2`, selected indicator cache routes=`6`, configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, focused tests=`2+1 passed`, and GitNexus graph output is stale for the new provider symbols until index refresh | Human review / PR merge decision; if accepted, refresh GitNexus or explicitly discount stale graph output before selecting another service lifecycle DI lane |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/flat-api-indicator-registry-route-provider-closeout-2026-05-24.json
+++ b/.planning/codebase/generated/flat-api-indicator-registry-route-provider-closeout-2026-05-24.json
@@ -1,0 +1,110 @@
+{
+  "artifact": "flat-api-indicator-registry-route-provider-closeout",
+  "workline": "G2.55",
+  "generated_at": "2026-05-24T17:38:30+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_head": "5b12a3c08cac",
+  "status": "ready_for_review",
+  "merge_evidence": {
+    "pr": 195,
+    "state": "MERGED",
+    "merged_at": "2026-05-24T09:34:02Z",
+    "merge_commit": "5b12a3c08cac3558c56af615ff14c05913d96f72",
+    "remote_checks_before_merge": {
+      "Validate API Contracts": "pass",
+      "Mainline Governance Gate": "pass",
+      "check-compliance": "pass",
+      "weekly-full-scan": "skipping"
+    }
+  },
+  "provider_surface": {
+    "file": "web/backend/app/services/indicator_registry.py",
+    "state_key": {
+      "name": "INDICATOR_REGISTRY_STATE_KEY",
+      "line": 631
+    },
+    "install_function": {
+      "name": "install_indicator_registry",
+      "line": 642
+    },
+    "dependency_function": {
+      "name": "get_indicator_registry_dependency",
+      "line": 649
+    },
+    "compatibility_getter": {
+      "name": "get_indicator_registry",
+      "line": 634,
+      "preserved": true
+    }
+  },
+  "route_dependency_usage": [
+    {
+      "file": "web/backend/app/api/indicators/indicator_cache.py",
+      "line": 80,
+      "handler": "get_indicator_registry_endpoint",
+      "dependency": "get_indicator_registry_dependency"
+    },
+    {
+      "file": "web/backend/app/api/indicators/indicator_cache.py",
+      "line": 201,
+      "handler": "get_indicators_by_category",
+      "dependency": "get_indicator_registry_dependency"
+    }
+  ],
+  "direct_getter_references": {
+    "web_backend_app_api_count": 0,
+    "web_backend_app_services_count": 7,
+    "web_backend_tests_count": 14,
+    "total": 21,
+    "remaining_non_route_surfaces": [
+      "web/backend/app/services/indicator_calculator.py",
+      "web/backend/app/services/indicator_registry.py",
+      "web/backend/app/services/indicators/defaults.py",
+      "web/backend/app/services/indicators/talib_adapter.py",
+      "web/backend/tests/unit/services/indicators/test_indicator_registry.py"
+    ]
+  },
+  "runtime_contract_evidence": {
+    "routes_total": 548,
+    "openapi_paths_total": 500,
+    "duplicate_operation_ids": 0,
+    "warnings": 0,
+    "selected_indicator_cache_routes": 6
+  },
+  "focused_checks": [
+    {
+      "command": "pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --tb=short --no-cov",
+      "status": "passed",
+      "summary": "2 passed in 1.68s"
+    },
+    {
+      "command": "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_v1_indicator_endpoints_have_examples_parameter_docs_and_descriptions -q --tb=short --no-cov",
+      "status": "passed",
+      "summary": "1 passed in 11.87s"
+    }
+  ],
+  "provider_inventory_refresh": {
+    "service_provider_state_key_records": 29,
+    "indicator_registry_provider_records": [
+      "INDICATOR_REGISTRY_STATE_KEY",
+      "install_indicator_registry",
+      "get_indicator_registry_dependency"
+    ]
+  },
+  "gitnexus_note": {
+    "state": "stale_for_new_provider_symbols",
+    "details": "GitNexus context did not yet resolve get_indicator_registry_dependency/install_indicator_registry after PR #195 and still reported stale direct route callers for get_indicator_registry. Refresh GitNexus before using graph impact to choose the next lane."
+  },
+  "known_residual_debt": [
+    {
+      "file": "web/backend/tests/test_indicators.py",
+      "status": "separate_test_path_debt",
+      "details": "legacy /api/indicators/* path assertions receive 404 while active routes are /api/v1/indicators/*"
+    }
+  ],
+  "decision": {
+    "g2_54_closed": true,
+    "additional_indicator_registry_route_provider_work_authorized": false,
+    "next_gate": "current-head candidate refresh after GitNexus index refresh or explicit stale-output discount"
+  }
+}

--- a/docs/reports/quality/backend-flat-api-indicator-registry-route-provider-closeout-2026-05-24.md
+++ b/docs/reports/quality/backend-flat-api-indicator-registry-route-provider-closeout-2026-05-24.md
@@ -1,0 +1,175 @@
+# Backend Flat API IndicatorRegistry Route Provider Closeout - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.55 closeout/current-head refresh after G2.54 flat API
+`IndicatorRegistry` route-provider implementation.
+
+Base branch: `wip/root-dirty-20260403`
+Current HEAD: `5b12a3c08cac`
+Generated at: `2026-05-24T17:38:30+08:00`
+
+## Status
+
+`READY_FOR_REVIEW`.
+
+This packet is closeout evidence only. It does not change backend source, tests,
+route paths, OpenAPI output, runtime behavior, or issue/OpenSpec state.
+
+## Merge Evidence
+
+| PR | State | Merge commit | Notes |
+| --- | --- | --- | --- |
+| `#195` | `MERGED` | `5b12a3c08cac3558c56af615ff14c05913d96f72` | G2.54 flat API `IndicatorRegistry` route-provider implementation |
+
+PR `#195` remote checks were green before merge:
+
+```text
+Validate API Contracts=pass
+Mainline Governance Gate=pass
+check-compliance=pass
+weekly-full-scan=skipping
+```
+
+## Current-Head Closeout Evidence
+
+Provider surface is present in
+`web/backend/app/services/indicator_registry.py`:
+
+```text
+line 631: INDICATOR_REGISTRY_STATE_KEY = "indicator_registry"
+line 642: def install_indicator_registry(app: Any, registry: IndicatorRegistry | None = None) -> IndicatorRegistry:
+line 649: def get_indicator_registry_dependency(request: Request) -> IndicatorRegistry:
+line 651: registry = getattr(request.app.state, INDICATOR_REGISTRY_STATE_KEY, None)
+```
+
+Route dependency usage is present in
+`web/backend/app/api/indicators/indicator_cache.py`:
+
+```text
+line 42: from app.services.indicator_registry import IndicatorCategory, IndicatorRegistry, get_indicator_registry_dependency
+line 80: registry: IndicatorRegistry = Depends(get_indicator_registry_dependency),
+line 201: registry: IndicatorRegistry = Depends(get_indicator_registry_dependency),
+```
+
+Route direct getter calls are closed:
+
+```text
+get_indicator_registry() references under web/backend/app/api: 0
+```
+
+Remaining `get_indicator_registry()` references are intentional compatibility
+and non-route surfaces:
+
+```text
+web/backend/app/services/indicator_calculator.py:43 self.registry = get_indicator_registry()
+web/backend/app/services/indicator_registry.py:634 def get_indicator_registry() -> IndicatorRegistry:
+web/backend/app/services/indicator_registry.py:644 selected_registry = registry if registry is not None else get_indicator_registry()
+web/backend/app/services/indicators/defaults.py:36 v2_registry = get_indicator_registry()
+web/backend/app/services/indicators/talib_adapter.py:39 registry = get_indicator_registry()
+unit tests for the package registry singleton behavior
+```
+
+The package registry and startup/jobs surface remain out of scope for this
+route-provider batch.
+
+## Runtime And Contract Evidence
+
+Configured app/OpenAPI smoke used non-sensitive placeholder environment
+variables only. It did not run PM2, intentionally connect to production
+resources, or authorize runtime promotion.
+
+```text
+routes_total=548
+openapi_paths_total=500
+duplicate_operation_ids=0
+warnings=0
+selected_indicator_cache_routes=6
+```
+
+Selected route inventory remains unchanged:
+
+```text
+GET  /api/v1/indicators/registry
+GET  /api/v1/indicators/registry/{category}
+POST /api/v1/indicators/calculate
+POST /api/v1/indicators/calculate/batch
+GET  /api/v1/indicators/cache/stats
+POST /api/v1/indicators/cache/clear
+```
+
+Focused checks:
+
+```text
+pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --tb=short --no-cov
+2 passed in 1.68s
+
+pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_v1_indicator_endpoints_have_examples_parameter_docs_and_descriptions -q --tb=short --no-cov
+1 passed in 11.87s
+```
+
+## Provider Inventory Refresh
+
+Static provider scan at current HEAD:
+
+```text
+service provider/state-key records=29
+```
+
+This count includes state keys, install functions, and dependency functions
+across existing service lifecycle DI surfaces. The new flat API indicator
+registry provider contributes:
+
+```text
+INDICATOR_REGISTRY_STATE_KEY
+install_indicator_registry
+get_indicator_registry_dependency
+```
+
+## GitNexus Note
+
+GitNexus context still resolved `get_indicator_registry()` to stale pre-merge
+route callers and did not yet resolve the new `get_indicator_registry_dependency`
+or `install_indicator_registry` symbols after PR `#195`.
+
+For this closeout packet, current-head static code evidence and runtime/OpenAPI
+smoke are treated as authoritative. Refresh the GitNexus index before using
+graph impact results to select the next implementation lane.
+
+## Residual Debt
+
+Known residual test debt from G2.54 remains:
+
+```text
+web/backend/tests/test_indicators.py
+legacy /api/indicators/* path assertions receive 404 while active routes are /api/v1/indicators/*
+```
+
+This closeout does not reopen that test debt or broaden the route-provider
+implementation scope.
+
+## Decision
+
+G2.54 is closed as implemented and merged.
+
+The flat API `IndicatorRegistry` route-provider migration is complete for the
+two selected route consumers:
+
+- `get_indicator_registry_endpoint`
+- `get_indicators_by_category`
+
+No additional `IndicatorRegistry` route-provider source work is authorized by
+this closeout.
+
+## Next Gate
+
+Before selecting another service lifecycle DI implementation lane:
+
+1. Refresh or explicitly discount stale GitNexus graph output.
+2. Run a current-head candidate refresh that excludes already-closed provider
+   surfaces.
+3. Keep `IndicatorCalculator`, package registry startup/jobs, and legacy
+   `/api/indicators/*` test path debt as separate decision lanes unless a future
+   approved packet explicitly scopes them.

--- a/governance/mainline/task-cards/pr-196.yaml
+++ b/governance/mainline/task-cards/pr-196.yaml
@@ -1,0 +1,115 @@
+version: "v0.2"
+
+task:
+  id: "pr-196"
+  title: "Close out flat API IndicatorRegistry route provider"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-flat-api-indicator-registry-route-provider-closeout"
+  objective: "record current-head closeout evidence after the flat API IndicatorRegistry route-provider implementation"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-flat-api-indicator-registry-route-provider-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-flat-api-indicator-registry-route-provider-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout packet records current-head evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/flat-api-indicator-registry-route-provider-closeout-2026-05-24.json"
+    - "docs/reports/quality/backend-flat-api-indicator-registry-route-provider-closeout-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-196.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, frontend source, tests, generated clients, docs/API, OpenSpec, PM2, route, OpenAPI, or runtime behavior changes"
+  - "No GitHub issue state, label, or ready-for-agent movement"
+  - "No source implementation in this PR"
+  - "No new service lifecycle DI implementation target authorization"
+  - "No package indicator registry startup/jobs design"
+  - "No IndicatorCalculator migration"
+  - "No legacy /api/indicators/* test path debt fix"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-flat-api-indicator-registry-route-provider-closeout-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/flat-api-indicator-registry-route-provider-closeout-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-196.yaml').read_text())\""
+      required: true
+    - id: "focused-route-provider-test"
+      command: "pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --tb=short --no-cov"
+      required: true
+    - id: "v1-indicator-openapi-doc-test"
+      command: "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_v1_indicator_endpoints_have_examples_parameter_docs_and_descriptions -q --tb=short --no-cov"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-196.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "python -c \"print('staged-gitnexus-scope: docs-only closeout packet; no source symbols changed')\""
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the closeout-only boundary"
+    - "If this closeout selects a new implementation lane, it bypasses the required separate candidate refresh"
+    - "If stale GitNexus output is treated as current code truth, the next lane may be selected from invalid graph evidence"
+  rollback_plan: "revert this governance-only closeout PR; PR #195 remains the source implementation record unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record closeout evidence after flat API IndicatorRegistry route-provider merge"
+    modified_scope: "closeout report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only closeout PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T17:34:02+08:00"
+    approval_note: "human maintainer approved continuing after PR #195 merge; this packet records G2.55 closeout/current-head refresh only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Add G2.55 current-head closeout for the flat API IndicatorRegistry route-provider implementation.
- Record PR #195 as merged at 5b12a3c08cac3558c56af615ff14c05913d96f72.
- Confirm provider surface is present and route direct get_indicator_registry() calls under web/backend/app/api are now 0.
- Confirm selected registry route dependency sites=2 and selected indicator cache routes=6.
- Record app/OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0.
- Record GitNexus graph output as stale for the new provider symbols until index refresh.

## Verification
- markdown governance gate: passed
- JSON parse: passed
- YAML parse: passed
- route provider focused test: 2 passed
- v1 indicator OpenAPI doc test: 1 passed
- mainline scope gate: pass=true
- git diff checks: passed
- GitNexus staged detect_changes: LOW, changed_files=4, changed_count=0, affected_count=0
