### PR TITLE
docs(governance): select next service lifecycle lane

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -479,7 +479,7 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-market-data-v2-2026-05-23.json`,
 │   │   `backend-market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.md`,
 │   │   `.planning/codebase/generated/market-data-service-v2-compatibility-getter-consumer-matrix-2026-05-23.json`
-│   ├── State: gitnexus-refresh-after-indicator-registry-prepared-for-review
+│   ├── State: service-lifecycle-next-lane-selection-prepared-for-review
 │   ├── Role: Track issue `#79` service lifecycle DI candidate classification,
 │   │         authorization, and first implementation pilot while preventing
 │   │         unapproved expansion to additional services
@@ -872,11 +872,20 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 is `LOW` with impacted count=`0`; route dependency counts
 │   │                 still require static FastAPI `Depends(...)` scans because
 │   │                 the refreshed graph does not model those route sites as
-│   │                 incoming call edges
-│   └── Next gate: Human review of the G2.57 GitNexus refresh PR; if accepted,
-│                  create a separate G2.58 candidate-selection or
-│                  implementation-authorization packet before any next service
-│                  lifecycle DI source edit
+│   │                 incoming call edges; PR `#198` merged at
+│   │                 `5dbb0ca0c387dafb313e9b5f2674f3023da65962`; G2.58 now
+│   │                 records next-lane selection at the same HEAD: ordinary
+│   │                 provider dependency rows are implemented/closed except
+│   │                 `get_data_source_dependency`, which is already
+│   │                 provider-shaped with `3` dashboard route sites; the next
+│   │                 design-only seam is `get_data_source_factory`, with `17`
+│   │                 direct API call sites across `9` files and refreshed
+│   │                 GitNexus upstream impact `CRITICAL` (`22` impacted, `21`
+│   │                 direct, `15` processes, `3` modules)
+│   └── Next gate: Human review of the G2.58 next-lane selection PR; if
+│                  accepted, create a separate G2.59 design/authorization packet
+│                  for `get_data_source_factory`; no source edit is authorized
+│                  until that later packet is reviewed and approved
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -973,6 +982,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-flat-api-indicator-registry-route-provider-closeout-2026-05-24.md` | G | G2.55 closeout prepared at current HEAD `5b12a3c08cac3558c56af615ff14c05913d96f72`: records PR `#195` as `MERGED`, confirms flat API registry provider surface remains present, route direct `get_indicator_registry()` references under `web/backend/app/api`=`0`, provider dependency route sites=`2`, selected indicator cache routes=`6`, configured app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, focused tests=`2+1 passed`, and GitNexus graph output is stale for the new provider symbols until index refresh | Human review / PR merge decision; if accepted, refresh GitNexus or explicitly discount stale graph output before selecting another service lifecycle DI lane |
 | `backend-service-lifecycle-di-candidate-refresh-after-indicator-registry-provider-2026-05-24.md` | G | G2.56 candidate refresh prepared at current HEAD `1fc4a4c7a86cf464dedb742612c052b911d4ef5f`: records PR `#196` as `MERGED`, scans API files=`219`, service files=`152`, backend tests=`195`, provider state keys=`10`, provider functions=`20`, provider records=`30`, route dependency sites=`353`, provider-style route dependency sites=`81`, getter-style route dependency sites=`272`, confirms route direct `get_indicator_registry()` refs=`0`, provider dependency route sites=`2`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and records GitNexus refresh blocked in the linked worktree by `ENOTDIR .git/info`; no source implementation target is authorized | Human review / PR merge decision; if accepted, refresh GitNexus from a non-linked checkout or explicitly record a stale-graph waiver before creating any next service lifecycle DI authorization packet |
 | `backend-gitnexus-refresh-after-indicator-registry-provider-2026-05-24.md` | G | G2.57 GitNexus refresh evidence prepared at current HEAD `3469a43855ef81d238e1a92745126fcb321b1af7`: records PR `#197` as `MERGED`, confirms a temporary non-linked clone with `.git` kind=`directory`, `gitnexus analyze` exit=`0`, nodes=`62623`, edges=`145799`, clusters=`3291`, flows=`300`, GitNexus repo `g2-57-gitnexus-index-checkout` state=`ready`, `get_indicator_registry_dependency` and `install_indicator_registry` resolve in the refreshed graph, upstream impact for `get_indicator_registry_dependency` is `LOW` with impacted count=`0`, and static route scan still reports route direct `get_indicator_registry()` refs=`0` plus provider route sites=`2`; no source implementation target is authorized | Human review / PR merge decision; if accepted, create a separate G2.58 candidate-selection or implementation-authorization packet before any next service lifecycle DI source edit |
+| `backend-service-lifecycle-di-next-lane-selection-after-gitnexus-refresh-2026-05-24.md` | G | G2.58 next-lane selection prepared at current HEAD `5dbb0ca0c387dafb313e9b5f2674f3023da65962`: records PR `#198` as `MERGED`, confirms fresh non-linked GitNexus analyze exit=`0`, nodes=`62621`, edges=`145801`, flows=`300`, current static scan route dependency sites=`353`, provider-style route dependency sites=`81`, getter-style route dependency sites=`272`, classifies all ordinary provider rows as implemented/closed except `get_data_source_dependency`, which is already provider-shaped with `3` dashboard route sites, and selects `get_data_source_factory` as the next design-only seam because it has `17` direct API call sites across `9` files and refreshed GitNexus upstream impact `CRITICAL` (`22` impacted, `21` direct, `15` processes, `3` modules); no source implementation target is authorized | Human review / PR merge decision; if accepted, create G2.59 `get_data_source_factory` design/authorization packet before any backend source edit |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/service-lifecycle-di-next-lane-selection-after-gitnexus-refresh-2026-05-24.json
+++ b/.planning/codebase/generated/service-lifecycle-di-next-lane-selection-after-gitnexus-refresh-2026-05-24.json
@@ -1,0 +1,83 @@
+{
+  "artifact": "service-lifecycle-di-next-lane-selection-after-gitnexus-refresh",
+  "workline": "G2.58",
+  "generated_at": "2026-05-24T19:22:00+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_branch": "g2-58-service-lifecycle-next-lane-selection",
+  "current_head": "5dbb0ca0c387",
+  "status": "ready_for_review",
+  "scope": {
+    "kind": "decision_only_next_lane_selection",
+    "source_edits_authorized": false,
+    "route_or_openapi_edits_authorized": false,
+    "compatibility_getter_cleanup_authorized": false,
+    "next_lifecycle_implementation_authorized": false
+  },
+  "upstream_merge_evidence": {
+    "workline": "G2.57",
+    "pr": 198,
+    "state": "MERGED",
+    "merge_commit": "5dbb0ca0c387dafb313e9b5f2674f3023da65962"
+  },
+  "gitnexus_refresh": {
+    "checkout_head": "5dbb0ca0c387",
+    "git_dot_kind": "directory",
+    "gitnexus_analyze_exit": 0,
+    "nodes": 62621,
+    "edges": 145801,
+    "clusters": 3287,
+    "flows": 300,
+    "duration_seconds": 65.4
+  },
+  "static_scan": {
+    "api_files_scanned": 219,
+    "service_files_scanned": 152,
+    "route_depends_sites": 353,
+    "provider_style_route_dependency_sites": 81,
+    "getter_style_route_dependency_sites": 272
+  },
+  "provider_group_classification": [
+    {"name": "get_advanced_analysis_service_dependency", "sites": 14, "files": 1, "classification": "implemented_or_closed"},
+    {"name": "get_market_data_service_v2_dependency", "sites": 14, "files": 2, "classification": "implemented_or_closed"},
+    {"name": "get_announcement_service_dependency", "sites": 11, "files": 1, "classification": "implemented_or_closed"},
+    {"name": "get_market_data_service_dependency", "sites": 7, "files": 1, "classification": "implemented_or_closed"},
+    {"name": "get_watchlist_service_dependency", "sites": 7, "files": 1, "classification": "implemented_or_closed"},
+    {"name": "get_email_service_dependency", "sites": 6, "files": 1, "classification": "implemented_or_closed"},
+    {"name": "get_stock_search_service_dependency", "sites": 6, "files": 2, "classification": "implemented_or_closed"},
+    {"name": "get_tradingview_service_dependency", "sites": 6, "files": 1, "classification": "implemented_or_closed"},
+    {"name": "get_tdx_service_dependency", "sites": 5, "files": 1, "classification": "implemented_or_closed"},
+    {"name": "get_indicator_registry_dependency", "sites": 2, "files": 1, "classification": "implemented_or_closed"},
+    {"name": "get_data_source_dependency", "sites": 3, "files": 1, "classification": "already_provider_shaped_needs_closeout_or_design_review"}
+  ],
+  "remaining_service_like_seams": [
+    {"surface": "get_data_source_factory", "evidence": "17 direct API call sites across 9 files", "gitnexus_risk": "CRITICAL", "disposition": "selected_for_next_design_only_packet"},
+    {"surface": "get_postgres_async", "evidence": "22 direct call sites across 8 API files", "disposition": "infrastructure_data_access_seam_not_ordinary_service_di"},
+    {"surface": "get_data_source", "evidence": "20 direct call sites across 4 API files", "disposition": "ambiguous_same_name_surface_requires_domain_separation"},
+    {"surface": "get_config_manager", "evidence": "17 direct call sites across active and historical API files", "disposition": "ambiguous_config_ownership_seam"}
+  ],
+  "selected_next_lane": {
+    "surface": "get_data_source_factory",
+    "next_workline": "G2.59",
+    "packet_type": "design_or_implementation_authorization_candidate",
+    "source_implementation_authorized_now": false,
+    "rationale": "largest remaining service-like direct-call seam with refreshed GitNexus CRITICAL impact"
+  },
+  "gitnexus_selected_seam": {
+    "symbol": "get_data_source_factory",
+    "file": "web/backend/app/services/data_source_factory/data_source_factory.py",
+    "startLine": 294,
+    "endLine": 300,
+    "risk": "CRITICAL",
+    "impactedCount": 22,
+    "direct": 21,
+    "processes_affected": 15,
+    "modules_affected": 3,
+    "affected_modules": ["Data", "Data_source_factory", "Api"]
+  },
+  "decision": {
+    "candidate_selection_complete": true,
+    "new_source_implementation_target_selected": false,
+    "next_design_candidate": "get_data_source_factory",
+    "next_gate": "human review, then separate G2.59 design or authorization packet before source edit"
+  }
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-next-lane-selection-after-gitnexus-refresh-2026-05-24.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-next-lane-selection-after-gitnexus-refresh-2026-05-24.md
@@ -1,0 +1,153 @@
+# Backend Service Lifecycle DI Next Lane Selection After GitNexus Refresh - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Generated at: `2026-05-24T19:22:00+08:00`
+
+Workline: G2.58 service lifecycle DI next-lane selection after G2.57
+GitNexus refresh.
+
+Base branch: `wip/root-dirty-20260403`
+
+Current HEAD: `5dbb0ca0c387`
+
+## Status
+
+G2.58 is a decision-only next-lane selection packet.
+
+It does not authorize backend source edits, route changes, OpenAPI changes,
+compatibility getter cleanup, issue label changes, or implementation work. Its
+only purpose is to decide which seam should receive the next separate design or
+authorization packet.
+
+## Upstream Evidence
+
+| Workline | PR | State | Commit | Notes |
+| --- | --- | --- | --- | --- |
+| G2.57 | `#198` | `MERGED` | `5dbb0ca0c387dafb313e9b5f2674f3023da65962` | Non-linked GitNexus refresh closed the stale-graph blocker for `IndicatorRegistry` provider symbols |
+
+## Current Refresh Evidence
+
+A fresh non-linked GitNexus refresh was run at current HEAD for this selection
+packet:
+
+```text
+checkout_head=5dbb0ca0c387
+git_dot_kind=directory
+gitnexus_analyze_exit=0
+Repository indexed successfully (65.4s)
+62,621 nodes | 145,801 edges | 3287 clusters | 300 flows
+```
+
+Static current-head scan in the G2.58 governance worktree reports:
+
+| Metric | Value |
+| --- | ---: |
+| API files scanned | `219` |
+| Service files scanned | `152` |
+| Route `Depends(...)` sites | `353` |
+| Provider-style route dependency sites | `81` |
+| Getter-style route dependency sites | `272` |
+
+## Provider Group Classification
+
+| Provider dependency | Sites | Files | Classification |
+| --- | ---: | ---: | --- |
+| `get_advanced_analysis_service_dependency` | `14` | `1` | Implemented / closed in prior G2 lane |
+| `get_market_data_service_v2_dependency` | `14` | `2` | Implemented / closed in prior G2 lane |
+| `get_announcement_service_dependency` | `11` | `1` | Implemented / closed in prior G2 lane |
+| `get_market_data_service_dependency` | `7` | `1` | Implemented / closed in prior G2 lane |
+| `get_watchlist_service_dependency` | `7` | `1` | Implemented / closed in prior G2 lane |
+| `get_email_service_dependency` | `6` | `1` | Implemented / closed in prior G2 lane |
+| `get_stock_search_service_dependency` | `6` | `2` | Implemented / closed in prior G2 lane |
+| `get_tradingview_service_dependency` | `6` | `1` | Implemented / closed in prior G2 lane |
+| `get_tdx_service_dependency` | `5` | `1` | Implemented / closed in prior G2 lane |
+| `get_indicator_registry_dependency` | `2` | `1` | Implemented / closed by G2.54-G2.57 |
+| `get_data_source_dependency` | `3` | `1` | Already provider-shaped; needs closeout/design review, not direct implementation |
+
+The ordinary route-provider implementation queue should not select another
+source edit directly from this table. The only unclassified provider row,
+`get_data_source_dependency`, already wraps `get_market_data_service_v2_dependency`
+and is used by three `dashboard.py` handlers.
+
+## Remaining Service-Like Seams
+
+| Surface | Evidence | Risk / disposition |
+| --- | --- | --- |
+| `get_data_source_factory` | `17` direct API call sites across `9` files | GitNexus upstream impact is `CRITICAL`; select next design packet only |
+| `get_postgres_async` | `22` direct call sites across `8` API files | Infrastructure/data-access seam; not ordinary service DI |
+| `get_data_source` | `20` direct call sites across `4` API files | Ambiguous same-name surface; requires domain separation before edits |
+| `get_config_manager` | `17` direct call sites across active and historical API files | Ambiguous config ownership seam; not selected for immediate DI |
+| Repository getters such as `get_strategy_repository` | Route/persistence boundary | Needs repository governance, not service lifecycle provider migration |
+
+## Selected Next Lane
+
+G2.58 selects `get_data_source_factory` as the next design-only seam.
+
+This is not a source implementation target. The next packet should be a
+dedicated G2.59 design/authorization candidate for the data-source factory
+direct-call seam.
+
+Selection rationale:
+
+- It is the largest remaining service-like direct-call seam with concrete route
+  consumers.
+- GitNexus can resolve the symbol in the refreshed graph.
+- GitNexus upstream impact is `CRITICAL`, with `22` impacted symbols, `21`
+  direct dependents, `15` affected processes, and `3` affected modules.
+- Because of that blast radius, direct implementation would be unsafe without a
+  narrower design packet.
+
+## GitNexus Evidence For Selected Seam
+
+GitNexus context for `get_data_source_factory` resolves to:
+
+```text
+web/backend/app/services/data_source_factory/data_source_factory.py
+startLine=294
+endLine=300
+```
+
+GitNexus upstream impact:
+
+```text
+risk=CRITICAL
+impactedCount=22
+direct=21
+processes_affected=15
+modules_affected=3
+```
+
+Affected modules include `Data`, `Data_source_factory`, and `Api`.
+
+## Required G2.59 Boundaries
+
+The next G2.59 packet must remain design/authorization-only unless explicitly
+approved later. It should include:
+
+1. Exact consumer matrix for the `17` API direct-call sites.
+2. Split between route-local dependency injection, service package provider,
+   and factory lifecycle ownership.
+3. Explicit exclusion or separate handling for `get_postgres_async`,
+   `get_config_manager`, repository getters, and same-name `get_data_source`
+   surfaces.
+4. Pre-edit GitNexus impact commands for each selected symbol.
+5. TDD plan and rollback boundary before any backend source edit.
+
+## Decision
+
+G2.58 closes candidate selection for the next service lifecycle DI planning
+step:
+
+- Do not start source implementation from this packet.
+- Do not treat `get_data_source_dependency` as a missing provider migration.
+- Prepare G2.59 as a dedicated `get_data_source_factory` design /
+  implementation-authorization candidate.
+
+## Next Gate
+
+Human review this G2.58 packet / PR. If accepted, create a separate G2.59
+design/authorization packet for `get_data_source_factory`; source edits remain
+locked until that later packet is reviewed and approved.

--- a/governance/mainline/task-cards/pr-199.yaml
+++ b/governance/mainline/task-cards/pr-199.yaml
@@ -1,0 +1,94 @@
+version: "v0.2"
+task:
+  id: "pr-199"
+  title: "Select next service lifecycle DI planning lane after GitNexus refresh"
+  owner: "main"
+  created_at: "2026-05-24"
+mainline:
+  id: "L1-service-lifecycle-di-next-lane-selection-after-gitnexus-refresh"
+  objective: "record the next service lifecycle DI design lane after GitNexus refresh"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-di-next-lane-selection"
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+openspec:
+  change_id: "not-required-service-lifecycle-di-next-lane-selection"
+  approval_status: "not_required"
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Next-lane selection packet records current-head governance evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-di-next-lane-selection-after-gitnexus-refresh-2026-05-24.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-next-lane-selection-after-gitnexus-refresh-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-199.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+non_goals:
+  - "Do not modify backend source code."
+  - "Do not modify route paths, response contracts, OpenAPI exposure, or generated clients."
+  - "Do not remove compatibility getters or wrappers."
+  - "Do not implement the selected next service lifecycle DI lane."
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-next-lane-selection-after-gitnexus-refresh-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-di-next-lane-selection-after-gitnexus-refresh-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-199.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-199.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "python -c \"print('staged-gitnexus-scope: docs-only next-lane selection packet; no source symbols modified')\""
+      required: true
+risk_and_rollback:
+  risks:
+    - "The selected design lane may be misread as immediate source implementation authorization."
+    - "CRITICAL GitNexus impact for get_data_source_factory requires later design decomposition before edits."
+  rollback_plan: "revert this governance-only PR; PR #198 remains the accepted GitNexus refresh record unless separately reverted"
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "select the next service lifecycle DI planning lane after GitNexus refresh"
+    modified_scope: "next-lane selection report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only selection PR if governance validation fails"
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T19:22:00+08:00"
+    approval_note: "human maintainer approved continuing after PR #198 merge; this packet records G2.58 next-lane selection only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records G2.58 next-lane selection after the G2.57 GitNexus refresh gate
- classifies current provider dependency rows and confirms ordinary provider rows are closed or already provider-shaped
- selects `get_data_source_factory` as the next design-only seam because refreshed GitNexus impact is CRITICAL
- updates the steward tree and adds mainline task card `pr-199.yaml`

## Scope
- docs/governance only
- no backend source edits
- no route/OpenAPI/response contract changes
- no implementation authorization

## Verification
- fresh non-linked `gitnexus analyze`: exit 0, 62,621 nodes, 145,801 edges, 300 flows
- static scan: route dependency sites=353, provider-style=81, getter-style=272
- GitNexus context: `get_data_source_factory` found
- GitNexus impact: `get_data_source_factory` CRITICAL, impactedCount=22, direct=21, processes=15, modules=3
- markdown governance gate: 2 checked files, 0 errors
- JSON parse: passed
- YAML parse: passed
- git diff --check: passed
- GitNexus staged scope: LOW, 0 changed symbols, 0 affected processes
- post-commit mainline scope gate: pass=True

## Notes
This PR does not authorize code changes. If accepted, the next step is a separate G2.59 design/authorization packet for `get_data_source_factory`, with exact consumer matrix, pre-edit impact gates, TDD plan, and rollback boundary.
