### PR TITLE
refactor(backend): add data source factory provider seam

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -899,13 +899,22 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 impact remains `CRITICAL`; the selected next source batch
 │   │                 is G2.61a provider-seam-only with `0` route calls migrated
 │   │                 and all route/API consumer rewrites locked for later
-│   │                 packets
-│   └── Next gate: Human review of the G2.60 consumer-matrix / implementation
-│                  authorization PR; if accepted, create G2.61a provider-seam
-│                  implementation with write scope limited to
-│                  `data_source_factory.py`, a focused lifecycle DI test,
-│                  implementation evidence, and a future task card; route
-│                  migration remains locked
+│   │                 packets; PR `#201` merged at
+│   │                 `ae6ba4e43b1470b524110fe506929df675bd8b93`; G2.61a now
+│   │                 implements that provider seam only: adds
+│   │                 `DATA_SOURCE_FACTORY_STATE_KEY`,
+│   │                 `install_data_source_factory`, and
+│   │                 `get_data_source_factory_dependency`, preserves
+│   │                 `get_data_source_factory()` plus `_global_factory`, keeps
+│   │                 route direct calls=`17`, route dependency refs=`0`, TDD
+│   │                 red=`3 failed, 1 passed`, focused green=`4 passed`,
+│   │                 existing factory tests=`38 passed`, app/OpenAPI smoke
+│   │                 routes=`548`, paths=`500`, duplicate operation IDs=`0`
+│   └── Next gate: Human review of the G2.61a implementation PR; if accepted,
+│                  create G2.61a closeout / current-head refresh before any
+│                  first route migration packet; `data_quality.py` remains the
+│                  recommended first route migration candidate but is not
+│                  authorized by G2.61a
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1005,6 +1014,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-di-next-lane-selection-after-gitnexus-refresh-2026-05-24.md` | G | G2.58 next-lane selection prepared at current HEAD `5dbb0ca0c387dafb313e9b5f2674f3023da65962`: records PR `#198` as `MERGED`, confirms fresh non-linked GitNexus analyze exit=`0`, nodes=`62621`, edges=`145801`, flows=`300`, current static scan route dependency sites=`353`, provider-style route dependency sites=`81`, getter-style route dependency sites=`272`, classifies all ordinary provider rows as implemented/closed except `get_data_source_dependency`, which is already provider-shaped with `3` dashboard route sites, and selects `get_data_source_factory` as the next design-only seam because it has `17` direct API call sites across `9` files and refreshed GitNexus upstream impact `CRITICAL` (`22` impacted, `21` direct, `15` processes, `3` modules); no source implementation target is authorized | Human review / PR merge decision; if accepted, create G2.59 `get_data_source_factory` design/authorization packet before any backend source edit |
 | `backend-data-source-factory-lifecycle-di-authorization-2026-05-24.md` | G | G2.59 authorization packet prepared at current HEAD `1880f0d1395e7c5594b70f3ba40478cff24f2d3a`: records PR `#199` as `MERGED`, confirms fresh non-linked GitNexus analyze exit=`0`, nodes=`62624`, edges=`145803`, flows=`300`, resolves `get_data_source_factory` at `web/backend/app/services/data_source_factory/data_source_factory.py:294-300`, static scan keeps direct API calls=`17` across `9` files, and refreshed GitNexus upstream impact remains `CRITICAL` (`22` impacted, `21` direct, `15` processes, `3` modules); no source, test, route, OpenAPI, OpenSpec, runtime, issue-label, or compatibility cleanup change is authorized | Human review / PR merge decision; if accepted, create G2.60 consumer-matrix / implementation-authorization packet before any backend source edit |
 | `backend-data-source-factory-consumer-matrix-implementation-authorization-2026-05-24.md` | G | G2.60 consumer matrix / implementation authorization prepared at current HEAD `265f38e53bddfa3a925f14cfbc5080b00dce26e6`: records PR `#200` as `MERGED`, confirms fresh non-linked GitNexus analyze exit=`0`, nodes=`62628`, edges=`145797`, flows=`300`, keeps direct API calls=`17` across `9` files, and selects G2.61a provider-seam-only as the next possible source batch with allowed future scope limited to `data_source_factory.py`, a focused lifecycle DI test, implementation evidence, and a future task card; route migration, compatibility getter cleanup, OpenAPI changes, issue-label changes, and runtime/PM2 changes remain locked | Human review / PR merge decision; if accepted, create G2.61a provider-seam-only implementation branch before any route migration |
+| `backend-data-source-factory-provider-seam-implementation-2026-05-24.md` | G | G2.61a provider-seam implementation prepared at current HEAD `ae6ba4e43b1470b524110fe506929df675bd8b93`: records PR `#201` as `MERGED`, confirms pre-edit non-linked GitNexus analyze exit=`0`, nodes=`62636`, edges=`145807`, flows=`300`, and CRITICAL impact remains expected; adds `DATA_SOURCE_FACTORY_STATE_KEY`, `install_data_source_factory`, and `get_data_source_factory_dependency` in `data_source_factory.py`, adds focused lifecycle DI tests, preserves `get_data_source_factory()` and `_global_factory`, keeps route direct calls=`17` and provider dependency API refs=`0`, TDD red=`3 failed, 1 passed`, green=`4 passed`, existing factory tests=`38 passed`, route-adjacent fallback test=`1 passed`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; `tests/backend/test_data_api_regression.py` still has baseline 404 failures in both modified and unmodified checkouts and is not part of this batch | Human review / PR merge decision; if accepted, run G2.61a closeout/current-head refresh before selecting any route migration packet |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/data-source-factory-provider-seam-implementation-2026-05-24.json
+++ b/.planning/codebase/generated/data-source-factory-provider-seam-implementation-2026-05-24.json
@@ -1,0 +1,100 @@
+{
+  "artifact": "data-source-factory-provider-seam-implementation",
+  "workline": "G2.61a",
+  "generated_at": "2026-05-24T20:32:00+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_branch": "g2-61a-data-source-factory-provider-seam",
+  "base_head": "ae6ba4e43b1470b524110fe506929df675bd8b93",
+  "status": "ready_for_review",
+  "scope": {
+    "kind": "provider_seam_only_implementation",
+    "route_calls_migrated": 0,
+    "route_or_openapi_edits": false,
+    "openspec_edits": false,
+    "issue_label_changes": false,
+    "runtime_or_pm2_changes": false,
+    "compatibility_getter_cleanup": false
+  },
+  "modified_runtime_files": [
+    "web/backend/app/services/data_source_factory/data_source_factory.py"
+  ],
+  "modified_test_files": [
+    "web/backend/tests/test_data_source_factory_lifecycle_di.py"
+  ],
+  "added_provider_symbols": [
+    "DATA_SOURCE_FACTORY_STATE_KEY",
+    "install_data_source_factory",
+    "get_data_source_factory_dependency"
+  ],
+  "preserved_symbols": [
+    "_global_factory",
+    "get_data_source_factory",
+    "get_data_source",
+    "get_market_data",
+    "get_dashboard_data",
+    "get_technical_analysis_data"
+  ],
+  "gitnexus_pre_edit": {
+    "checkout": ".worktrees/g2-61a-gitnexus-index-checkout",
+    "git_dot_kind": "directory",
+    "head": "ae6ba4e43b14",
+    "analyze_exit": 0,
+    "nodes": 62636,
+    "edges": 145807,
+    "clusters": 3296,
+    "flows": 300,
+    "target": "get_data_source_factory",
+    "risk": "CRITICAL",
+    "impacted_count": 22,
+    "direct": 21,
+    "processes_affected": 15,
+    "modules_affected": 3
+  },
+  "tdd": {
+    "red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short",
+      "result": "3 failed, 1 passed",
+      "expected_failures": [
+        "missing install_data_source_factory",
+        "missing DATA_SOURCE_FACTORY_STATE_KEY",
+        "missing get_data_source_factory_dependency"
+      ]
+    },
+    "green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short",
+      "result": "4 passed"
+    }
+  },
+  "verification": {
+    "focused_lifecycle_test": "4 passed",
+    "existing_data_source_factory_test": "38 passed",
+    "data_stocks_runtime_fallback": "1 passed",
+    "ruff_touched": "passed",
+    "black_check_touched": "passed",
+    "app_import_with_test_env": "passed",
+    "routes": 548,
+    "openapi_paths": 500,
+    "operation_ids": 536,
+    "duplicate_operation_ids": 0,
+    "static_api_files_scanned": 219,
+    "direct_get_data_source_factory_api_calls": 17,
+    "get_data_source_factory_dependency_api_refs": 0
+  },
+  "known_existing_test_debt": {
+    "test_file": "tests/backend/test_data_api_regression.py",
+    "result_in_modified_worktree": "3 failed",
+    "result_in_unmodified_checkout": "3 failed",
+    "failure_type": "404 route expectations",
+    "not_caused_by_this_batch": true
+  },
+  "residuals": [
+    "data_source_factory package __init__.py does not re-export new provider symbols in this batch",
+    "17 API direct calls remain for later route migration packets",
+    "data_quality.py remains the recommended first route migration candidate after closeout"
+  ],
+  "decision": {
+    "provider_seam_implemented": true,
+    "route_migration_status": "locked",
+    "next_gate": "G2.61a closeout / current-head refresh before selecting first route migration"
+  }
+}

--- a/docs/reports/quality/backend-data-source-factory-provider-seam-implementation-2026-05-24.md
+++ b/docs/reports/quality/backend-data-source-factory-provider-seam-implementation-2026-05-24.md
@@ -1,0 +1,200 @@
+# Backend Data Source Factory Provider Seam Implementation - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Workline: G2.61a data-source factory provider seam implementation
+
+Base branch: `wip/root-dirty-20260403`
+
+Current HEAD before this branch: `ae6ba4e43b1470b524110fe506929df675bd8b93`
+
+## Scope Boundary
+
+G2.61a implements the provider-seam-only source batch authorized by G2.60.
+
+This batch changes only:
+
+- `web/backend/app/services/data_source_factory/data_source_factory.py`
+- `web/backend/tests/test_data_source_factory_lifecycle_di.py`
+- This implementation evidence report
+- The generated evidence artifact
+- The mainline task card
+- The steward tree
+
+This batch does not migrate route consumers, does not change route paths,
+response contracts, OpenAPI exposure, generated clients, OpenSpec files, issue
+labels, runtime process state, PM2 state, or compatibility getter cleanup.
+
+## GitNexus Pre-Edit Evidence
+
+GitNexus was refreshed from a temporary non-linked checkout:
+
+- Checkout: `.worktrees/g2-61a-gitnexus-index-checkout`
+- `.git` kind: `directory`
+- HEAD: `ae6ba4e43b14`
+- `gitnexus analyze` exit: `0`
+- Nodes: `62636`
+- Edges: `145807`
+- Clusters: `3296`
+- Flows: `300`
+
+GitNexus context resolved `get_data_source_factory` to:
+
+```text
+web/backend/app/services/data_source_factory/data_source_factory.py
+lines 294-300
+```
+
+Pre-edit upstream impact:
+
+```text
+risk=CRITICAL
+impactedCount=22
+direct=21
+processes_affected=15
+modules_affected=3
+```
+
+The CRITICAL risk is expected for this seam and is why G2.61a is limited to a
+provider seam with `0` route calls migrated.
+
+## Implementation
+
+`data_source_factory.py` now exposes:
+
+- `DATA_SOURCE_FACTORY_STATE_KEY`
+- `install_data_source_factory(app, factory=None)`
+- `get_data_source_factory_dependency(request)`
+
+The existing compatibility getter remains unchanged in purpose:
+
+- `get_data_source_factory()` still owns `_global_factory` fallback creation.
+- `_global_factory` is preserved.
+- Existing convenience functions still call `get_data_source_factory()`.
+
+`get_data_source_factory_dependency(request)` reads an installed app-state
+factory when present and falls back to `install_data_source_factory(request.app)`
+when missing.
+
+No API route imports or route handler signatures were changed.
+
+## TDD Evidence
+
+Red:
+
+```text
+pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short
+3 failed, 1 passed
+```
+
+Expected red failures:
+
+- Missing `install_data_source_factory`
+- Missing `DATA_SOURCE_FACTORY_STATE_KEY`
+- Missing `get_data_source_factory_dependency`
+
+Green:
+
+```text
+pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short
+4 passed
+```
+
+Existing data-source factory regression:
+
+```text
+pytest -o addopts= web/backend/tests/test_data_source_factory.py -q --no-cov --tb=short
+38 passed
+```
+
+Route-adjacent runtime fallback regression:
+
+```text
+pytest -o addopts= web/backend/tests/test_data_stocks_runtime_fallback.py -q --no-cov --tb=short
+1 passed
+```
+
+## Static Route Guard
+
+Post-implementation static scan confirms no route migration occurred:
+
+- API files scanned: `219`
+- Direct `get_data_source_factory()` API calls: `17`
+- `get_data_source_factory_dependency` API refs: `0`
+
+The `17` route/API direct call sites remain intentionally unchanged for future
+route-specific batches.
+
+## App And OpenAPI Smoke
+
+Initial app smoke without test env values failed at the environment validation
+gate:
+
+```text
+missing POSTGRESQL_HOST, POSTGRESQL_USER, POSTGRESQL_PASSWORD,
+JWT_SECRET_KEY, BACKEND_PORT, BACKEND_BACKUP_PORT
+```
+
+With non-secret test env values injected, app/OpenAPI smoke passed:
+
+```text
+app_import=passed
+routes=548
+openapi_paths=500
+operation_ids=536
+duplicate_operation_ids=0
+```
+
+This confirms the provider seam did not change route registration or OpenAPI
+shape.
+
+## Formatting And Lint
+
+```text
+ruff check web/backend/app/services/data_source_factory/data_source_factory.py web/backend/tests/test_data_source_factory_lifecycle_di.py
+All checks passed
+```
+
+```text
+black --check web/backend/app/services/data_source_factory/data_source_factory.py web/backend/tests/test_data_source_factory_lifecycle_di.py
+2 files would be left unchanged
+```
+
+## Known Existing Test Debt
+
+`tests/backend/test_data_api_regression.py` still fails with three `404` route
+expectations:
+
+- `/api/v1/data/stocks/basic`
+- `/api/v1/data/markets/overview`
+- `/api/v1/data/stocks/daily?symbol=000001`
+
+The same three failures reproduce in the unmodified G2.61a GitNexus checkout at
+HEAD `ae6ba4e43b14`, so they are current baseline route-test debt and not caused
+by this provider seam.
+
+This batch does not fix those tests because G2.61a explicitly forbids route
+migration and route contract changes.
+
+## Residuals
+
+- Package-level re-export from `web/backend/app/services/data_source_factory/__init__.py`
+  is not changed in this batch because G2.60 limited the source scope to the
+  implementation module and focused test.
+- Future route migration packets may either import the provider from the
+  implementation module directly or authorize a separate package export update.
+- All `17` direct API route calls remain to be handled by later reviewed
+  route-specific packets.
+
+## Next Gate
+
+Human review this implementation PR.
+
+If accepted, create G2.61a closeout / current-head refresh before selecting the
+first route migration batch. The currently recommended first route migration
+candidate remains `web/backend/app/api/data_quality.py`, but it is not
+authorized by this implementation PR.

--- a/governance/mainline/task-cards/pr-202.yaml
+++ b/governance/mainline/task-cards/pr-202.yaml
@@ -1,0 +1,127 @@
+version: "v0.2"
+
+task:
+  id: "pr-202"
+  title: "Implement data source factory provider seam"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-data-source-factory-provider-seam-implementation"
+  objective: "implement the G2.61a provider-seam-only lifecycle DI batch for get_data_source_factory"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-provider-seam"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-provider-seam-implementation"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Provider seam preserves existing route behavior and does not change product navigation, route paths, OpenAPI exposure, or frontend entrypoints"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-provider-seam-implementation-2026-05-24.json"
+    - "docs/reports/quality/backend-data-source-factory-provider-seam-implementation-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-202.yaml"
+    - "web/backend/app/services/data_source_factory/data_source_factory.py"
+    - "web/backend/tests/test_data_source_factory_lifecycle_di.py"
+  forbidden_paths:
+    - "web/backend/app/api/**"
+    - "web/backend/app/services/data_source_factory/__init__.py"
+    - "web/backend/app/services/data_source_factory/data_source_mode.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No route migration or API consumer rewrite in this PR"
+  - "No route path, query parameter, response contract, OpenAPI exposure, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No compatibility getter cleanup or _global_factory removal"
+  - "No package __init__.py export update in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-provider-seam-implementation-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-provider-seam-implementation-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-202.yaml').read_text())\""
+      required: true
+    - id: "focused-provider-seam-test"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "existing-data-source-factory-test"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory.py -q --no-cov --tb=short"
+      required: true
+    - id: "data-stocks-runtime-fallback-test"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_stocks_runtime_fallback.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/data_source_factory/data_source_factory.py web/backend/tests/test_data_source_factory_lifecycle_di.py"
+      required: true
+    - id: "black-check-touched"
+      command: "black --check web/backend/app/services/data_source_factory/data_source_factory.py web/backend/tests/test_data_source_factory_lifecycle_di.py"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-202.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "gitnexus detect-changes --scope staged"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If web/backend/app/api/** is changed, the PR exceeds the provider-seam-only boundary"
+    - "If compatibility get_data_source_factory() or _global_factory is removed, existing route and service callers may break"
+    - "If package __init__.py is changed, this PR exceeds the G2.60 authorized path scope"
+  rollback_plan: "revert this implementation PR; PR #201 remains the accepted consumer matrix and implementation authorization unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "add app-state provider seam for DataSourceFactory while preserving compatibility getter fallback"
+    modified_scope: "data_source_factory implementation module, focused lifecycle DI test, implementation evidence, generated artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "compatibility getter and _global_factory preserved; route consumers unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused provider-seam tests, route static guard, or OpenAPI smoke fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T20:32:00+08:00"
+    approval_note: "human maintainer approved continuing after PR #201; this implementation stays within the G2.60 provider-seam-only boundary"
+    secondary_approved: false

--- a/web/backend/app/services/data_source_factory/data_source_factory.py
+++ b/web/backend/app/services/data_source_factory/data_source_factory.py
@@ -10,6 +10,8 @@ from contextlib import asynccontextmanager
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from fastapi import Request
+
 from config.data_sources_loader import JSON_DATA_SOURCES_CONFIG_PATH
 
 from app.core.config import settings
@@ -43,6 +45,7 @@ logger = logging.getLogger(__name__)
 
 def _log_unhealthy_data_source(source_name: str, health: HealthStatus) -> None:
     logger.warning("Data source '%s' is %s: %s", source_name, health.status.value, health.message)
+
 
 class DataSourceFactory:
     """数据源工厂 - 核心工厂类"""
@@ -290,7 +293,9 @@ class DataSourceFactory:
             yield data_source
 
 
+DATA_SOURCE_FACTORY_STATE_KEY = "data_source_factory"
 _global_factory: Optional[DataSourceFactory] = None
+
 
 async def get_data_source_factory() -> DataSourceFactory:
     """获取全局数据源工厂实例"""
@@ -299,6 +304,19 @@ async def get_data_source_factory() -> DataSourceFactory:
         _global_factory = DataSourceFactory()
         await _global_factory.initialize()
     return _global_factory
+
+
+async def install_data_source_factory(app: Any, factory: Optional[DataSourceFactory] = None) -> DataSourceFactory:
+    selected_factory = factory if factory is not None else await get_data_source_factory()
+    setattr(app.state, DATA_SOURCE_FACTORY_STATE_KEY, selected_factory)
+    return selected_factory
+
+
+async def get_data_source_factory_dependency(request: Request) -> DataSourceFactory:
+    factory = getattr(request.app.state, DATA_SOURCE_FACTORY_STATE_KEY, None)
+    if factory is None:
+        factory = await install_data_source_factory(request.app)
+    return factory
 
 
 async def get_data_source(source_name: str) -> Optional[IDataSource]:

--- a/web/backend/tests/test_data_source_factory_lifecycle_di.py
+++ b/web/backend/tests/test_data_source_factory_lifecycle_di.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.data_source_factory import data_source_factory as data_source_factory_module
+
+
+@pytest.mark.asyncio
+async def test_install_data_source_factory_accepts_explicit_factory():
+    fake_factory = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+
+    result = await data_source_factory_module.install_data_source_factory(fake_app, fake_factory)
+
+    assert result is fake_factory
+    assert getattr(fake_app.state, data_source_factory_module.DATA_SOURCE_FACTORY_STATE_KEY) is fake_factory
+
+
+@pytest.mark.asyncio
+async def test_data_source_factory_dependency_returns_installed_factory(monkeypatch):
+    fake_factory = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+    setattr(fake_app.state, data_source_factory_module.DATA_SOURCE_FACTORY_STATE_KEY, fake_factory)
+    request = SimpleNamespace(app=fake_app)
+
+    async def unexpected_fallback():
+        raise AssertionError("fallback getter should not run when app-state factory is installed")
+
+    monkeypatch.setattr(data_source_factory_module, "get_data_source_factory", unexpected_fallback)
+
+    result = await data_source_factory_module.get_data_source_factory_dependency(request)
+
+    assert result is fake_factory
+
+
+@pytest.mark.asyncio
+async def test_data_source_factory_dependency_installs_fallback_factory(monkeypatch):
+    fake_factory = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+    request = SimpleNamespace(app=fake_app)
+    calls = []
+
+    async def fake_get_data_source_factory():
+        calls.append("fallback")
+        return fake_factory
+
+    monkeypatch.setattr(data_source_factory_module, "get_data_source_factory", fake_get_data_source_factory)
+
+    result = await data_source_factory_module.get_data_source_factory_dependency(request)
+
+    assert result is fake_factory
+    assert getattr(fake_app.state, data_source_factory_module.DATA_SOURCE_FACTORY_STATE_KEY) is fake_factory
+    assert calls == ["fallback"]
+
+
+@pytest.mark.asyncio
+async def test_get_data_source_factory_compatibility_getter_still_initializes(monkeypatch):
+    class FakeDataSourceFactory:
+        def __init__(self):
+            self.initialized = False
+
+        async def initialize(self):
+            self.initialized = True
+
+    monkeypatch.setattr(data_source_factory_module, "DataSourceFactory", FakeDataSourceFactory)
+    monkeypatch.setattr(data_source_factory_module, "_global_factory", None)
+
+    result = await data_source_factory_module.get_data_source_factory()
+
+    assert isinstance(result, FakeDataSourceFactory)
+    assert result.initialized is True
+    assert data_source_factory_module._global_factory is result


### PR DESCRIPTION
## Summary
- add app-state provider seam for `DataSourceFactory`
- preserve `get_data_source_factory()` compatibility getter and `_global_factory`
- add focused lifecycle DI tests for installer, dependency provider, fallback, and compatibility getter behavior
- keep route migration locked: 17 direct API calls remain unchanged and API provider refs remain 0

## Verification
- GitNexus pre-edit impact for `get_data_source_factory`: CRITICAL, expected and authorized by G2.60; implementation stayed provider-seam-only
- TDD red: 3 failed, 1 passed for missing provider seam
- focused provider seam test: 4 passed
- existing `test_data_source_factory.py`: 38 passed
- `test_data_stocks_runtime_fallback.py`: 1 passed
- ruff touched files: passed
- black check touched files: passed
- app/OpenAPI smoke with test env: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0
- route guard: api_files=219, direct_get_data_source_factory_calls=17, dependency_refs=0
- post-commit mainline scope gate: pass=True
- GitNexus staged detect: LOW, 0 changed symbols, 0 affected processes

## Existing test debt
`tests/backend/test_data_api_regression.py` still fails with three baseline 404 route expectations in both this worktree and an unmodified checkout. This PR does not touch route migration or route contracts, so that debt is recorded but not fixed here.

## Boundary
No API route, OpenAPI, OpenSpec, issue-label, runtime, PM2, package export, or compatibility cleanup changes are included.