### PR TITLE
docs(governance): close out market factory route migration

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -990,9 +990,20 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 tests pass `114`, provider tests pass `4`, touched-file
 │   │                 ruff/black pass, and app/OpenAPI smoke remains routes=`548`,
 │   │                 paths=`500`, duplicate operation IDs=`0`
-│   └── Next gate: Human review of the G2.65 implementation PR; if accepted,
-│                  run a separate G2.65 closeout/current-head refresh before
-│                  selecting another DataSourceFactory route consumer packet
+│   │                 PR `#211` merged at
+│   │                 `277fdd412b2bbf68b64c5186fee943dc50080480`; G2.65
+│   │                 closeout confirms current-head stability: health route
+│   │                 conflict tests=`114 passed`, provider tests=`4 passed`,
+│   │                 route direct calls remain `13`, `market.py` direct refs
+│   │                 remain `0`, OpenAPI paths remain `500`, duplicate
+│   │                 operation IDs remain `0`, and refreshed GitNexus at
+│   │                 `277fdd412` reports `market.py` LOW/1 and provider
+│   │                 dependency LOW/0
+│   └── Next gate: Create a separate G2.66 authorization-only packet before
+│                  any next DataSourceFactory route consumer edit; remaining
+│                  candidates are `kline.py`, `futures.py`, `lhb.py`,
+│                  `stocks.py`, `margin.py`, and
+│                  `market/market_data_request.py`
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1102,6 +1113,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-financial-route-migration-closeout-2026-05-24.md` | G | G2.63 closeout prepared at current HEAD `229cd7fe0a21cb9bf7b9079d07e9551baaf0a4c7`: records PR `#208` as `MERGED`, confirms current-head route guard direct API calls=`14`, `financial.py` direct refs=`0`, provider dependency API refs=`5`, health route conflict tests=`113 passed`, provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus at `229cd7fe0` with analyze exit=`0`, nodes=`62659`, edges=`145822`, flows=`300`, file-level `financial.py` LOW/1 upstream impact and provider dependency LOW/0; recommends a separate G2.64 authorization-only packet before any next route consumer edit | Human review / PR merge decision; if accepted, create G2.64 authorization-only packet for the next DataSourceFactory route consumer; recommended candidate is `web/backend/app/api/data/market.py`, and all other remaining consumers stay locked |
 | `backend-data-source-factory-market-route-migration-authorization-2026-05-24.md` | G | G2.64 authorization prepared at current HEAD `cfb98f079c488c7e33c270e44342408a0e10db44`: records PR `#209` as `MERGED`, selects `web/backend/app/api/data/market.py` for future G2.65 because it has one direct factory call at line `98` inside `get_market_overview`, records the four-route file surface, confirms direct API calls=`14`, provider dependency refs=`5`, health route conflict tests=`113 passed`, provider lifecycle tests=`4 passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus at `cfb98f079` with analyze exit=`0`, nodes=`62656`, edges=`145824`, flows=`300`, file-level `market.py` LOW/1 upstream impact and provider dependency LOW/0; candidate style baseline notes existing `market.py` E701/black debt to fix inside a future same-file implementation | Human review / PR merge decision; if accepted, create G2.65 path-limited `market.py` implementation branch; all other remaining consumers stay locked |
 | `backend-data-source-factory-market-route-migration-implementation-2026-05-24.md` | G | G2.65 implementation prepared at current HEAD `20a7b67f1898506586e7858840d0ae058461fe93`: records PR `#210` as `MERGED`, refreshes non-linked GitNexus before source edits with analyze exit=`0`, nodes=`62665`, edges=`145822`, flows=`300`, records file-level `market.py` upstream impact LOW/1 and provider dependency LOW/0, follows TDD red=`1 failed: KeyError factory` then green=`1 passed`, migrates `market.py` direct calls from `1` to `0`, reduces total API direct calls from `14` to `13`, clears same-file `market.py` E701/black debt inside the authorized file, preserves `get_data_source_factory()` plus `_global_factory`, verifies health route conflict tests=`114 passed`, provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`; remaining `13` route/API consumers stay locked | Human review / PR merge decision; if accepted, run G2.65 closeout/current-head refresh before selecting another DataSourceFactory route consumer packet |
+| `backend-data-source-factory-market-route-migration-closeout-2026-05-24.md` | G | G2.65 closeout prepared at current HEAD `277fdd412b2bbf68b64c5186fee943dc50080480`: records PR `#211` as `MERGED`, confirms current-head route guard direct API calls=`13`, `market.py` direct refs=`0`, provider dependency API refs=`7`, health route conflict tests=`114 passed`, provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus at `277fdd412` with analyze exit=`0`, nodes=`62667`, edges=`145820`, flows=`300`, file-level `market.py` LOW/1 upstream impact and provider dependency LOW/0; recommends G2.66 authorization-only candidate comparison before any next route consumer edit | Human review / PR merge decision; if accepted, create G2.66 consumer-selection authorization packet; all remaining `13` route/API consumers stay locked |
 
 ## Completed And Reviewed Ledger
 

--- a/.planning/codebase/generated/data-source-factory-market-route-migration-closeout-2026-05-24.json
+++ b/.planning/codebase/generated/data-source-factory-market-route-migration-closeout-2026-05-24.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": "1.0",
+  "artifact": "data-source-factory-market-route-migration-closeout",
+  "generated_at": "2026-05-25T01:13:39+08:00",
+  "workline": "G2.65-closeout",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_head": "277fdd412b2bbf68b64c5186fee943dc50080480",
+  "status": "ready_for_review",
+  "merged_implementation": {
+    "pr": 211,
+    "merge_commit": "277fdd412b2bbf68b64c5186fee943dc50080480",
+    "implementation_report": "docs/reports/quality/backend-data-source-factory-market-route-migration-implementation-2026-05-24.md"
+  },
+  "scope_boundary": {
+    "kind": "closeout_current_head_refresh",
+    "backend_source_modified": false,
+    "tests_modified": false,
+    "route_paths_modified": false,
+    "openapi_modified": false,
+    "openspec_modified": false,
+    "issue_labels_modified": false,
+    "runtime_or_pm2_modified": false
+  },
+  "route_guard": {
+    "api_files_scanned": 219,
+    "direct_get_data_source_factory_calls": 13,
+    "get_data_source_factory_dependency_api_refs": 7,
+    "market_py_direct_refs": 0,
+    "market_py_dependency_refs": 2,
+    "remaining_direct_call_files": {
+      "web/backend/app/api/data/kline.py": 2,
+      "web/backend/app/api/data/margin.py": 3,
+      "web/backend/app/api/data/futures.py": 2,
+      "web/backend/app/api/data/stocks.py": 2,
+      "web/backend/app/api/data/lhb.py": 2,
+      "web/backend/app/api/market/market_data_request.py": 2
+    }
+  },
+  "verification": {
+    "health_route_conflicts_tests": "114 passed",
+    "provider_lifecycle_tests": "4 passed",
+    "ruff_touched_files": "passed",
+    "black_touched_files": "3 files unchanged",
+    "app_openapi_smoke": {
+      "app_import": "passed",
+      "routes": 548,
+      "openapi_paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 121
+    }
+  },
+  "gitnexus_refresh": {
+    "repo": "g2-65-closeout-gitnexus-index-checkout",
+    "head": "277fdd412",
+    "git_kind": "directory",
+    "analyze_exit": 0,
+    "nodes": 62667,
+    "edges": 145820,
+    "flows": 300,
+    "impacts": {
+      "web/backend/app/api/data/market.py": {
+        "risk": "LOW",
+        "impacted_count": 1,
+        "direct": 1,
+        "processes_affected": 0
+      },
+      "get_data_source_factory_dependency": {
+        "risk": "LOW",
+        "impacted_count": 0,
+        "direct": 0,
+        "processes_affected": 0
+      }
+    }
+  },
+  "next_gate": {
+    "recommended_workline": "G2.66",
+    "recommended_scope": "authorization-only packet for the next remaining DataSourceFactory route consumer",
+    "candidate_files": [
+      "web/backend/app/api/data/kline.py",
+      "web/backend/app/api/data/futures.py",
+      "web/backend/app/api/data/lhb.py",
+      "web/backend/app/api/data/stocks.py",
+      "web/backend/app/api/data/margin.py",
+      "web/backend/app/api/market/market_data_request.py"
+    ],
+    "remaining_direct_route_calls": 13,
+    "remaining_consumers_locked_until_authorized": true
+  }
+}

--- a/docs/reports/quality/backend-data-source-factory-market-route-migration-closeout-2026-05-24.md
+++ b/docs/reports/quality/backend-data-source-factory-market-route-migration-closeout-2026-05-24.md
@@ -1,0 +1,118 @@
+# Backend DataSourceFactory Market Route Migration Closeout - 2026-05-24
+
+> **历史总结说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Workline: G2.65 closeout / current-head refresh
+
+Base branch: `wip/root-dirty-20260403`
+
+Current HEAD: `277fdd412b2bbf68b64c5186fee943dc50080480`
+
+## Scope Boundary
+
+This closeout records the merged G2.65 result. It does not change backend
+source code, tests, route paths, response contracts, OpenAPI exposure, generated
+clients, OpenSpec files, issue labels, runtime process state, or PM2 state.
+
+## Merge Evidence
+
+PR `#211` was merged at
+`277fdd412b2bbf68b64c5186fee943dc50080480`.
+
+Merged implementation summary:
+
+- Migrated `web/backend/app/api/data/market.py` route handler
+  `get_market_overview` to `Depends(get_data_source_factory_dependency)`.
+- Removed the inline `await get_data_source_factory()` call from `market.py`.
+- Resolved same-file `market.py` E701/black debt authorized by G2.64.
+- Preserved `get_data_source_factory()` and `_global_factory` compatibility
+  surfaces.
+- Kept route paths, response models, OpenAPI exposure, and response shape
+  unchanged.
+
+## Current-Head Route Guard
+
+Post-merge static scan reports:
+
+- API files scanned: `219`
+- Direct `get_data_source_factory()` API calls: `13`
+- `get_data_source_factory_dependency` API refs: `7`
+- `market.py` direct refs: `0`
+- `market.py` dependency refs: `2`
+
+Remaining direct-call files:
+
+| File | Calls |
+|---|---:|
+| `web/backend/app/api/data/futures.py` | 2 |
+| `web/backend/app/api/data/kline.py` | 2 |
+| `web/backend/app/api/data/lhb.py` | 2 |
+| `web/backend/app/api/data/margin.py` | 3 |
+| `web/backend/app/api/data/stocks.py` | 2 |
+| `web/backend/app/api/market/market_data_request.py` | 2 |
+
+The remaining `13` route/API consumers stay locked until a separate
+authorization packet selects the next batch.
+
+## Verification
+
+Executed at current HEAD:
+
+| Check | Result |
+|---|---|
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `114 passed` |
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | `4 passed` |
+| `ruff check` on touched source/test files | passed |
+| `black --check` on touched source/test files | `3 files would be left unchanged` |
+| app import / OpenAPI smoke with non-secret test env | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+
+The app/OpenAPI smoke still reports `warning_count=121`, including the existing
+local GPU fallback warning for the NumPy/Numba mismatch.
+
+## GitNexus Refresh
+
+GitNexus was refreshed from a non-linked checkout:
+
+- Repo: `g2-65-closeout-gitnexus-index-checkout`
+- HEAD: `277fdd412`
+- `.git` kind: `directory`
+- `gitnexus analyze` exit: `0`
+- Nodes: `62667`
+- Edges: `145820`
+- Flows: `300`
+
+Current-head upstream impact:
+
+| Target | Risk | Impacted count | Direct | Processes affected |
+|---|---|---:|---:|---:|
+| `web/backend/app/api/data/market.py` | LOW | 1 | 1 | 0 |
+| `get_data_source_factory_dependency` | LOW | 0 | 0 | 0 |
+
+## Decision
+
+G2.65 is closed as merged and stable at current HEAD.
+
+The third DataSourceFactory route consumer migration is now complete:
+
+- `market.py`: `1` direct call -> `0`;
+- API total: `14` direct calls -> `13`;
+- route/OpenAPI contract unchanged.
+
+## Next Gate
+
+Prepare a separate G2.66 authorization-only packet before any further route
+edits.
+
+Recommended G2.66 candidate selection should compare the remaining direct-call
+files instead of editing one directly:
+
+- `web/backend/app/api/data/kline.py`
+- `web/backend/app/api/data/futures.py`
+- `web/backend/app/api/data/lhb.py`
+- `web/backend/app/api/data/stocks.py`
+- `web/backend/app/api/data/margin.py`
+- `web/backend/app/api/market/market_data_request.py`

--- a/governance/mainline/task-cards/pr-212.yaml
+++ b/governance/mainline/task-cards/pr-212.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-212"
+  title: "Close out market DataSourceFactory route migration"
+  owner: "main"
+  created_at: "2026-05-24"
+
+mainline:
+  id: "L1-data-source-factory-market-route-migration-closeout"
+  objective: "record current-head closeout evidence for the merged market.py DataSourceFactory route migration"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-market-route-migration-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-market-route-migration-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout records merged route migration evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-market-route-migration-closeout-2026-05-24.json"
+    - "docs/reports/quality/backend-data-source-factory-market-route-migration-closeout-2026-05-24.md"
+    - "governance/mainline/task-cards/pr-212.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No next route consumer migration in this PR"
+  - "No compatibility getter cleanup in this PR"
+
+acceptance:
+  checks:
+    - id: "health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-evidence-files"
+      command: "ruff check web/backend/app/api/data/market.py web/backend/tests/test_health_route_conflicts.py web/backend/app/services/data_source_factory/__init__.py"
+      required: true
+    - id: "black-evidence-files"
+      command: "black --check web/backend/app/api/data/market.py web/backend/tests/test_health_route_conflicts.py web/backend/app/services/data_source_factory/__init__.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-market-route-migration-closeout-2026-05-24.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-market-route-migration-closeout-2026-05-24.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-212.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-212.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the closeout-only boundary"
+    - "If this PR selects or migrates the next consumer, it bypasses the next authorization review gate"
+  rollback_plan: "revert this governance-only closeout PR; PR #211 remains the implementation source of truth unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out the merged market.py DataSourceFactory route migration"
+    modified_scope: "closeout report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none in this PR"
+    legacy_logic_impact: "none; remaining route consumers and compatibility getter remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only closeout PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T01:13:39+08:00"
+    approval_note: "human maintainer approved continuing after G2.65 implementation; this packet records closeout evidence only and authorizes no backend source edit"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Close out merged PR #211 at current HEAD 277fdd412b2b for the market.py DataSourceFactory route migration.
- Record current-head evidence: market.py direct factory calls = 0, total remaining direct calls = 13 across six route files.
- Update the steward tree, generated evidence artifact, closeout report, and mainline task card only.

## Verification
- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short: 114 passed.
- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short: 4 passed.
- ruff check / black --check touched files: passed.
- OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0.
- GitNexus: market.py LOW/1, get_data_source_factory_dependency LOW/0; staged docs-only scope low/0.
- Post-commit mainline scope gate: pass=True.

## Boundary
This PR is closeout evidence only. It authorizes no backend source edits and does not select or migrate the next route consumer. Next gate is G2.66 authorization-only candidate comparison.