### PR TITLE
refactor(api): inject data source factory in data_quality routes

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -929,11 +929,20 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 data-quality mock configuration tests pass `2`, and
 │   │                 app/OpenAPI smoke remains routes=`548`, paths=`500`,
 │   │                 duplicate operation IDs=`0`
-│   └── Next gate: Human review of the G2.61b authorization PR; if accepted,
-│                  create a separate G2.61c implementation branch limited to
-│                  `data_quality.py`, the data-source-factory package export,
-│                  focused tests, implementation evidence, and a task card; the
-│                  remaining `15` route/API consumers remain locked
+│   │                 PR `#204` merged at
+│   │                 `52a2aaa57150db834bcef3a526a4b78e37ac438a`; G2.61c now
+│   │                 implements the approved first route migration:
+│   │                 `data_quality.py` direct calls move from `2` to `0`,
+│   │                 total API direct calls move from `17` to `15`, package
+│   │                 `__init__.py` re-exports
+│   │                 `get_data_source_factory_dependency`, focused route tests
+│   │                 pass `4`, provider tests pass `4`, existing factory tests
+│   │                 pass `38`, and app/OpenAPI smoke remains routes=`548`,
+│   │                 paths=`500`, duplicate operation IDs=`0`
+│   └── Next gate: Human review of the G2.61c implementation PR; if accepted,
+│                  run a separate G2.61c closeout/current-head refresh before
+│                  selecting the next DataSourceFactory route consumer packet;
+│                  the remaining `15` route/API consumers remain locked
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1036,6 +1045,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-provider-seam-implementation-2026-05-24.md` | G | G2.61a provider-seam implementation prepared at current HEAD `ae6ba4e43b1470b524110fe506929df675bd8b93`: records PR `#201` as `MERGED`, confirms pre-edit non-linked GitNexus analyze exit=`0`, nodes=`62636`, edges=`145807`, flows=`300`, and CRITICAL impact remains expected; adds `DATA_SOURCE_FACTORY_STATE_KEY`, `install_data_source_factory`, and `get_data_source_factory_dependency` in `data_source_factory.py`, adds focused lifecycle DI tests, preserves `get_data_source_factory()` and `_global_factory`, keeps route direct calls=`17` and provider dependency API refs=`0`, TDD red=`3 failed, 1 passed`, green=`4 passed`, existing factory tests=`38 passed`, route-adjacent fallback test=`1 passed`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; `tests/backend/test_data_api_regression.py` still has baseline 404 failures in both modified and unmodified checkouts and is not part of this batch | Human review / PR merge decision; if accepted, run G2.61a closeout/current-head refresh before selecting any route migration packet |
 | `backend-data-source-factory-provider-seam-closeout-2026-05-24.md` | G | G2.61a closeout prepared at current HEAD `0aadb27801c86e97e65ffdb4426276e1bd14c352`: records PR `#202` as `MERGED`, confirms provider symbols remain present, route direct calls remain `17`, provider dependency API refs remain `0`, focused lifecycle DI test=`4 passed`, existing factory test=`38 passed`, route-adjacent runtime fallback=`1 passed`, ruff/black passed, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus resolves `get_data_source_factory_dependency` plus `install_data_source_factory` with LOW upstream impact and `0` callers; no source, test, route, OpenAPI, OpenSpec, issue-label, runtime, PM2, package export, or compatibility cleanup change is authorized | Human review / PR merge decision; if accepted, create G2.61b `data_quality.py` route migration authorization / consumer-matrix packet before any route edit |
 | `backend-data-quality-data-source-factory-route-migration-authorization-2026-05-24.md` | G | G2.61b route migration authorization prepared at current HEAD `ee2c74f3c8e1c4f690d2a1737db29c97c39a54d2`: records PR `#203` as `MERGED`, confirms `data_quality.py` has two DataSourceFactory compatibility getter calls at lines `58` and `369`, keeps total API direct calls=`17` across `9` files and provider dependency API refs=`0`, records package export gap for `get_data_source_factory_dependency`, verifies provider lifecycle tests=`4 passed`, existing factory tests=`38 passed`, data-quality mock configuration tests=`2 passed`, ruff candidate files=`passed`, and app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; authorizes only a future G2.61c path-limited implementation packet for `data_quality.py` plus data-source-factory package export and focused tests | Human review / PR merge decision; if accepted, create G2.61c path-limited route migration implementation branch; remaining `15` route/API consumers stay locked |
+| `backend-data-quality-data-source-factory-route-migration-implementation-2026-05-24.md` | G | G2.61c implementation prepared at current HEAD `52a2aaa57150db834bcef3a526a4b78e37ac438a`: records PR `#204` as `MERGED`, refreshes non-linked GitNexus at the same HEAD with analyze exit=`0`, nodes=`62644`, edges=`145830`, flows=`300`, records LOW/0 upstream impact for `get_sources_health`, `get_system_status_overview`, `get_data_source_factory_dependency`, and `install_data_source_factory`, follows TDD red=`2 failed, 2 passed` then green=`4 passed`, re-exports `get_data_source_factory_dependency`, migrates `data_quality.py` direct calls from `2` to `0`, reduces total API direct calls from `17` to `15`, preserves `get_data_source_factory()` plus `_global_factory`, verifies provider tests=`4 passed`, existing factory tests=`38 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; remaining `15` route/API consumers stay locked | Human review / PR merge decision; if accepted, run G2.61c closeout/current-head refresh before selecting another DataSourceFactory route consumer packet |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/data-quality-data-source-factory-route-migration-implementation-2026-05-24.json
+++ b/.planning/codebase/generated/data-quality-data-source-factory-route-migration-implementation-2026-05-24.json
@@ -1,0 +1,129 @@
+{
+  "schema_version": "1.0",
+  "artifact": "data-quality-data-source-factory-route-migration-implementation",
+  "generated_at": "2026-05-24T22:01:08+08:00",
+  "workline": "G2.61c",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "52a2aaa57150db834bcef3a526a4b78e37ac438a",
+  "status": "ready_for_review",
+  "authorization": {
+    "source_report": "docs/reports/quality/backend-data-quality-data-source-factory-route-migration-authorization-2026-05-24.md",
+    "source_pr": 204,
+    "source_merge": "52a2aaa57150db834bcef3a526a4b78e37ac438a"
+  },
+  "scope_boundary": {
+    "backend_source_modified": true,
+    "allowed_source_paths": [
+      "web/backend/app/services/data_source_factory/__init__.py",
+      "web/backend/app/api/data_quality.py"
+    ],
+    "allowed_test_paths": [
+      "web/backend/tests/test_data_quality_mock_configuration.py"
+    ],
+    "route_paths_modified": false,
+    "response_contracts_modified": false,
+    "openapi_exposure_modified": false,
+    "compatibility_getter_removed": false,
+    "openspec_modified": false,
+    "issue_labels_modified": false,
+    "runtime_or_pm2_modified": false
+  },
+  "gitnexus_pre_edit": {
+    "index_repo": "g2-61c-gitnexus-index-checkout",
+    "index_head": "52a2aaa57",
+    "index_git_kind": "directory",
+    "analyze_exit": 0,
+    "nodes": 62644,
+    "edges": 145830,
+    "flows": 300,
+    "impacts": {
+      "get_sources_health": {
+        "risk": "LOW",
+        "impacted_count": 0
+      },
+      "get_system_status_overview": {
+        "risk": "LOW",
+        "impacted_count": 0
+      },
+      "get_data_source_factory_dependency": {
+        "risk": "LOW",
+        "impacted_count": 0
+      },
+      "install_data_source_factory": {
+        "risk": "LOW",
+        "impacted_count": 0
+      }
+    }
+  },
+  "tdd": {
+    "red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_mock_configuration.py -q --no-cov --tb=short",
+      "result": "2 failed, 2 passed",
+      "expected_failures": [
+        "package get_data_source_factory_dependency export missing",
+        "data_quality route handlers missing factory dependency parameter"
+      ]
+    },
+    "green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_mock_configuration.py -q --no-cov --tb=short",
+      "result": "4 passed"
+    }
+  },
+  "implementation": {
+    "package_exports_added": [
+      "get_data_source_factory_dependency"
+    ],
+    "route_handlers_migrated": [
+      "get_sources_health",
+      "get_system_status_overview"
+    ],
+    "direct_getter_calls_removed_from_data_quality": 2,
+    "compatibility_getter_preserved": true,
+    "global_factory_preserved": true
+  },
+  "route_guard": {
+    "api_files_scanned": 219,
+    "before_total_direct_get_data_source_factory_calls": 17,
+    "after_total_direct_get_data_source_factory_calls": 15,
+    "before_data_quality_direct_calls": 2,
+    "after_data_quality_direct_calls": 0,
+    "get_data_source_factory_dependency_api_refs": 3,
+    "remaining_direct_call_files": {
+      "web/backend/app/api/data/financial.py": 1,
+      "web/backend/app/api/data/futures.py": 2,
+      "web/backend/app/api/data/kline.py": 2,
+      "web/backend/app/api/data/lhb.py": 2,
+      "web/backend/app/api/data/margin.py": 3,
+      "web/backend/app/api/data/market.py": 1,
+      "web/backend/app/api/data/stocks.py": 2,
+      "web/backend/app/api/market/market_data_request.py": 2
+    }
+  },
+  "verification": {
+    "data_quality_mock_configuration_tests": "4 passed",
+    "provider_lifecycle_tests": "4 passed",
+    "data_source_factory_tests": "38 passed",
+    "ruff_touched_files": "passed",
+    "black_check_touched_files": "4 files would be left unchanged",
+    "direct_handler_call_refs": 0,
+    "app_openapi_smoke": {
+      "app_import": "passed",
+      "routes": 548,
+      "openapi_paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 121
+    },
+    "staged_gitinex_root_scope": {
+      "repo": "mystocks_spec",
+      "result": "HIGH",
+      "note": "root staged detect_changes used the older project index and over-approximated the modified route file; authoritative current-head non-linked impact remained LOW/0 for the edited route symbols"
+    }
+  },
+  "next_gate": {
+    "recommended": "G2.61c closeout/current-head refresh before selecting the next DataSourceFactory route consumer packet",
+    "remaining_direct_route_calls": 15,
+    "remaining_consumers_locked": true
+  }
+}

--- a/docs/reports/quality/backend-data-quality-data-source-factory-route-migration-implementation-2026-05-24.md
+++ b/docs/reports/quality/backend-data-quality-data-source-factory-route-migration-implementation-2026-05-24.md
@@ -1,0 +1,183 @@
+# Backend Data Quality DataSourceFactory Route Migration Implementation - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Workline: G2.61c data-quality DataSourceFactory route migration implementation
+
+Base branch: `wip/root-dirty-20260403`
+
+Base HEAD: `52a2aaa57150db834bcef3a526a4b78e37ac438a`
+
+## Scope Boundary
+
+This implementation follows the G2.61b authorization packet.
+
+Modified source/test paths:
+
+- `web/backend/app/services/data_source_factory/__init__.py`
+- `web/backend/app/api/data_quality.py`
+- `web/backend/tests/test_data_quality_mock_configuration.py`
+
+Modified governance paths:
+
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/data-quality-data-source-factory-route-migration-implementation-2026-05-24.json`
+- `docs/reports/quality/backend-data-quality-data-source-factory-route-migration-implementation-2026-05-24.md`
+- `governance/mainline/task-cards/pr-205.yaml`
+
+This implementation does not change route paths, response models, response
+shape, OpenAPI exposure, generated clients, frontend code, PM2/runtime process
+state, OpenSpec files, issue labels, or the remaining DataSourceFactory route
+consumers.
+
+## Authorization
+
+G2.61b was merged by PR `#204` at
+`52a2aaa57150db834bcef3a526a4b78e37ac438a`.
+
+It authorized only a path-limited implementation for:
+
+- package export of `get_data_source_factory_dependency`;
+- the two `web/backend/app/api/data_quality.py` call sites;
+- focused tests and implementation evidence.
+
+## GitNexus Evidence
+
+Before source edits, GitNexus was refreshed in a non-linked checkout because the
+root `mystocks_spec` index still pointed at an older dirty HEAD.
+
+Refresh details:
+
+- Repo: `g2-61c-gitnexus-index-checkout`
+- HEAD: `52a2aaa57`
+- `.git` kind: `directory`
+- `gitnexus analyze` exit: `0`
+- Nodes: `62644`
+- Edges: `145830`
+- Flows: `300`
+
+Pre-edit upstream impact:
+
+| Symbol | Risk | Impacted count |
+|---|---|---:|
+| `get_sources_health` | LOW | 0 |
+| `get_system_status_overview` | LOW | 0 |
+| `get_data_source_factory_dependency` | LOW | 0 |
+| `install_data_source_factory` | LOW | 0 |
+
+## TDD
+
+RED:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_mock_configuration.py -q --no-cov --tb=short
+```
+
+Result: `2 failed, 2 passed`.
+
+Expected failures:
+
+- package `app.services.data_source_factory` did not export
+  `get_data_source_factory_dependency`;
+- `get_sources_health` and `get_system_status_overview` did not expose a
+  `factory` dependency parameter.
+
+GREEN:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_mock_configuration.py -q --no-cov --tb=short
+```
+
+Result: `4 passed`.
+
+## Implementation
+
+Implemented changes:
+
+- Re-exported `get_data_source_factory_dependency` from
+  `web/backend/app/services/data_source_factory/__init__.py`.
+- Added `Depends(get_data_source_factory_dependency)` to:
+  - `get_sources_health`
+  - `get_system_status_overview`
+- Removed both direct `await get_data_source_factory()` calls from
+  `web/backend/app/api/data_quality.py`.
+- Preserved `get_data_source_factory()` and `_global_factory`.
+
+## Route Guard
+
+Post-change static scan:
+
+- API files scanned: `219`
+- Total direct `get_data_source_factory()` API calls: `15`
+- `data_quality.py` direct calls: `0`
+- `get_data_source_factory_dependency` API refs: `3`
+- Direct handler call references to `get_sources_health(...)` or
+  `get_system_status_overview(...)`: `0`
+
+Remaining direct-call files:
+
+| File | Calls |
+|---|---:|
+| `web/backend/app/api/data/financial.py` | 1 |
+| `web/backend/app/api/data/futures.py` | 2 |
+| `web/backend/app/api/data/kline.py` | 2 |
+| `web/backend/app/api/data/lhb.py` | 2 |
+| `web/backend/app/api/data/margin.py` | 3 |
+| `web/backend/app/api/data/market.py` | 1 |
+| `web/backend/app/api/data/stocks.py` | 2 |
+| `web/backend/app/api/market/market_data_request.py` | 2 |
+
+The remaining `15` route/API consumers stay locked for later authorization
+packets.
+
+## Verification
+
+Executed after implementation:
+
+| Check | Result |
+|---|---|
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_mock_configuration.py -q --no-cov --tb=short` | `4 passed` |
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | `4 passed` |
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory.py -q --no-cov --tb=short` | `38 passed` |
+| `ruff check` on touched source/test files | passed |
+| `black --check` on touched source/test files | `4 files would be left unchanged` |
+| app import / OpenAPI smoke with non-secret test env | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+
+The app/OpenAPI smoke still reports `warning_count=121`, including the existing
+GPU fallback warning for the local NumPy/Numba mismatch. No duplicate operation
+ID warning was emitted.
+
+The root `mystocks_spec` staged detect_changes run still reported `HIGH`
+because it used the older project index and over-approximated the modified route
+file. The non-linked current-head GitNexus refresh used for the actual edit
+authorization remained LOW/0 for the edited route symbols.
+
+## Non-Goals
+
+This implementation does not authorize:
+
+- migrating the remaining `15` DataSourceFactory route/API direct calls;
+- deleting `get_data_source_factory()` or `_global_factory`;
+- changing data-source factory construction semantics;
+- changing route paths, response models, response shape, or OpenAPI exposure;
+- touching frontend, generated clients, PM2/runtime process state, OpenSpec
+  files, issue labels, docs/API examples, or unrelated service seams.
+
+## Decision
+
+G2.61c completes the first DataSourceFactory route consumer migration:
+
+- `data_quality.py`: `2` direct calls -> `0`;
+- API total: `17` direct calls -> `15`;
+- route/OpenAPI contract unchanged.
+
+## Next Gate
+
+Human review of this implementation PR.
+
+If accepted and merged, run a separate G2.61c closeout/current-head refresh
+before selecting the next DataSourceFactory route consumer packet.

--- a/governance/mainline/task-cards/pr-205.yaml
+++ b/governance/mainline/task-cards/pr-205.yaml
@@ -1,0 +1,127 @@
+version: "v0.2"
+
+task:
+  id: "pr-205"
+  title: "Migrate data_quality DataSourceFactory route consumers"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-data-quality-data-source-factory-route-migration"
+  objective: "migrate the two data_quality.py DataSourceFactory compatibility getter consumers to the app-state provider dependency"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-quality-data-source-factory-route-migration"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-quality-data-source-factory-route-migration"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Path-limited route dependency injection migration preserves route paths, response contracts, OpenAPI exposure, and product behavior"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/services/data_source_factory/__init__.py"
+    - "web/backend/app/api/data_quality.py"
+    - "web/backend/tests/test_data_quality_mock_configuration.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-quality-data-source-factory-route-migration-implementation-2026-05-24.json"
+    - "docs/reports/quality/backend-data-quality-data-source-factory-route-migration-implementation-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-205.yaml"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+    - "web/backend/app/api/data/**"
+    - "web/backend/app/api/market/**"
+
+non_goals:
+  - "No migration of remaining non-data_quality DataSourceFactory route consumers"
+  - "No route path, response model, response shape, OpenAPI exposure, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No compatibility getter or _global_factory deletion"
+  - "No data source factory construction semantic change"
+
+acceptance:
+  checks:
+    - id: "focused-data-quality-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_mock_configuration.py -q --no-cov --tb=short"
+      required: true
+    - id: "provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "factory-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/api/data_quality.py web/backend/app/services/data_source_factory/__init__.py web/backend/tests/test_data_quality_mock_configuration.py web/backend/tests/test_data_source_factory_lifecycle_di.py"
+      required: true
+    - id: "black-check-touched"
+      command: "black --check web/backend/app/api/data_quality.py web/backend/app/services/data_source_factory/__init__.py web/backend/tests/test_data_quality_mock_configuration.py web/backend/tests/test_data_source_factory_lifecycle_di.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-quality-data-source-factory-route-migration-implementation-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-quality-data-source-factory-route-migration-implementation-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-205.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-205.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "gitnexus detect-changes --scope staged"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "A direct test caller could bypass FastAPI dependency injection; static scan found no direct references"
+    - "If non-data_quality consumers are edited, the PR exceeds the authorized route scope"
+    - "If route paths or response contracts change, the PR exceeds the authorized compatibility boundary"
+  rollback_plan: "revert this path-limited implementation PR; G2.61b authorization and G2.61a provider seam remain accepted unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "migrate data_quality.py DataSourceFactory consumers to the app-state provider dependency"
+    modified_scope: "data_quality.py, data_source_factory package export, focused test, implementation report, generated artifact, steward tree, and this task card"
+    dependency_changes: "adds package export for get_data_source_factory_dependency"
+    legacy_logic_impact: "compatibility getter and _global_factory remain preserved; remaining route consumers stay locked"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this path-limited implementation PR if route/OpenAPI or focused tests regress"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T22:01:08+08:00"
+    approval_note: "human maintainer approved continuing after G2.61b authorization; this packet implements only the approved data_quality.py route migration scope"
+    secondary_approved: false

--- a/web/backend/app/api/data_quality.py
+++ b/web/backend/app/api/data_quality.py
@@ -17,14 +17,15 @@ import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Body, Path, Query
+from fastapi import APIRouter, Body, Depends, Path, Query
 
 from app.core.config import settings
 from app.core.exceptions import NotFoundException
 from app.core.responses import UnifiedResponse, create_error_response, create_success_response
 from app.services.data_quality_monitor import get_data_quality_monitor, monitor_data_quality
 from app.services.data_source_factory import (
-    get_data_source_factory,
+    DataSourceFactory,
+    get_data_source_factory_dependency,
     get_data_source_mode as get_factory_mode,
     is_fallback_enabled,
 )
@@ -45,6 +46,7 @@ from app.api._data_quality_responses import (
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/data-quality", tags=["data-quality"], responses=DATA_QUALITY_ERROR_RESPONSES)
 
+
 @router.get(
     "/health",
     response_model=UnifiedResponse[Dict[str, Any]],
@@ -52,10 +54,9 @@ router = APIRouter(prefix="/data-quality", tags=["data-quality"], responses=DATA
     description="汇总所有数据源的健康状态、响应时间和可用性指标，供运维与数据质量监控面板使用。",
     responses=DATA_QUALITY_HEALTH_RESPONSES,
 )
-async def get_sources_health():
+async def get_sources_health(factory: DataSourceFactory = Depends(get_data_source_factory_dependency)):
     """获取所有数据源健康状态"""
     try:
-        factory = await get_data_source_factory()
         health_results = await factory.health_check_all()
 
         # 格式化健康状态
@@ -362,11 +363,10 @@ async def get_data_source_mode():
     description="汇总数据源健康分、告警数量、运行模式和近期性能指标，用于数据质量总览面板展示。",
     responses=DATA_QUALITY_OVERVIEW_RESPONSES,
 )
-async def get_system_status_overview():
+async def get_system_status_overview(factory: DataSourceFactory = Depends(get_data_source_factory_dependency)):
     """获取系统状态概览"""
     try:
         # 获取数据源工厂状态
-        factory = await get_data_source_factory()
         health_results = await factory.health_check_all()
         available_sources = factory.get_available_sources()
 

--- a/web/backend/app/services/data_source_factory/__init__.py
+++ b/web/backend/app/services/data_source_factory/__init__.py
@@ -1,4 +1,5 @@
 """data_source_factory 拆分包"""
+
 from .data_source_mode import DataSourceMode  # noqa: F401
 from .data_source_mode import DataSourceMetrics  # noqa: F401
 from .data_source_mode import DataSourceConfig  # noqa: F401
@@ -9,6 +10,7 @@ from .data_source_mode import HybridDataSource  # noqa: F401
 from .data_source_mode import DynamicConfigManager  # noqa: F401
 from .data_source_factory import DataSourceFactory  # noqa: F401
 from .data_source_factory import get_data_source_factory  # noqa: F401
+from .data_source_factory import get_data_source_factory_dependency  # noqa: F401
 from .data_source_factory import get_data_source  # noqa: F401
 from .data_source_factory import get_market_data  # noqa: F401
 from .data_source_factory import get_dashboard_data  # noqa: F401
@@ -16,4 +18,22 @@ from .data_source_factory import get_technical_analysis_data  # noqa: F401
 from .data_source_factory import get_data_source_mode  # noqa: F401
 from .data_source_factory import is_fallback_enabled  # noqa: F401
 
-__all__ = ['DataSourceMode', 'DataSourceMetrics', 'DataSourceConfig', 'BaseDataSource', 'MockDataSource', 'RealDataSource', 'HybridDataSource', 'DynamicConfigManager', 'DataSourceFactory', 'get_data_source_factory', 'get_data_source', 'get_market_data', 'get_dashboard_data', 'get_technical_analysis_data', 'get_data_source_mode', 'is_fallback_enabled']
+__all__ = [
+    "DataSourceMode",
+    "DataSourceMetrics",
+    "DataSourceConfig",
+    "BaseDataSource",
+    "MockDataSource",
+    "RealDataSource",
+    "HybridDataSource",
+    "DynamicConfigManager",
+    "DataSourceFactory",
+    "get_data_source_factory",
+    "get_data_source_factory_dependency",
+    "get_data_source",
+    "get_market_data",
+    "get_dashboard_data",
+    "get_technical_analysis_data",
+    "get_data_source_mode",
+    "is_fallback_enabled",
+]

--- a/web/backend/tests/test_data_quality_mock_configuration.py
+++ b/web/backend/tests/test_data_quality_mock_configuration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -12,6 +13,21 @@ def test_data_quality_source_contains_no_direct_use_mock_env_reads():
     source = Path(module.__file__).read_text(encoding="utf-8")
 
     assert 'os.getenv("USE_MOCK_DATA"' not in source
+
+
+def test_data_source_factory_package_exports_route_dependency():
+    from app.services import data_source_factory as package
+    from app.services.data_source_factory.data_source_factory import get_data_source_factory_dependency
+
+    assert package.get_data_source_factory_dependency is get_data_source_factory_dependency
+
+
+def test_data_quality_routes_use_data_source_factory_dependency():
+    for handler_name in ("get_sources_health", "get_system_status_overview"):
+        handler = getattr(module, handler_name)
+        factory_param = inspect.signature(handler).parameters["factory"]
+
+        assert getattr(factory_param.default, "dependency", None) is module.get_data_source_factory_dependency
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- migrates the two data_quality.py DataSourceFactory consumers to Depends(get_data_source_factory_dependency)
- re-exports get_data_source_factory_dependency from app.services.data_source_factory
- preserves route paths, response models, OpenAPI exposure, get_data_source_factory(), and _global_factory

## Verification
- TDD RED: 2 failed, 2 passed
- TDD GREEN: data quality focused tests 4 passed
- provider lifecycle tests: 4 passed
- data source factory tests: 38 passed
- ruff touched files: passed
- black --check touched files: 4 unchanged
- route guard: data_quality direct calls 2 -> 0, total API direct calls 17 -> 15
- app/OpenAPI smoke: routes=548, paths=500, duplicate operation IDs=0
- post-commit mainline gate: pass=True

## Notes
- current-head non-linked GitNexus impact was LOW/0 for edited route/provider symbols
- root staged detect_changes still over-approximated the changed route file as HIGH because the root index is older; this is documented in the report