### PR TITLE
docs(governance): close data source factory provider seam

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -909,12 +909,20 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 route direct calls=`17`, route dependency refs=`0`, TDD
 │   │                 red=`3 failed, 1 passed`, focused green=`4 passed`,
 │   │                 existing factory tests=`38 passed`, app/OpenAPI smoke
-│   │                 routes=`548`, paths=`500`, duplicate operation IDs=`0`
-│   └── Next gate: Human review of the G2.61a implementation PR; if accepted,
-│                  create G2.61a closeout / current-head refresh before any
-│                  first route migration packet; `data_quality.py` remains the
-│                  recommended first route migration candidate but is not
-│                  authorized by G2.61a
+│   │                 routes=`548`, paths=`500`, duplicate operation IDs=`0`;
+│   │                 PR `#202` merged at
+│   │                 `0aadb27801c86e97e65ffdb4426276e1bd14c352`; G2.61a
+│   │                 closeout now records current-head provider evidence:
+│   │                 focused tests=`4 passed`, existing factory tests=`38`
+│   │                 passed, runtime fallback=`1 passed`, route direct calls
+│   │                 remain `17`, provider dependency API refs remain `0`,
+│   │                 OpenAPI paths=`500`, duplicate operation IDs=`0`, and
+│   │                 refreshed GitNexus resolves both new provider symbols with
+│   │                 LOW upstream impact and `0` callers
+│   └── Next gate: Human review of the G2.61a closeout PR; if accepted, create a
+│                  separate G2.61b `data_quality.py` route migration
+│                  authorization / consumer-matrix packet; no route edit is
+│                  authorized until that packet is reviewed
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1015,6 +1023,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-lifecycle-di-authorization-2026-05-24.md` | G | G2.59 authorization packet prepared at current HEAD `1880f0d1395e7c5594b70f3ba40478cff24f2d3a`: records PR `#199` as `MERGED`, confirms fresh non-linked GitNexus analyze exit=`0`, nodes=`62624`, edges=`145803`, flows=`300`, resolves `get_data_source_factory` at `web/backend/app/services/data_source_factory/data_source_factory.py:294-300`, static scan keeps direct API calls=`17` across `9` files, and refreshed GitNexus upstream impact remains `CRITICAL` (`22` impacted, `21` direct, `15` processes, `3` modules); no source, test, route, OpenAPI, OpenSpec, runtime, issue-label, or compatibility cleanup change is authorized | Human review / PR merge decision; if accepted, create G2.60 consumer-matrix / implementation-authorization packet before any backend source edit |
 | `backend-data-source-factory-consumer-matrix-implementation-authorization-2026-05-24.md` | G | G2.60 consumer matrix / implementation authorization prepared at current HEAD `265f38e53bddfa3a925f14cfbc5080b00dce26e6`: records PR `#200` as `MERGED`, confirms fresh non-linked GitNexus analyze exit=`0`, nodes=`62628`, edges=`145797`, flows=`300`, keeps direct API calls=`17` across `9` files, and selects G2.61a provider-seam-only as the next possible source batch with allowed future scope limited to `data_source_factory.py`, a focused lifecycle DI test, implementation evidence, and a future task card; route migration, compatibility getter cleanup, OpenAPI changes, issue-label changes, and runtime/PM2 changes remain locked | Human review / PR merge decision; if accepted, create G2.61a provider-seam-only implementation branch before any route migration |
 | `backend-data-source-factory-provider-seam-implementation-2026-05-24.md` | G | G2.61a provider-seam implementation prepared at current HEAD `ae6ba4e43b1470b524110fe506929df675bd8b93`: records PR `#201` as `MERGED`, confirms pre-edit non-linked GitNexus analyze exit=`0`, nodes=`62636`, edges=`145807`, flows=`300`, and CRITICAL impact remains expected; adds `DATA_SOURCE_FACTORY_STATE_KEY`, `install_data_source_factory`, and `get_data_source_factory_dependency` in `data_source_factory.py`, adds focused lifecycle DI tests, preserves `get_data_source_factory()` and `_global_factory`, keeps route direct calls=`17` and provider dependency API refs=`0`, TDD red=`3 failed, 1 passed`, green=`4 passed`, existing factory tests=`38 passed`, route-adjacent fallback test=`1 passed`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; `tests/backend/test_data_api_regression.py` still has baseline 404 failures in both modified and unmodified checkouts and is not part of this batch | Human review / PR merge decision; if accepted, run G2.61a closeout/current-head refresh before selecting any route migration packet |
+| `backend-data-source-factory-provider-seam-closeout-2026-05-24.md` | G | G2.61a closeout prepared at current HEAD `0aadb27801c86e97e65ffdb4426276e1bd14c352`: records PR `#202` as `MERGED`, confirms provider symbols remain present, route direct calls remain `17`, provider dependency API refs remain `0`, focused lifecycle DI test=`4 passed`, existing factory test=`38 passed`, route-adjacent runtime fallback=`1 passed`, ruff/black passed, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus resolves `get_data_source_factory_dependency` plus `install_data_source_factory` with LOW upstream impact and `0` callers; no source, test, route, OpenAPI, OpenSpec, issue-label, runtime, PM2, package export, or compatibility cleanup change is authorized | Human review / PR merge decision; if accepted, create G2.61b `data_quality.py` route migration authorization / consumer-matrix packet before any route edit |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/data-source-factory-provider-seam-closeout-2026-05-24.json
+++ b/.planning/codebase/generated/data-source-factory-provider-seam-closeout-2026-05-24.json
@@ -1,0 +1,87 @@
+{
+  "artifact": "data-source-factory-provider-seam-closeout",
+  "workline": "G2.61a-closeout",
+  "generated_at": "2026-05-24T21:02:45+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_branch": "g2-61a-data-source-factory-provider-closeout",
+  "current_head": "0aadb27801c86e97e65ffdb4426276e1bd14c352",
+  "status": "ready_for_review",
+  "scope": {
+    "kind": "closeout_current_head_refresh",
+    "source_edits": false,
+    "test_edits": false,
+    "route_or_openapi_edits": false,
+    "openspec_edits": false,
+    "runtime_or_pm2_changes": false,
+    "issue_label_changes": false
+  },
+  "merge_evidence": {
+    "implementation_pr": 202,
+    "implementation_merge_commit": "0aadb27801c86e97e65ffdb4426276e1bd14c352",
+    "provider_symbols": [
+      "DATA_SOURCE_FACTORY_STATE_KEY",
+      "install_data_source_factory",
+      "get_data_source_factory_dependency"
+    ],
+    "preserved_symbols": [
+      "get_data_source_factory",
+      "_global_factory"
+    ]
+  },
+  "route_guard": {
+    "api_files_scanned": 219,
+    "direct_get_data_source_factory_calls": 17,
+    "get_data_source_factory_dependency_api_refs": 0,
+    "route_migration_performed": false
+  },
+  "gitnexus_refresh": {
+    "checkout": ".worktrees/g2-61a-closeout-gitnexus-index-checkout",
+    "git_dot_kind": "directory",
+    "head": "0aadb27801c8",
+    "analyze_exit": 0,
+    "nodes": 62642,
+    "edges": 145826,
+    "clusters": 3288,
+    "flows": 300
+  },
+  "gitnexus_symbols": [
+    {
+      "symbol": "get_data_source_factory_dependency",
+      "file": "web/backend/app/services/data_source_factory/data_source_factory.py",
+      "lines": "314-318",
+      "incoming_callers": 0,
+      "upstream_risk": "LOW",
+      "impacted_count": 0
+    },
+    {
+      "symbol": "install_data_source_factory",
+      "file": "web/backend/app/services/data_source_factory/data_source_factory.py",
+      "lines": "308-311",
+      "incoming_callers": 0,
+      "upstream_risk": "LOW",
+      "impacted_count": 0
+    }
+  ],
+  "verification": {
+    "focused_lifecycle_di_test": "4 passed",
+    "existing_data_source_factory_test": "38 passed",
+    "data_stocks_runtime_fallback": "1 passed",
+    "ruff_touched": "passed",
+    "black_check_touched": "passed",
+    "app_import_with_test_env": "passed",
+    "routes": 548,
+    "openapi_paths": 500,
+    "operation_ids": 536,
+    "duplicate_operation_ids": 0
+  },
+  "residuals": [
+    "data_source_factory package __init__.py does not re-export provider symbols",
+    "17 direct API route calls remain unchanged",
+    "tests/backend/test_data_api_regression.py still has baseline 404 expectations"
+  ],
+  "decision": {
+    "provider_seam_closed": true,
+    "route_migration_status": "locked_until_next_packet",
+    "recommended_next_packet": "G2.61b data_quality.py route migration authorization / consumer matrix"
+  }
+}

--- a/docs/reports/quality/backend-data-source-factory-provider-seam-closeout-2026-05-24.md
+++ b/docs/reports/quality/backend-data-source-factory-provider-seam-closeout-2026-05-24.md
@@ -1,0 +1,149 @@
+# Backend Data Source Factory Provider Seam Closeout - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Workline: G2.61a closeout / current-head refresh
+
+Base branch: `wip/root-dirty-20260403`
+
+Current HEAD: `0aadb27801c86e97e65ffdb4426276e1bd14c352`
+
+## Scope Boundary
+
+This closeout records the merged G2.61a result. It does not change backend
+source code, tests, route paths, response contracts, OpenAPI exposure, generated
+clients, OpenSpec files, issue labels, runtime process state, or PM2 state.
+
+## Merge Evidence
+
+PR `#202` was merged at
+`0aadb27801c86e97e65ffdb4426276e1bd14c352`.
+
+Merged implementation summary:
+
+- Added `DATA_SOURCE_FACTORY_STATE_KEY`.
+- Added `install_data_source_factory(app, factory=None)`.
+- Added `get_data_source_factory_dependency(request)`.
+- Preserved `get_data_source_factory()` and `_global_factory`.
+- Added focused lifecycle DI tests.
+- Did not migrate any API route consumers.
+
+## Current-Head Provider Surface
+
+Current HEAD contains the provider seam in:
+
+```text
+web/backend/app/services/data_source_factory/data_source_factory.py
+```
+
+The focused lifecycle DI test remains in:
+
+```text
+web/backend/tests/test_data_source_factory_lifecycle_di.py
+```
+
+## Route Guard
+
+Post-merge static scan reports:
+
+- API files scanned: `219`
+- Direct `get_data_source_factory()` API calls: `17`
+- `get_data_source_factory_dependency` API refs: `0`
+
+This confirms G2.61a did not perform route migration. The `17` direct route/API
+calls remain intentionally locked for later route-specific packets.
+
+## GitNexus Refresh
+
+GitNexus was refreshed from a temporary non-linked checkout:
+
+- Checkout: `.worktrees/g2-61a-closeout-gitnexus-index-checkout`
+- `.git` kind: `directory`
+- HEAD: `0aadb27801c8`
+- `gitnexus analyze` exit: `0`
+- Nodes: `62642`
+- Edges: `145826`
+- Clusters: `3288`
+- Flows: `300`
+
+Refreshed graph results:
+
+| Symbol | Location | Incoming callers | Upstream risk |
+|---|---|---:|---|
+| `get_data_source_factory_dependency` | `data_source_factory.py:314-318` | 0 | LOW |
+| `install_data_source_factory` | `data_source_factory.py:308-311` | 0 | LOW |
+
+This closes the stale-graph risk for the new provider symbols.
+
+## Verification
+
+Focused lifecycle DI test:
+
+```text
+pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short
+4 passed
+```
+
+Existing factory regression:
+
+```text
+pytest -o addopts= web/backend/tests/test_data_source_factory.py -q --no-cov --tb=short
+38 passed
+```
+
+Route-adjacent runtime fallback:
+
+```text
+pytest -o addopts= web/backend/tests/test_data_stocks_runtime_fallback.py -q --no-cov --tb=short
+1 passed
+```
+
+Lint and formatting:
+
+```text
+ruff check ...data_source_factory.py ...test_data_source_factory_lifecycle_di.py
+All checks passed
+```
+
+```text
+black --check ...data_source_factory.py ...test_data_source_factory_lifecycle_di.py
+2 files would be left unchanged
+```
+
+App/OpenAPI smoke with non-secret test env values:
+
+```text
+app_import=passed
+routes=548
+openapi_paths=500
+operation_ids=536
+duplicate_operation_ids=0
+```
+
+## Residuals
+
+- `web/backend/app/services/data_source_factory/__init__.py` does not re-export
+  the new provider symbols. This remains outside G2.61a and should be decided by
+  the first route migration authorization packet if route code wants package
+  imports.
+- `17` direct API route calls remain unchanged.
+- `tests/backend/test_data_api_regression.py` still has baseline 404
+  expectations, already reproduced in an unmodified checkout during G2.61a.
+
+## Next Gate
+
+G2.61a closeout supports opening a separate first route migration planning
+packet.
+
+Recommended next packet:
+
+- G2.61b: `data_quality.py` route migration authorization / consumer matrix.
+
+G2.61b should remain decision/authorization-first and must not migrate routes
+until reviewed. It should decide whether to import
+`get_data_source_factory_dependency` from the implementation module directly or
+authorize a package `__init__.py` export update before route edits.

--- a/governance/mainline/task-cards/pr-203.yaml
+++ b/governance/mainline/task-cards/pr-203.yaml
@@ -1,0 +1,108 @@
+version: "v0.2"
+
+task:
+  id: "pr-203"
+  title: "Close out data source factory provider seam"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-data-source-factory-provider-seam-closeout"
+  objective: "record current-head closeout evidence after the G2.61a DataSourceFactory provider-seam implementation"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-provider-seam-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-provider-seam-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout records current-head evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-provider-seam-closeout-2026-05-24.json"
+    - "docs/reports/quality/backend-data-source-factory-provider-seam-closeout-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-203.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No route migration or API consumer rewrite in this PR"
+  - "No package __init__.py export update in this PR"
+  - "No compatibility getter cleanup in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-provider-seam-closeout-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-provider-seam-closeout-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-203.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-203.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "gitnexus detect-changes --scope staged"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the closeout boundary"
+    - "If this PR authorizes route migration, it bypasses the next packet gate"
+    - "If package exports are changed, this PR exceeds the closeout boundary"
+  rollback_plan: "revert this governance-only closeout PR; PR #202 remains the accepted implementation unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record post-merge closeout evidence for the DataSourceFactory provider seam"
+    modified_scope: "closeout report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none in this PR"
+    legacy_logic_impact: "none; route consumers and compatibility getter remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only closeout PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T21:02:45+08:00"
+    approval_note: "human maintainer approved continuing after PR #202; this packet records closeout evidence only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record G2.61a closeout after PR #202 merged
- confirm DataSourceFactory provider symbols resolve in refreshed GitNexus graph
- record current-head tests, route guard, app/OpenAPI smoke, and residual route migration lock
- keep next gate as G2.61b `data_quality.py` route migration authorization / consumer matrix

## Verification
- markdown governance gate: 2 checked files, 0 errors
- JSON parse: passed
- YAML parse: passed
- focused provider seam test: 4 passed
- existing `test_data_source_factory.py`: 38 passed
- `test_data_stocks_runtime_fallback.py`: 1 passed
- ruff touched files: passed
- black check touched files: passed
- app/OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0
- route guard: api_files=219, direct_get_data_source_factory_calls=17, dependency_refs=0
- GitNexus refresh: provider symbols resolve; upstream impact LOW, impacted_count=0
- post-commit mainline scope gate: pass=True
- GitNexus staged detect: LOW, 0 changed symbols, 0 affected processes

## Boundary
No source, test, route, OpenAPI, OpenSpec, issue-label, runtime, PM2, package export, or compatibility cleanup changes are included.