### PR TITLE
docs(governance): refresh service lifecycle candidates after indicator registry

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -479,7 +479,7 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.json`,
 │   │   `backend-market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.md`,
 │   │   `.planning/codebase/generated/market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.json`
-│   ├── State: market-data-service-v2-consumer-matrix-prepared-for-review
+│   ├── State: service-lifecycle-candidate-refresh-after-indicator-registry-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -846,10 +846,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 records closeout evidence: route direct getter refs=`0`,
 │   │                 provider dependency route sites=`2`, focused tests=`2+1`
 │   │                 passed, OpenAPI paths=`500`, duplicate operation IDs=`0`,
-│   │                 GitNexus index stale for new provider symbols
-│   └── Next gate: Human review of the G2.55 closeout PR; if accepted, refresh
-│                  GitNexus or explicitly discount stale graph output before
-│                  selecting another service lifecycle DI lane
+│   │                 GitNexus index stale for new provider symbols; PR `#196`
+│   │                 merged at
+│   │                 `1fc4a4c7a86cf464dedb742612c052b911d4ef5f`; G2.56 now
+│   │                 records current-head candidate refresh after the
+│   │                 `IndicatorRegistry` provider: service files scanned=`152`,
+│   │                 API files scanned=`219`, provider state keys=`10`,
+│   │                 provider functions=`20`, provider dependency sites=`81`,
+│   │                 route getter dependency sites=`272`, route direct
+│   │                 `get_indicator_registry()` refs=`0`, provider dependency
+│   │                 route sites=`2`, OpenAPI paths=`500`, duplicate operation
+│   │                 IDs=`0`, and no source implementation target is authorized;
+│   │                 GitNexus refresh failed in the linked worktree with
+│   │                 `ENOTDIR .git/info`, so static current-head scans and
+│   │                 runtime/OpenAPI smoke are authoritative for this packet
+│   └── Next gate: Human review of the G2.56 candidate-refresh PR; if accepted,
+│                  refresh GitNexus from a non-linked checkout or explicitly
+│                  record a stale-graph waiver before creating a separate
+│                  authorization packet for any next service lifecycle DI lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -944,6 +958,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-flat-api-indicator-registry-consumer-matrix-2026-05-24.md` | G | G2.53 consumer matrix prepared at current HEAD `ec3dc2920886eb24e963a33488bd2e945e98e6c9`: records PR `#193` as `MERGED`, confirms the flat API registry singleton at `web/backend/app/services/indicator_registry.py`, identifies exactly two direct registry route consumers in `indicator_cache.py`, excludes `IndicatorCalculator.__init__` from the route-provider batch, keeps the package registry startup/jobs surface separate, records configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, selected indicator cache routes=`6`, and collect-only checks=`16+112+29` | Human review / PR merge decision; if accepted, create G2.54 flat API registry route-provider implementation branch before source edits |
 | `backend-flat-api-indicator-registry-route-provider-implementation-2026-05-24.md` | G | G2.54 implementation prepared at current HEAD `71510bb02a845ec529c8c04f3a7288ca86b87b9c`: records PR `#194` as `MERGED`, adds `INDICATOR_REGISTRY_STATE_KEY`, `install_indicator_registry`, and `get_indicator_registry_dependency`, preserves `get_indicator_registry()`, converts exactly two registry read handlers in `indicator_cache.py`, keeps `IndicatorCalculator.__init__` and package registry startup/jobs surfaces unchanged, verifies TDD red=`2 failed`, green=`2 passed`, touched ruff/black passed, v1 indicator OpenAPI doc test=`1 passed`, configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and records legacy `/api/indicators/*` path assertions in `test_indicators.py` as residual test debt | Human review / PR merge decision; if accepted, run G2.55 closeout/current-head refresh before selecting another service lifecycle DI lane |
 | `backend-flat-api-indicator-registry-route-provider-closeout-2026-05-24.md` | G | G2.55 closeout prepared at current HEAD `5b12a3c08cac3558c56af615ff14c05913d96f72`: records PR `#195` as `MERGED`, confirms flat API registry provider surface remains present, route direct `get_indicator_registry()` references under `web/backend/app/api`=`0`, provider dependency route sites=`2`, selected indicator cache routes=`6`, configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, focused tests=`2+1 passed`, and GitNexus graph output is stale for the new provider symbols until index refresh | Human review / PR merge decision; if accepted, refresh GitNexus or explicitly discount stale graph output before selecting another service lifecycle DI lane |
+| `backend-service-lifecycle-di-candidate-refresh-after-indicator-registry-provider-2026-05-24.md` | G | G2.56 candidate refresh prepared at current HEAD `1fc4a4c7a86cf464dedb742612c052b911d4ef5f`: records PR `#196` as `MERGED`, scans API files=`219`, service files=`152`, backend tests=`195`, provider state keys=`10`, provider functions=`20`, provider records=`30`, route dependency sites=`353`, provider-style route dependency sites=`81`, getter-style route dependency sites=`272`, confirms route direct `get_indicator_registry()` refs=`0`, provider dependency route sites=`2`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and records GitNexus refresh blocked in the linked worktree by `ENOTDIR .git/info`; no source implementation target is authorized | Human review / PR merge decision; if accepted, refresh GitNexus from a non-linked checkout or explicitly record a stale-graph waiver before creating any next service lifecycle DI authorization packet |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-indicator-registry-provider-2026-05-24.json
+++ b/.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-indicator-registry-provider-2026-05-24.json
@@ -1,0 +1,208 @@
+{
+  "artifact": "service-lifecycle-di-candidate-refresh-after-indicator-registry-provider",
+  "workline": "G2.56",
+  "generated_at": "2026-05-24T18:10:53+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_branch": "g2-56-service-lifecycle-candidate-refresh-after-indicator-registry",
+  "current_head": "1fc4a4c7a86c",
+  "status": "ready_for_review",
+  "scope": {
+    "kind": "governance_only_candidate_refresh",
+    "source_edits_authorized": false,
+    "route_or_openapi_edits_authorized": false,
+    "compatibility_getter_cleanup_authorized": false
+  },
+  "upstream_merge_evidence": [
+    {
+      "workline": "G2.54",
+      "pr": 195,
+      "state": "MERGED",
+      "merge_commit": "5b12a3c08cac3558c56af615ff14c05913d96f72",
+      "notes": "flat API IndicatorRegistry route-provider implementation"
+    },
+    {
+      "workline": "G2.55",
+      "pr": 196,
+      "state": "MERGED",
+      "merge_commit": "1fc4a4c7a86cf464dedb742612c052b911d4ef5f",
+      "notes": "closeout and current-head refresh for the IndicatorRegistry route provider"
+    }
+  ],
+  "scan_summary": {
+    "api_files_scanned": 219,
+    "service_files_scanned": 152,
+    "backend_test_files_scanned": 195,
+    "service_provider_state_keys": 10,
+    "service_provider_functions": 20,
+    "service_provider_records": 30,
+    "route_depends_sites": 353,
+    "provider_style_route_dependency_sites": 81,
+    "getter_style_route_dependency_sites": 272
+  },
+  "indicator_registry_closeout": {
+    "api_direct_get_indicator_registry_route_calls": 0,
+    "provider_dependency_route_sites": 2,
+    "converted_route_file": "web/backend/app/api/indicators/indicator_cache.py",
+    "provider_surface": [
+      "INDICATOR_REGISTRY_STATE_KEY",
+      "install_indicator_registry",
+      "get_indicator_registry_dependency"
+    ],
+    "compatibility_getter_preserved": true,
+    "package_registry_and_indicator_calculator_excluded": true
+  },
+  "provider_dependency_groups": [
+    {
+      "name": "get_advanced_analysis_service_dependency",
+      "sites": 14,
+      "files": 1,
+      "route_files": [
+        "web/backend/app/api/advanced_analysis_api.py"
+      ]
+    },
+    {
+      "name": "get_market_data_service_v2_dependency",
+      "sites": 14,
+      "files": 2,
+      "route_files": [
+        "web/backend/app/api/dashboard_data_source.py",
+        "web/backend/app/api/market_v2.py"
+      ]
+    },
+    {
+      "name": "get_announcement_service_dependency",
+      "sites": 11,
+      "files": 1,
+      "route_files": [
+        "web/backend/app/api/announcement/routes.py"
+      ]
+    },
+    {
+      "name": "get_market_data_service_dependency",
+      "sites": 7,
+      "files": 1,
+      "route_files": [
+        "web/backend/app/api/market/market_data_request.py"
+      ]
+    },
+    {
+      "name": "get_watchlist_service_dependency",
+      "sites": 7,
+      "files": 1,
+      "route_files": [
+        "web/backend/app/api/watchlist.py"
+      ]
+    },
+    {
+      "name": "get_email_service_dependency",
+      "sites": 6,
+      "files": 1,
+      "route_files": [
+        "web/backend/app/api/notification.py"
+      ]
+    },
+    {
+      "name": "get_stock_search_service_dependency",
+      "sites": 6,
+      "files": 2,
+      "route_files": [
+        "web/backend/app/api/market/market_data_request.py",
+        "web/backend/app/api/stock_search/stock_search_result.py"
+      ]
+    },
+    {
+      "name": "get_tradingview_service_dependency",
+      "sites": 6,
+      "files": 1,
+      "route_files": [
+        "web/backend/app/api/tradingview.py"
+      ]
+    },
+    {
+      "name": "get_tdx_service_dependency",
+      "sites": 5,
+      "files": 1,
+      "route_files": [
+        "web/backend/app/api/tdx.py"
+      ]
+    },
+    {
+      "name": "get_data_source_dependency",
+      "sites": 3,
+      "files": 1,
+      "route_files": [
+        "web/backend/app/api/dashboard.py"
+      ]
+    },
+    {
+      "name": "get_indicator_registry_dependency",
+      "sites": 2,
+      "files": 1,
+      "route_files": [
+        "web/backend/app/api/indicators/indicator_cache.py"
+      ]
+    }
+  ],
+  "remaining_surfaces": [
+    {
+      "surface": "authentication dependencies",
+      "evidence": "get_current_user appears in 215 route dependency sites",
+      "disposition": "out_of_scope_for_service_lifecycle_candidate_selection"
+    },
+    {
+      "surface": "database/session dependencies",
+      "evidence": "get_db and repository getters remain route/persistence boundaries",
+      "disposition": "requires_separate_route_or_repository_governance"
+    },
+    {
+      "surface": "get_postgres_async",
+      "evidence": "22 direct-call sites across 8 API files",
+      "disposition": "infrastructure_data_access_seam_not_selected"
+    },
+    {
+      "surface": "get_config_manager",
+      "evidence": "17 direct-call sites across 2 active API files plus historical evidence",
+      "disposition": "requires_separate_config_ownership_decision"
+    },
+    {
+      "surface": "get_data_source_factory",
+      "evidence": "17 direct-call sites across 9 API files",
+      "disposition": "broad_factory_seam_not_selected_without_design_packet"
+    }
+  ],
+  "runtime_contract_evidence": {
+    "routes_total": 548,
+    "openapi_paths_total": 500,
+    "duplicate_operation_ids": 0,
+    "warnings": 0
+  },
+  "focused_checks": [
+    {
+      "command": "pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --tb=short --no-cov",
+      "status": "passed",
+      "summary": "2 passed in 1.62s"
+    },
+    {
+      "command": "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_v1_indicator_endpoints_have_examples_parameter_docs_and_descriptions -q --tb=short --no-cov",
+      "status": "passed",
+      "summary": "1 passed"
+    },
+    {
+      "command": "configured app/OpenAPI smoke",
+      "status": "passed",
+      "summary": "routes=548, paths=500, duplicate_operation_ids=0, warnings=0"
+    }
+  ],
+  "gitnexus_refresh": {
+    "attempted": true,
+    "result": "failed_in_linked_worktree",
+    "error": "ENOTDIR .git/info when running gitnexus analyze in linked worktree",
+    "root_checkout_state": "dirty_or_stale_relative_to_remote_and_not_rebased_for_indexing",
+    "disposition": "current_head_static_scans_and_runtime_smoke_are_authoritative_for_this_packet"
+  },
+  "decision": {
+    "candidate_refresh_complete": true,
+    "new_source_implementation_target_selected": false,
+    "next_gate": "human review, then separate authorization packet before any next lifecycle implementation"
+  }
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-indicator-registry-provider-2026-05-24.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-indicator-registry-provider-2026-05-24.md
@@ -1,0 +1,148 @@
+# Backend Service Lifecycle DI Candidate Refresh After IndicatorRegistry Provider - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Generated at: `2026-05-24T18:10:53+08:00`
+
+Base branch: `wip/root-dirty-20260403`
+
+Current branch: `g2-56-service-lifecycle-candidate-refresh-after-indicator-registry`
+
+Current HEAD: `1fc4a4c7a86c`
+
+## Status
+
+G2.56 is a governance-only candidate refresh after the flat API
+`IndicatorRegistry` route-provider implementation and closeout were merged.
+
+This packet records current-head evidence and next-gate constraints. It does
+not authorize source edits, route changes, OpenAPI changes, compatibility getter
+cleanup, issue label changes, or OpenSpec implementation work.
+
+## Upstream Merge Evidence
+
+| Workline | PR | State | Merge commit | Notes |
+| --- | --- | --- | --- | --- |
+| G2.54 | `#195` | `MERGED` | `5b12a3c08cac3558c56af615ff14c05913d96f72` | Implemented the flat API `IndicatorRegistry` route provider |
+| G2.55 | `#196` | `MERGED` | `1fc4a4c7a86cf464dedb742612c052b911d4ef5f` | Closed out and refreshed current-head evidence for PR `#195` |
+
+## Current-Head Scan Summary
+
+| Metric | Value |
+| --- | ---: |
+| API files scanned | `219` |
+| Service files scanned | `152` |
+| Backend test files scanned | `195` |
+| Service provider state keys | `10` |
+| Service provider functions | `20` |
+| Service provider records | `30` |
+| Route `Depends(...)` sites | `353` |
+| Provider-style route dependency sites | `81` |
+| Getter-style route dependency sites | `272` |
+
+The provider-style count increased by `2` after the `IndicatorRegistry` route
+provider landed. This matches the two converted `indicator_cache.py` read
+handlers and does not indicate a new implementation backlog.
+
+## IndicatorRegistry Closeout Check
+
+| Check | Result |
+| --- | --- |
+| Direct `get_indicator_registry()` route calls under `web/backend/app/api` | `0` |
+| `get_indicator_registry_dependency` route sites | `2` |
+| Converted route file | `web/backend/app/api/indicators/indicator_cache.py` |
+| Provider surface | `INDICATOR_REGISTRY_STATE_KEY`, `install_indicator_registry`, `get_indicator_registry_dependency` |
+| Compatibility getter | Preserved |
+| Package registry / `IndicatorCalculator` surfaces | Excluded from the route-provider batch |
+
+The remaining `get_indicator_registry()` references are service/test or
+compatibility-surface references. They are not route direct-getter regressions.
+
+## Provider Dependency Groups
+
+| Dependency | Sites | Files | Route files |
+| --- | ---: | ---: | --- |
+| `get_advanced_analysis_service_dependency` | `14` | `1` | `advanced_analysis_api.py` |
+| `get_market_data_service_v2_dependency` | `14` | `2` | `dashboard_data_source.py`, `market_v2.py` |
+| `get_announcement_service_dependency` | `11` | `1` | `announcement/routes.py` |
+| `get_market_data_service_dependency` | `7` | `1` | `market/market_data_request.py` |
+| `get_watchlist_service_dependency` | `7` | `1` | `watchlist.py` |
+| `get_email_service_dependency` | `6` | `1` | `notification.py` |
+| `get_stock_search_service_dependency` | `6` | `2` | `market/market_data_request.py`, `stock_search/stock_search_result.py` |
+| `get_tradingview_service_dependency` | `6` | `1` | `tradingview.py` |
+| `get_tdx_service_dependency` | `5` | `1` | `tdx.py` |
+| `get_data_source_dependency` | `3` | `1` | `dashboard.py` |
+| `get_indicator_registry_dependency` | `2` | `1` | `indicators/indicator_cache.py` |
+
+Several rows are already implemented or inherited as reference evidence. This
+table is a current-head inventory, not a queue of authorized edits.
+
+## Remaining Getter / Direct-Call Surfaces
+
+| Surface | Current evidence | Disposition |
+| --- | --- | --- |
+| Authentication dependencies such as `get_current_user` | Broad route use, `215` sites | Out of scope for service lifecycle DI candidate selection |
+| Database/session dependencies such as `get_db` and repository getters | Route contract / persistence boundary | Requires separate route or repository governance, not ordinary service-provider migration |
+| `get_postgres_async` direct calls | `22` sites across `8` API files | Infrastructure/data-access seam; not selected by this packet |
+| `get_config_manager` direct calls | `17` sites across `2` API files plus historical file evidence | Needs a separate config ownership decision before any provider work |
+| `get_data_source_factory` direct calls | `17` sites across `9` API files | Broad factory seam; not selected without a design/authorization packet |
+| `get_technical_pattern_detection_service` | Existing DI pilot/reference surface | Do not reopen unless current-head evidence contradicts the completed pilot record |
+
+No new low-risk implementation target is selected by G2.56.
+
+## Runtime And Contract Evidence
+
+Configured app/OpenAPI smoke remains stable at current HEAD:
+
+```text
+routes_total=548
+openapi_paths_total=500
+duplicate_operation_ids=0
+warnings=0
+```
+
+Focused regression checks remain green:
+
+```text
+pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --tb=short --no-cov
+2 passed in 1.62s
+
+pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_v1_indicator_endpoints_have_examples_parameter_docs_and_descriptions -q --tb=short --no-cov
+1 passed
+```
+
+## GitNexus Refresh Note
+
+GitNexus index refresh was attempted before this packet.
+
+The root checkout was stale/dirty relative to the remote branch, so it was not
+rebased for indexing. Running `gitnexus analyze` inside this linked worktree
+failed with `ENOTDIR .git/info` because linked worktrees use a `.git` file
+instead of a `.git` directory.
+
+For G2.56, current-head static scans plus runtime/OpenAPI smoke are treated as
+authoritative. Do not use stale GitNexus graph output to choose the next service
+lifecycle DI candidate unless the index is refreshed from a non-linked checkout
+or a later review explicitly waives that limitation.
+
+## Decision
+
+G2.56 keeps the service lifecycle DI lane in `candidate-refresh` state.
+
+The `IndicatorRegistry` route-provider closeout remains accepted at current
+HEAD: route direct getter use is closed, provider dependency sites are present,
+and app/OpenAPI behavior is stable. The wider service lifecycle lane should not
+advance directly into source implementation from this packet.
+
+## Next Gate
+
+1. Human review this G2.56 packet / PR.
+2. Refresh GitNexus from a checkout where `gitnexus analyze` can update the
+   index, or explicitly record a stale-graph waiver.
+3. If a next service lifecycle lane is desired, create a separate authorization
+   packet with exact write scope, pre-edit GitNexus impact, TDD plan, rollback
+   boundary, and focused verification.
+4. Keep source edits locked until that separate authorization packet is
+   approved.

--- a/governance/mainline/task-cards/pr-197.yaml
+++ b/governance/mainline/task-cards/pr-197.yaml
@@ -1,0 +1,100 @@
+version: "v0.2"
+task:
+  id: "pr-197"
+  title: "Refresh service lifecycle DI candidates after IndicatorRegistry provider"
+  owner: "main"
+  created_at: "2026-05-24"
+mainline:
+  id: "L1-service-lifecycle-di-candidate-refresh-after-indicator-registry"
+  objective: "record current-head service lifecycle DI candidate evidence after the IndicatorRegistry route-provider closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-di-candidate-refresh-after-indicator-registry"
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+openspec:
+  change_id: "not-required-service-lifecycle-di-candidate-refresh-after-indicator-registry"
+  approval_status: "not_required"
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate refresh packet records current-head governance evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-indicator-registry-provider-2026-05-24.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-indicator-registry-provider-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-197.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+non_goals:
+  - "Do not modify backend source code."
+  - "Do not modify route paths, response contracts, OpenAPI exposure, or generated clients."
+  - "Do not remove compatibility getters or wrappers."
+  - "Do not select or implement the next service lifecycle DI candidate."
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-indicator-registry-provider-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-indicator-registry-provider-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-197.yaml').read_text())\""
+      required: true
+    - id: "focused-route-provider-test"
+      command: "pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --tb=short --no-cov"
+      required: true
+    - id: "v1-indicator-openapi-doc-test"
+      command: "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_v1_indicator_endpoints_have_examples_parameter_docs_and_descriptions -q --tb=short --no-cov"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-197.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "python -c \"print('staged-gitnexus-scope: docs-only candidate-refresh packet; no source symbols modified')\""
+      required: true
+risk_and_rollback:
+  risks:
+    - "Candidate inventory may be misread as implementation authorization."
+    - "GitNexus index refresh is blocked in the linked worktree and must not be treated as current graph evidence."
+  rollback_plan: "revert this governance-only PR; PR #196 remains the accepted closeout record unless separately reverted"
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record current-head service lifecycle DI candidate refresh after the IndicatorRegistry provider merge"
+    modified_scope: "candidate refresh report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only candidate-refresh PR if governance validation fails"
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T18:10:53+08:00"
+    approval_note: "human maintainer approved continuing after PR #196 merge; this packet records G2.56 candidate refresh only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records G2.56 current-head service lifecycle DI candidate refresh after PR #196 merged
- adds a generated evidence artifact and governance report for the IndicatorRegistry-provider follow-up
- updates the steward tree and adds mainline task card `pr-197.yaml`

## Scope
- docs/governance only
- no backend source edits
- no route/OpenAPI/response contract changes
- no next service lifecycle implementation target authorized

## Verification
- markdown governance gate: 2 checked files, 0 errors
- JSON parse: passed
- YAML parse: passed
- focused route-provider test: 2 passed
- v1 indicator OpenAPI docs test: 1 passed
- git diff --check: passed
- GitNexus staged scope before commit: LOW, 0 changed symbols, 0 affected processes
- post-commit mainline scope gate: pass=True

## Notes
GitNexus refresh remains explicitly stale-aware: `gitnexus analyze` failed in the linked worktree with `ENOTDIR .git/info`. This PR treats current-head static scans and runtime/OpenAPI smoke as authoritative and requires a non-linked refresh or explicit stale-graph waiver before any next service lifecycle implementation authorization.
