### PR TITLE
docs(governance): record gitnexus refresh after indicator registry

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -479,7 +479,7 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.json`,
 │   │   `backend-market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.md`,
 │   │   `.planning/codebase/generated/market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.json`
-│   ├── State: service-lifecycle-candidate-refresh-after-indicator-registry-prepared-for-review
+│   ├── State: gitnexus-refresh-after-indicator-registry-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -859,11 +859,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 IDs=`0`, and no source implementation target is authorized;
 │   │                 GitNexus refresh failed in the linked worktree with
 │   │                 `ENOTDIR .git/info`, so static current-head scans and
-│   │                 runtime/OpenAPI smoke are authoritative for this packet
-│   └── Next gate: Human review of the G2.56 candidate-refresh PR; if accepted,
-│                  refresh GitNexus from a non-linked checkout or explicitly
-│                  record a stale-graph waiver before creating a separate
-│                  authorization packet for any next service lifecycle DI lane
+│   │                 runtime/OpenAPI smoke are authoritative for this packet;
+│   │                 PR `#197` merged at
+│   │                 `3469a43855ef81d238e1a92745126fcb321b1af7`; G2.57 now
+│   │                 records non-linked GitNexus refresh success at the same
+│   │                 HEAD: `.git` kind=`directory`, analyze exit=`0`,
+│   │                 nodes=`62623`, edges=`145799`, flows=`300`, repo
+│   │                 `g2-57-gitnexus-index-checkout` state=`ready`, and
+│   │                 `get_indicator_registry_dependency` plus
+│   │                 `install_indicator_registry` resolve in the refreshed graph;
+│   │                 upstream impact for `get_indicator_registry_dependency`
+│   │                 is `LOW` with impacted count=`0`; route dependency counts
+│   │                 still require static FastAPI `Depends(...)` scans because
+│   │                 the refreshed graph does not model those route sites as
+│   │                 incoming call edges
+│   └── Next gate: Human review of the G2.57 GitNexus refresh PR; if accepted,
+│                  create a separate G2.58 candidate-selection or
+│                  implementation-authorization packet before any next service
+│                  lifecycle DI source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -959,6 +972,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-flat-api-indicator-registry-route-provider-implementation-2026-05-24.md` | G | G2.54 implementation prepared at current HEAD `71510bb02a845ec529c8c04f3a7288ca86b87b9c`: records PR `#194` as `MERGED`, adds `INDICATOR_REGISTRY_STATE_KEY`, `install_indicator_registry`, and `get_indicator_registry_dependency`, preserves `get_indicator_registry()`, converts exactly two registry read handlers in `indicator_cache.py`, keeps `IndicatorCalculator.__init__` and package registry startup/jobs surfaces unchanged, verifies TDD red=`2 failed`, green=`2 passed`, touched ruff/black passed, v1 indicator OpenAPI doc test=`1 passed`, configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and records legacy `/api/indicators/*` path assertions in `test_indicators.py` as residual test debt | Human review / PR merge decision; if accepted, run G2.55 closeout/current-head refresh before selecting another service lifecycle DI lane |
 | `backend-flat-api-indicator-registry-route-provider-closeout-2026-05-24.md` | G | G2.55 closeout prepared at current HEAD `5b12a3c08cac3558c56af615ff14c05913d96f72`: records PR `#195` as `MERGED`, confirms flat API registry provider surface remains present, route direct `get_indicator_registry()` references under `web/backend/app/api`=`0`, provider dependency route sites=`2`, selected indicator cache routes=`6`, configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, focused tests=`2+1 passed`, and GitNexus graph output is stale for the new provider symbols until index refresh | Human review / PR merge decision; if accepted, refresh GitNexus or explicitly discount stale graph output before selecting another service lifecycle DI lane |
 | `backend-service-lifecycle-di-candidate-refresh-after-indicator-registry-provider-2026-05-24.md` | G | G2.56 candidate refresh prepared at current HEAD `1fc4a4c7a86cf464dedb742612c052b911d4ef5f`: records PR `#196` as `MERGED`, scans API files=`219`, service files=`152`, backend tests=`195`, provider state keys=`10`, provider functions=`20`, provider records=`30`, route dependency sites=`353`, provider-style route dependency sites=`81`, getter-style route dependency sites=`272`, confirms route direct `get_indicator_registry()` refs=`0`, provider dependency route sites=`2`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and records GitNexus refresh blocked in the linked worktree by `ENOTDIR .git/info`; no source implementation target is authorized | Human review / PR merge decision; if accepted, refresh GitNexus from a non-linked checkout or explicitly record a stale-graph waiver before creating any next service lifecycle DI authorization packet |
+| `backend-gitnexus-refresh-after-indicator-registry-provider-2026-05-24.md` | G | G2.57 GitNexus refresh evidence prepared at current HEAD `3469a43855ef81d238e1a92745126fcb321b1af7`: records PR `#197` as `MERGED`, confirms a temporary non-linked clone with `.git` kind=`directory`, `gitnexus analyze` exit=`0`, nodes=`62623`, edges=`145799`, clusters=`3291`, flows=`300`, GitNexus repo `g2-57-gitnexus-index-checkout` state=`ready`, `get_indicator_registry_dependency` and `install_indicator_registry` resolve in the refreshed graph, upstream impact for `get_indicator_registry_dependency` is `LOW` with impacted count=`0`, and static route scan still reports route direct `get_indicator_registry()` refs=`0` plus provider route sites=`2`; no source implementation target is authorized | Human review / PR merge decision; if accepted, create a separate G2.58 candidate-selection or implementation-authorization packet before any next service lifecycle DI source edit |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/gitnexus-refresh-after-indicator-registry-provider-2026-05-24.json
+++ b/.planning/codebase/generated/gitnexus-refresh-after-indicator-registry-provider-2026-05-24.json
@@ -1,0 +1,97 @@
+{
+  "artifact": "gitnexus-refresh-after-indicator-registry-provider",
+  "workline": "G2.57",
+  "generated_at": "2026-05-24T19:11:51+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_branch": "g2-57-gitnexus-refresh-waiver",
+  "current_head": "3469a43855ef",
+  "status": "ready_for_review",
+  "scope": {
+    "kind": "governance_only_gitnexus_refresh_evidence",
+    "source_edits_authorized": false,
+    "route_or_openapi_edits_authorized": false,
+    "compatibility_getter_cleanup_authorized": false,
+    "next_lifecycle_implementation_authorized": false
+  },
+  "upstream_merge_evidence": {
+    "workline": "G2.56",
+    "pr": 197,
+    "state": "MERGED",
+    "merge_commit": "3469a43855ef81d238e1a92745126fcb321b1af7",
+    "notes": "service lifecycle DI candidate refresh after IndicatorRegistry provider closeout"
+  },
+  "refresh_method": {
+    "root_checkout_rebased": false,
+    "linked_worktree_problem": "gitnexus analyze fails in linked worktree with ENOTDIR .git/info because linked worktrees use a .git file",
+    "non_linked_checkout_kind": "temporary ignored local clone",
+    "checkout_head": "3469a43855ef",
+    "git_dot_kind": "directory",
+    "gitnexus_analyze_exit": 0
+  },
+  "gitnexus_analyze_result": {
+    "status": "success",
+    "duration_seconds": 69.7,
+    "nodes": 62623,
+    "edges": 145799,
+    "clusters": 3291,
+    "flows": 300,
+    "kuzu_seconds": 18.8,
+    "fts_seconds": 24.8,
+    "embeddings": 0
+  },
+  "gitnexus_repo_record": {
+    "repo": "g2-57-gitnexus-index-checkout",
+    "indexState": "ready",
+    "lastCommit": "3469a43855ef81d238e1a92745126fcb321b1af7",
+    "files": 9129,
+    "nodes": 62623,
+    "edges": 145799,
+    "processes": 300,
+    "embeddings": 0
+  },
+  "symbol_resolution": [
+    {
+      "symbol": "get_indicator_registry_dependency",
+      "status": "found",
+      "file": "web/backend/app/services/indicator_registry.py",
+      "startLine": 648,
+      "endLine": 653
+    },
+    {
+      "symbol": "install_indicator_registry",
+      "status": "found",
+      "file": "web/backend/app/services/indicator_registry.py",
+      "startLine": 641,
+      "endLine": 645
+    }
+  ],
+  "gitnexus_impact": {
+    "target": "get_indicator_registry_dependency",
+    "repo": "g2-57-gitnexus-index-checkout",
+    "direction": "upstream",
+    "risk": "LOW",
+    "impactedCount": 0,
+    "direct": 0,
+    "processes_affected": 0,
+    "modules_affected": 0
+  },
+  "static_route_scan": {
+    "api_files_scanned": 219,
+    "service_files_scanned": 152,
+    "backend_test_files_scanned": 195,
+    "service_provider_state_keys": 10,
+    "service_provider_functions": 20,
+    "service_provider_records": 30,
+    "route_depends_sites": 353,
+    "provider_style_route_dependency_sites": 81,
+    "getter_style_route_dependency_sites": 272,
+    "direct_route_get_indicator_registry_refs": 0,
+    "get_indicator_registry_dependency_route_sites": 2
+  },
+  "decision": {
+    "stale_graph_waiver_required": false,
+    "stale_graph_blocker_closed_for_indicator_registry_provider_symbols": true,
+    "static_fastapi_depends_scan_still_required": true,
+    "next_gate": "human review, then separate G2.58 candidate-selection or implementation-authorization packet before any source edit"
+  }
+}

--- a/docs/reports/quality/backend-gitnexus-refresh-after-indicator-registry-provider-2026-05-24.md
+++ b/docs/reports/quality/backend-gitnexus-refresh-after-indicator-registry-provider-2026-05-24.md
@@ -1,0 +1,137 @@
+# Backend GitNexus Refresh After IndicatorRegistry Provider - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Generated at: `2026-05-24T19:11:51+08:00`
+
+Workline: G2.57 GitNexus refresh gate after G2.56 service lifecycle DI
+candidate refresh.
+
+Base branch: `wip/root-dirty-20260403`
+
+Current HEAD: `3469a43855ef`
+
+## Status
+
+G2.57 closes the stale-graph blocker recorded by G2.55 and G2.56 for the
+`IndicatorRegistry` provider symbols.
+
+This packet is evidence-only. It does not authorize backend source edits, route
+changes, OpenAPI changes, compatibility getter cleanup, issue label changes, or
+the next service lifecycle DI implementation lane.
+
+## Upstream Evidence
+
+| Workline | PR | State | Commit | Notes |
+| --- | --- | --- | --- | --- |
+| G2.56 | `#197` | `MERGED` | `3469a43855ef81d238e1a92745126fcb321b1af7` | Service lifecycle DI candidate refresh after `IndicatorRegistry` provider closeout |
+
+G2.56 required either a non-linked GitNexus refresh or an explicit stale-graph
+waiver before selecting any next service lifecycle DI lane. G2.57 performed the
+non-linked refresh path.
+
+## Refresh Method
+
+The root checkout remains dirty and was not rebased. The linked worktree mode
+was already known to fail `gitnexus analyze` with `ENOTDIR .git/info`, because
+linked worktrees use a `.git` file instead of a `.git` directory.
+
+For G2.57, a temporary non-linked clone was created under the ignored local
+`.worktrees/` area:
+
+```text
+checkout_head=3469a43855ef
+git_dot_kind=directory
+gitnexus_analyze_exit=0
+```
+
+GitNexus analyze completed successfully:
+
+```text
+Repository indexed successfully (69.7s)
+62,623 nodes | 145,799 edges | 3291 clusters | 300 flows
+KuzuDB 18.8s | FTS 24.8s | Embeddings off
+```
+
+GitNexus MCP then reported the refreshed non-linked repo as:
+
+```text
+repo=g2-57-gitnexus-index-checkout
+lastCommit=3469a43855ef81d238e1a92745126fcb321b1af7
+indexState=ready
+files=9129
+nodes=62623
+edges=145799
+processes=300
+embeddings=0
+```
+
+## Symbol Resolution Evidence
+
+| Symbol | Result | File | Lines | Notes |
+| --- | --- | --- | --- | --- |
+| `get_indicator_registry_dependency` | `found` | `web/backend/app/services/indicator_registry.py` | `648-653` | New provider dependency symbol resolves in refreshed GitNexus index |
+| `install_indicator_registry` | `found` | `web/backend/app/services/indicator_registry.py` | `641-645` | New install symbol resolves in refreshed GitNexus index |
+
+GitNexus upstream impact for `get_indicator_registry_dependency` in the
+refreshed non-linked repo:
+
+```text
+risk=LOW
+impactedCount=0
+direct=0
+processes_affected=0
+modules_affected=0
+```
+
+This proves the previous stale-symbol condition is closed for symbol lookup and
+pre-edit impact usage.
+
+## Static Route Evidence Still Required
+
+The refreshed graph resolves the provider symbols, but it does not model the
+FastAPI `Depends(get_indicator_registry_dependency)` route sites as incoming
+call edges for this symbol. Therefore route dependency counts must continue to
+come from static FastAPI route scans.
+
+Current-head static scan in the G2.57 governance worktree reports:
+
+| Metric | Value |
+| --- | ---: |
+| API files scanned | `219` |
+| Service files scanned | `152` |
+| Backend test files scanned | `195` |
+| Service provider state keys | `10` |
+| Service provider functions | `20` |
+| Service provider records | `30` |
+| Route `Depends(...)` sites | `353` |
+| Provider-style route dependency sites | `81` |
+| Getter-style route dependency sites | `272` |
+| Direct route `get_indicator_registry()` refs | `0` |
+| `get_indicator_registry_dependency` route sites | `2` |
+
+## Decision
+
+No stale-graph waiver is required for the `IndicatorRegistry` provider symbols:
+the non-linked GitNexus refresh succeeded and the target provider symbols are
+resolvable.
+
+However, the refreshed graph does not replace static FastAPI dependency scans
+for route-provider site counts. Any future service lifecycle DI authorization
+packet must use both:
+
+- GitNexus context / impact for symbol-level blast radius.
+- Static route scans for `Depends(...)` route dependency sites.
+
+## Next Gate
+
+1. Human review this G2.57 packet / PR.
+2. If accepted, treat the stale-graph blocker as closed for the
+   `IndicatorRegistry` provider follow-up.
+3. Create a separate G2.58 candidate-selection or implementation-authorization
+   packet before any next service lifecycle DI source edit.
+4. Keep source edits locked until that separate packet defines exact write
+   scope, pre-edit GitNexus impact checks, TDD plan, rollback boundary, and
+   focused verification.

--- a/governance/mainline/task-cards/pr-198.yaml
+++ b/governance/mainline/task-cards/pr-198.yaml
@@ -1,0 +1,94 @@
+version: "v0.2"
+task:
+  id: "pr-198"
+  title: "Record GitNexus refresh after IndicatorRegistry provider"
+  owner: "main"
+  created_at: "2026-05-24"
+mainline:
+  id: "L1-gitnexus-refresh-after-indicator-registry-provider"
+  objective: "record non-linked GitNexus refresh evidence after the IndicatorRegistry provider candidate refresh"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-gitnexus-refresh-after-indicator-registry-provider"
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+openspec:
+  change_id: "not-required-gitnexus-refresh-after-indicator-registry-provider"
+  approval_status: "not_required"
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "GitNexus refresh packet records current-head governance evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/gitnexus-refresh-after-indicator-registry-provider-2026-05-24.json"
+    - "docs/reports/quality/backend-gitnexus-refresh-after-indicator-registry-provider-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-198.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+non_goals:
+  - "Do not modify backend source code."
+  - "Do not modify route paths, response contracts, OpenAPI exposure, or generated clients."
+  - "Do not remove compatibility getters or wrappers."
+  - "Do not select or implement the next service lifecycle DI candidate."
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-gitnexus-refresh-after-indicator-registry-provider-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/gitnexus-refresh-after-indicator-registry-provider-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-198.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-198.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "python -c \"print('staged-gitnexus-scope: docs-only GitNexus refresh evidence packet; no source symbols modified')\""
+      required: true
+risk_and_rollback:
+  risks:
+    - "GitNexus symbol resolution may be misread as a route dependency count source."
+    - "The packet may be misread as implementation authorization instead of a refresh gate record."
+  rollback_plan: "revert this governance-only PR; PR #197 remains the accepted candidate-refresh record unless separately reverted"
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record non-linked GitNexus refresh evidence after the IndicatorRegistry provider closeout"
+    modified_scope: "GitNexus refresh report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only refresh PR if governance validation fails"
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T19:11:51+08:00"
+    approval_note: "human maintainer approved continuing after PR #197 merge; this packet records G2.57 GitNexus refresh evidence only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records G2.57 non-linked GitNexus refresh evidence after PR #197 merged
- confirms `gitnexus analyze` succeeds from a non-linked checkout at `3469a43855ef`
- confirms `get_indicator_registry_dependency` and `install_indicator_registry` resolve in the refreshed graph
- updates the steward tree and adds mainline task card `pr-198.yaml`

## Scope
- docs/governance only
- no backend source edits
- no route/OpenAPI/response contract changes
- no next service lifecycle implementation target authorized

## Verification
- non-linked `gitnexus analyze`: exit 0, 62,623 nodes, 145,799 edges, 300 flows
- GitNexus context: `get_indicator_registry_dependency` found
- GitNexus context: `install_indicator_registry` found
- GitNexus impact: `get_indicator_registry_dependency` LOW, impactedCount=0
- markdown governance gate: 2 checked files, 0 errors
- JSON parse: passed
- YAML parse: passed
- git diff --check: passed
- GitNexus staged scope: LOW, 0 changed symbols, 0 affected processes
- post-commit mainline scope gate: pass=True

## Notes
No stale-graph waiver is required for the IndicatorRegistry provider symbols after this refresh. Static FastAPI route scans remain required for `Depends(...)` route dependency counts because the refreshed graph does not model those route dependency sites as incoming call edges.
