### PR TITLE
refactor(api): inject data source factory in market route

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -982,10 +982,17 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 and candidate style baseline records existing `market.py`
 │   │                 E701/black debt that a future same-file implementation must
 │   │                 normalize
-│   └── Next gate: Human review of the G2.64 authorization PR; if accepted,
-│                  create a separate G2.65 path-limited implementation branch
-│                  for `web/backend/app/api/data/market.py` only, with all other
-│                  remaining consumers still locked
+│   │                 PR `#210` merged at
+│   │                 `20a7b67f1898506586e7858840d0ae058461fe93`; G2.65 now
+│   │                 implements the approved `market.py` migration:
+│   │                 `market.py` direct calls move from `1` to `0`, total API
+│   │                 direct calls move from `14` to `13`, health route conflict
+│   │                 tests pass `114`, provider tests pass `4`, touched-file
+│   │                 ruff/black pass, and app/OpenAPI smoke remains routes=`548`,
+│   │                 paths=`500`, duplicate operation IDs=`0`
+│   └── Next gate: Human review of the G2.65 implementation PR; if accepted,
+│                  run a separate G2.65 closeout/current-head refresh before
+│                  selecting another DataSourceFactory route consumer packet
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1094,6 +1101,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-financial-route-migration-implementation-2026-05-24.md` | G | G2.63 implementation prepared at current HEAD `7c1b8fce44b3931c44ac5398e12f5715a28833e3`: records PR `#207` as `MERGED`, refreshes non-linked GitNexus at the same HEAD with analyze exit=`0`, nodes=`62644`, edges=`145819`, flows=`300`, records file-level `financial.py` upstream impact LOW/2 and provider dependency LOW/0, follows TDD red=`1 failed, 112 passed` then green=`113 passed`, migrates `financial.py` direct calls from `1` to `0`, reduces total API direct calls from `15` to `14`, preserves `get_data_source_factory()` plus `_global_factory`, verifies provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, duplicate operation IDs=`0`; remaining `14` route/API consumers stay locked | Human review / PR merge decision; if accepted, run G2.63 closeout/current-head refresh before selecting another DataSourceFactory route consumer packet |
 | `backend-data-source-factory-financial-route-migration-closeout-2026-05-24.md` | G | G2.63 closeout prepared at current HEAD `229cd7fe0a21cb9bf7b9079d07e9551baaf0a4c7`: records PR `#208` as `MERGED`, confirms current-head route guard direct API calls=`14`, `financial.py` direct refs=`0`, provider dependency API refs=`5`, health route conflict tests=`113 passed`, provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus at `229cd7fe0` with analyze exit=`0`, nodes=`62659`, edges=`145822`, flows=`300`, file-level `financial.py` LOW/1 upstream impact and provider dependency LOW/0; recommends a separate G2.64 authorization-only packet before any next route consumer edit | Human review / PR merge decision; if accepted, create G2.64 authorization-only packet for the next DataSourceFactory route consumer; recommended candidate is `web/backend/app/api/data/market.py`, and all other remaining consumers stay locked |
 | `backend-data-source-factory-market-route-migration-authorization-2026-05-24.md` | G | G2.64 authorization prepared at current HEAD `cfb98f079c488c7e33c270e44342408a0e10db44`: records PR `#209` as `MERGED`, selects `web/backend/app/api/data/market.py` for future G2.65 because it has one direct factory call at line `98` inside `get_market_overview`, records the four-route file surface, confirms direct API calls=`14`, provider dependency refs=`5`, health route conflict tests=`113 passed`, provider lifecycle tests=`4 passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus at `cfb98f079` with analyze exit=`0`, nodes=`62656`, edges=`145824`, flows=`300`, file-level `market.py` LOW/1 upstream impact and provider dependency LOW/0; candidate style baseline notes existing `market.py` E701/black debt to fix inside a future same-file implementation | Human review / PR merge decision; if accepted, create G2.65 path-limited `market.py` implementation branch; all other remaining consumers stay locked |
+| `backend-data-source-factory-market-route-migration-implementation-2026-05-24.md` | G | G2.65 implementation prepared at current HEAD `20a7b67f1898506586e7858840d0ae058461fe93`: records PR `#210` as `MERGED`, refreshes non-linked GitNexus before source edits with analyze exit=`0`, nodes=`62665`, edges=`145822`, flows=`300`, records file-level `market.py` upstream impact LOW/1 and provider dependency LOW/0, follows TDD red=`1 failed: KeyError factory` then green=`1 passed`, migrates `market.py` direct calls from `1` to `0`, reduces total API direct calls from `14` to `13`, clears same-file `market.py` E701/black debt inside the authorized file, preserves `get_data_source_factory()` plus `_global_factory`, verifies health route conflict tests=`114 passed`, provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`; remaining `13` route/API consumers stay locked | Human review / PR merge decision; if accepted, run G2.65 closeout/current-head refresh before selecting another DataSourceFactory route consumer packet |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/data-source-factory-market-route-migration-implementation-2026-05-24.json
+++ b/.planning/codebase/generated/data-source-factory-market-route-migration-implementation-2026-05-24.json
@@ -1,0 +1,129 @@
+{
+  "schema_version": "1.0",
+  "artifact": "data-source-factory-market-route-migration-implementation",
+  "generated_at": "2026-05-25T00:54:13+08:00",
+  "workline": "G2.65-implementation",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_head_before_commit": "20a7b67f1898506586e7858840d0ae058461fe93",
+  "status": "ready_for_review",
+  "authorization": {
+    "workline": "G2.64-authorization",
+    "pr": 210,
+    "merge_commit": "20a7b67f1898506586e7858840d0ae058461fe93",
+    "report": "docs/reports/quality/backend-data-source-factory-market-route-migration-authorization-2026-05-24.md"
+  },
+  "scope_boundary": {
+    "kind": "path_limited_source_implementation",
+    "backend_source_modified": true,
+    "tests_modified": true,
+    "route_paths_modified": false,
+    "openapi_modified": false,
+    "openspec_modified": false,
+    "issue_labels_modified": false,
+    "runtime_or_pm2_modified": false
+  },
+  "modified_files": [
+    "web/backend/app/api/data/market.py",
+    "web/backend/tests/test_health_route_conflicts.py",
+    ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+    ".planning/codebase/generated/data-source-factory-market-route-migration-implementation-2026-05-24.json",
+    "docs/reports/quality/backend-data-source-factory-market-route-migration-implementation-2026-05-24.md",
+    "governance/mainline/task-cards/pr-211.yaml"
+  ],
+  "implementation": {
+    "route_file": "web/backend/app/api/data/market.py",
+    "handler": "get_market_overview",
+    "change": "Injected DataSourceFactory through Depends(get_data_source_factory_dependency) and removed inline await get_data_source_factory()",
+    "same_file_style_debt_fixed": [
+      {
+        "line_before": 123,
+        "code": "E701",
+        "disposition": "expanded to two-line if/return"
+      },
+      {
+        "line_before": 154,
+        "code": "E701",
+        "disposition": "expanded to two-line if/return"
+      },
+      {
+        "line_before": 179,
+        "code": "E701",
+        "disposition": "expanded to two-line if/return"
+      }
+    ],
+    "compatibility_surfaces_preserved": [
+      "get_data_source_factory()",
+      "_global_factory"
+    ]
+  },
+  "tdd": {
+    "red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_market_overview_route_uses_data_source_factory_dependency -q --no-cov --tb=short",
+      "result": "1 failed",
+      "failure": "KeyError: 'factory'"
+    },
+    "green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_market_overview_route_uses_data_source_factory_dependency -q --no-cov --tb=short",
+      "result": "1 passed"
+    }
+  },
+  "route_guard": {
+    "api_files_scanned": 219,
+    "direct_get_data_source_factory_calls": 13,
+    "get_data_source_factory_dependency_api_refs": 7,
+    "market_py_direct_refs": 0,
+    "market_py_dependency_refs": 2,
+    "remaining_direct_call_files": {
+      "web/backend/app/api/data/kline.py": 2,
+      "web/backend/app/api/data/margin.py": 3,
+      "web/backend/app/api/data/futures.py": 2,
+      "web/backend/app/api/data/stocks.py": 2,
+      "web/backend/app/api/data/lhb.py": 2,
+      "web/backend/app/api/market/market_data_request.py": 2
+    }
+  },
+  "verification": {
+    "health_route_conflicts_tests": "114 passed",
+    "provider_lifecycle_tests": "4 passed",
+    "ruff_touched_files": "passed",
+    "black_touched_files": "3 files unchanged",
+    "app_openapi_smoke": {
+      "app_import": "passed",
+      "routes": 548,
+      "openapi_paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 121
+    }
+  },
+  "gitnexus_pre_edit": {
+    "repo": "g2-65-gitnexus-index-checkout",
+    "head": "20a7b67f1",
+    "git_kind": "directory",
+    "analyze_exit": 0,
+    "nodes": 62665,
+    "edges": 145822,
+    "flows": 300,
+    "impacts": {
+      "web/backend/app/api/data/market.py": {
+        "risk": "LOW",
+        "impacted_count": 1,
+        "direct": 1,
+        "processes_affected": 0
+      },
+      "get_data_source_factory_dependency": {
+        "risk": "LOW",
+        "impacted_count": 0,
+        "direct": 0,
+        "processes_affected": 0
+      }
+    }
+  },
+  "next_gate": {
+    "recommended_workline": "G2.65-closeout",
+    "recommended_scope": "current-head closeout refresh before selecting another DataSourceFactory route consumer",
+    "remaining_direct_route_calls": 13,
+    "remaining_consumers_locked_until_authorized": true
+  }
+}

--- a/docs/reports/quality/backend-data-source-factory-market-route-migration-implementation-2026-05-24.md
+++ b/docs/reports/quality/backend-data-source-factory-market-route-migration-implementation-2026-05-24.md
@@ -1,0 +1,139 @@
+# Backend DataSourceFactory Market Route Migration Implementation - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Workline: G2.65 path-limited implementation
+
+Base branch: `wip/root-dirty-20260403`
+
+Current HEAD before commit: `20a7b67f1898506586e7858840d0ae058461fe93`
+
+## Scope Boundary
+
+This implementation follows the G2.64 authorization packet. It changes only the
+selected route file, the focused route-contract test, this evidence report, the
+generated JSON artifact, the steward tree, and the mainline task card.
+
+It does not change route paths, response contracts, OpenAPI exposure, generated
+clients, OpenSpec files, issue labels, runtime process state, PM2 state,
+frontend code, or any non-`market.py` DataSourceFactory route consumer.
+
+## Implementation
+
+Modified source:
+
+- `web/backend/app/api/data/market.py`
+- `web/backend/tests/test_health_route_conflicts.py`
+
+Runtime change:
+
+- `get_market_overview` now injects `DataSourceFactory` through
+  `Depends(get_data_source_factory_dependency)`.
+- The inline `from app.services.data_source_factory import get_data_source_factory`
+  and `await get_data_source_factory()` call were removed from the handler.
+- `get_data_source_factory()` and `_global_factory` compatibility surfaces remain
+  intact.
+
+Same-file style debt resolved inside the authorized `market.py` scope:
+
+- line `123` previous `if cached_data: return cached_data`
+- line `154` previous `if cached_data: return cached_data`
+- line `179` previous `if cached_data: return cached_data`
+
+Those lines were expanded so touched-file ruff and black gates pass. No broad
+formatting cleanup outside `market.py` was performed.
+
+## TDD Evidence
+
+RED:
+
+| Check | Result |
+|---|---|
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_market_overview_route_uses_data_source_factory_dependency -q --no-cov --tb=short` | `1 failed`: `KeyError: 'factory'` |
+
+GREEN:
+
+| Check | Result |
+|---|---|
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_market_overview_route_uses_data_source_factory_dependency -q --no-cov --tb=short` | `1 passed` |
+
+## Route Guard
+
+Post-implementation static scan reports:
+
+- API files scanned: `219`
+- Direct `get_data_source_factory()` API calls: `13`
+- `get_data_source_factory_dependency` API refs: `7`
+- `market.py` direct refs: `0`
+- `market.py` dependency refs: `2`
+
+Remaining direct-call files:
+
+| File | Calls |
+|---|---:|
+| `web/backend/app/api/data/futures.py` | 2 |
+| `web/backend/app/api/data/kline.py` | 2 |
+| `web/backend/app/api/data/lhb.py` | 2 |
+| `web/backend/app/api/data/margin.py` | 3 |
+| `web/backend/app/api/data/stocks.py` | 2 |
+| `web/backend/app/api/market/market_data_request.py` | 2 |
+
+The remaining `13` route/API consumers stay locked until a separate
+authorization packet selects the next batch.
+
+## Verification
+
+Executed after implementation:
+
+| Check | Result |
+|---|---|
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `114 passed` |
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | `4 passed` |
+| `ruff check` on touched source/test files | passed |
+| `black --check` on touched source/test files | `3 files would be left unchanged` |
+| app import / OpenAPI smoke with non-secret test env | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+
+The app/OpenAPI smoke still reports `warning_count=121`, including the existing
+local GPU fallback warning for the NumPy/Numba mismatch.
+
+## GitNexus Pre-Edit Evidence
+
+GitNexus was refreshed from a non-linked checkout before source edits:
+
+- Repo: `g2-65-gitnexus-index-checkout`
+- HEAD: `20a7b67f1`
+- `.git` kind: `directory`
+- `gitnexus analyze` exit: `0`
+- Nodes: `62665`
+- Edges: `145822`
+- Flows: `300`
+
+Pre-edit upstream impact:
+
+| Target | Risk | Impacted count | Direct | Processes affected |
+|---|---|---:|---:|---:|
+| `web/backend/app/api/data/market.py` | LOW | 1 | 1 | 0 |
+| `get_data_source_factory_dependency` | LOW | 0 | 0 | 0 |
+
+## Decision
+
+G2.65 is ready for review as the `market.py` DataSourceFactory route consumer
+migration.
+
+This implementation completes the authorized migration:
+
+- `market.py`: `1` direct call -> `0`
+- API total: `14` direct calls -> `13`
+- route/OpenAPI contract unchanged
+- existing `market.py` same-file style debt cleared enough for touched-file gates
+
+## Next Gate
+
+Human review of this implementation PR.
+
+If accepted and merged, run a separate G2.65 closeout/current-head refresh
+before selecting another DataSourceFactory route consumer packet.

--- a/governance/mainline/task-cards/pr-211.yaml
+++ b/governance/mainline/task-cards/pr-211.yaml
@@ -1,0 +1,127 @@
+version: "v0.2"
+
+task:
+  id: "pr-211"
+  title: "Implement market DataSourceFactory route migration"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-data-source-factory-market-route-migration-implementation"
+  objective: "migrate market.py get_market_overview from direct DataSourceFactory getter usage to provider dependency injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-market-route-migration-implementation"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-market-route-migration-implementation"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Provider injection preserves route path, response shape, OpenAPI exposure, and compatibility getter surfaces"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/api/data/market.py"
+    - "web/backend/tests/test_health_route_conflicts.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-market-route-migration-implementation-2026-05-24.json"
+    - "docs/reports/quality/backend-data-source-factory-market-route-migration-implementation-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-211.yaml"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+    - "web/backend/app/api/data/futures.py"
+    - "web/backend/app/api/data/kline.py"
+    - "web/backend/app/api/data/lhb.py"
+    - "web/backend/app/api/data/margin.py"
+    - "web/backend/app/api/data/stocks.py"
+    - "web/backend/app/api/market/**"
+
+non_goals:
+  - "No route path, response model, response shape, OpenAPI exposure, docs/API, generated client, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No non-market.py DataSourceFactory route consumer migration"
+  - "No deletion of get_data_source_factory() or _global_factory compatibility surfaces"
+  - "No broad formatting cleanup outside web/backend/app/api/data/market.py"
+
+acceptance:
+  checks:
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_market_overview_route_uses_data_source_factory_dependency -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-files"
+      command: "ruff check web/backend/app/api/data/market.py web/backend/tests/test_health_route_conflicts.py web/backend/app/services/data_source_factory/__init__.py"
+      required: true
+    - id: "black-touched-files"
+      command: "black --check web/backend/app/api/data/market.py web/backend/tests/test_health_route_conflicts.py web/backend/app/services/data_source_factory/__init__.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-market-route-migration-implementation-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-market-route-migration-implementation-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-211.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-211.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If non-market.py route consumers are edited, the PR exceeds the G2.64 authorization boundary"
+    - "If route paths or OpenAPI exposure change, frontend/API consumers may observe contract drift"
+  rollback_plan: "revert this path-limited implementation PR; G2.64 authorization remains the prior decision record unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "migrate market.py get_market_overview to DataSourceFactory provider dependency injection"
+    modified_scope: "market.py, focused route-conflict test, implementation report, generated artifact, steward tree, and this task card"
+    dependency_changes: "uses existing get_data_source_factory_dependency provider; no new dependency package"
+    legacy_logic_impact: "get_data_source_factory() and _global_factory compatibility surfaces remain"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this path-limited PR if route guard, OpenAPI smoke, or focused tests regress"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T00:54:13+08:00"
+    approval_note: "G2.64 authorization PR #210 merged; this implementation stays inside the approved market.py path-limited scope"
+    secondary_approved: false

--- a/web/backend/app/api/data/market.py
+++ b/web/backend/app/api/data/market.py
@@ -1,6 +1,7 @@
 """
 市场概览与热度路由 (Market Overview)
 """
+
 from datetime import datetime
 from typing import Any, Dict
 from fastapi import APIRouter, Depends, Query
@@ -9,6 +10,7 @@ from app.core.database import db_service
 from app.core.exceptions import BusinessException
 from app.core.security import User, get_current_user
 from app.openapi_config import COMMON_RESPONSES
+from app.services.data_source_factory import DataSourceFactory, get_data_source_factory_dependency
 
 router = APIRouter()
 
@@ -91,11 +93,12 @@ HOT_CONCEPTS_RESPONSES = {
     description="返回当前全市场的涨跌家数、市场状态等概览统计，适用于 A 股盘面总览和首页概况卡片。",
     responses=MARKET_OVERVIEW_RESPONSES,
 )
-async def get_market_overview(current_user: User = Depends(get_current_user)) -> Dict[str, Any]:
+async def get_market_overview(
+    current_user: User = Depends(get_current_user),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
+) -> Dict[str, Any]:
     """获取市场概览数据"""
     try:
-        from app.services.data_source_factory import get_data_source_factory
-        factory = await get_data_source_factory()
         result = await factory.get_data("data", "markets/overview", {})
         if result.get("status") == "success":
             return {
@@ -120,9 +123,11 @@ async def get_price_distribution(current_user: User = Depends(get_current_user))
     try:
         cache_key = "market:price-distribution"
         cached_data = db_service.get_cache_data(cache_key)
-        if cached_data: return cached_data
+        if cached_data:
+            return cached_data
 
         import random
+
         random.seed(42)
         distribution = {
             "上涨>5%": random.randint(50, 200),
@@ -137,6 +142,7 @@ async def get_price_distribution(current_user: User = Depends(get_current_user))
     except Exception as e:
         raise BusinessException(detail=str(e), status_code=500)
 
+
 @router.get(
     "/markets/hot-industries",
     summary="查询热门行业表现",
@@ -145,13 +151,14 @@ async def get_price_distribution(current_user: User = Depends(get_current_user))
 )
 async def get_hot_industries(
     limit: int = Query(5, description="返回行业条数，范围 1 到 20", ge=1, le=20),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user),
 ) -> Dict[str, Any]:
     """获取热门行业表现数据"""
     try:
         cache_key = f"market:hot-industries:{limit}"
         cached_data = db_service.get_cache_data(cache_key)
-        if cached_data: return cached_data
+        if cached_data:
+            return cached_data
 
         # Simplified logic
         data = [{"industry_name": "半导体", "avg_change": 2.5, "stock_count": 150}]
@@ -170,13 +177,14 @@ async def get_hot_industries(
 )
 async def get_hot_concepts(
     limit: int = Query(5, description="返回概念条数，范围 1 到 20", ge=1, le=20),
-    current_user: User = Depends(get_current_user)
+    current_user: User = Depends(get_current_user),
 ) -> Dict[str, Any]:
     """获取热门概念表现数据"""
     try:
         cache_key = f"market:hot-concepts:{limit}"
         cached_data = db_service.get_cache_data(cache_key)
-        if cached_data: return cached_data
+        if cached_data:
+            return cached_data
 
         data = [{"concept_name": "人工智能", "avg_change": 3.2, "stock_count": 45}]
         result = {"success": True, "data": data, "total": len(data), "timestamp": datetime.now().isoformat()}

--- a/web/backend/tests/test_health_route_conflicts.py
+++ b/web/backend/tests/test_health_route_conflicts.py
@@ -6,6 +6,7 @@ import inspect
 from fastapi.routing import APIRoute
 
 from app.api.data import financial as financial_module
+from app.api.data import market as market_module
 from app.main import app
 
 
@@ -44,6 +45,12 @@ def test_financial_route_uses_data_source_factory_dependency() -> None:
     factory_param = inspect.signature(financial_module.get_financial_data).parameters["factory"]
 
     assert getattr(factory_param.default, "dependency", None) is financial_module.get_data_source_factory_dependency
+
+
+def test_market_overview_route_uses_data_source_factory_dependency() -> None:
+    factory_param = inspect.signature(market_module.get_market_overview).parameters["factory"]
+
+    assert getattr(factory_param.default, "dependency", None) is market_module.get_data_source_factory_dependency
 
 
 def test_root_and_socketio_status_have_documented_examples_and_errors() -> None:


### PR DESCRIPTION
## Summary\n- Migrate market.py get_market_overview from direct get_data_source_factory() to Depends(get_data_source_factory_dependency)\n- Add focused route signature regression test following TDD red/green\n- Resolve same-file market.py E701/black debt authorized by G2.64 while keeping route/OpenAPI contracts unchanged\n\n## Verification\n- TDD RED: market overview dependency test failed with KeyError: factory\n- TDD GREEN: market overview dependency test passed\n- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short => 114 passed\n- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short => 4 passed\n- ruff check touched files => passed\n- black --check touched files => passed\n- route guard: direct API get_data_source_factory calls 14 -> 13; market.py direct refs 1 -> 0\n- app import / OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate operation_ids=0\n- GitNexus staged detect_changes: low risk