### PR TITLE
docs(governance): close out data_quality route migration

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -939,10 +939,18 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 pass `4`, provider tests pass `4`, existing factory tests
 │   │                 pass `38`, and app/OpenAPI smoke remains routes=`548`,
 │   │                 paths=`500`, duplicate operation IDs=`0`
-│   └── Next gate: Human review of the G2.61c implementation PR; if accepted,
-│                  run a separate G2.61c closeout/current-head refresh before
-│                  selecting the next DataSourceFactory route consumer packet;
-│                  the remaining `15` route/API consumers remain locked
+│   │                 PR `#205` merged at
+│   │                 `b9d0bb31a72d362dc67a38dcd719578de56af739`; G2.61c
+│   │                 closeout confirms current-head stability: data-quality
+│   │                 focused tests=`4 passed`, provider tests=`4 passed`,
+│   │                 factory tests=`38 passed`, route direct calls remain `15`,
+│   │                 `data_quality.py` direct refs remain `0`, OpenAPI paths
+│   │                 remain `500`, duplicate operation IDs remain `0`, and
+│   │                 refreshed GitNexus at `b9d0bb31a` keeps edited symbols at
+│   │                 LOW upstream impact with `0` callers
+│   └── Next gate: Create G2.62 authorization-only packet for the next
+│                  remaining one-call DataSourceFactory route consumer; no route
+│                  edit is authorized until that packet is reviewed
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1046,6 +1054,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-provider-seam-closeout-2026-05-24.md` | G | G2.61a closeout prepared at current HEAD `0aadb27801c86e97e65ffdb4426276e1bd14c352`: records PR `#202` as `MERGED`, confirms provider symbols remain present, route direct calls remain `17`, provider dependency API refs remain `0`, focused lifecycle DI test=`4 passed`, existing factory test=`38 passed`, route-adjacent runtime fallback=`1 passed`, ruff/black passed, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus resolves `get_data_source_factory_dependency` plus `install_data_source_factory` with LOW upstream impact and `0` callers; no source, test, route, OpenAPI, OpenSpec, issue-label, runtime, PM2, package export, or compatibility cleanup change is authorized | Human review / PR merge decision; if accepted, create G2.61b `data_quality.py` route migration authorization / consumer-matrix packet before any route edit |
 | `backend-data-quality-data-source-factory-route-migration-authorization-2026-05-24.md` | G | G2.61b route migration authorization prepared at current HEAD `ee2c74f3c8e1c4f690d2a1737db29c97c39a54d2`: records PR `#203` as `MERGED`, confirms `data_quality.py` has two DataSourceFactory compatibility getter calls at lines `58` and `369`, keeps total API direct calls=`17` across `9` files and provider dependency API refs=`0`, records package export gap for `get_data_source_factory_dependency`, verifies provider lifecycle tests=`4 passed`, existing factory tests=`38 passed`, data-quality mock configuration tests=`2 passed`, ruff candidate files=`passed`, and app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; authorizes only a future G2.61c path-limited implementation packet for `data_quality.py` plus data-source-factory package export and focused tests | Human review / PR merge decision; if accepted, create G2.61c path-limited route migration implementation branch; remaining `15` route/API consumers stay locked |
 | `backend-data-quality-data-source-factory-route-migration-implementation-2026-05-24.md` | G | G2.61c implementation prepared at current HEAD `52a2aaa57150db834bcef3a526a4b78e37ac438a`: records PR `#204` as `MERGED`, refreshes non-linked GitNexus at the same HEAD with analyze exit=`0`, nodes=`62644`, edges=`145830`, flows=`300`, records LOW/0 upstream impact for `get_sources_health`, `get_system_status_overview`, `get_data_source_factory_dependency`, and `install_data_source_factory`, follows TDD red=`2 failed, 2 passed` then green=`4 passed`, re-exports `get_data_source_factory_dependency`, migrates `data_quality.py` direct calls from `2` to `0`, reduces total API direct calls from `17` to `15`, preserves `get_data_source_factory()` plus `_global_factory`, verifies provider tests=`4 passed`, existing factory tests=`38 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; remaining `15` route/API consumers stay locked | Human review / PR merge decision; if accepted, run G2.61c closeout/current-head refresh before selecting another DataSourceFactory route consumer packet |
+| `backend-data-quality-data-source-factory-route-migration-closeout-2026-05-24.md` | G | G2.61c closeout prepared at current HEAD `b9d0bb31a72d362dc67a38dcd719578de56af739`: records PR `#205` as `MERGED`, confirms current-head route guard direct API calls=`15`, `data_quality.py` direct refs=`0`, provider dependency API refs=`3`, focused data-quality tests=`4 passed`, provider lifecycle tests=`4 passed`, factory tests=`38 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus at `b9d0bb31a` with analyze exit=`0`, nodes=`62656`, edges=`145815`, flows=`300`, LOW/0 upstream impact for `get_sources_health`, `get_system_status_overview`, and `get_data_source_factory_dependency`; recommends G2.62 authorization-only packet for the next one-call consumer candidate (`data/financial.py` or `data/market.py`) | Human review / PR merge decision; if accepted, create G2.62 consumer-selection authorization packet before any further route edit |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/data-quality-data-source-factory-route-migration-closeout-2026-05-24.json
+++ b/.planning/codebase/generated/data-quality-data-source-factory-route-migration-closeout-2026-05-24.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "1.0",
+  "artifact": "data-quality-data-source-factory-route-migration-closeout",
+  "generated_at": "2026-05-24T22:31:26+08:00",
+  "workline": "G2.61c-closeout",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_head": "b9d0bb31a72d362dc67a38dcd719578de56af739",
+  "status": "ready_for_review",
+  "merged_implementation": {
+    "pr": 205,
+    "merge_commit": "b9d0bb31a72d362dc67a38dcd719578de56af739",
+    "implementation_report": "docs/reports/quality/backend-data-quality-data-source-factory-route-migration-implementation-2026-05-24.md"
+  },
+  "scope_boundary": {
+    "kind": "closeout_current_head_refresh",
+    "backend_source_modified": false,
+    "tests_modified": false,
+    "route_paths_modified": false,
+    "openapi_modified": false,
+    "openspec_modified": false,
+    "issue_labels_modified": false,
+    "runtime_or_pm2_modified": false
+  },
+  "current_head_route_guard": {
+    "api_files_scanned": 219,
+    "direct_get_data_source_factory_calls": 15,
+    "get_data_source_factory_dependency_api_refs": 3,
+    "data_quality_direct_refs": 0,
+    "data_quality_dependency_refs": 3,
+    "direct_handler_call_refs": 0,
+    "remaining_direct_call_files": {
+      "web/backend/app/api/data/financial.py": 1,
+      "web/backend/app/api/data/futures.py": 2,
+      "web/backend/app/api/data/kline.py": 2,
+      "web/backend/app/api/data/lhb.py": 2,
+      "web/backend/app/api/data/margin.py": 3,
+      "web/backend/app/api/data/market.py": 1,
+      "web/backend/app/api/data/stocks.py": 2,
+      "web/backend/app/api/market/market_data_request.py": 2
+    }
+  },
+  "verification": {
+    "data_quality_mock_configuration_tests": "4 passed",
+    "provider_lifecycle_tests": "4 passed",
+    "data_source_factory_tests": "38 passed",
+    "ruff_black_touched_files": "passed; 4 files unchanged",
+    "app_openapi_smoke": {
+      "app_import": "passed",
+      "routes": 548,
+      "openapi_paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 121
+    }
+  },
+  "gitnexus_refresh": {
+    "repo": "g2-61c-closeout-gitnexus-index-checkout",
+    "head": "b9d0bb31a",
+    "git_kind": "directory",
+    "analyze_exit": 0,
+    "nodes": 62656,
+    "edges": 145815,
+    "flows": 300,
+    "impacts": {
+      "get_sources_health": {
+        "risk": "LOW",
+        "impacted_count": 0
+      },
+      "get_system_status_overview": {
+        "risk": "LOW",
+        "impacted_count": 0
+      },
+      "get_data_source_factory_dependency": {
+        "risk": "LOW",
+        "impacted_count": 0
+      }
+    }
+  },
+  "next_gate": {
+    "recommended_workline": "G2.62",
+    "recommended_scope": "authorization-only packet for the next remaining one-call DataSourceFactory route consumer",
+    "candidate_files": [
+      "web/backend/app/api/data/financial.py",
+      "web/backend/app/api/data/market.py"
+    ],
+    "remaining_direct_route_calls": 15,
+    "remaining_consumers_locked_until_authorized": true
+  }
+}

--- a/docs/reports/quality/backend-data-quality-data-source-factory-route-migration-closeout-2026-05-24.md
+++ b/docs/reports/quality/backend-data-quality-data-source-factory-route-migration-closeout-2026-05-24.md
@@ -1,0 +1,120 @@
+# Backend Data Quality DataSourceFactory Route Migration Closeout - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Workline: G2.61c closeout / current-head refresh
+
+Base branch: `wip/root-dirty-20260403`
+
+Current HEAD: `b9d0bb31a72d362dc67a38dcd719578de56af739`
+
+## Scope Boundary
+
+This closeout records the merged G2.61c result. It does not change backend
+source code, tests, route paths, response contracts, OpenAPI exposure, generated
+clients, OpenSpec files, issue labels, runtime process state, or PM2 state.
+
+## Merge Evidence
+
+PR `#205` was merged at
+`b9d0bb31a72d362dc67a38dcd719578de56af739`.
+
+Merged implementation summary:
+
+- Re-exported `get_data_source_factory_dependency` from
+  `app.services.data_source_factory`.
+- Migrated `get_sources_health` and `get_system_status_overview` to
+  `Depends(get_data_source_factory_dependency)`.
+- Removed both `data_quality.py` direct `await get_data_source_factory()` calls.
+- Preserved `get_data_source_factory()` and `_global_factory`.
+- Kept route paths, response models, OpenAPI exposure, and response shape
+  unchanged.
+
+## Current-Head Route Guard
+
+Post-merge static scan reports:
+
+- API files scanned: `219`
+- Direct `get_data_source_factory()` API calls: `15`
+- `get_data_source_factory_dependency` API refs: `3`
+- `data_quality.py` direct refs: `0`
+- `data_quality.py` dependency refs: `3`
+- Direct handler call refs to the migrated functions: `0`
+
+Remaining direct-call files:
+
+| File | Calls |
+|---|---:|
+| `web/backend/app/api/data/financial.py` | 1 |
+| `web/backend/app/api/data/futures.py` | 2 |
+| `web/backend/app/api/data/kline.py` | 2 |
+| `web/backend/app/api/data/lhb.py` | 2 |
+| `web/backend/app/api/data/margin.py` | 3 |
+| `web/backend/app/api/data/market.py` | 1 |
+| `web/backend/app/api/data/stocks.py` | 2 |
+| `web/backend/app/api/market/market_data_request.py` | 2 |
+
+The remaining `15` route/API consumers stay locked until a separate
+authorization packet selects the next batch.
+
+## Verification
+
+Executed at current HEAD:
+
+| Check | Result |
+|---|---|
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_mock_configuration.py -q --no-cov --tb=short` | `4 passed` |
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | `4 passed` |
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory.py -q --no-cov --tb=short` | `38 passed` |
+| `ruff check` + `black --check` on touched source/test files | passed; `4 files would be left unchanged` |
+| app import / OpenAPI smoke with non-secret test env | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+
+The app/OpenAPI smoke still reports `warning_count=121`, including the existing
+local GPU fallback warning for the NumPy/Numba mismatch.
+
+## GitNexus Refresh
+
+GitNexus was refreshed from a non-linked checkout:
+
+- Repo: `g2-61c-closeout-gitnexus-index-checkout`
+- HEAD: `b9d0bb31a`
+- `.git` kind: `directory`
+- `gitnexus analyze` exit: `0`
+- Nodes: `62656`
+- Edges: `145815`
+- Flows: `300`
+
+Current-head upstream impact:
+
+| Symbol | Risk | Impacted count |
+|---|---|---:|
+| `get_sources_health` | LOW | 0 |
+| `get_system_status_overview` | LOW | 0 |
+| `get_data_source_factory_dependency` | LOW | 0 |
+
+## Decision
+
+G2.61c is closed as merged and stable at current HEAD.
+
+The first DataSourceFactory route consumer migration is now complete:
+
+- `data_quality.py`: `2` direct calls -> `0`;
+- API total: `17` direct calls -> `15`;
+- route/OpenAPI contract unchanged.
+
+## Next Gate
+
+Prepare a separate G2.62 authorization-only packet before any further route
+edits.
+
+Recommended G2.62 candidates are the remaining one-call route consumers:
+
+- `web/backend/app/api/data/financial.py`
+- `web/backend/app/api/data/market.py`
+
+The G2.62 packet should choose one candidate, define TDD and rollback scope, and
+keep all other remaining direct consumers locked.

--- a/governance/mainline/task-cards/pr-206.yaml
+++ b/governance/mainline/task-cards/pr-206.yaml
@@ -1,0 +1,106 @@
+version: "v0.2"
+
+task:
+  id: "pr-206"
+  title: "Close out data_quality DataSourceFactory route migration"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-data-quality-data-source-factory-route-migration-closeout"
+  objective: "record current-head closeout evidence after the G2.61c data_quality route migration implementation"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-quality-data-source-factory-route-migration-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-quality-data-source-factory-route-migration-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout records current-head evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-quality-data-source-factory-route-migration-closeout-2026-05-24.json"
+    - "docs/reports/quality/backend-data-quality-data-source-factory-route-migration-closeout-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-206.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No additional DataSourceFactory route consumer migration in this PR"
+  - "No compatibility getter cleanup in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-quality-data-source-factory-route-migration-closeout-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-quality-data-source-factory-route-migration-closeout-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-206.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-206.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "gitnexus detect-changes --scope staged"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the closeout boundary"
+    - "If this PR selects and implements the next consumer, it bypasses the next authorization gate"
+  rollback_plan: "revert this governance-only closeout PR; PR #205 remains the accepted implementation unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record post-merge closeout evidence for the data_quality DataSourceFactory route migration"
+    modified_scope: "closeout report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none in this PR"
+    legacy_logic_impact: "none; remaining route consumers and compatibility getter remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only closeout PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T22:31:26+08:00"
+    approval_note: "human maintainer approved continuing after PR #205; this packet records closeout evidence only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records current-head closeout after PR #205 data_quality DataSourceFactory route migration
- confirms direct DataSourceFactory API calls remain 15 and data_quality direct refs remain 0
- keeps this PR docs/governance only with no backend source, route, OpenAPI, OpenSpec, PM2, or issue-label changes

## Verification
- data_quality focused tests: 4 passed
- provider lifecycle tests: 4 passed
- data source factory tests: 38 passed
- ruff + black touched files: passed
- route guard: total direct calls=15, data_quality direct refs=0
- app/OpenAPI smoke: routes=548, paths=500, duplicate operation IDs=0
- GitNexus closeout refresh: b9d0bb31a, LOW/0 for edited symbols
- staged GitNexus scope: LOW, changed symbols=0, affected processes=0
- post-commit mainline gate: pass=True