### PR TITLE
docs(governance): authorize data source factory lifecycle design

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -881,11 +881,21 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 design-only seam is `get_data_source_factory`, with `17`
 │   │                 direct API call sites across `9` files and refreshed
 │   │                 GitNexus upstream impact `CRITICAL` (`22` impacted, `21`
-│   │                 direct, `15` processes, `3` modules)
-│   └── Next gate: Human review of the G2.58 next-lane selection PR; if
-│                  accepted, create a separate G2.59 design/authorization packet
-│                  for `get_data_source_factory`; no source edit is authorized
-│                  until that later packet is reviewed and approved
+│   │                 direct, `15` processes, `3` modules); PR `#199` merged at
+│   │                 `1880f0d1395e7c5594b70f3ba40478cff24f2d3a`; G2.59 now
+│   │                 records a dedicated authorization packet for
+│   │                 `get_data_source_factory`: non-linked GitNexus analyze
+│   │                 exit=`0`, nodes=`62624`, edges=`145803`, flows=`300`,
+│   │                 symbol lines=`294-300`, static API scan remains `17`
+│   │                 direct calls across `9` files, and upstream impact remains
+│   │                 `CRITICAL` (`22` impacted, `21` direct, `15` processes,
+│   │                 `3` modules); no source implementation is authorized by
+│   │                 G2.59
+│   └── Next gate: Human review of the G2.59 authorization PR; if accepted,
+│                  create a separate G2.60 consumer-matrix / implementation
+│                  authorization packet for `get_data_source_factory`; because
+│                  the seam is `CRITICAL`, source edits remain locked until a
+│                  later reviewed implementation packet explicitly allows them
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -983,6 +993,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-di-candidate-refresh-after-indicator-registry-provider-2026-05-24.md` | G | G2.56 candidate refresh prepared at current HEAD `1fc4a4c7a86cf464dedb742612c052b911d4ef5f`: records PR `#196` as `MERGED`, scans API files=`219`, service files=`152`, backend tests=`195`, provider state keys=`10`, provider functions=`20`, provider records=`30`, route dependency sites=`353`, provider-style route dependency sites=`81`, getter-style route dependency sites=`272`, confirms route direct `get_indicator_registry()` refs=`0`, provider dependency route sites=`2`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and records GitNexus refresh blocked in the linked worktree by `ENOTDIR .git/info`; no source implementation target is authorized | Human review / PR merge decision; if accepted, refresh GitNexus from a non-linked checkout or explicitly record a stale-graph waiver before creating any next service lifecycle DI authorization packet |
 | `backend-gitnexus-refresh-after-indicator-registry-provider-2026-05-24.md` | G | G2.57 GitNexus refresh evidence prepared at current HEAD `3469a43855ef81d238e1a92745126fcb321b1af7`: records PR `#197` as `MERGED`, confirms a temporary non-linked clone with `.git` kind=`directory`, `gitnexus analyze` exit=`0`, nodes=`62623`, edges=`145799`, clusters=`3291`, flows=`300`, GitNexus repo `g2-57-gitnexus-index-checkout` state=`ready`, `get_indicator_registry_dependency` and `install_indicator_registry` resolve in the refreshed graph, upstream impact for `get_indicator_registry_dependency` is `LOW` with impacted count=`0`, and static route scan still reports route direct `get_indicator_registry()` refs=`0` plus provider route sites=`2`; no source implementation target is authorized | Human review / PR merge decision; if accepted, create a separate G2.58 candidate-selection or implementation-authorization packet before any next service lifecycle DI source edit |
 | `backend-service-lifecycle-di-next-lane-selection-after-gitnexus-refresh-2026-05-24.md` | G | G2.58 next-lane selection prepared at current HEAD `5dbb0ca0c387dafb313e9b5f2674f3023da65962`: records PR `#198` as `MERGED`, confirms fresh non-linked GitNexus analyze exit=`0`, nodes=`62621`, edges=`145801`, flows=`300`, current static scan route dependency sites=`353`, provider-style route dependency sites=`81`, getter-style route dependency sites=`272`, classifies all ordinary provider rows as implemented/closed except `get_data_source_dependency`, which is already provider-shaped with `3` dashboard route sites, and selects `get_data_source_factory` as the next design-only seam because it has `17` direct API call sites across `9` files and refreshed GitNexus upstream impact `CRITICAL` (`22` impacted, `21` direct, `15` processes, `3` modules); no source implementation target is authorized | Human review / PR merge decision; if accepted, create G2.59 `get_data_source_factory` design/authorization packet before any backend source edit |
+| `backend-data-source-factory-lifecycle-di-authorization-2026-05-24.md` | G | G2.59 authorization packet prepared at current HEAD `1880f0d1395e7c5594b70f3ba40478cff24f2d3a`: records PR `#199` as `MERGED`, confirms fresh non-linked GitNexus analyze exit=`0`, nodes=`62624`, edges=`145803`, flows=`300`, resolves `get_data_source_factory` at `web/backend/app/services/data_source_factory/data_source_factory.py:294-300`, static scan keeps direct API calls=`17` across `9` files, and refreshed GitNexus upstream impact remains `CRITICAL` (`22` impacted, `21` direct, `15` processes, `3` modules); no source, test, route, OpenAPI, OpenSpec, runtime, issue-label, or compatibility cleanup change is authorized | Human review / PR merge decision; if accepted, create G2.60 consumer-matrix / implementation-authorization packet before any backend source edit |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/data-source-factory-lifecycle-di-authorization-2026-05-24.json
+++ b/.planning/codebase/generated/data-source-factory-lifecycle-di-authorization-2026-05-24.json
@@ -1,0 +1,215 @@
+{
+  "artifact": "data-source-factory-lifecycle-di-authorization",
+  "workline": "G2.59",
+  "generated_at": "2026-05-24T19:53:23+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_branch": "g2-59-data-source-factory-authorization",
+  "current_head": "1880f0d1395e7c5594b70f3ba40478cff24f2d3a",
+  "status": "ready_for_review",
+  "scope": {
+    "kind": "governance_authorization_packet",
+    "source_edits_authorized": false,
+    "route_or_openapi_edits_authorized": false,
+    "test_edits_authorized": false,
+    "openspec_edits_authorized": false,
+    "issue_label_changes_authorized": false,
+    "runtime_or_pm2_changes_authorized": false
+  },
+  "upstream_merge_evidence": {
+    "previous_workline": "G2.58",
+    "previous_pr": 199,
+    "previous_merge_commit": "1880f0d1395e7c5594b70f3ba40478cff24f2d3a",
+    "selected_seam": "get_data_source_factory",
+    "selected_reason": "17 direct API call sites across 9 files and refreshed GitNexus CRITICAL impact"
+  },
+  "static_scan": {
+    "api_files_scanned": 219,
+    "direct_get_data_source_factory_call_count": 17,
+    "api_file_count": 9,
+    "consumer_matrix": [
+      {
+        "file": "web/backend/app/api/data/financial.py",
+        "calls": 1,
+        "call_lines": [
+          69
+        ],
+        "import_lines": [
+          67
+        ]
+      },
+      {
+        "file": "web/backend/app/api/data/futures.py",
+        "calls": 2,
+        "call_lines": [
+          91,
+          114
+        ],
+        "import_lines": [
+          89,
+          112
+        ]
+      },
+      {
+        "file": "web/backend/app/api/data/kline.py",
+        "calls": 2,
+        "call_lines": [
+          145,
+          245
+        ],
+        "import_lines": [
+          144,
+          244
+        ]
+      },
+      {
+        "file": "web/backend/app/api/data/lhb.py",
+        "calls": 2,
+        "call_lines": [
+          90,
+          115
+        ],
+        "import_lines": [
+          88,
+          113
+        ]
+      },
+      {
+        "file": "web/backend/app/api/data/margin.py",
+        "calls": 3,
+        "call_lines": [
+          104,
+          128,
+          150
+        ],
+        "import_lines": [
+          102,
+          126,
+          148
+        ]
+      },
+      {
+        "file": "web/backend/app/api/data/market.py",
+        "calls": 1,
+        "call_lines": [
+          98
+        ],
+        "import_lines": [
+          97
+        ]
+      },
+      {
+        "file": "web/backend/app/api/data/stocks.py",
+        "calls": 2,
+        "call_lines": [
+          269,
+          371
+        ],
+        "import_lines": [
+          267,
+          370
+        ]
+      },
+      {
+        "file": "web/backend/app/api/data_quality.py",
+        "calls": 2,
+        "call_lines": [
+          58,
+          369
+        ],
+        "import_lines": [
+          27
+        ]
+      },
+      {
+        "file": "web/backend/app/api/market/market_data_request.py",
+        "calls": 2,
+        "call_lines": [
+          134,
+          427
+        ],
+        "import_lines": [
+          132,
+          425
+        ]
+      }
+    ]
+  },
+  "service_surface": {
+    "file": "web/backend/app/services/data_source_factory/data_source_factory.py",
+    "global_singleton": "_global_factory",
+    "getter": "get_data_source_factory",
+    "getter_lines": "294-300",
+    "behavior": "creates DataSourceFactory, awaits initialize, and returns the module-level singleton",
+    "compatibility_functions_to_preserve": [
+      "get_data_source",
+      "get_market_data",
+      "get_dashboard_data",
+      "get_technical_analysis_data"
+    ]
+  },
+  "gitnexus_refresh": {
+    "checkout": ".worktrees/g2-59-gitnexus-index-checkout",
+    "git_dot_kind": "directory",
+    "head": "1880f0d1395e",
+    "analyze_exit": 0,
+    "nodes": 62624,
+    "edges": 145803,
+    "clusters": 3288,
+    "flows": 300,
+    "embeddings": "off"
+  },
+  "gitnexus_selected_seam": {
+    "symbol": "get_data_source_factory",
+    "uid": "Function:web/backend/app/services/data_source_factory/data_source_factory.py:get_data_source_factory",
+    "file": "web/backend/app/services/data_source_factory/data_source_factory.py",
+    "start_line": 294,
+    "end_line": 300,
+    "risk": "CRITICAL",
+    "impacted_count": 22,
+    "direct": 21,
+    "processes_affected": 15,
+    "modules_affected": 3,
+    "affected_modules": [
+      "Data",
+      "Data_source_factory",
+      "Api"
+    ]
+  },
+  "future_candidate_scope": {
+    "next_gate": "G2.60 consumer-matrix and implementation-authorization packet",
+    "implementation_authorized_by_this_packet": false,
+    "likely_future_write_scope": [
+      "web/backend/app/services/data_source_factory/data_source_factory.py",
+      "focused lifecycle DI tests",
+      "future implementation evidence report",
+      "future mainline task card"
+    ],
+    "possible_provider_design": [
+      "add app-state key",
+      "add installer",
+      "add FastAPI dependency provider",
+      "preserve get_data_source_factory compatibility getter",
+      "preserve convenience functions"
+    ]
+  },
+  "explicit_exclusions": [
+    "no web/backend/app/api edits",
+    "no backend source edits",
+    "no backend test edits",
+    "no route path or response contract changes",
+    "no OpenAPI exposure changes",
+    "no get_data_source_factory removal or rename",
+    "no _global_factory removal",
+    "no ambiguous get_data_source broad rewrite",
+    "no get_postgres_async migration",
+    "no get_config_manager migration",
+    "no OpenSpec edits",
+    "no issue label changes"
+  ],
+  "decision": {
+    "selected_as_next_planning_target": true,
+    "source_implementation_status": "locked",
+    "reason": "CRITICAL blast radius requires a separate reviewed decomposition gate before source edits",
+    "recommended_next_step": "create G2.60 source-free consumer-matrix / implementation-authorization packet"
+  }
+}

--- a/docs/reports/quality/backend-data-source-factory-lifecycle-di-authorization-2026-05-24.md
+++ b/docs/reports/quality/backend-data-source-factory-lifecycle-di-authorization-2026-05-24.md
@@ -1,0 +1,201 @@
+# Backend Data Source Factory Lifecycle DI Authorization - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Workline: G2.59 data-source factory lifecycle DI authorization
+
+Base branch: `wip/root-dirty-20260403`
+
+Current HEAD: `1880f0d1395e7c5594b70f3ba40478cff24f2d3a`
+
+## Scope Boundary
+
+G2.59 is a governance and authorization packet only.
+
+This packet does not modify backend source code, tests, route paths, response
+contracts, OpenAPI exposure, generated clients, OpenSpec files, issue labels,
+runtime processes, or PM2 state.
+
+The purpose is to decide whether `get_data_source_factory` is a suitable next
+service lifecycle DI seam and to define the next gate before any source edit.
+
+## Upstream Evidence
+
+G2.58 selected `get_data_source_factory` as the next design-only seam after the
+G2.57 GitNexus refresh.
+
+Upstream accepted state:
+
+- PR `#199` merged at `1880f0d1395e7c5594b70f3ba40478cff24f2d3a`.
+- Ordinary provider-style rows were implemented or closed.
+- `get_data_source_dependency` was classified as already provider-shaped with
+  `3` dashboard route sites.
+- `get_data_source_factory` remained the next candidate because it had `17`
+  direct API call sites across `9` files.
+
+## Current Evidence
+
+Static current-head scan in this G2.59 worktree reports:
+
+- API files scanned: `219`
+- Direct `get_data_source_factory()` API calls: `17`
+- API files containing direct calls: `9`
+
+Consumer matrix:
+
+| File | Calls | Lines |
+|---|---:|---|
+| `web/backend/app/api/data/financial.py` | 1 | `69` |
+| `web/backend/app/api/data/futures.py` | 2 | `91`, `114` |
+| `web/backend/app/api/data/kline.py` | 2 | `145`, `245` |
+| `web/backend/app/api/data/lhb.py` | 2 | `90`, `115` |
+| `web/backend/app/api/data/margin.py` | 3 | `104`, `128`, `150` |
+| `web/backend/app/api/data/market.py` | 1 | `98` |
+| `web/backend/app/api/data/stocks.py` | 2 | `269`, `371` |
+| `web/backend/app/api/data_quality.py` | 2 | `58`, `369` |
+| `web/backend/app/api/market/market_data_request.py` | 2 | `134`, `427` |
+
+The canonical singleton surface remains:
+
+- `web/backend/app/services/data_source_factory/data_source_factory.py`
+- `_global_factory: Optional[DataSourceFactory] = None`
+- `async def get_data_source_factory() -> DataSourceFactory`
+- The getter creates `DataSourceFactory()`, awaits `initialize()`, and returns
+  the module-level singleton.
+
+## GitNexus Evidence
+
+GitNexus was refreshed from a temporary non-linked checkout:
+
+- Checkout: `.worktrees/g2-59-gitnexus-index-checkout`
+- `.git` kind: `directory`
+- HEAD: `1880f0d1395e`
+- `gitnexus analyze` exit: `0`
+- Nodes: `62624`
+- Edges: `145803`
+- Clusters: `3288`
+- Flows: `300`
+
+GitNexus context resolves `get_data_source_factory` to:
+
+```text
+web/backend/app/services/data_source_factory/data_source_factory.py
+lines 294-300
+```
+
+Refreshed upstream impact remains high enough to forbid an opportunistic code
+edit:
+
+```text
+risk=CRITICAL
+impactedCount=22
+direct=21
+processes_affected=15
+modules_affected=3
+```
+
+Direct incoming callers include:
+
+- `web/backend/app/api/data_quality.py:get_sources_health`
+- `web/backend/app/api/data_quality.py:get_system_status_overview`
+- `web/backend/app/services/data_source_factory/data_source_factory.py:get_data_source`
+- `web/backend/app/services/data_source_factory/data_source_factory.py:get_market_data`
+- `web/backend/app/services/data_source_factory/data_source_factory.py:get_dashboard_data`
+- `web/backend/app/services/data_source_factory/data_source_factory.py:get_technical_analysis_data`
+- `web/backend/app/api/market/market_data_request.py:get_fund_flow`
+- `web/backend/app/api/market/market_data_request.py:get_market_quotes`
+- `web/backend/app/api/data/stocks.py:get_stocks_basic`
+- `web/backend/app/api/data/stocks.py:search_stocks`
+- `web/backend/app/api/data/market.py:get_market_overview`
+- `web/backend/app/api/data/margin.py:get_margin_account_info`
+- `web/backend/app/api/data/margin.py:get_margin_detail_sse`
+- `web/backend/app/api/data/margin.py:get_margin_detail_szse`
+- `web/backend/app/api/data/lhb.py:get_dragon_tiger_detail`
+- `web/backend/app/api/data/lhb.py:get_dragon_tiger_institution_stats`
+- `web/backend/app/api/data/kline.py:get_daily_kline`
+- `web/backend/app/api/data/kline.py:get_intraday_data`
+- `web/backend/app/api/data/futures.py:get_futures_index_daily`
+- `web/backend/app/api/data/futures.py:get_futures_index_realtime`
+- `web/backend/app/api/data/financial.py:get_financial_data`
+
+Affected modules include `Data`, `Data_source_factory`, and `Api`.
+
+## Decision
+
+G2.59 authorizes no source implementation.
+
+The seam is selected as the next planning target, but its CRITICAL blast radius
+requires one more decomposition gate before source edits.
+
+Recommended next gate:
+
+1. Create G2.60 as a dedicated `get_data_source_factory` consumer-matrix and
+   implementation-authorization packet.
+2. Keep G2.60 source-free unless it is explicitly split into a separate
+   implementation branch after review.
+3. Decide whether the first implementation slice should only add an app-state
+   provider seam while preserving all existing callers, or whether a very small
+   route migration batch is safe.
+
+## Future Implementation Candidate Scope
+
+If G2.60 or a later reviewed packet authorizes code, the likely write scope is:
+
+- `web/backend/app/services/data_source_factory/data_source_factory.py`
+- A focused lifecycle DI test for the provider seam and fallback getter behavior
+- A future implementation evidence report and mainline task card
+
+Potential future service changes may include:
+
+- Add a stable state key for `DataSourceFactory`.
+- Add an installer that places a provided or initialized factory on `app.state`.
+- Add a FastAPI dependency provider that reads the request app state.
+- Preserve `get_data_source_factory()` as the compatibility getter.
+- Preserve convenience functions such as `get_data_source`, `get_market_data`,
+  `get_dashboard_data`, and `get_technical_analysis_data`.
+
+Route migration must be a later explicit batch. The `17` direct API call sites
+are not automatically authorized for bulk rewrite by this packet.
+
+## Explicit Exclusions
+
+This packet does not authorize:
+
+- Editing `web/backend/app/api/**`.
+- Editing `web/backend/app/services/data_source_factory/data_source_factory.py`.
+- Removing or renaming `get_data_source_factory`.
+- Removing `_global_factory`.
+- Rewriting ambiguous same-name `get_data_source` surfaces.
+- Migrating `get_postgres_async`, `get_config_manager`, repository getters, or
+  unrelated service seams.
+- Changing route paths, query parameters, response shapes, OpenAPI exposure, or
+  operation IDs.
+- Creating or modifying OpenSpec changes.
+- Moving issue labels or declaring issue `#79` closed.
+
+## Acceptance For The Next Source Packet
+
+A future implementation packet must include:
+
+- Fresh GitNexus impact and context before editing the service symbol.
+- A current static consumer matrix for all `17` route/API call sites.
+- A TDD plan that proves both app-state provider behavior and compatibility
+  getter fallback behavior.
+- Focused tests for at least one representative route consumer before any route
+  migration.
+- Ruff, formatting, app import, OpenAPI path count, and duplicate operation ID
+  checks after implementation.
+- `gitnexus_detect_changes(scope=staged)` before commit.
+
+## Closeout
+
+G2.59 converts the G2.58 next-lane selection into a concrete authorization
+boundary.
+
+The next step is human review of this packet. If accepted, open G2.60 as a
+separate `get_data_source_factory` consumer-matrix / implementation-authorization
+packet before any backend source edit.

--- a/governance/mainline/task-cards/pr-200.yaml
+++ b/governance/mainline/task-cards/pr-200.yaml
@@ -1,0 +1,107 @@
+version: "v0.2"
+
+task:
+  id: "pr-200"
+  title: "Authorize data source factory lifecycle DI planning"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-data-source-factory-lifecycle-di-authorization"
+  objective: "record the G2.59 authorization boundary for the get_data_source_factory lifecycle DI seam"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-lifecycle-di-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-lifecycle-di-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization packet records future service lifecycle DI planning scope only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-lifecycle-di-authorization-2026-05-24.json"
+    - "docs/reports/quality/backend-data-source-factory-lifecycle-di-authorization-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-200.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No get_data_source_factory cleanup, removal, rename, provider creation, state-key creation, or route dependency rewiring in this PR"
+  - "No migration of get_postgres_async, get_config_manager, repository getters, or ambiguous same-name get_data_source surfaces in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-lifecycle-di-authorization-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-lifecycle-di-authorization-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-200.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-200.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "gitnexus detect-changes --scope staged"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the authorization-only boundary"
+    - "If this PR rewires any of the 17 API call sites, it bypasses the required CRITICAL-impact implementation gate"
+    - "If this PR authorizes get_data_source_factory removal, it contradicts the current compatibility boundary"
+  rollback_plan: "revert this governance-only PR; prior G2.58 next-lane selection remains merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record the future get_data_source_factory lifecycle DI authorization boundary"
+    modified_scope: "authorization report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none in this PR"
+    legacy_logic_impact: "none; get_data_source_factory and _global_factory remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only authorization PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T19:53:23+08:00"
+    approval_note: "human maintainer approved continuing after PR #199; this packet only records future implementation authorization boundaries"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- add G2.59 `get_data_source_factory` lifecycle DI authorization evidence
- record current static consumer matrix: 17 direct API calls across 9 API files
- refresh non-linked GitNexus evidence and keep source edits locked because impact remains CRITICAL
- update the steward tree and mainline task card for the next G2.60 gate

## Verification
- markdown governance gate: 2 checked files, 0 errors
- JSON parse: passed
- YAML parse: passed
- git diff --cached --check: passed
- GitNexus staged detect: LOW, 0 changed symbols, 0 affected processes
- post-commit mainline scope gate: pass=True

## Boundary
No backend source, test, route, OpenAPI, OpenSpec, issue-label, runtime, PM2, or compatibility cleanup changes are included. G2.59 is authorization/planning only.