### PR TITLE
docs(governance): authorize financial data source factory migration

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -948,9 +948,16 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 remain `500`, duplicate operation IDs remain `0`, and
 │   │                 refreshed GitNexus at `b9d0bb31a` keeps edited symbols at
 │   │                 LOW upstream impact with `0` callers
-│   └── Next gate: Create G2.62 authorization-only packet for the next
-│                  remaining one-call DataSourceFactory route consumer; no route
-│                  edit is authorized until that packet is reviewed
+│   │                 PR `#206` merged at
+│   │                 `fcc438de0965f80af7d485525fb494511976595b`; G2.62 now
+│   │                 selects the next one-call consumer: `financial.py` has one
+│   │                 direct call at line `69` in one route function, while
+│   │                 `market.py` has one direct call but a broader four-route
+│   │                 file surface; no source edit is included
+│   └── Next gate: Human review of the G2.62 authorization PR; if accepted,
+│                  create G2.63 path-limited implementation branch for
+│                  `financial.py` only; remaining route/API consumers stay
+│                  locked
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1055,6 +1062,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-quality-data-source-factory-route-migration-authorization-2026-05-24.md` | G | G2.61b route migration authorization prepared at current HEAD `ee2c74f3c8e1c4f690d2a1737db29c97c39a54d2`: records PR `#203` as `MERGED`, confirms `data_quality.py` has two DataSourceFactory compatibility getter calls at lines `58` and `369`, keeps total API direct calls=`17` across `9` files and provider dependency API refs=`0`, records package export gap for `get_data_source_factory_dependency`, verifies provider lifecycle tests=`4 passed`, existing factory tests=`38 passed`, data-quality mock configuration tests=`2 passed`, ruff candidate files=`passed`, and app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; authorizes only a future G2.61c path-limited implementation packet for `data_quality.py` plus data-source-factory package export and focused tests | Human review / PR merge decision; if accepted, create G2.61c path-limited route migration implementation branch; remaining `15` route/API consumers stay locked |
 | `backend-data-quality-data-source-factory-route-migration-implementation-2026-05-24.md` | G | G2.61c implementation prepared at current HEAD `52a2aaa57150db834bcef3a526a4b78e37ac438a`: records PR `#204` as `MERGED`, refreshes non-linked GitNexus at the same HEAD with analyze exit=`0`, nodes=`62644`, edges=`145830`, flows=`300`, records LOW/0 upstream impact for `get_sources_health`, `get_system_status_overview`, `get_data_source_factory_dependency`, and `install_data_source_factory`, follows TDD red=`2 failed, 2 passed` then green=`4 passed`, re-exports `get_data_source_factory_dependency`, migrates `data_quality.py` direct calls from `2` to `0`, reduces total API direct calls from `17` to `15`, preserves `get_data_source_factory()` plus `_global_factory`, verifies provider tests=`4 passed`, existing factory tests=`38 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; remaining `15` route/API consumers stay locked | Human review / PR merge decision; if accepted, run G2.61c closeout/current-head refresh before selecting another DataSourceFactory route consumer packet |
 | `backend-data-quality-data-source-factory-route-migration-closeout-2026-05-24.md` | G | G2.61c closeout prepared at current HEAD `b9d0bb31a72d362dc67a38dcd719578de56af739`: records PR `#205` as `MERGED`, confirms current-head route guard direct API calls=`15`, `data_quality.py` direct refs=`0`, provider dependency API refs=`3`, focused data-quality tests=`4 passed`, provider lifecycle tests=`4 passed`, factory tests=`38 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus at `b9d0bb31a` with analyze exit=`0`, nodes=`62656`, edges=`145815`, flows=`300`, LOW/0 upstream impact for `get_sources_health`, `get_system_status_overview`, and `get_data_source_factory_dependency`; recommends G2.62 authorization-only packet for the next one-call consumer candidate (`data/financial.py` or `data/market.py`) | Human review / PR merge decision; if accepted, create G2.62 consumer-selection authorization packet before any further route edit |
+| `backend-data-source-factory-next-route-consumer-authorization-2026-05-24.md` | G | G2.62 authorization prepared at current HEAD `fcc438de0965f80af7d485525fb494511976595b`: records PR `#206` as `MERGED`, compares the remaining one-call candidates and selects `web/backend/app/api/data/financial.py` for future G2.63 because it has one direct factory call at line `69` inside one route function, while `web/backend/app/api/data/market.py` has one direct call at line `98` but a broader four-route file surface; this PR authorizes only a future `financial.py` implementation branch and does not edit source, tests, routes, OpenAPI, OpenSpec, issue labels, runtime, or PM2 state | Human review / PR merge decision; if accepted, create G2.63 path-limited `financial.py` implementation branch; all other remaining consumers stay locked |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/data-source-factory-next-route-consumer-authorization-2026-05-24.json
+++ b/.planning/codebase/generated/data-source-factory-next-route-consumer-authorization-2026-05-24.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "1.0",
+  "artifact": "data-source-factory-next-route-consumer-authorization",
+  "generated_at": "2026-05-24T22:40:56+08:00",
+  "workline": "G2.62",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_head": "fcc438de0965f80af7d485525fb494511976595b",
+  "status": "ready_for_review",
+  "scope_boundary": {
+    "kind": "governance_authorization_only",
+    "backend_source_modified": false,
+    "tests_modified": false,
+    "route_paths_modified": false,
+    "openapi_modified": false,
+    "openspec_modified": false,
+    "issue_labels_modified": false,
+    "runtime_or_pm2_modified": false
+  },
+  "upstream_state": {
+    "previous_closeout_pr": 206,
+    "previous_closeout_merge": "fcc438de0965f80af7d485525fb494511976595b",
+    "remaining_direct_get_data_source_factory_calls": 15
+  },
+  "candidate_comparison": {
+    "web/backend/app/api/data/financial.py": {
+      "direct_calls": 1,
+      "line": 69,
+      "handler": "get_financial_data",
+      "route_functions_in_file": 1,
+      "existing_auth_dependency": "current_user: User = Depends(get_current_user)",
+      "test_surface": "small",
+      "disposition": "selected_for_future_G2.63"
+    },
+    "web/backend/app/api/data/market.py": {
+      "direct_calls": 1,
+      "line": 98,
+      "handler": "get_market_overview",
+      "route_functions_in_file": 4,
+      "existing_auth_dependency": "current_user: User = Depends(get_current_user)",
+      "test_surface": "broader market route/test surface",
+      "disposition": "locked_for_later_packet"
+    }
+  },
+  "authorized_future_batch": {
+    "id": "G2.63",
+    "kind": "financial_route_consumer_migration",
+    "selected_file": "web/backend/app/api/data/financial.py",
+    "selected_handler": "get_financial_data",
+    "allowed_paths": [
+      "web/backend/app/api/data/financial.py",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py",
+      "web/backend/tests/test_health_route_conflicts.py",
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/data-source-factory-financial-route-migration-implementation-*.json",
+      "docs/reports/quality/backend-data-source-factory-financial-route-migration-implementation-*.md",
+      "governance/mainline/task-cards/pr-*.yaml"
+    ],
+    "acceptance_criteria": [
+      "financial.py direct get_data_source_factory() calls reduce from 1 to 0",
+      "total API direct get_data_source_factory() calls reduce from 15 to 14",
+      "get_financial_data uses Depends(get_data_source_factory_dependency) or an explicitly documented equivalent",
+      "route path, query parameters, response shape, and OpenAPI path count remain unchanged",
+      "compatibility getter get_data_source_factory() and _global_factory remain preserved"
+    ],
+    "blocked_until_reviewed": true
+  }
+}

--- a/docs/reports/quality/backend-data-source-factory-next-route-consumer-authorization-2026-05-24.md
+++ b/docs/reports/quality/backend-data-source-factory-next-route-consumer-authorization-2026-05-24.md
@@ -1,0 +1,114 @@
+# Backend DataSourceFactory Next Route Consumer Authorization - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Workline: G2.62 next DataSourceFactory route consumer authorization
+
+Base branch: `wip/root-dirty-20260403`
+
+Current HEAD: `fcc438de0965f80af7d485525fb494511976595b`
+
+## Scope Boundary
+
+G2.62 is a governance and implementation-authorization packet only.
+
+This packet does not modify backend source code, tests, route paths, response
+contracts, OpenAPI exposure, generated clients, OpenSpec files, issue labels,
+runtime processes, or PM2 state.
+
+## Upstream State
+
+G2.61c closeout was merged by PR `#206` at
+`fcc438de0965f80af7d485525fb494511976595b`.
+
+Accepted current-head facts:
+
+- `data_quality.py` direct DataSourceFactory calls remain `0`.
+- Total API direct `get_data_source_factory()` calls remain `15`.
+- Remaining direct consumers are locked until individually authorized.
+
+## Candidate Comparison
+
+The next search is intentionally limited to one-call consumers.
+
+| Candidate | Direct calls | Handler | Route functions in file | Disposition |
+|---|---:|---|---:|---|
+| `web/backend/app/api/data/financial.py` | 1 | `get_financial_data` | 1 | selected for future G2.63 |
+| `web/backend/app/api/data/market.py` | 1 | `get_market_overview` | 4 | locked for later packet |
+
+`financial.py` is selected because it has the narrower route surface: one route
+function and one direct factory call. `market.py` also has one direct call, but
+the file carries a broader market route/test surface, so it should wait for a
+separate route-specific packet.
+
+## Selected Future Scope
+
+If this packet is accepted, a future G2.63 implementation branch may migrate:
+
+```text
+web/backend/app/api/data/financial.py
+```
+
+Selected call site:
+
+| Handler | Line | Current statement |
+|---|---:|---|
+| `get_financial_data` | `69` | `factory = await get_data_source_factory()` |
+
+Allowed future source/test paths:
+
+- `web/backend/app/api/data/financial.py`
+- `web/backend/tests/test_data_source_factory_lifecycle_di.py`
+- `web/backend/tests/test_health_route_conflicts.py`
+
+Allowed future governance paths:
+
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/data-source-factory-financial-route-migration-implementation-*.json`
+- `docs/reports/quality/backend-data-source-factory-financial-route-migration-implementation-*.md`
+- `governance/mainline/task-cards/pr-*.yaml`
+
+## Future Acceptance Criteria
+
+The future G2.63 implementation must satisfy all of the following:
+
+- `web/backend/app/api/data/financial.py` direct
+  `get_data_source_factory()` calls reduce from `1` to `0`.
+- Total API direct `get_data_source_factory()` calls reduce from `15` to `14`.
+- `get_financial_data` uses `Depends(get_data_source_factory_dependency)` or an
+  explicitly documented equivalent reviewed in the implementation packet.
+- Route path, query parameters, response shape, OpenAPI path count, and duplicate
+  operation ID count remain unchanged.
+- `get_data_source_factory()` and `_global_factory` remain preserved.
+- The future branch must run GitNexus impact before source edits and
+  `gitnexus detect-changes --scope staged` before commit.
+
+## Non-Goals
+
+G2.62 and the future G2.63 implementation do not authorize:
+
+- migrating `web/backend/app/api/data/market.py`;
+- migrating the other remaining `14` direct route/API consumers;
+- deleting `get_data_source_factory()` or `_global_factory`;
+- changing route paths, response models, response shape, OpenAPI exposure,
+  frontend code, generated clients, PM2/runtime process state, OpenSpec files,
+  issue labels, or docs/API examples.
+
+## Decision
+
+Authorize `web/backend/app/api/data/financial.py` as the next single-consumer
+DataSourceFactory route migration candidate.
+
+Do not edit route code under this G2.62 packet. If accepted, create a separate
+G2.63 implementation branch with the path and acceptance boundaries above.
+
+## Next Gate
+
+Human review of this G2.62 authorization PR.
+
+If accepted and merged, open G2.63 as a path-limited implementation branch for
+`financial.py` only.

--- a/governance/mainline/task-cards/pr-207.yaml
+++ b/governance/mainline/task-cards/pr-207.yaml
@@ -1,0 +1,108 @@
+version: "v0.2"
+
+task:
+  id: "pr-207"
+  title: "Authorize next DataSourceFactory route consumer"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-data-source-factory-next-route-consumer-authorization"
+  objective: "select the next one-call DataSourceFactory route consumer for a future path-limited implementation branch"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-next-route-consumer-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-next-route-consumer-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization packet records route consumer evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-next-route-consumer-authorization-2026-05-24.json"
+    - "docs/reports/quality/backend-data-source-factory-next-route-consumer-authorization-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-207.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No financial.py source migration in this PR"
+  - "No market.py or remaining consumer migration in this PR"
+  - "No compatibility getter cleanup in this PR"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-next-route-consumer-authorization-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-next-route-consumer-authorization-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-207.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-207.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "gitnexus detect-changes --scope staged"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the authorization-only boundary"
+    - "If this PR performs the financial.py route migration, it bypasses the implementation review gate"
+    - "If market.py is edited, the PR exceeds the selected candidate boundary"
+  rollback_plan: "revert this governance-only authorization PR; G2.61c closeout remains accepted unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize financial.py as the next DataSourceFactory route consumer migration candidate"
+    modified_scope: "authorization report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none in this PR"
+    legacy_logic_impact: "none; route consumers and compatibility getter remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only authorization PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T22:40:56+08:00"
+    approval_note: "human maintainer approved continuing after G2.61c closeout; this packet authorizes only a future reviewed financial.py route migration branch"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- selects web/backend/app/api/data/financial.py as the next one-call DataSourceFactory route consumer candidate
- compares financial.py and market.py, keeping market.py locked for a later packet
- keeps this PR governance-only with no backend source, route, OpenAPI, OpenSpec, PM2, or issue-label changes

## Verification
- candidate scan: financial.py direct call line 69, market.py direct call line 98
- markdown governance: 2 checked, 0 errors
- json/yaml parse: passed
- GitNexus staged scope: LOW, changed symbols=0, affected processes=0
- post-commit mainline gate: pass=True