### PR TITLE
docs(governance): authorize data source factory provider seam

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -890,12 +890,22 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 direct calls across `9` files, and upstream impact remains
 │   │                 `CRITICAL` (`22` impacted, `21` direct, `15` processes,
 │   │                 `3` modules); no source implementation is authorized by
-│   │                 G2.59
-│   └── Next gate: Human review of the G2.59 authorization PR; if accepted,
-│                  create a separate G2.60 consumer-matrix / implementation
-│                  authorization packet for `get_data_source_factory`; because
-│                  the seam is `CRITICAL`, source edits remain locked until a
-│                  later reviewed implementation packet explicitly allows them
+│   │                 G2.59; PR `#200` merged at
+│   │                 `265f38e53bddfa3a925f14cfbc5080b00dce26e6`; G2.60 now
+│   │                 records the consumer matrix and future implementation
+│   │                 boundary: static API scan still reports `17` direct calls
+│   │                 across `9` files, non-linked GitNexus analyze exit=`0`,
+│   │                 nodes=`62628`, edges=`145797`, flows=`300`, and upstream
+│   │                 impact remains `CRITICAL`; the selected next source batch
+│   │                 is G2.61a provider-seam-only with `0` route calls migrated
+│   │                 and all route/API consumer rewrites locked for later
+│   │                 packets
+│   └── Next gate: Human review of the G2.60 consumer-matrix / implementation
+│                  authorization PR; if accepted, create G2.61a provider-seam
+│                  implementation with write scope limited to
+│                  `data_source_factory.py`, a focused lifecycle DI test,
+│                  implementation evidence, and a future task card; route
+│                  migration remains locked
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -994,6 +1004,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-gitnexus-refresh-after-indicator-registry-provider-2026-05-24.md` | G | G2.57 GitNexus refresh evidence prepared at current HEAD `3469a43855ef81d238e1a92745126fcb321b1af7`: records PR `#197` as `MERGED`, confirms a temporary non-linked clone with `.git` kind=`directory`, `gitnexus analyze` exit=`0`, nodes=`62623`, edges=`145799`, clusters=`3291`, flows=`300`, GitNexus repo `g2-57-gitnexus-index-checkout` state=`ready`, `get_indicator_registry_dependency` and `install_indicator_registry` resolve in the refreshed graph, upstream impact for `get_indicator_registry_dependency` is `LOW` with impacted count=`0`, and static route scan still reports route direct `get_indicator_registry()` refs=`0` plus provider route sites=`2`; no source implementation target is authorized | Human review / PR merge decision; if accepted, create a separate G2.58 candidate-selection or implementation-authorization packet before any next service lifecycle DI source edit |
 | `backend-service-lifecycle-di-next-lane-selection-after-gitnexus-refresh-2026-05-24.md` | G | G2.58 next-lane selection prepared at current HEAD `5dbb0ca0c387dafb313e9b5f2674f3023da65962`: records PR `#198` as `MERGED`, confirms fresh non-linked GitNexus analyze exit=`0`, nodes=`62621`, edges=`145801`, flows=`300`, current static scan route dependency sites=`353`, provider-style route dependency sites=`81`, getter-style route dependency sites=`272`, classifies all ordinary provider rows as implemented/closed except `get_data_source_dependency`, which is already provider-shaped with `3` dashboard route sites, and selects `get_data_source_factory` as the next design-only seam because it has `17` direct API call sites across `9` files and refreshed GitNexus upstream impact `CRITICAL` (`22` impacted, `21` direct, `15` processes, `3` modules); no source implementation target is authorized | Human review / PR merge decision; if accepted, create G2.59 `get_data_source_factory` design/authorization packet before any backend source edit |
 | `backend-data-source-factory-lifecycle-di-authorization-2026-05-24.md` | G | G2.59 authorization packet prepared at current HEAD `1880f0d1395e7c5594b70f3ba40478cff24f2d3a`: records PR `#199` as `MERGED`, confirms fresh non-linked GitNexus analyze exit=`0`, nodes=`62624`, edges=`145803`, flows=`300`, resolves `get_data_source_factory` at `web/backend/app/services/data_source_factory/data_source_factory.py:294-300`, static scan keeps direct API calls=`17` across `9` files, and refreshed GitNexus upstream impact remains `CRITICAL` (`22` impacted, `21` direct, `15` processes, `3` modules); no source, test, route, OpenAPI, OpenSpec, runtime, issue-label, or compatibility cleanup change is authorized | Human review / PR merge decision; if accepted, create G2.60 consumer-matrix / implementation-authorization packet before any backend source edit |
+| `backend-data-source-factory-consumer-matrix-implementation-authorization-2026-05-24.md` | G | G2.60 consumer matrix / implementation authorization prepared at current HEAD `265f38e53bddfa3a925f14cfbc5080b00dce26e6`: records PR `#200` as `MERGED`, confirms fresh non-linked GitNexus analyze exit=`0`, nodes=`62628`, edges=`145797`, flows=`300`, keeps direct API calls=`17` across `9` files, and selects G2.61a provider-seam-only as the next possible source batch with allowed future scope limited to `data_source_factory.py`, a focused lifecycle DI test, implementation evidence, and a future task card; route migration, compatibility getter cleanup, OpenAPI changes, issue-label changes, and runtime/PM2 changes remain locked | Human review / PR merge decision; if accepted, create G2.61a provider-seam-only implementation branch before any route migration |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/data-source-factory-consumer-matrix-implementation-authorization-2026-05-24.json
+++ b/.planning/codebase/generated/data-source-factory-consumer-matrix-implementation-authorization-2026-05-24.json
@@ -1,0 +1,225 @@
+{
+  "artifact": "data-source-factory-consumer-matrix-implementation-authorization",
+  "workline": "G2.60",
+  "generated_at": "2026-05-24T20:10:13+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_branch": "g2-60-data-source-factory-consumer-matrix-authorization",
+  "current_head": "265f38e53bddfa3a925f14cfbc5080b00dce26e6",
+  "status": "ready_for_review",
+  "scope": {
+    "kind": "consumer_matrix_and_implementation_authorization_packet",
+    "source_edits_in_this_packet": false,
+    "route_or_openapi_edits_in_this_packet": false,
+    "test_edits_in_this_packet": false,
+    "openspec_edits_in_this_packet": false,
+    "future_provider_seam_implementation_authorized_if_accepted": true,
+    "future_route_migration_authorized_if_accepted": false
+  },
+  "upstream_merge_evidence": {
+    "previous_workline": "G2.59",
+    "previous_pr": 200,
+    "previous_merge_commit": "265f38e53bddfa3a925f14cfbc5080b00dce26e6",
+    "selected_seam": "get_data_source_factory",
+    "source_implementation_status": "locked_until_G2.60_review"
+  },
+  "static_scan": {
+    "api_files_scanned": 219,
+    "direct_get_data_source_factory_call_count": 17,
+    "api_file_count": 9,
+    "consumer_matrix": [
+      {
+        "file": "web/backend/app/api/data/financial.py",
+        "calls": 1,
+        "call_lines": [
+          69
+        ],
+        "proposed_disposition": "later_domain_route_batch"
+      },
+      {
+        "file": "web/backend/app/api/data/futures.py",
+        "calls": 2,
+        "call_lines": [
+          91,
+          114
+        ],
+        "proposed_disposition": "later_domain_route_batch"
+      },
+      {
+        "file": "web/backend/app/api/data/kline.py",
+        "calls": 2,
+        "call_lines": [
+          145,
+          245
+        ],
+        "proposed_disposition": "later_domain_route_batch"
+      },
+      {
+        "file": "web/backend/app/api/data/lhb.py",
+        "calls": 2,
+        "call_lines": [
+          90,
+          115
+        ],
+        "proposed_disposition": "later_domain_route_batch"
+      },
+      {
+        "file": "web/backend/app/api/data/margin.py",
+        "calls": 3,
+        "call_lines": [
+          104,
+          128,
+          150
+        ],
+        "proposed_disposition": "later_domain_route_batch"
+      },
+      {
+        "file": "web/backend/app/api/data/market.py",
+        "calls": 1,
+        "call_lines": [
+          98
+        ],
+        "proposed_disposition": "later_domain_route_batch"
+      },
+      {
+        "file": "web/backend/app/api/data/stocks.py",
+        "calls": 2,
+        "call_lines": [
+          269,
+          371
+        ],
+        "proposed_disposition": "later_domain_route_batch"
+      },
+      {
+        "file": "web/backend/app/api/data_quality.py",
+        "calls": 2,
+        "call_lines": [
+          58,
+          369
+        ],
+        "proposed_disposition": "first_route_migration_candidate_after_provider_closeout"
+      },
+      {
+        "file": "web/backend/app/api/market/market_data_request.py",
+        "calls": 2,
+        "call_lines": [
+          134,
+          427
+        ],
+        "proposed_disposition": "later_market_route_batch"
+      }
+    ]
+  },
+  "gitnexus_refresh": {
+    "checkout": ".worktrees/g2-60-gitnexus-index-checkout",
+    "git_dot_kind": "directory",
+    "head": "265f38e53bdd",
+    "analyze_exit": 0,
+    "nodes": 62628,
+    "edges": 145797,
+    "clusters": 3291,
+    "flows": 300,
+    "embeddings": "off"
+  },
+  "gitnexus_selected_seam": {
+    "symbol": "get_data_source_factory",
+    "uid": "Function:web/backend/app/services/data_source_factory/data_source_factory.py:get_data_source_factory",
+    "file": "web/backend/app/services/data_source_factory/data_source_factory.py",
+    "start_line": 294,
+    "end_line": 300,
+    "risk": "CRITICAL",
+    "impacted_count": 22,
+    "direct": 21,
+    "processes_affected": 15,
+    "modules_affected": 3,
+    "affected_modules": [
+      "Data",
+      "Data_source_factory",
+      "Api"
+    ]
+  },
+  "existing_test_surface": [
+    "web/backend/tests/test_data_source_factory.py",
+    "web/backend/tests/_test_data_source_factory_convenience.py",
+    "web/backend/tests/_test_data_source_factory_management.py",
+    "web/backend/tests/_test_data_source_factory_sources.py",
+    "web/backend/tests/_test_data_source_factory_support.py",
+    "web/backend/tests/test_data_source_manager_regressions.py",
+    "web/backend/tests/test_data_stocks_runtime_fallback.py",
+    "tests/backend/test_data_api_regression.py",
+    "web/backend/tests/test_market_api_integration.py"
+  ],
+  "batch_decision": {
+    "selected_next_batch": "G2.61a",
+    "selected_kind": "provider_seam_only",
+    "route_calls_migrated": 0,
+    "reason": "lowest behavioral disturbance; proves app-state provider plus compatibility getter fallback before touching 17 route call sites",
+    "future_route_candidate": "G2.61b data_quality.py after G2.61a closeout"
+  },
+  "authorized_future_g2_61a_scope": {
+    "implementation_authorized_if_this_packet_is_accepted": true,
+    "allowed_paths": [
+      "web/backend/app/services/data_source_factory/data_source_factory.py",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py",
+      "docs/reports/quality/backend-data-source-factory-provider-seam-implementation-2026-05-24.md",
+      "governance/mainline/task-cards/pr-202.yaml"
+    ],
+    "allowed_changes": [
+      "add stable DataSourceFactory app-state key",
+      "add installer accepting provided or initialized factory",
+      "add FastAPI dependency provider reading app state with fallback",
+      "preserve get_data_source_factory compatibility getter",
+      "preserve _global_factory",
+      "preserve convenience functions"
+    ],
+    "explicit_non_goals": [
+      "no web/backend/app/api edits",
+      "no route dependency rewiring",
+      "no route path changes",
+      "no response shape changes",
+      "no OpenAPI exposure changes",
+      "no compatibility getter cleanup",
+      "no get_postgres_async migration",
+      "no get_config_manager migration",
+      "no issue label changes",
+      "no runtime or PM2 changes"
+    ]
+  },
+  "future_route_migration_order": [
+    {
+      "workline": "G2.61b_or_later",
+      "files": [
+        "web/backend/app/api/data_quality.py"
+      ],
+      "calls": 2,
+      "condition": "only after provider-seam closeout"
+    },
+    {
+      "workline": "later_domain_batches",
+      "files": [
+        "web/backend/app/api/data/financial.py",
+        "web/backend/app/api/data/futures.py",
+        "web/backend/app/api/data/kline.py",
+        "web/backend/app/api/data/lhb.py",
+        "web/backend/app/api/data/margin.py",
+        "web/backend/app/api/data/market.py",
+        "web/backend/app/api/data/stocks.py"
+      ],
+      "calls": 13,
+      "condition": "separate reviewed packet"
+    },
+    {
+      "workline": "later_market_route_batch",
+      "files": [
+        "web/backend/app/api/market/market_data_request.py"
+      ],
+      "calls": 2,
+      "condition": "separate reviewed packet"
+    }
+  ],
+  "decision": {
+    "source_implementation_in_this_packet": false,
+    "next_source_branch": "G2.61a provider seam only",
+    "route_migration_locked": true,
+    "compatibility_getter_cleanup_locked": true
+  }
+}

--- a/docs/reports/quality/backend-data-source-factory-consumer-matrix-implementation-authorization-2026-05-24.md
+++ b/docs/reports/quality/backend-data-source-factory-consumer-matrix-implementation-authorization-2026-05-24.md
@@ -1,0 +1,219 @@
+# Backend Data Source Factory Consumer Matrix And Implementation Authorization - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Workline: G2.60 data-source factory consumer matrix / implementation authorization
+
+Base branch: `wip/root-dirty-20260403`
+
+Current HEAD: `265f38e53bddfa3a925f14cfbc5080b00dce26e6`
+
+## Scope Boundary
+
+G2.60 is a governance and implementation-authorization packet only.
+
+This packet does not modify backend source code, tests, route paths, response
+contracts, OpenAPI exposure, generated clients, OpenSpec files, issue labels,
+runtime processes, or PM2 state.
+
+Its purpose is to split the `get_data_source_factory` seam into executable
+batches and authorize the first future implementation branch only if this packet
+is accepted.
+
+## Upstream State
+
+G2.59 was merged by PR `#200` at
+`265f38e53bddfa3a925f14cfbc5080b00dce26e6`.
+
+Accepted G2.59 facts:
+
+- `get_data_source_factory` resolves to
+  `web/backend/app/services/data_source_factory/data_source_factory.py:294-300`.
+- Static API direct calls: `17` across `9` files.
+- GitNexus upstream impact: `CRITICAL`, with `22` impacted symbols, `21`
+  direct callers, `15` affected processes, and `3` affected modules.
+- No source implementation was authorized by G2.59.
+
+## Current Evidence
+
+Static current-head scan in the G2.60 worktree reports:
+
+- API files scanned: `219`
+- Direct `get_data_source_factory()` API calls: `17`
+- API files containing direct calls: `9`
+
+Consumer matrix:
+
+| File | Calls | Lines | Proposed disposition |
+|---|---:|---|---|
+| `web/backend/app/api/data/financial.py` | 1 | `69` | later domain route batch |
+| `web/backend/app/api/data/futures.py` | 2 | `91`, `114` | later domain route batch |
+| `web/backend/app/api/data/kline.py` | 2 | `145`, `245` | later domain route batch |
+| `web/backend/app/api/data/lhb.py` | 2 | `90`, `115` | later domain route batch |
+| `web/backend/app/api/data/margin.py` | 3 | `104`, `128`, `150` | later domain route batch |
+| `web/backend/app/api/data/market.py` | 1 | `98` | later domain route batch |
+| `web/backend/app/api/data/stocks.py` | 2 | `269`, `371` | later domain route batch |
+| `web/backend/app/api/data_quality.py` | 2 | `58`, `369` | first route migration candidate after provider closeout |
+| `web/backend/app/api/market/market_data_request.py` | 2 | `134`, `427` | later market route batch |
+
+Service-internal compatibility callers remain in:
+
+- `get_data_source`
+- `get_market_data`
+- `get_dashboard_data`
+- `get_technical_analysis_data`
+
+These are compatibility or convenience functions, not deletion candidates.
+
+## GitNexus Evidence
+
+GitNexus was refreshed from a temporary non-linked checkout:
+
+- Checkout: `.worktrees/g2-60-gitnexus-index-checkout`
+- `.git` kind: `directory`
+- HEAD: `265f38e53bdd`
+- `gitnexus analyze` exit: `0`
+- Nodes: `62628`
+- Edges: `145797`
+- Clusters: `3291`
+- Flows: `300`
+
+GitNexus context resolves `get_data_source_factory` to:
+
+```text
+web/backend/app/services/data_source_factory/data_source_factory.py
+lines 294-300
+```
+
+Refreshed upstream impact:
+
+```text
+risk=CRITICAL
+impactedCount=22
+direct=21
+processes_affected=15
+modules_affected=3
+```
+
+The direct incoming callers are the same route/service surfaces recorded in
+G2.59. Affected modules are `Data`, `Data_source_factory`, and `Api`.
+
+## Existing Test Surface
+
+The current checkout already has data-source factory and route-adjacent tests
+that should inform future TDD:
+
+- `web/backend/tests/test_data_source_factory.py`
+- `web/backend/tests/_test_data_source_factory_convenience.py`
+- `web/backend/tests/_test_data_source_factory_management.py`
+- `web/backend/tests/_test_data_source_factory_sources.py`
+- `web/backend/tests/_test_data_source_factory_support.py`
+- `web/backend/tests/test_data_source_manager_regressions.py`
+- `web/backend/tests/test_data_stocks_runtime_fallback.py`
+- `tests/backend/test_data_api_regression.py`
+- `web/backend/tests/test_market_api_integration.py`
+
+## Batch Decision
+
+Because the seam is `CRITICAL`, route migration must not be the first
+implementation step.
+
+G2.60 selects a two-level decomposition:
+
+1. G2.61a: provider seam only, no route migration.
+2. G2.61b or later: route migration batches only after G2.61a closeout proves
+   provider behavior and fallback compatibility.
+
+## Authorized Future G2.61a Scope
+
+If this packet is accepted, the next source branch may implement only the
+provider seam.
+
+Allowed future write scope for G2.61a:
+
+- `web/backend/app/services/data_source_factory/data_source_factory.py`
+- `web/backend/tests/test_data_source_factory_lifecycle_di.py`
+- `docs/reports/quality/backend-data-source-factory-provider-seam-implementation-2026-05-24.md`
+- `governance/mainline/task-cards/pr-202.yaml`
+
+Allowed future service changes:
+
+- Add a stable state key for `DataSourceFactory`.
+- Add an installer that can place a provided or initialized factory on
+  `app.state`.
+- Add a FastAPI dependency provider that returns the app-state factory when
+  present and preserves fallback behavior when absent.
+- Preserve `get_data_source_factory()` as the public compatibility getter.
+- Preserve `_global_factory`.
+- Preserve service-internal convenience functions.
+
+Explicit G2.61a non-goals:
+
+- No edits under `web/backend/app/api/**`.
+- No route dependency rewiring.
+- No route path, query parameter, response shape, OpenAPI exposure, or operation
+  ID change.
+- No compatibility getter cleanup.
+- No `get_postgres_async`, `get_config_manager`, repository getter, or
+  ambiguous same-name `get_data_source` migration.
+- No startup/runtime process, PM2, or issue-label change.
+
+## Future Route Migration Order
+
+After G2.61a is implemented, merged, and closed out, route migration should be
+split as separate reviewed packets.
+
+Recommended order:
+
+1. G2.61b: `web/backend/app/api/data_quality.py`, `2` calls, first route
+   migration candidate.
+2. Later data-domain batches:
+   `financial.py`, `futures.py`, `kline.py`, `lhb.py`, `margin.py`,
+   `market.py`, and `stocks.py`.
+3. Later market route batch:
+   `web/backend/app/api/market/market_data_request.py`.
+
+Each route batch must rerun the static consumer matrix, OpenAPI path count,
+duplicate operation ID check, focused route tests, and GitNexus staged-scope
+check before commit.
+
+## Future G2.61a TDD Plan
+
+Before implementation, write failing focused tests for:
+
+- Installing a provided `DataSourceFactory` on app state.
+- Dependency provider returning the installed factory.
+- Dependency provider preserving fallback behavior when app state is missing.
+- Existing `get_data_source_factory()` compatibility getter still returning an
+  initialized factory.
+- Convenience functions still delegating through the compatibility getter.
+
+Minimum green checks for G2.61a:
+
+- `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov`
+- `pytest -o addopts= web/backend/tests/test_data_source_factory.py -q --no-cov`
+- Ruff on touched backend source/test files.
+- App import smoke.
+- OpenAPI smoke: path count and duplicate operation ID count.
+- `gitnexus_detect_changes(scope=staged)`.
+
+## Decision
+
+G2.60 authorizes the future G2.61a provider-seam implementation boundary only
+after human review / PR acceptance of this packet.
+
+It does not authorize route migration. The `17` direct API call sites remain
+locked until a later route-specific packet is reviewed and accepted.
+
+## Next Gate
+
+Human review this G2.60 packet / PR.
+
+If accepted, create a separate G2.61a implementation branch for the provider
+seam only. That branch must start with GitNexus impact/context for
+`get_data_source_factory` and must stop if the refreshed risk differs from the
+authorized CRITICAL route/provider seam described here.

--- a/governance/mainline/task-cards/pr-201.yaml
+++ b/governance/mainline/task-cards/pr-201.yaml
@@ -1,0 +1,108 @@
+version: "v0.2"
+
+task:
+  id: "pr-201"
+  title: "Authorize data source factory provider-seam batch"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-data-source-factory-consumer-matrix-implementation-authorization"
+  objective: "record the G2.60 consumer matrix and future provider-seam-only implementation boundary"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-consumer-matrix-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-consumer-matrix-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Consumer matrix and implementation authorization packet records future provider-seam-only scope and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-consumer-matrix-implementation-authorization-2026-05-24.json"
+    - "docs/reports/quality/backend-data-source-factory-consumer-matrix-implementation-authorization-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-201.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No get_data_source_factory implementation in this PR"
+  - "No route migration or API consumer rewrite in this PR"
+  - "No compatibility getter cleanup or _global_factory removal in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-consumer-matrix-implementation-authorization-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-consumer-matrix-implementation-authorization-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-201.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-201.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "gitnexus detect-changes --scope staged"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the authorization-only boundary"
+    - "If this PR authorizes route migration, it bypasses the provider-seam-only first batch"
+    - "If this PR authorizes get_data_source_factory removal, it contradicts compatibility evidence"
+  rollback_plan: "revert this governance-only PR; prior G2.59 authorization remains merged unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record the future provider-seam-only implementation boundary for get_data_source_factory"
+    modified_scope: "consumer matrix report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none in this PR"
+    legacy_logic_impact: "none; get_data_source_factory, _global_factory, and all route consumers remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only authorization PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T20:10:13+08:00"
+    approval_note: "human maintainer approved continuing after PR #200; this packet only records future provider-seam-only implementation boundaries"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- add G2.60 consumer matrix and implementation authorization packet for `get_data_source_factory`
- refresh current static matrix: 17 direct API calls across 9 files
- refresh non-linked GitNexus evidence at current HEAD and confirm CRITICAL impact remains
- select G2.61a provider-seam-only as the next possible source batch with 0 route calls migrated

## Verification
- markdown governance gate: 2 checked files, 0 errors
- JSON parse: passed
- YAML parse: passed
- git diff --cached --check: passed
- GitNexus staged detect: LOW, 0 changed symbols, 0 affected processes
- post-commit mainline scope gate: pass=True

## Boundary
No backend source, test, route, OpenAPI, OpenSpec, issue-label, runtime, PM2, or compatibility cleanup changes are included. Route migration remains locked for later packets.