### PR TITLE
docs(governance): authorize data_quality data source factory migration

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -919,10 +919,21 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 OpenAPI paths=`500`, duplicate operation IDs=`0`, and
 │   │                 refreshed GitNexus resolves both new provider symbols with
 │   │                 LOW upstream impact and `0` callers
-│   └── Next gate: Human review of the G2.61a closeout PR; if accepted, create a
-│                  separate G2.61b `data_quality.py` route migration
-│                  authorization / consumer-matrix packet; no route edit is
-│                  authorized until that packet is reviewed
+│   │                 PR `#203` merged at
+│   │                 `ee2c74f3c8e1c4f690d2a1737db29c97c39a54d2`; G2.61b now
+│   │                 records the first route-migration authorization packet:
+│   │                 `data_quality.py` has direct factory calls at lines `58`
+│   │                 and `369`, package `__init__.py` exports the legacy getter
+│   │                 but not the provider dependency, focused provider tests
+│   │                 pass `4`, existing factory tests pass `38`,
+│   │                 data-quality mock configuration tests pass `2`, and
+│   │                 app/OpenAPI smoke remains routes=`548`, paths=`500`,
+│   │                 duplicate operation IDs=`0`
+│   └── Next gate: Human review of the G2.61b authorization PR; if accepted,
+│                  create a separate G2.61c implementation branch limited to
+│                  `data_quality.py`, the data-source-factory package export,
+│                  focused tests, implementation evidence, and a task card; the
+│                  remaining `15` route/API consumers remain locked
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1024,6 +1035,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-consumer-matrix-implementation-authorization-2026-05-24.md` | G | G2.60 consumer matrix / implementation authorization prepared at current HEAD `265f38e53bddfa3a925f14cfbc5080b00dce26e6`: records PR `#200` as `MERGED`, confirms fresh non-linked GitNexus analyze exit=`0`, nodes=`62628`, edges=`145797`, flows=`300`, keeps direct API calls=`17` across `9` files, and selects G2.61a provider-seam-only as the next possible source batch with allowed future scope limited to `data_source_factory.py`, a focused lifecycle DI test, implementation evidence, and a future task card; route migration, compatibility getter cleanup, OpenAPI changes, issue-label changes, and runtime/PM2 changes remain locked | Human review / PR merge decision; if accepted, create G2.61a provider-seam-only implementation branch before any route migration |
 | `backend-data-source-factory-provider-seam-implementation-2026-05-24.md` | G | G2.61a provider-seam implementation prepared at current HEAD `ae6ba4e43b1470b524110fe506929df675bd8b93`: records PR `#201` as `MERGED`, confirms pre-edit non-linked GitNexus analyze exit=`0`, nodes=`62636`, edges=`145807`, flows=`300`, and CRITICAL impact remains expected; adds `DATA_SOURCE_FACTORY_STATE_KEY`, `install_data_source_factory`, and `get_data_source_factory_dependency` in `data_source_factory.py`, adds focused lifecycle DI tests, preserves `get_data_source_factory()` and `_global_factory`, keeps route direct calls=`17` and provider dependency API refs=`0`, TDD red=`3 failed, 1 passed`, green=`4 passed`, existing factory tests=`38 passed`, route-adjacent fallback test=`1 passed`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; `tests/backend/test_data_api_regression.py` still has baseline 404 failures in both modified and unmodified checkouts and is not part of this batch | Human review / PR merge decision; if accepted, run G2.61a closeout/current-head refresh before selecting any route migration packet |
 | `backend-data-source-factory-provider-seam-closeout-2026-05-24.md` | G | G2.61a closeout prepared at current HEAD `0aadb27801c86e97e65ffdb4426276e1bd14c352`: records PR `#202` as `MERGED`, confirms provider symbols remain present, route direct calls remain `17`, provider dependency API refs remain `0`, focused lifecycle DI test=`4 passed`, existing factory test=`38 passed`, route-adjacent runtime fallback=`1 passed`, ruff/black passed, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus resolves `get_data_source_factory_dependency` plus `install_data_source_factory` with LOW upstream impact and `0` callers; no source, test, route, OpenAPI, OpenSpec, issue-label, runtime, PM2, package export, or compatibility cleanup change is authorized | Human review / PR merge decision; if accepted, create G2.61b `data_quality.py` route migration authorization / consumer-matrix packet before any route edit |
+| `backend-data-quality-data-source-factory-route-migration-authorization-2026-05-24.md` | G | G2.61b route migration authorization prepared at current HEAD `ee2c74f3c8e1c4f690d2a1737db29c97c39a54d2`: records PR `#203` as `MERGED`, confirms `data_quality.py` has two DataSourceFactory compatibility getter calls at lines `58` and `369`, keeps total API direct calls=`17` across `9` files and provider dependency API refs=`0`, records package export gap for `get_data_source_factory_dependency`, verifies provider lifecycle tests=`4 passed`, existing factory tests=`38 passed`, data-quality mock configuration tests=`2 passed`, ruff candidate files=`passed`, and app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; authorizes only a future G2.61c path-limited implementation packet for `data_quality.py` plus data-source-factory package export and focused tests | Human review / PR merge decision; if accepted, create G2.61c path-limited route migration implementation branch; remaining `15` route/API consumers stay locked |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/data-quality-data-source-factory-route-migration-authorization-2026-05-24.json
+++ b/.planning/codebase/generated/data-quality-data-source-factory-route-migration-authorization-2026-05-24.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "1.0",
+  "artifact": "data-quality-data-source-factory-route-migration-authorization",
+  "generated_at": "2026-05-24T21:18:36+08:00",
+  "workline": "G2.61b",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_head": "ee2c74f3c8e1c4f690d2a1737db29c97c39a54d2",
+  "status": "ready_for_review",
+  "scope_boundary": {
+    "kind": "governance_authorization_only",
+    "backend_source_modified": false,
+    "tests_modified": false,
+    "route_paths_modified": false,
+    "openapi_modified": false,
+    "openspec_modified": false,
+    "issue_labels_modified": false,
+    "runtime_or_pm2_modified": false
+  },
+  "upstream_state": {
+    "provider_seam_implementation_pr": 202,
+    "provider_seam_implementation_merge": "0aadb27801c86e97e65ffdb4426276e1bd14c352",
+    "provider_seam_closeout_pr": 203,
+    "provider_seam_closeout_merge": "ee2c74f3c8e1c4f690d2a1737db29c97c39a54d2",
+    "provider_symbols_present": [
+      "DATA_SOURCE_FACTORY_STATE_KEY",
+      "install_data_source_factory",
+      "get_data_source_factory_dependency",
+      "get_data_source_factory"
+    ]
+  },
+  "static_scan": {
+    "api_files_scanned": 219,
+    "direct_get_data_source_factory_calls": 17,
+    "get_data_source_factory_dependency_api_refs": 0,
+    "direct_call_files": {
+      "web/backend/app/api/data_quality.py": 2,
+      "web/backend/app/api/data/financial.py": 1,
+      "web/backend/app/api/data/futures.py": 2,
+      "web/backend/app/api/data/kline.py": 2,
+      "web/backend/app/api/data/lhb.py": 2,
+      "web/backend/app/api/data/margin.py": 3,
+      "web/backend/app/api/data/market.py": 1,
+      "web/backend/app/api/data/stocks.py": 2,
+      "web/backend/app/api/market/market_data_request.py": 2
+    }
+  },
+  "data_quality_candidate": {
+    "file": "web/backend/app/api/data_quality.py",
+    "direct_calls": [
+      {
+        "line": 58,
+        "function": "get_sources_health",
+        "statement": "factory = await get_data_source_factory()"
+      },
+      {
+        "line": 369,
+        "function": "get_system_status_overview",
+        "statement": "factory = await get_data_source_factory()"
+      }
+    ],
+    "existing_import": "from app.services.data_source_factory import get_data_source_factory",
+    "current_response_contract": "UnifiedResponse[Dict[str, Any]]",
+    "reason_selected": "Smallest mixed data-quality/status API surface with exactly two direct factory calls and existing focused mock-configuration test coverage."
+  },
+  "package_export_state": {
+    "file": "web/backend/app/services/data_source_factory/__init__.py",
+    "exports_get_data_source_factory": true,
+    "exports_get_data_source_factory_dependency": false,
+    "exports_install_data_source_factory": false,
+    "recommended_disposition": "Authorize a package re-export update together with the first route migration so route modules can keep package-level imports."
+  },
+  "verification": {
+    "provider_seam_focused_tests": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short",
+      "result": "4 passed"
+    },
+    "existing_factory_tests": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory.py -q --no-cov --tb=short",
+      "result": "38 passed"
+    },
+    "data_quality_mock_configuration_tests": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_mock_configuration.py -q --no-cov --tb=short",
+      "result": "2 passed"
+    },
+    "ruff": {
+      "command": "ruff check web/backend/app/services/data_source_factory/data_source_factory.py web/backend/app/services/data_source_factory/__init__.py web/backend/app/api/data_quality.py web/backend/tests/test_data_source_factory_lifecycle_di.py web/backend/tests/test_data_quality_mock_configuration.py",
+      "result": "passed"
+    },
+    "app_openapi_smoke": {
+      "result": "passed",
+      "routes": 548,
+      "openapi_paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 121,
+      "notes": "Smoke used non-secret test environment defaults and project root plus web/backend on sys.path."
+    }
+  },
+  "authorized_future_batch": {
+    "id": "G2.61c",
+    "kind": "first_route_migration_implementation",
+    "allowed_paths": [
+      "web/backend/app/services/data_source_factory/__init__.py",
+      "web/backend/app/api/data_quality.py",
+      "web/backend/tests/test_data_quality_mock_configuration.py",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py",
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/data-quality-data-source-factory-route-migration-implementation-*.json",
+      "docs/reports/quality/backend-data-quality-data-source-factory-route-migration-implementation-*.md",
+      "governance/mainline/task-cards/pr-*.yaml"
+    ],
+    "acceptance_criteria": [
+      "data_quality.py direct get_data_source_factory() calls reduce from 2 to 0",
+      "total API direct get_data_source_factory() calls reduce from 17 to 15",
+      "data_quality.py uses FastAPI Depends(get_data_source_factory_dependency) or an explicitly documented equivalent",
+      "package __init__.py re-exports get_data_source_factory_dependency if route imports remain package-level",
+      "route paths, response_model declarations, OpenAPI path count, and duplicate operation ID count remain unchanged",
+      "compatibility getter get_data_source_factory() and _global_factory remain preserved"
+    ],
+    "blocked_until_reviewed": true
+  }
+}

--- a/docs/reports/quality/backend-data-quality-data-source-factory-route-migration-authorization-2026-05-24.md
+++ b/docs/reports/quality/backend-data-quality-data-source-factory-route-migration-authorization-2026-05-24.md
@@ -1,0 +1,190 @@
+# Backend Data Quality DataSourceFactory Route Migration Authorization - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Workline: G2.61b data-quality route migration authorization
+
+Base branch: `wip/root-dirty-20260403`
+
+Current HEAD: `ee2c74f3c8e1c4f690d2a1737db29c97c39a54d2`
+
+## Scope Boundary
+
+G2.61b is a governance and implementation-authorization packet only.
+
+This packet does not modify backend source code, tests, route paths, response
+contracts, OpenAPI exposure, generated clients, OpenSpec files, issue labels,
+runtime processes, or PM2 state.
+
+Its purpose is to authorize a future path-limited implementation branch for the
+first DataSourceFactory route consumer migration after the G2.61a provider seam
+was implemented and closed out.
+
+## Upstream State
+
+Accepted upstream facts:
+
+- PR `#202` merged the provider seam at
+  `0aadb27801c86e97e65ffdb4426276e1bd14c352`.
+- PR `#203` merged the closeout/current-head refresh at
+  `ee2c74f3c8e1c4f690d2a1737db29c97c39a54d2`.
+- `DATA_SOURCE_FACTORY_STATE_KEY`, `install_data_source_factory(app,
+  factory=None)`, and `get_data_source_factory_dependency(request)` exist in
+  `web/backend/app/services/data_source_factory/data_source_factory.py`.
+- `get_data_source_factory()` and `_global_factory` remain preserved as
+  compatibility surfaces.
+- No API route consumer has been migrated yet.
+
+## Current Evidence
+
+Static current-head scan reports:
+
+- API files scanned: `219`
+- Direct `get_data_source_factory()` API calls: `17`
+- API files containing direct calls: `9`
+- `get_data_source_factory_dependency` API refs: `0`
+
+Consumer matrix:
+
+| File | Calls | Lines | Disposition |
+|---|---:|---|---|
+| `web/backend/app/api/data_quality.py` | 2 | `58`, `369` | first route migration candidate |
+| `web/backend/app/api/data/financial.py` | 1 | `69` | later domain route batch |
+| `web/backend/app/api/data/futures.py` | 2 | `91`, `114` | later domain route batch |
+| `web/backend/app/api/data/kline.py` | 2 | `145`, `245` | later domain route batch |
+| `web/backend/app/api/data/lhb.py` | 2 | `90`, `115` | later domain route batch |
+| `web/backend/app/api/data/margin.py` | 3 | `104`, `128`, `150` | later domain route batch |
+| `web/backend/app/api/data/market.py` | 1 | `98` | later domain route batch |
+| `web/backend/app/api/data/stocks.py` | 2 | `269`, `371` | later domain route batch |
+| `web/backend/app/api/market/market_data_request.py` | 2 | `134`, `427` | later market route batch |
+
+## Selected Candidate
+
+The selected first route consumer is:
+
+```text
+web/backend/app/api/data_quality.py
+```
+
+It has exactly two direct calls:
+
+| Function | Line | Current statement |
+|---|---:|---|
+| `get_sources_health` | `58` | `factory = await get_data_source_factory()` |
+| `get_system_status_overview` | `369` | `factory = await get_data_source_factory()` |
+
+Both routes already return `UnifiedResponse[Dict[str, Any]]`. The future
+implementation must not change route paths, response models, OpenAPI exposure,
+or response shape.
+
+## Package Export Decision
+
+Current package export state:
+
+- `web/backend/app/services/data_source_factory/__init__.py` exports
+  `get_data_source_factory`.
+- It does not export `get_data_source_factory_dependency`.
+- It does not export `install_data_source_factory`.
+
+Recommended future disposition:
+
+- Authorize a package-level re-export of `get_data_source_factory_dependency`
+  in the same path-limited implementation branch as the `data_quality.py`
+  migration.
+- Keep existing route imports at the package boundary:
+  `from app.services.data_source_factory import ...`.
+- Do not force route modules to import from the implementation file unless a
+  later reviewed packet explicitly chooses that style.
+
+This keeps the provider seam discoverable at the same package boundary already
+used by route consumers.
+
+## Verification
+
+Executed in the G2.61b worktree at current HEAD
+`ee2c74f3c8e1c4f690d2a1737db29c97c39a54d2`:
+
+| Check | Result |
+|---|---|
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | `4 passed` |
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory.py -q --no-cov --tb=short` | `38 passed` |
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_mock_configuration.py -q --no-cov --tb=short` | `2 passed` |
+| `ruff check` on provider/data-quality touched candidate files | passed |
+| app import / OpenAPI smoke with non-secret test env | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+
+The first app smoke without the complete required environment failed before
+import with missing environment variables. The successful smoke used non-secret
+test defaults for `POSTGRESQL_*`, backend ports, TDengine, Redis, JWT, and app
+secret settings, with both project root and `web/backend` on `sys.path`.
+
+## Authorized Future G2.61c Scope
+
+If this packet is accepted, a separate implementation branch may be created for
+G2.61c with this exact purpose:
+
+> Migrate the two `data_quality.py` DataSourceFactory consumers from direct
+> compatibility getter calls to the app-state provider dependency while
+> preserving route contracts and compatibility surfaces.
+
+Allowed future source/test paths:
+
+- `web/backend/app/services/data_source_factory/__init__.py`
+- `web/backend/app/api/data_quality.py`
+- `web/backend/tests/test_data_quality_mock_configuration.py`
+- `web/backend/tests/test_data_source_factory_lifecycle_di.py`
+
+Allowed future governance paths:
+
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/data-quality-data-source-factory-route-migration-implementation-*.json`
+- `docs/reports/quality/backend-data-quality-data-source-factory-route-migration-implementation-*.md`
+- `governance/mainline/task-cards/pr-*.yaml`
+
+## Future Acceptance Criteria
+
+The future implementation must satisfy all of the following:
+
+- `web/backend/app/api/data_quality.py` direct
+  `get_data_source_factory()` calls reduce from `2` to `0`.
+- Total API direct `get_data_source_factory()` calls reduce from `17` to `15`.
+- `data_quality.py` uses `Depends(get_data_source_factory_dependency)` or an
+  explicitly documented equivalent reviewed in the implementation packet.
+- Package-level imports remain valid; if `data_quality.py` imports the
+  dependency from `app.services.data_source_factory`, `__init__.py` must export
+  it.
+- `get_data_source_factory()` and `_global_factory` remain preserved.
+- Route paths, response models, OpenAPI path count, duplicate operation ID count,
+  and response shapes remain unchanged.
+- The future branch must run GitNexus impact before source edits and
+  `gitnexus detect-changes --scope staged` before commit.
+
+## Non-Goals
+
+G2.61b and the future G2.61c route migration do not authorize:
+
+- migrating the remaining `15` route/API direct calls;
+- changing data source factory construction semantics;
+- deleting `_global_factory` or `get_data_source_factory()`;
+- changing OpenAPI exposure, route paths, response models, or response shape;
+- touching frontend, generated clients, PM2/runtime process state, OpenSpec
+  files, issue labels, docs/API examples, or unrelated service seams.
+
+## Decision
+
+Approve `web/backend/app/api/data_quality.py` as the first route migration
+candidate after the DataSourceFactory provider seam.
+
+Do not edit route code under this G2.61b packet. If accepted, create a separate
+G2.61c implementation branch with the path and acceptance boundaries above.
+
+## Next Gate
+
+Human review of this G2.61b authorization PR.
+
+If accepted and merged, open G2.61c as a path-limited implementation branch for
+`data_quality.py` only. The remaining route consumers stay locked for later
+consumer-specific authorization packets.

--- a/governance/mainline/task-cards/pr-204.yaml
+++ b/governance/mainline/task-cards/pr-204.yaml
@@ -1,0 +1,109 @@
+version: "v0.2"
+
+task:
+  id: "pr-204"
+  title: "Authorize first DataSourceFactory route migration candidate"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-data-quality-data-source-factory-route-migration-authorization"
+  objective: "authorize a future path-limited data_quality.py migration from DataSourceFactory compatibility getter calls to the app-state provider dependency"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-quality-data-source-factory-route-migration-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-quality-data-source-factory-route-migration-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization packet records route consumer evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-quality-data-source-factory-route-migration-authorization-2026-05-24.json"
+    - "docs/reports/quality/backend-data-quality-data-source-factory-route-migration-authorization-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-204.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No data_quality.py source migration in this PR"
+  - "No package __init__.py export update in this PR"
+  - "No compatibility getter cleanup in this PR"
+  - "No migration of the remaining non-data_quality route consumers in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-quality-data-source-factory-route-migration-authorization-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-quality-data-source-factory-route-migration-authorization-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-204.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-204.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "gitnexus detect-changes --scope staged"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the authorization-only boundary"
+    - "If this PR performs the data_quality.py route migration, it bypasses the implementation review gate"
+    - "If package exports are changed, this PR exceeds the authorization-only boundary"
+  rollback_plan: "revert this governance-only authorization PR; the G2.61a provider seam and closeout remain accepted unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize a future data_quality.py DataSourceFactory route migration candidate"
+    modified_scope: "authorization report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none in this PR"
+    legacy_logic_impact: "none; route consumers and compatibility getter remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only authorization PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T21:18:36+08:00"
+    approval_note: "human maintainer approved continuing after G2.61a closeout; this packet authorizes only a future reviewed data_quality.py route migration branch"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records G2.61b authorization for the first DataSourceFactory route consumer migration
- selects web/backend/app/api/data_quality.py as the next path-limited route migration candidate
- keeps this PR governance-only with no backend source, route, OpenAPI, OpenSpec, PM2, or issue-label changes

## Verification
- markdown governance: 2 checked, 0 errors
- json/yaml parse: passed
- focused provider tests: 4 passed
- existing factory tests: 38 passed
- data quality mock configuration tests: 2 passed
- ruff candidate files: passed
- app/OpenAPI smoke: routes=548, paths=500, duplicate operation IDs=0
- GitNexus staged scope: LOW, changed symbols=0, affected processes=0
- post-commit mainline gate: pass=True