### PR TITLE
docs(governance): authorize market factory route migration

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -971,10 +971,21 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 operation IDs remain `0`, and refreshed GitNexus at
 │   │                 `229cd7fe0` reports `financial.py` LOW/1 and provider
 │   │                 dependency LOW/0
-│   └── Next gate: Create a separate G2.64 authorization-only packet before
-│                  any next DataSourceFactory route consumer edit; recommended
-│                  candidate is `web/backend/app/api/data/market.py`, with all
-│                  other remaining consumers still locked
+│   │                 PR `#209` merged at
+│   │                 `cfb98f079c488c7e33c270e44342408a0e10db44`; G2.64 now
+│   │                 authorizes the next route candidate: `market.py` has one
+│   │                 direct call at line `98` in `get_market_overview`, the file
+│   │                 has four route handlers, current direct API calls remain
+│   │                 `14`, provider dependency refs remain `5`, health route
+│   │                 conflict tests pass `113`, provider tests pass `4`,
+│   │                 OpenAPI remains paths=`500` with duplicate operation IDs=`0`,
+│   │                 and candidate style baseline records existing `market.py`
+│   │                 E701/black debt that a future same-file implementation must
+│   │                 normalize
+│   └── Next gate: Human review of the G2.64 authorization PR; if accepted,
+│                  create a separate G2.65 path-limited implementation branch
+│                  for `web/backend/app/api/data/market.py` only, with all other
+│                  remaining consumers still locked
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1082,6 +1093,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-next-route-consumer-authorization-2026-05-24.md` | G | G2.62 authorization prepared at current HEAD `fcc438de0965f80af7d485525fb494511976595b`: records PR `#206` as `MERGED`, compares the remaining one-call candidates and selects `web/backend/app/api/data/financial.py` for future G2.63 because it has one direct factory call at line `69` inside one route function, while `web/backend/app/api/data/market.py` has one direct call at line `98` but a broader four-route file surface; this PR authorizes only a future `financial.py` implementation branch and does not edit source, tests, routes, OpenAPI, OpenSpec, issue labels, runtime, or PM2 state | Human review / PR merge decision; if accepted, create G2.63 path-limited `financial.py` implementation branch; all other remaining consumers stay locked |
 | `backend-data-source-factory-financial-route-migration-implementation-2026-05-24.md` | G | G2.63 implementation prepared at current HEAD `7c1b8fce44b3931c44ac5398e12f5715a28833e3`: records PR `#207` as `MERGED`, refreshes non-linked GitNexus at the same HEAD with analyze exit=`0`, nodes=`62644`, edges=`145819`, flows=`300`, records file-level `financial.py` upstream impact LOW/2 and provider dependency LOW/0, follows TDD red=`1 failed, 112 passed` then green=`113 passed`, migrates `financial.py` direct calls from `1` to `0`, reduces total API direct calls from `15` to `14`, preserves `get_data_source_factory()` plus `_global_factory`, verifies provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; remaining `14` route/API consumers stay locked | Human review / PR merge decision; if accepted, run G2.63 closeout/current-head refresh before selecting another DataSourceFactory route consumer packet |
 | `backend-data-source-factory-financial-route-migration-closeout-2026-05-24.md` | G | G2.63 closeout prepared at current HEAD `229cd7fe0a21cb9bf7b9079d07e9551baaf0a4c7`: records PR `#208` as `MERGED`, confirms current-head route guard direct API calls=`14`, `financial.py` direct refs=`0`, provider dependency API refs=`5`, health route conflict tests=`113 passed`, provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus at `229cd7fe0` with analyze exit=`0`, nodes=`62659`, edges=`145822`, flows=`300`, file-level `financial.py` LOW/1 upstream impact and provider dependency LOW/0; recommends a separate G2.64 authorization-only packet before any next route consumer edit | Human review / PR merge decision; if accepted, create G2.64 authorization-only packet for the next DataSourceFactory route consumer; recommended candidate is `web/backend/app/api/data/market.py`, and all other remaining consumers stay locked |
+| `backend-data-source-factory-market-route-migration-authorization-2026-05-24.md` | G | G2.64 authorization prepared at current HEAD `cfb98f079c488c7e33c270e44342408a0e10db44`: records PR `#209` as `MERGED`, selects `web/backend/app/api/data/market.py` for future G2.65 because it has one direct factory call at line `98` inside `get_market_overview`, records the four-route file surface, confirms direct API calls=`14`, provider dependency refs=`5`, health route conflict tests=`113 passed`, provider lifecycle tests=`4 passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus at `cfb98f079` with analyze exit=`0`, nodes=`62656`, edges=`145824`, flows=`300`, file-level `market.py` LOW/1 upstream impact and provider dependency LOW/0; candidate style baseline notes existing `market.py` E701/black debt to fix inside a future same-file implementation | Human review / PR merge decision; if accepted, create G2.65 path-limited `market.py` implementation branch; all other remaining consumers stay locked |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/data-source-factory-market-route-migration-authorization-2026-05-24.json
+++ b/.planning/codebase/generated/data-source-factory-market-route-migration-authorization-2026-05-24.json
@@ -1,0 +1,167 @@
+{
+  "schema_version": "1.0",
+  "artifact": "data-source-factory-market-route-migration-authorization",
+  "generated_at": "2026-05-25T00:34:03+08:00",
+  "workline": "G2.64-authorization",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_head": "cfb98f079c488c7e33c270e44342408a0e10db44",
+  "status": "ready_for_review",
+  "upstream_closeout": {
+    "workline": "G2.63-closeout",
+    "pr": 209,
+    "merge_commit": "cfb98f079c488c7e33c270e44342408a0e10db44",
+    "report": "docs/reports/quality/backend-data-source-factory-financial-route-migration-closeout-2026-05-24.md"
+  },
+  "scope_boundary": {
+    "kind": "authorization_only",
+    "backend_source_modified": false,
+    "tests_modified": false,
+    "route_paths_modified": false,
+    "openapi_modified": false,
+    "openspec_modified": false,
+    "issue_labels_modified": false,
+    "runtime_or_pm2_modified": false
+  },
+  "candidate": {
+    "file": "web/backend/app/api/data/market.py",
+    "selected_for_future_workline": "G2.65",
+    "direct_get_data_source_factory_calls": [
+      {
+        "line": 98,
+        "handler": "get_market_overview",
+        "text": "factory = await get_data_source_factory()"
+      }
+    ],
+    "route_functions_in_file": [
+      {
+        "line": 94,
+        "name": "get_market_overview",
+        "path": "/markets/overview"
+      },
+      {
+        "line": 118,
+        "name": "get_price_distribution",
+        "path": "/markets/price-distribution"
+      },
+      {
+        "line": 146,
+        "name": "get_hot_industries",
+        "path": "/markets/hot-industries"
+      },
+      {
+        "line": 171,
+        "name": "get_hot_concepts",
+        "path": "/markets/hot-concepts"
+      }
+    ],
+    "reason_selected": "market.py is now the remaining one-call route consumer after financial.py closeout; it has broader four-route file surface and therefore requires this separate authorization packet before source edits"
+  },
+  "current_head_route_guard": {
+    "api_files_scanned": 219,
+    "direct_get_data_source_factory_calls": 14,
+    "get_data_source_factory_dependency_api_refs": 5,
+    "market_py_direct_refs": 1,
+    "market_py_dependency_refs": 0,
+    "remaining_direct_call_files": {
+      "web/backend/app/api/data/kline.py": 2,
+      "web/backend/app/api/data/market.py": 1,
+      "web/backend/app/api/data/margin.py": 3,
+      "web/backend/app/api/data/futures.py": 2,
+      "web/backend/app/api/data/stocks.py": 2,
+      "web/backend/app/api/data/lhb.py": 2,
+      "web/backend/app/api/market/market_data_request.py": 2
+    }
+  },
+  "candidate_style_baseline": {
+    "ruff_candidate_files": {
+      "status": "failed_existing_debt",
+      "errors": [
+        {
+          "file": "web/backend/app/api/data/market.py",
+          "line": 123,
+          "code": "E701",
+          "message": "Multiple statements on one line"
+        },
+        {
+          "file": "web/backend/app/api/data/market.py",
+          "line": 154,
+          "code": "E701",
+          "message": "Multiple statements on one line"
+        },
+        {
+          "file": "web/backend/app/api/data/market.py",
+          "line": 179,
+          "code": "E701",
+          "message": "Multiple statements on one line"
+        }
+      ]
+    },
+    "black_candidate_files": {
+      "status": "failed_existing_debt",
+      "message": "would reformat web/backend/app/api/data/market.py"
+    },
+    "future_scope_disposition": "A future G2.65 implementation branch may normalize only web/backend/app/api/data/market.py formatting while migrating its single DataSourceFactory call; no other file formatting cleanup is authorized by this packet"
+  },
+  "verification": {
+    "health_route_conflicts_tests": "113 passed",
+    "provider_lifecycle_tests": "4 passed",
+    "app_openapi_smoke": {
+      "app_import": "passed",
+      "routes": 548,
+      "openapi_paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 121
+    }
+  },
+  "gitnexus_refresh": {
+    "repo": "g2-64-gitnexus-index-checkout",
+    "head": "cfb98f079",
+    "git_kind": "directory",
+    "analyze_exit": 0,
+    "nodes": 62656,
+    "edges": 145824,
+    "flows": 300,
+    "impacts": {
+      "web/backend/app/api/data/market.py": {
+        "risk": "LOW",
+        "impacted_count": 1,
+        "direct": 1,
+        "processes_affected": 0
+      },
+      "get_data_source_factory_dependency": {
+        "risk": "LOW",
+        "impacted_count": 0,
+        "direct": 0,
+        "processes_affected": 0
+      },
+      "get_market_overview_name_lookup": {
+        "status": "ambiguous_symbol_name",
+        "note": "GitNexus name lookup resolves multiple get_market_overview symbols; file-level market.py impact is authoritative for this authorization packet"
+      }
+    }
+  },
+  "future_g2_65_allowed_scope": {
+    "allowed_paths": [
+      "web/backend/app/api/data/market.py",
+      "web/backend/tests/test_health_route_conflicts.py",
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/data-source-factory-market-route-migration-implementation-2026-05-24.json",
+      "docs/reports/quality/backend-data-source-factory-market-route-migration-implementation-2026-05-24.md",
+      "governance/mainline/task-cards/pr-211.yaml"
+    ],
+    "expected_after_future_migration": {
+      "market_py_direct_refs": 0,
+      "api_direct_get_data_source_factory_calls": 13,
+      "route_paths_modified": false,
+      "openapi_modified": false,
+      "compatibility_getter_removed": false
+    }
+  },
+  "next_gate": {
+    "recommended_workline": "G2.65",
+    "recommended_scope": "path-limited source implementation for market.py only",
+    "remaining_consumers_locked_until_authorized": true
+  }
+}

--- a/docs/reports/quality/backend-data-source-factory-market-route-migration-authorization-2026-05-24.md
+++ b/docs/reports/quality/backend-data-source-factory-market-route-migration-authorization-2026-05-24.md
@@ -1,0 +1,170 @@
+# Backend DataSourceFactory Market Route Migration Authorization - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Workline: G2.64 authorization-only packet
+
+Base branch: `wip/root-dirty-20260403`
+
+Current HEAD: `cfb98f079c488c7e33c270e44342408a0e10db44`
+
+## Scope Boundary
+
+This packet authorizes a future implementation branch only. It does not change
+backend source code, tests, route paths, response contracts, OpenAPI exposure,
+generated clients, OpenSpec files, issue labels, runtime process state, or PM2
+state.
+
+## Upstream State
+
+G2.63 closeout is merged as PR `#209` at
+`cfb98f079c488c7e33c270e44342408a0e10db44`.
+
+Current-head route guard reports:
+
+- API files scanned: `219`
+- Direct `get_data_source_factory()` API calls: `14`
+- `get_data_source_factory_dependency` API refs: `5`
+- `market.py` direct refs: `1`
+- `market.py` dependency refs: `0`
+
+Remaining direct-call files:
+
+| File | Calls |
+|---|---:|
+| `web/backend/app/api/data/futures.py` | 2 |
+| `web/backend/app/api/data/kline.py` | 2 |
+| `web/backend/app/api/data/lhb.py` | 2 |
+| `web/backend/app/api/data/market.py` | 1 |
+| `web/backend/app/api/data/margin.py` | 3 |
+| `web/backend/app/api/data/stocks.py` | 2 |
+| `web/backend/app/api/market/market_data_request.py` | 2 |
+
+## Candidate Evidence
+
+Selected future implementation candidate:
+
+| Candidate | Direct calls | Handler | Route functions in file | Disposition |
+|---|---:|---|---:|---|
+| `web/backend/app/api/data/market.py` | 1 | `get_market_overview` | 4 | selected for future G2.65 |
+
+The single direct call is:
+
+| Line | Handler | Current call |
+|---:|---|---|
+| 98 | `get_market_overview` | `factory = await get_data_source_factory()` |
+
+Route functions in `market.py`:
+
+| Line | Function | Path |
+|---:|---|---|
+| 94 | `get_market_overview` | `/markets/overview` |
+| 118 | `get_price_distribution` | `/markets/price-distribution` |
+| 146 | `get_hot_industries` | `/markets/hot-industries` |
+| 171 | `get_hot_concepts` | `/markets/hot-concepts` |
+
+`market.py` is selected because it is now the remaining one-call
+DataSourceFactory route consumer after the `financial.py` migration. It has a
+broader route surface than `financial.py`, so the future implementation must
+remain path-limited and test-gated.
+
+## Candidate Style Baseline
+
+Candidate file style checks currently expose existing debt:
+
+| Check | Result |
+|---|---|
+| `ruff check web/backend/app/api/data/market.py web/backend/tests/test_health_route_conflicts.py web/backend/app/services/data_source_factory/__init__.py` | failed: `market.py` has three existing `E701` issues at lines `123`, `154`, `179` |
+| `black --check web/backend/app/api/data/market.py web/backend/tests/test_health_route_conflicts.py web/backend/app/services/data_source_factory/__init__.py` | failed: `market.py` would be reformatted |
+
+This G2.64 packet does not fix those lines. A future G2.65 implementation may
+normalize formatting inside `web/backend/app/api/data/market.py` while migrating
+the single factory call. No other file formatting cleanup is authorized by this
+packet.
+
+## Verification
+
+Executed at current HEAD:
+
+| Check | Result |
+|---|---|
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `113 passed` |
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | `4 passed` |
+| app import / OpenAPI smoke with non-secret test env | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+
+The app/OpenAPI smoke still reports `warning_count=121`, including the existing
+local GPU fallback warning for the NumPy/Numba mismatch.
+
+## GitNexus Refresh
+
+GitNexus was refreshed from a non-linked checkout:
+
+- Repo: `g2-64-gitnexus-index-checkout`
+- HEAD: `cfb98f079`
+- `.git` kind: `directory`
+- `gitnexus analyze` exit: `0`
+- Nodes: `62656`
+- Edges: `145824`
+- Flows: `300`
+
+Current-head upstream impact:
+
+| Target | Risk | Impacted count | Direct | Processes affected |
+|---|---|---:|---:|---:|
+| `web/backend/app/api/data/market.py` | LOW | 1 | 1 | 0 |
+| `get_data_source_factory_dependency` | LOW | 0 | 0 | 0 |
+
+`get_market_overview` is an ambiguous symbol name in GitNexus because multiple
+modules define a function with that name. For this packet, file-level
+`market.py` impact is the authoritative risk signal.
+
+## Future G2.65 Scope
+
+If this packet is reviewed and merged, the future source branch may edit only:
+
+- `web/backend/app/api/data/market.py`
+- `web/backend/tests/test_health_route_conflicts.py`
+- implementation evidence report and generated JSON
+- the steward tree
+- the future mainline task card
+
+Expected future outcome:
+
+- `market.py` direct factory refs: `1` -> `0`
+- total direct API `get_data_source_factory()` calls: `14` -> `13`
+- route paths unchanged
+- response shape unchanged
+- OpenAPI exposure unchanged
+- `get_data_source_factory()` and `_global_factory` retained
+- `market.py` formatting normalized enough for ruff/black touched-file gates
+
+## Non-Goals
+
+This packet and the future G2.65 implementation do not authorize:
+
+- migrating any non-`market.py` route/API consumer;
+- deleting `get_data_source_factory()` or `_global_factory`;
+- changing route paths, response models, response shape, OpenAPI exposure,
+  frontend code, generated clients, PM2/runtime process state, OpenSpec files,
+  issue labels, or docs/API examples;
+- broad formatting cleanup outside `web/backend/app/api/data/market.py`.
+
+## Decision
+
+Authorize `web/backend/app/api/data/market.py` as the next DataSourceFactory
+route migration candidate.
+
+Do not edit route code under this G2.64 packet. If accepted, create a separate
+G2.65 implementation branch with the path, TDD, rollback, and style-debt
+boundaries above.
+
+## Next Gate
+
+Human review of this G2.64 authorization PR.
+
+If accepted and merged, open G2.65 as a path-limited implementation branch for
+`market.py` only.

--- a/governance/mainline/task-cards/pr-210.yaml
+++ b/governance/mainline/task-cards/pr-210.yaml
@@ -1,0 +1,117 @@
+version: "v0.2"
+
+task:
+  id: "pr-210"
+  title: "Authorize market DataSourceFactory route migration"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-data-source-factory-market-route-migration-authorization"
+  objective: "authorize market.py as the next path-limited DataSourceFactory route consumer migration candidate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-market-route-migration-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-market-route-migration-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization packet records candidate evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-market-route-migration-authorization-2026-05-24.json"
+    - "docs/reports/quality/backend-data-source-factory-market-route-migration-authorization-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-210.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No market.py source migration in this PR"
+  - "No non-market.py consumer migration in this PR"
+  - "No compatibility getter cleanup in this PR"
+
+acceptance:
+  checks:
+    - id: "health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "candidate-style-baseline"
+      command: "ruff/black candidate-file baseline is recorded as existing market.py debt; future G2.65 must fix inside market.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-market-route-migration-authorization-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-market-route-migration-authorization-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-210.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-210.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the authorization-only boundary"
+    - "If this PR performs the market.py route migration, it bypasses the implementation review gate"
+    - "If a future implementation treats the existing market.py formatting debt as broad cleanup, it may exceed the path-limited scope"
+  rollback_plan: "revert this governance-only authorization PR; G2.63 closeout remains accepted unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize market.py as the next DataSourceFactory route consumer migration candidate"
+    modified_scope: "authorization report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none in this PR"
+    legacy_logic_impact: "none; route consumers and compatibility getter remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only authorization PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T00:34:03+08:00"
+    approval_note: "human maintainer approved continuing after G2.63 closeout; this packet authorizes only a future reviewed market.py route migration branch"
+    secondary_approved: false


### PR DESCRIPTION
## Summary\n- Authorize market.py as the next DataSourceFactory route consumer migration candidate for future G2.65\n- Record current-head route guard, OpenAPI, test, and GitNexus evidence\n- Capture existing market.py ruff/black style debt as future same-file implementation scope, with no source edit in this PR\n\n## Verification\n- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short\n- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short\n- app import / OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate operation_ids=0\n- non-linked GitNexus analyze: nodes=62656, edges=145824, flows=300\n- markdown governance gate passed\n- JSON/YAML parse passed\n- mainline scope gate passed post-commit\n- staged GitNexus detect_changes risk low