### PR TITLE
refactor(api): inject data source factory in financial route

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -954,10 +954,17 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 direct call at line `69` in one route function, while
 │   │                 `market.py` has one direct call but a broader four-route
 │   │                 file surface; no source edit is included
-│   └── Next gate: Human review of the G2.62 authorization PR; if accepted,
-│                  create G2.63 path-limited implementation branch for
-│                  `financial.py` only; remaining route/API consumers stay
-│                  locked
+│   │                 PR `#207` merged at
+│   │                 `7c1b8fce44b3931c44ac5398e12f5715a28833e3`; G2.63 now
+│   │                 implements the approved `financial.py` migration:
+│   │                 `financial.py` direct calls move from `1` to `0`, total
+│   │                 API direct calls move from `15` to `14`, focused health
+│   │                 route conflict tests pass `113`, provider tests pass `4`,
+│   │                 and app/OpenAPI smoke remains routes=`548`, paths=`500`,
+│   │                 duplicate operation IDs=`0`
+│   └── Next gate: Human review of the G2.63 implementation PR; if accepted,
+│                  run a separate G2.63 closeout/current-head refresh before
+│                  selecting the next DataSourceFactory route consumer packet
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1063,6 +1070,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-quality-data-source-factory-route-migration-implementation-2026-05-24.md` | G | G2.61c implementation prepared at current HEAD `52a2aaa57150db834bcef3a526a4b78e37ac438a`: records PR `#204` as `MERGED`, refreshes non-linked GitNexus at the same HEAD with analyze exit=`0`, nodes=`62644`, edges=`145830`, flows=`300`, records LOW/0 upstream impact for `get_sources_health`, `get_system_status_overview`, `get_data_source_factory_dependency`, and `install_data_source_factory`, follows TDD red=`2 failed, 2 passed` then green=`4 passed`, re-exports `get_data_source_factory_dependency`, migrates `data_quality.py` direct calls from `2` to `0`, reduces total API direct calls from `17` to `15`, preserves `get_data_source_factory()` plus `_global_factory`, verifies provider tests=`4 passed`, existing factory tests=`38 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; remaining `15` route/API consumers stay locked | Human review / PR merge decision; if accepted, run G2.61c closeout/current-head refresh before selecting another DataSourceFactory route consumer packet |
 | `backend-data-quality-data-source-factory-route-migration-closeout-2026-05-24.md` | G | G2.61c closeout prepared at current HEAD `b9d0bb31a72d362dc67a38dcd719578de56af739`: records PR `#205` as `MERGED`, confirms current-head route guard direct API calls=`15`, `data_quality.py` direct refs=`0`, provider dependency API refs=`3`, focused data-quality tests=`4 passed`, provider lifecycle tests=`4 passed`, factory tests=`38 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus at `b9d0bb31a` with analyze exit=`0`, nodes=`62656`, edges=`145815`, flows=`300`, LOW/0 upstream impact for `get_sources_health`, `get_system_status_overview`, and `get_data_source_factory_dependency`; recommends G2.62 authorization-only packet for the next one-call consumer candidate (`data/financial.py` or `data/market.py`) | Human review / PR merge decision; if accepted, create G2.62 consumer-selection authorization packet before any further route edit |
 | `backend-data-source-factory-next-route-consumer-authorization-2026-05-24.md` | G | G2.62 authorization prepared at current HEAD `fcc438de0965f80af7d485525fb494511976595b`: records PR `#206` as `MERGED`, compares the remaining one-call candidates and selects `web/backend/app/api/data/financial.py` for future G2.63 because it has one direct factory call at line `69` inside one route function, while `web/backend/app/api/data/market.py` has one direct call at line `98` but a broader four-route file surface; this PR authorizes only a future `financial.py` implementation branch and does not edit source, tests, routes, OpenAPI, OpenSpec, issue labels, runtime, or PM2 state | Human review / PR merge decision; if accepted, create G2.63 path-limited `financial.py` implementation branch; all other remaining consumers stay locked |
+| `backend-data-source-factory-financial-route-migration-implementation-2026-05-24.md` | G | G2.63 implementation prepared at current HEAD `7c1b8fce44b3931c44ac5398e12f5715a28833e3`: records PR `#207` as `MERGED`, refreshes non-linked GitNexus at the same HEAD with analyze exit=`0`, nodes=`62644`, edges=`145819`, flows=`300`, records file-level `financial.py` upstream impact LOW/2 and provider dependency LOW/0, follows TDD red=`1 failed, 112 passed` then green=`113 passed`, migrates `financial.py` direct calls from `1` to `0`, reduces total API direct calls from `15` to `14`, preserves `get_data_source_factory()` plus `_global_factory`, verifies provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; remaining `14` route/API consumers stay locked | Human review / PR merge decision; if accepted, run G2.63 closeout/current-head refresh before selecting another DataSourceFactory route consumer packet |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/data-source-factory-financial-route-migration-implementation-2026-05-24.json
+++ b/.planning/codebase/generated/data-source-factory-financial-route-migration-implementation-2026-05-24.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": "1.0",
+  "artifact": "data-source-factory-financial-route-migration-implementation",
+  "generated_at": "2026-05-24T23:04:18+08:00",
+  "workline": "G2.63",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "7c1b8fce44b3931c44ac5398e12f5715a28833e3",
+  "status": "ready_for_review",
+  "authorization": {
+    "source_pr": 207,
+    "source_merge": "7c1b8fce44b3931c44ac5398e12f5715a28833e3",
+    "source_report": "docs/reports/quality/backend-data-source-factory-next-route-consumer-authorization-2026-05-24.md"
+  },
+  "scope_boundary": {
+    "backend_source_modified": true,
+    "allowed_source_paths": [
+      "web/backend/app/api/data/financial.py"
+    ],
+    "allowed_test_paths": [
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "route_paths_modified": false,
+    "response_contracts_modified": false,
+    "openapi_exposure_modified": false,
+    "compatibility_getter_removed": false
+  },
+  "gitnexus_pre_edit": {
+    "index_repo": "g2-63-gitnexus-index-checkout",
+    "index_head": "7c1b8fce4",
+    "analyze_exit": 0,
+    "nodes": 62644,
+    "edges": 145819,
+    "flows": 300,
+    "financial_file_impact": {
+      "risk": "LOW",
+      "impacted_count": 2,
+      "direct": 1
+    },
+    "get_data_source_factory_dependency_impact": {
+      "risk": "LOW",
+      "impacted_count": 0
+    }
+  },
+  "tdd": {
+    "red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "1 failed, 112 passed",
+      "expected_failure": "get_financial_data missing factory dependency parameter"
+    },
+    "green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "113 passed"
+    }
+  },
+  "implementation": {
+    "file": "web/backend/app/api/data/financial.py",
+    "handler": "get_financial_data",
+    "direct_getter_calls_removed": 1,
+    "uses_dependency": "Depends(get_data_source_factory_dependency)",
+    "compatibility_getter_preserved": true
+  },
+  "route_guard": {
+    "api_files_scanned": 219,
+    "before_total_direct_get_data_source_factory_calls": 15,
+    "after_total_direct_get_data_source_factory_calls": 14,
+    "before_financial_direct_calls": 1,
+    "after_financial_direct_calls": 0,
+    "get_data_source_factory_dependency_api_refs": 5,
+    "financial_dependency_refs": 2
+  },
+  "verification": {
+    "health_route_conflicts_tests": "113 passed",
+    "provider_lifecycle_tests": "4 passed",
+    "ruff_touched_files": "passed",
+    "black_check_touched_files": "2 files would be left unchanged",
+    "app_openapi_smoke": {
+      "app_import": "passed",
+      "routes": 548,
+      "openapi_paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 121
+    }
+  },
+  "next_gate": {
+    "recommended": "G2.63 closeout/current-head refresh before selecting the next DataSourceFactory route consumer packet",
+    "remaining_direct_route_calls": 14,
+    "remaining_consumers_locked": true
+  }
+}

--- a/docs/reports/quality/backend-data-source-factory-financial-route-migration-implementation-2026-05-24.md
+++ b/docs/reports/quality/backend-data-source-factory-financial-route-migration-implementation-2026-05-24.md
@@ -1,0 +1,132 @@
+# Backend DataSourceFactory Financial Route Migration Implementation - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Workline: G2.63 financial route DataSourceFactory migration implementation
+
+Base branch: `wip/root-dirty-20260403`
+
+Base HEAD: `7c1b8fce44b3931c44ac5398e12f5715a28833e3`
+
+## Scope Boundary
+
+This implementation follows the G2.62 authorization packet.
+
+Modified source/test paths:
+
+- `web/backend/app/api/data/financial.py`
+- `web/backend/tests/test_health_route_conflicts.py`
+
+This implementation does not change route paths, query parameters, response
+shape, OpenAPI exposure, generated clients, frontend code, PM2/runtime process
+state, OpenSpec files, issue labels, or any remaining DataSourceFactory route
+consumer.
+
+## GitNexus Evidence
+
+Before source edits, GitNexus was refreshed in a non-linked checkout:
+
+- Repo: `g2-63-gitnexus-index-checkout`
+- HEAD: `7c1b8fce4`
+- `gitnexus analyze` exit: `0`
+- Nodes: `62644`
+- Edges: `145819`
+- Flows: `300`
+
+Pre-edit impact:
+
+| Target | Risk | Impacted count | Notes |
+|---|---|---:|---|
+| `web/backend/app/api/data/financial.py` | LOW | 2 | direct importer `data/__init__.py`; secondary regression test import |
+| `get_data_source_factory_dependency` | LOW | 0 | provider dependency symbol |
+
+`get_financial_data` is name-ambiguous in GitNexus, so the file-level impact is
+the authoritative pre-edit blast-radius check for this batch.
+
+## TDD
+
+RED:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short
+```
+
+Result: `1 failed, 112 passed`.
+
+Expected failure: `get_financial_data` did not expose a `factory` dependency
+parameter.
+
+GREEN:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short
+```
+
+Result: `113 passed`.
+
+## Implementation
+
+Implemented changes:
+
+- Imported `DataSourceFactory` and `get_data_source_factory_dependency` in
+  `web/backend/app/api/data/financial.py`.
+- Added `factory: DataSourceFactory =
+  Depends(get_data_source_factory_dependency)` to `get_financial_data`.
+- Removed the inline `await get_data_source_factory()` call.
+- Preserved `get_data_source_factory()` and `_global_factory`.
+
+## Route Guard
+
+Post-change static scan:
+
+- API files scanned: `219`
+- Total direct `get_data_source_factory()` API calls: `14`
+- `financial.py` direct calls: `0`
+- `get_data_source_factory_dependency` API refs: `5`
+- `financial.py` dependency refs: `2`
+
+Remaining direct-call files:
+
+| File | Calls |
+|---|---:|
+| `web/backend/app/api/data/futures.py` | 2 |
+| `web/backend/app/api/data/kline.py` | 2 |
+| `web/backend/app/api/data/lhb.py` | 2 |
+| `web/backend/app/api/data/margin.py` | 3 |
+| `web/backend/app/api/data/market.py` | 1 |
+| `web/backend/app/api/data/stocks.py` | 2 |
+| `web/backend/app/api/market/market_data_request.py` | 2 |
+
+## Verification
+
+Executed after implementation:
+
+| Check | Result |
+|---|---|
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `113 passed` |
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | `4 passed` |
+| `ruff check` on touched files | passed |
+| `black --check` on touched files | `2 files would be left unchanged` |
+| app import / OpenAPI smoke with non-secret test env | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+
+The app/OpenAPI smoke still reports `warning_count=121`, including the existing
+local GPU fallback warning for the NumPy/Numba mismatch.
+
+## Decision
+
+G2.63 completes the financial route DataSourceFactory consumer migration:
+
+- `financial.py`: `1` direct call -> `0`;
+- API total: `15` direct calls -> `14`;
+- route/OpenAPI contract unchanged.
+
+## Next Gate
+
+Human review of this implementation PR.
+
+If accepted and merged, run a separate G2.63 closeout/current-head refresh
+before selecting another DataSourceFactory route consumer packet.

--- a/governance/mainline/task-cards/pr-208.yaml
+++ b/governance/mainline/task-cards/pr-208.yaml
@@ -1,0 +1,126 @@
+version: "v0.2"
+
+task:
+  id: "pr-208"
+  title: "Migrate financial DataSourceFactory route consumer"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-data-source-factory-financial-route-migration"
+  objective: "migrate the financial.py DataSourceFactory compatibility getter consumer to the app-state provider dependency"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-financial-route-migration"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-financial-route-migration"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Path-limited route dependency injection migration preserves route paths, response contracts, OpenAPI exposure, and product behavior"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/api/data/financial.py"
+    - "web/backend/tests/test_health_route_conflicts.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-financial-route-migration-implementation-2026-05-24.json"
+    - "docs/reports/quality/backend-data-source-factory-financial-route-migration-implementation-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-208.yaml"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+    - "web/backend/app/api/data/market.py"
+    - "web/backend/app/api/data/futures.py"
+    - "web/backend/app/api/data/kline.py"
+    - "web/backend/app/api/data/lhb.py"
+    - "web/backend/app/api/data/margin.py"
+    - "web/backend/app/api/data/stocks.py"
+    - "web/backend/app/api/market/**"
+
+non_goals:
+  - "No migration of remaining non-financial DataSourceFactory route consumers"
+  - "No route path, query parameter, response shape, OpenAPI exposure, docs/API, generated client, frontend, PM2, or runtime process change"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No compatibility getter or _global_factory deletion"
+
+acceptance:
+  checks:
+    - id: "health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/api/data/financial.py web/backend/tests/test_health_route_conflicts.py"
+      required: true
+    - id: "black-check-touched"
+      command: "black --check web/backend/app/api/data/financial.py web/backend/tests/test_health_route_conflicts.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-financial-route-migration-implementation-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-financial-route-migration-implementation-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-208.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-208.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "gitnexus detect-changes --scope staged"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If non-financial route consumers are edited, the PR exceeds the authorized route scope"
+    - "If route paths or response contracts change, the PR exceeds the authorized compatibility boundary"
+  rollback_plan: "revert this path-limited implementation PR; G2.62 authorization remains accepted unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "migrate financial.py DataSourceFactory consumer to the app-state provider dependency"
+    modified_scope: "financial.py, focused health route conflict test, implementation report, generated artifact, steward tree, and this task card"
+    dependency_changes: "uses existing get_data_source_factory_dependency export"
+    legacy_logic_impact: "compatibility getter and _global_factory remain preserved; remaining route consumers stay locked"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this path-limited implementation PR if route/OpenAPI or focused tests regress"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-24T23:04:18+08:00"
+    approval_note: "human maintainer approved continuing after G2.62 authorization; this packet implements only the approved financial.py route migration scope"
+    secondary_approved: false

--- a/web/backend/app/api/data/financial.py
+++ b/web/backend/app/api/data/financial.py
@@ -1,6 +1,7 @@
 """
 财务数据路由 (Financial Data)
 """
+
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, Query
@@ -8,6 +9,7 @@ from fastapi import APIRouter, Depends, Query
 from app.core.exceptions import BusinessException
 from app.core.security import User, get_current_user
 from app.openapi_config import COMMON_RESPONSES
+from app.services.data_source_factory import DataSourceFactory, get_data_source_factory_dependency
 
 router = APIRouter()
 
@@ -62,11 +64,9 @@ async def get_financial_data(
     period: str = Query("all", description="报告期间筛选，例如 annual、quarterly 或 all。"),
     limit: int = Query(20, description="单次请求返回的最大财务记录数。"),
     current_user: User = Depends(get_current_user),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
 ) -> Dict[str, Any]:
     try:
-        from app.services.data_source_factory import get_data_source_factory
-
-        factory = await get_data_source_factory()
         params = {"symbol": symbol, "report_type": report_type, "period": period, "limit": limit}
         result = await factory.get_data("data", "financial", params)
         if result.get("status") != "success":

--- a/web/backend/tests/test_health_route_conflicts.py
+++ b/web/backend/tests/test_health_route_conflicts.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import warnings
+import inspect
 
 from fastapi.routing import APIRoute
 
+from app.api.data import financial as financial_module
 from app.main import app
 
 
@@ -12,9 +14,7 @@ def _matching_routes(path: str, method: str = "GET") -> list[APIRoute]:
     return [
         route
         for route in app.routes
-        if isinstance(route, APIRoute)
-        and route.path == path
-        and normalized_method in (route.methods or set())
+        if isinstance(route, APIRoute) and route.path == path and normalized_method in (route.methods or set())
     ]
 
 
@@ -32,16 +32,18 @@ def test_health_routes_are_unique_and_domain_scoped() -> None:
         warnings.simplefilter("always")
         schema = app.openapi()
 
-    duplicate_warnings = [
-        str(item.message)
-        for item in captured
-        if "Duplicate Operation ID" in str(item.message)
-    ]
+    duplicate_warnings = [str(item.message) for item in captured if "Duplicate Operation ID" in str(item.message)]
 
     assert not duplicate_warnings
     assert "/api/health" in schema["paths"]
     assert "/api/signals/health" in schema["paths"]
     assert "/api/metrics/health" in schema["paths"]
+
+
+def test_financial_route_uses_data_source_factory_dependency() -> None:
+    factory_param = inspect.signature(financial_module.get_financial_data).parameters["factory"]
+
+    assert getattr(factory_param.default, "dependency", None) is financial_module.get_data_source_factory_dependency
 
 
 def test_root_and_socketio_status_have_documented_examples_and_errors() -> None:
@@ -310,7 +312,14 @@ def test_v1_strategy_runtime_endpoints_have_success_examples_and_parameter_docs(
         ("/api/v1/strategy/definitions", "get"): set(),
         ("/api/v1/strategy/run/single", "post"): {"strategy_code", "symbol", "stock_name", "check_date"},
         ("/api/v1/strategy/run/batch", "post"): {"strategy_code", "symbols", "market", "limit", "check_date"},
-        ("/api/v1/strategy/results", "get"): {"strategy_code", "symbol", "check_date", "match_result", "limit", "offset"},
+        ("/api/v1/strategy/results", "get"): {
+            "strategy_code",
+            "symbol",
+            "check_date",
+            "match_result",
+            "limit",
+            "offset",
+        },
         ("/api/v1/strategy/matched-stocks", "get"): {"strategy_code", "check_date", "limit"},
         ("/api/v1/strategy/stats/summary", "get"): {"check_date"},
     }
@@ -323,7 +332,8 @@ def test_v1_strategy_runtime_endpoints_have_success_examples_and_parameter_docs(
         assert len(operation.get("description", "")) >= 20
         for parameter_name in expected_params:
             assert any(
-                param["name"] == parameter_name and param.get("description") for param in operation.get("parameters", [])
+                param["name"] == parameter_name and param.get("description")
+                for param in operation.get("parameters", [])
             )
         assert "example" in success_json or "examples" in success_json
         assert any(code.startswith(("4", "5")) for code in operation["responses"])
@@ -486,7 +496,9 @@ def test_public_announcement_endpoints_have_success_examples_and_error_responses
     assert len(analyze_operation.get("description", "")) >= 20
     assert "example" in analyze_json or "examples" in analyze_json
     assert "example" in analyze_success_json or "examples" in analyze_success_json
-    analyze_example = analyze_success_json.get("example") or next(iter(analyze_success_json["examples"].values()))["value"]
+    analyze_example = (
+        analyze_success_json.get("example") or next(iter(analyze_success_json["examples"].values()))["value"]
+    )
     assert analyze_example["success"] is True
     assert analyze_example["code"] == 200
     assert analyze_example["data"]["status"] == "available"
@@ -518,6 +530,7 @@ def test_public_announcement_endpoints_have_success_examples_and_error_responses
     evaluate_success_json = evaluate_operation["responses"]["200"]["content"]["application/json"]
     assert "example" in evaluate_success_json or "examples" in evaluate_success_json
     assert any(code.startswith(("4", "5")) for code in evaluate_operation["responses"])
+
 
 def test_signal_history_endpoint_has_query_parameter_descriptions() -> None:
     app.openapi_schema = None
@@ -836,8 +849,7 @@ def test_tdx_and_metrics_endpoints_have_parameter_docs_and_error_responses() -> 
     assert quote_operation.get("summary")
     assert len(quote_operation.get("description", "")) >= 20
     assert any(
-        param["name"] == "symbol" and param["in"] == "path" and param.get("description")
-        for param in quote_parameters
+        param["name"] == "symbol" and param["in"] == "path" and param.get("description") for param in quote_parameters
     )
     assert any(code.startswith(("4", "5")) for code in quote_operation["responses"])
 
@@ -864,8 +876,7 @@ def test_ml_endpoints_have_request_response_examples_and_parameter_docs() -> Non
     assert market_operation.get("summary")
     assert len(market_operation.get("description", "")) >= 20
     assert any(
-        param["name"] == "market" and param["in"] == "path" and param.get("description")
-        for param in market_parameters
+        param["name"] == "market" and param["in"] == "path" and param.get("description") for param in market_parameters
     )
     assert "example" in market_success_json or "examples" in market_success_json
     assert any(code.startswith(("4", "5")) for code in market_operation["responses"])
@@ -910,7 +921,9 @@ def test_multi_source_endpoints_have_descriptions_examples_and_error_responses()
     assert len(analyze_operation.get("description", "")) >= 20
     assert "example" in analyze_json or "examples" in analyze_json
     assert "example" in analyze_success_json or "examples" in analyze_success_json
-    analyze_example = analyze_success_json.get("example") or next(iter(analyze_success_json["examples"].values()))["value"]
+    analyze_example = (
+        analyze_success_json.get("example") or next(iter(analyze_success_json["examples"].values()))["value"]
+    )
     assert analyze_example["success"] is True
     assert analyze_example["code"] == 200
     assert analyze_example["data"]["status"] == "available"
@@ -1019,7 +1032,9 @@ def test_sentiment_endpoint_has_docs_examples_and_parameter_descriptions() -> No
     for parameter_name in ["symbol", "days"]:
         assert any(param["name"] == parameter_name and param.get("description") for param in sentiment_parameters)
     assert "example" in sentiment_success_json or "examples" in sentiment_success_json
-    sentiment_example = sentiment_success_json.get("example") or next(iter(sentiment_success_json["examples"].values()))["value"]
+    sentiment_example = (
+        sentiment_success_json.get("example") or next(iter(sentiment_success_json["examples"].values()))["value"]
+    )
     assert sentiment_example["success"] is True
     assert sentiment_example["code"] == 200
     assert sentiment_example["data"]["latest_sentiment"] in {"positive", "negative", "neutral"}
@@ -1040,7 +1055,9 @@ def test_technical_patterns_endpoint_has_docs_examples_and_parameter_description
     for parameter_name in ["symbol", "period"]:
         assert any(param["name"] == parameter_name and param.get("description") for param in patterns_parameters)
     assert "example" in patterns_success_json or "examples" in patterns_success_json
-    patterns_example = patterns_success_json.get("example") or next(iter(patterns_success_json["examples"].values()))["value"]
+    patterns_example = (
+        patterns_success_json.get("example") or next(iter(patterns_success_json["examples"].values()))["value"]
+    )
     assert patterns_example["success"] is True
     assert patterns_example["code"] == 200
     assert patterns_example["data"]["symbol"]
@@ -1075,11 +1092,12 @@ def test_audit_endpoints_have_parameter_descriptions() -> None:
     assert log_detail_operation.get("summary")
     assert len(log_detail_operation.get("description", "")) >= 20
     assert any(
-        param["name"] == "log_id" and param.get("description")
-        for param in log_detail_operation.get("parameters", [])
+        param["name"] == "log_id" and param.get("description") for param in log_detail_operation.get("parameters", [])
     )
     assert "example" in log_detail_success_json or "examples" in log_detail_success_json
-    log_detail_example = log_detail_success_json.get("example") or next(iter(log_detail_success_json["examples"].values()))["value"]
+    log_detail_example = (
+        log_detail_success_json.get("example") or next(iter(log_detail_success_json["examples"].values()))["value"]
+    )
     assert log_detail_example["success"] is True
     assert log_detail_example["code"] == 200
     assert log_detail_example["data"]
@@ -1095,7 +1113,9 @@ def test_audit_endpoints_have_parameter_descriptions() -> None:
             for param in statistics_operation.get("parameters", [])
         )
     assert "example" in statistics_success_json or "examples" in statistics_success_json
-    statistics_example = statistics_success_json.get("example") or next(iter(statistics_success_json["examples"].values()))["value"]
+    statistics_example = (
+        statistics_success_json.get("example") or next(iter(statistics_success_json["examples"].values()))["value"]
+    )
     assert statistics_example["success"] is True
     assert statistics_example["code"] == 200
     assert statistics_example["data"]
@@ -1440,7 +1460,14 @@ def test_data_source_registry_read_endpoints_have_examples_and_error_responses()
     schema = app.openapi()
 
     endpoint_expectations = {
-        "/api/v1/data-sources/": {"data_category", "classification_level", "source_type", "only_healthy", "keyword", "status"},
+        "/api/v1/data-sources/": {
+            "data_category",
+            "classification_level",
+            "source_type",
+            "only_healthy",
+            "keyword",
+            "status",
+        },
         "/api/v1/data-sources/categories": set(),
         "/api/v1/data-sources/{endpoint_name}": {"endpoint_name"},
         "/api/v1/data-sources/{endpoint_name}/health-check": {"endpoint_name", "Authorization"},
@@ -1798,9 +1825,9 @@ def test_strategy_mgmt_legacy_endpoints_have_success_examples_and_error_docs() -
             assert any(param["name"] == parameter_name and param.get("description") for param in parameters)
 
         if expects_success_example:
-            success_json = operation["responses"][next(code for code in operation["responses"] if code.startswith("2"))][
-                "content"
-            ]["application/json"]
+            success_json = operation["responses"][
+                next(code for code in operation["responses"] if code.startswith("2"))
+            ]["content"]["application/json"]
             assert "example" in success_json or "examples" in success_json
 
         assert any(code.startswith(("4", "5")) for code in operation["responses"])
@@ -2348,7 +2375,9 @@ def test_trade_endpoints_have_examples_parameter_docs_and_error_responses() -> N
     assert portfolio_operation.get("summary")
     assert len(portfolio_operation.get("description", "")) >= 20
     assert "example" in portfolio_success_json or "examples" in portfolio_success_json
-    portfolio_example = portfolio_success_json.get("example") or next(iter(portfolio_success_json["examples"].values()))["value"]
+    portfolio_example = (
+        portfolio_success_json.get("example") or next(iter(portfolio_success_json["examples"].values()))["value"]
+    )
     assert portfolio_example["success"] is True
     assert portfolio_example["code"] == 200
     assert portfolio_example["data"]["status"] == "available"
@@ -2359,7 +2388,9 @@ def test_trade_endpoints_have_examples_parameter_docs_and_error_responses() -> N
     assert positions_operation.get("summary")
     assert len(positions_operation.get("description", "")) >= 20
     assert "example" in positions_success_json or "examples" in positions_success_json
-    positions_example = positions_success_json.get("example") or next(iter(positions_success_json["examples"].values()))["value"]
+    positions_example = (
+        positions_success_json.get("example") or next(iter(positions_success_json["examples"].values()))["value"]
+    )
     assert positions_example["success"] is True
     assert positions_example["code"] == 200
     assert positions_example["data"]["status"] == "available"
@@ -2367,12 +2398,13 @@ def test_trade_endpoints_have_examples_parameter_docs_and_error_responses() -> N
     assert any(code.startswith("5") for code in positions_operation["responses"])
 
     assert any(
-        param["name"] == "limit" and param.get("description")
-        for param in signals_operation.get("parameters", [])
+        param["name"] == "limit" and param.get("description") for param in signals_operation.get("parameters", [])
     )
     signals_success_json = signals_operation["responses"]["200"]["content"]["application/json"]
     assert "example" in signals_success_json or "examples" in signals_success_json
-    signals_example = signals_success_json.get("example") or next(iter(signals_success_json["examples"].values()))["value"]
+    signals_example = (
+        signals_success_json.get("example") or next(iter(signals_success_json["examples"].values()))["value"]
+    )
     assert signals_example["success"] is True
     assert signals_example["code"] == 200
     assert signals_example["data"]["status"] == "available"
@@ -2399,7 +2431,9 @@ def test_trade_endpoints_have_examples_parameter_docs_and_error_responses() -> N
     assert statistics_operation.get("summary")
     assert len(statistics_operation.get("description", "")) >= 20
     assert "example" in statistics_success_json or "examples" in statistics_success_json
-    statistics_example = statistics_success_json.get("example") or next(iter(statistics_success_json["examples"].values()))["value"]
+    statistics_example = (
+        statistics_success_json.get("example") or next(iter(statistics_success_json["examples"].values()))["value"]
+    )
     assert statistics_example["success"] is True
     assert statistics_example["code"] == 200
     assert statistics_example["data"]["status"] == "available"
@@ -2410,7 +2444,9 @@ def test_trade_endpoints_have_examples_parameter_docs_and_error_responses() -> N
     execute_success_json = execute_operation["responses"]["200"]["content"]["application/json"]
     assert "example" in execute_json or "examples" in execute_json
     assert "example" in execute_success_json or "examples" in execute_success_json
-    execute_example = execute_success_json.get("example") or next(iter(execute_success_json["examples"].values()))["value"]
+    execute_example = (
+        execute_success_json.get("example") or next(iter(execute_success_json["examples"].values()))["value"]
+    )
     assert execute_example["success"] is True
     assert execute_example["code"] == 200
     assert execute_example["data"]["status"] == "available"
@@ -2457,7 +2493,8 @@ def test_technical_analysis_endpoints_have_examples_parameter_docs_and_error_res
         assert len(operation.get("description", "")) >= 20
         for parameter_name in expectations["parameters"]:
             assert any(
-                param["name"] == parameter_name and param.get("description") for param in operation.get("parameters", [])
+                param["name"] == parameter_name and param.get("description")
+                for param in operation.get("parameters", [])
             )
         assert "example" in success_json or "examples" in success_json
         assert any(code.startswith(("4", "5")) for code in operation["responses"])
@@ -3002,7 +3039,8 @@ def test_v1_strategy_management_endpoints_have_success_examples_and_parameter_do
         assert len(operation.get("description", "")) >= 20
         for parameter_name in expected_params:
             assert any(
-                param["name"] == parameter_name and param.get("description") for param in operation.get("parameters", [])
+                param["name"] == parameter_name and param.get("description")
+                for param in operation.get("parameters", [])
             )
         if "requestBody" in operation:
             request_json = operation["requestBody"]["content"]["application/json"]
@@ -3050,7 +3088,9 @@ def test_v1_data_route_sentiment_strategy_and_optimization_endpoints_have_docs()
     assert len(data_route_operation.get("description", "")) >= 20
     assert "example" in data_route_request_json or "examples" in data_route_request_json
     assert "example" in data_route_success_json or "examples" in data_route_success_json
-    data_route_example = data_route_success_json.get("example") or next(iter(data_route_success_json["examples"].values()))["value"]
+    data_route_example = (
+        data_route_success_json.get("example") or next(iter(data_route_success_json["examples"].values()))["value"]
+    )
     assert data_route_example["success"] is True
     assert data_route_example["code"] == 200
     assert data_route_example["data"]["route_selected"] in {"tdengine", "postgresql"}
@@ -3063,7 +3103,9 @@ def test_v1_data_route_sentiment_strategy_and_optimization_endpoints_have_docs()
     assert len(sentiment_operation.get("description", "")) >= 20
     assert "example" in sentiment_request_json or "examples" in sentiment_request_json
     assert "example" in sentiment_success_json or "examples" in sentiment_success_json
-    sentiment_example = sentiment_success_json.get("example") or next(iter(sentiment_success_json["examples"].values()))["value"]
+    sentiment_example = (
+        sentiment_success_json.get("example") or next(iter(sentiment_success_json["examples"].values()))["value"]
+    )
     assert sentiment_example["success"] is True
     assert sentiment_example["code"] == 200
     assert sentiment_example["data"]["sentiment"] in {"positive", "negative", "neutral"}
@@ -3074,7 +3116,10 @@ def test_v1_data_route_sentiment_strategy_and_optimization_endpoints_have_docs()
     assert market_sentiment_operation.get("summary")
     assert len(market_sentiment_operation.get("description", "")) >= 20
     assert "example" in market_sentiment_success_json or "examples" in market_sentiment_success_json
-    market_sentiment_example = market_sentiment_success_json.get("example") or next(iter(market_sentiment_success_json["examples"].values()))["value"]
+    market_sentiment_example = (
+        market_sentiment_success_json.get("example")
+        or next(iter(market_sentiment_success_json["examples"].values()))["value"]
+    )
     assert market_sentiment_example["success"] is True
     assert market_sentiment_example["code"] == 200
     assert market_sentiment_example["data"]["sentiment"] in {"positive", "negative", "neutral"}
@@ -3082,16 +3127,20 @@ def test_v1_data_route_sentiment_strategy_and_optimization_endpoints_have_docs()
 
     technical_indicators_operation = schema["paths"]["/api/v1/technical-indicators"]["get"]
     technical_indicators_parameters = technical_indicators_operation.get("parameters", [])
-    technical_indicators_success_json = technical_indicators_operation["responses"]["200"]["content"]["application/json"]
+    technical_indicators_success_json = technical_indicators_operation["responses"]["200"]["content"][
+        "application/json"
+    ]
     assert technical_indicators_operation.get("summary")
     assert len(technical_indicators_operation.get("description", "")) >= 20
     for parameter_name in ["symbol", "indicators", "period"]:
         assert any(
-            param["name"] == parameter_name and param.get("description")
-            for param in technical_indicators_parameters
+            param["name"] == parameter_name and param.get("description") for param in technical_indicators_parameters
         )
     assert "example" in technical_indicators_success_json or "examples" in technical_indicators_success_json
-    technical_indicators_example = technical_indicators_success_json.get("example") or next(iter(technical_indicators_success_json["examples"].values()))["value"]
+    technical_indicators_example = (
+        technical_indicators_success_json.get("example")
+        or next(iter(technical_indicators_success_json["examples"].values()))["value"]
+    )
     assert technical_indicators_example["success"] is True
     assert technical_indicators_example["code"] == 200
     assert technical_indicators_example["data"]["symbol"]
@@ -3104,14 +3153,13 @@ def test_v1_data_route_sentiment_strategy_and_optimization_endpoints_have_docs()
     assert strategies_operation.get("summary")
     assert len(strategies_operation.get("description", "")) >= 20
     assert "example" in strategies_success_json or "examples" in strategies_success_json
-    strategies_example = strategies_success_json.get("example") or next(iter(strategies_success_json["examples"].values()))["value"]
+    strategies_example = (
+        strategies_success_json.get("example") or next(iter(strategies_success_json["examples"].values()))["value"]
+    )
     assert strategies_example["success"] is True
     assert strategies_example["code"] == 200
     assert strategies_example["data"]
-    assert any(
-        param["name"] == "strategy_type" and param.get("description")
-        for param in strategies_parameters
-    )
+    assert any(param["name"] == "strategy_type" and param.get("description") for param in strategies_parameters)
     assert any(code.startswith(("4", "5")) for code in strategies_operation["responses"])
 
     optimization_expectations = {
@@ -3165,10 +3213,7 @@ def test_remaining_signal_health_and_task_endpoints_have_parameter_docs_and_desc
     signal_quality_parameters = signal_quality_operation.get("parameters", [])
     assert signal_quality_operation.get("summary")
     assert len(signal_quality_operation.get("description", "")) >= 20
-    assert any(
-        param["name"] == "strategy_id" and param.get("description")
-        for param in signal_quality_parameters
-    )
+    assert any(param["name"] == "strategy_id" and param.get("description") for param in signal_quality_parameters)
 
     realtime_operation = schema["paths"]["/api/strategies/{strategy_id}/realtime"]["get"]
     realtime_parameters = realtime_operation.get("parameters", [])
@@ -3187,6 +3232,5 @@ def test_remaining_signal_health_and_task_endpoints_have_parameter_docs_and_desc
     assert task_operation.get("summary")
     assert len(task_operation.get("description", "")) >= 20
     assert any(
-        param["name"] == "task_id" and param["in"] == "path" and param.get("description")
-        for param in task_parameters
+        param["name"] == "task_id" and param["in"] == "path" and param.get("description") for param in task_parameters
     )


### PR DESCRIPTION
## Summary
- migrates financial.py get_financial_data from direct get_data_source_factory() to Depends(get_data_source_factory_dependency)
- adds a focused route dependency test in test_health_route_conflicts.py
- preserves route path, query parameters, response shape, OpenAPI exposure, get_data_source_factory(), and _global_factory

## Verification
- TDD RED: 1 failed, 112 passed
- TDD GREEN: 113 passed
- provider lifecycle tests: 4 passed
- ruff touched files: passed
- black --check touched files: 2 unchanged
- route guard: financial direct calls 1 -> 0, total API direct calls 15 -> 14
- app/OpenAPI smoke: routes=548, paths=500, duplicate operation IDs=0
- GitNexus staged scope: LOW, affected processes=0
- post-commit mainline gate: pass=True