### PR TITLE
docs(governance): authorize next factory route candidate

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -999,11 +999,23 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                 operation IDs remain `0`, and refreshed GitNexus at
 │   │                 `277fdd412` reports `market.py` LOW/1 and provider
 │   │                 dependency LOW/0
-│   └── Next gate: Create a separate G2.66 authorization-only packet before
-│                  any next DataSourceFactory route consumer edit; remaining
-│                  candidates are `kline.py`, `futures.py`, `lhb.py`,
-│                  `stocks.py`, `margin.py`, and
-│                  `market/market_data_request.py`
+│   ├── G2.66 DataSourceFactory route candidate authorization
+│   │   ├── State: ready for review; PR `#213` candidate packet
+│   │   ├── Evidence: `backend-data-source-factory-route-candidate-authorization-2026-05-25.md`
+│   │   ├── Current HEAD: `d30f2c12d642fbc613689d85b39697999805bbb8`
+│   │   ├── Result: compares the remaining six route/API consumers and selects
+│   │   │          `web/backend/app/api/data/margin.py` for a future G2.67
+│   │   │          implementation because it has LOW/1 GitNexus impact, ruff
+│   │   │          clean, black unchanged, three route handlers, and three direct
+│   │   │          factory refs that can move from `3` to `0`
+│   │   └── Boundary: authorization-only; no source edit, route contract edit,
+│   │                compatibility getter removal, frontend edit, PM2/runtime
+│   │                gate, or issue-label change is authorized
+│   └── Next gate: Human review / PR merge decision for G2.66; if accepted,
+│                  create a separate G2.67 path-limited `margin.py`
+│                  implementation branch. Other remaining candidates
+│                  (`kline.py`, `futures.py`, `lhb.py`, `stocks.py`, and
+│                  `market/market_data_request.py`) stay locked
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1114,6 +1126,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-market-route-migration-authorization-2026-05-24.md` | G | G2.64 authorization prepared at current HEAD `cfb98f079c488c7e33c270e44342408a0e10db44`: records PR `#209` as `MERGED`, selects `web/backend/app/api/data/market.py` for future G2.65 because it has one direct factory call at line `98` inside `get_market_overview`, records the four-route file surface, confirms direct API calls=`14`, provider dependency refs=`5`, health route conflict tests=`113 passed`, provider lifecycle tests=`4 passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus at `cfb98f079` with analyze exit=`0`, nodes=`62656`, edges=`145824`, flows=`300`, file-level `market.py` LOW/1 upstream impact and provider dependency LOW/0; candidate style baseline notes existing `market.py` E701/black debt to fix inside a future same-file implementation | Human review / PR merge decision; if accepted, create G2.65 path-limited `market.py` implementation branch; all other remaining consumers stay locked |
 | `backend-data-source-factory-market-route-migration-implementation-2026-05-24.md` | G | G2.65 implementation prepared at current HEAD `20a7b67f1898506586e7858840d0ae058461fe93`: records PR `#210` as `MERGED`, refreshes non-linked GitNexus before source edits with analyze exit=`0`, nodes=`62665`, edges=`145822`, flows=`300`, records file-level `market.py` upstream impact LOW/1 and provider dependency LOW/0, follows TDD red=`1 failed: KeyError factory` then green=`1 passed`, migrates `market.py` direct calls from `1` to `0`, reduces total API direct calls from `14` to `13`, clears same-file `market.py` E701/black debt inside the authorized file, preserves `get_data_source_factory()` plus `_global_factory`, verifies health route conflict tests=`114 passed`, provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`; remaining `13` route/API consumers stay locked | Human review / PR merge decision; if accepted, run G2.65 closeout/current-head refresh before selecting another DataSourceFactory route consumer packet |
 | `backend-data-source-factory-market-route-migration-closeout-2026-05-24.md` | G | G2.65 closeout prepared at current HEAD `277fdd412b2bbf68b64c5186fee943dc50080480`: records PR `#211` as `MERGED`, confirms current-head route guard direct API calls=`13`, `market.py` direct refs=`0`, provider dependency API refs=`7`, health route conflict tests=`114 passed`, provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus at `277fdd412` with analyze exit=`0`, nodes=`62667`, edges=`145820`, flows=`300`, file-level `market.py` LOW/1 upstream impact and provider dependency LOW/0; recommends G2.66 authorization-only candidate comparison before any next route consumer edit | Human review / PR merge decision; if accepted, create G2.66 consumer-selection authorization packet; all remaining `13` route/API consumers stay locked |
+
+| `backend-data-source-factory-route-candidate-authorization-2026-05-25.md` | G | G2.66 authorization prepared at current HEAD `d30f2c12d642fbc613689d85b39697999805bbb8`: records PR `#212` as `MERGED`, confirms remaining route/API direct factory calls=`13`, compares six candidates, selects `web/backend/app/api/data/margin.py` for future G2.67 because it has direct refs=`3`, route handlers=`3`, LOC=`155`, ruff=`pass`, black=`unchanged`, GitNexus=`LOW/1`, and expected post-implementation direct refs `3 -> 0` / total direct refs `13 -> 10`; defers `lhb.py` due black reformat debt, `market_data_request.py` due broad 11-route surface, `kline.py` and `stocks.py` due E701/black debt, and `futures.py` due a CRITICAL/91 file-level GitNexus anomaly requiring narrower impact analysis | Human review / PR merge decision; if accepted, create G2.67 path-limited `margin.py` implementation branch; all other remaining consumers stay locked |
 
 ## Completed And Reviewed Ledger
 
@@ -1265,6 +1279,8 @@ review, PR review, or OpenSpec archive review.
 | G2.10 watchlist service DI implementation | Third route-surface service lifecycle DI source pilot | `b14ef842` | PR `#150` merged after human approval; `watchlist_service.py` now exposes an app-state provider dependency, seven `watchlist.py` group route handlers inject `WatchlistService`, focused tests and GitHub checks passed, and watchlist adapter/data helper files remain untouched |
 | G2.11 watchlist service DI closeout | Merged implementation closeout | `b14ef842` | Closeout recorded: `watchlist_service.py` is recorded as merged-and-reviewed; next service lifecycle DI movement requires a separate fourth-candidate, adapter-aware cleanup, or pause/resume decision packet |
 | G2.63 financial DataSourceFactory route migration closeout | Merged implementation closeout | `229cd7fe0` | PR `#208` merged and closeout evidence is recorded: `financial.py` direct factory refs remain `0`, total API direct factory calls remain `14`, health route conflict tests pass `113`, provider lifecycle tests pass `4`, OpenAPI stays paths=`500` with duplicate operation IDs=`0`, and next movement requires a separate G2.64 authorization packet for `market.py` or another selected remaining consumer |
+
+| G2.66 DataSourceFactory route candidate authorization | Ready for review | `d30f2c12` | Candidate comparison recorded after PR `#212`: selects `margin.py` for future G2.67 because it is ruff clean, black unchanged, GitNexus LOW/1, three routes, and three direct refs; this row authorizes no source edit until human review accepts the packet |
 
 ## Update Protocol
 

--- a/.planning/codebase/generated/data-source-factory-route-candidate-authorization-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-route-candidate-authorization-2026-05-25.json
@@ -1,0 +1,135 @@
+{
+  "artifact": "data-source-factory-route-candidate-authorization-2026-05-25",
+  "workline": "G2.66",
+  "status": "ready_for_review",
+  "generated_at": "2026-05-25T01:40:08+08:00",
+  "current_head": "d30f2c12d642fbc613689d85b39697999805bbb8",
+  "source_boundary": "authorization-only; no backend source edits in this packet",
+  "previous_gate": {
+    "workline": "G2.65",
+    "merged_pr": 212,
+    "merge_commit": "d30f2c12d642fbc613689d85b39697999805bbb8",
+    "result": "market.py closeout recorded; market.py direct factory refs remain 0"
+  },
+  "remaining_direct_factory_calls": {
+    "total": 13,
+    "files": [
+      {
+        "file": "web/backend/app/api/data/kline.py",
+        "direct_calls": 2,
+        "direct_call_lines": [145, 245],
+        "route_count": 4,
+        "loc": 252,
+        "ruff_status": "fails_E701",
+        "black_status": "would_reformat",
+        "gitnexus_upstream_impact": "LOW/1"
+      },
+      {
+        "file": "web/backend/app/api/data/futures.py",
+        "direct_calls": 2,
+        "direct_call_lines": [91, 114],
+        "route_count": 2,
+        "loc": 123,
+        "ruff_status": "passed",
+        "black_status": "would_reformat",
+        "gitnexus_upstream_impact": "CRITICAL/91_file_level_anomaly",
+        "note": "defer until a narrower symbol-level impact pass explains or clears the file-level GitNexus result"
+      },
+      {
+        "file": "web/backend/app/api/data/lhb.py",
+        "direct_calls": 2,
+        "direct_call_lines": [90, 115],
+        "route_count": 2,
+        "loc": 128,
+        "ruff_status": "passed",
+        "black_status": "would_reformat",
+        "gitnexus_upstream_impact": "LOW/1"
+      },
+      {
+        "file": "web/backend/app/api/data/stocks.py",
+        "direct_calls": 2,
+        "direct_call_lines": [269, 371],
+        "route_count": 5,
+        "loc": 417,
+        "ruff_status": "fails_E701",
+        "black_status": "would_reformat",
+        "gitnexus_upstream_impact": "LOW/1"
+      },
+      {
+        "file": "web/backend/app/api/data/margin.py",
+        "direct_calls": 3,
+        "direct_call_lines": [104, 128, 150],
+        "route_count": 3,
+        "loc": 155,
+        "ruff_status": "passed",
+        "black_status": "unchanged",
+        "gitnexus_upstream_impact": "LOW/1"
+      },
+      {
+        "file": "web/backend/app/api/market/market_data_request.py",
+        "direct_calls": 2,
+        "direct_call_lines": [134, 427],
+        "route_count": 11,
+        "loc": 645,
+        "ruff_status": "passed",
+        "black_status": "unchanged",
+        "gitnexus_upstream_impact": "LOW/1"
+      }
+    ]
+  },
+  "selected_next_candidate": {
+    "workline": "G2.67",
+    "file": "web/backend/app/api/data/margin.py",
+    "reason": "LOW GitNexus impact, ruff clean, black clean, three route handlers, and clears three remaining direct factory calls without extra formatting debt.",
+    "allowed_future_source_scope": [
+      "web/backend/app/api/data/margin.py",
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "locked_out_of_scope": [
+      "web/backend/app/api/data/kline.py",
+      "web/backend/app/api/data/futures.py",
+      "web/backend/app/api/data/lhb.py",
+      "web/backend/app/api/data/stocks.py",
+      "web/backend/app/api/market/market_data_request.py",
+      "web/frontend/**",
+      "src/**",
+      "openspec/changes/**",
+      "docs/api/**"
+    ],
+    "required_pre_edit_gate": [
+      "read architecture/STANDARDS.md",
+      "run GitNexus impact/context for margin.py or its route handlers",
+      "add failing dependency-injection wiring tests for get_margin_account_info, get_margin_detail_sse, and get_margin_detail_szse",
+      "stop if any HIGH or CRITICAL risk appears"
+    ],
+    "required_verification": [
+      "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short",
+      "ruff check web/backend/app/api/data/margin.py web/backend/tests/test_health_route_conflicts.py web/backend/app/services/data_source_factory/__init__.py",
+      "black --check web/backend/app/api/data/margin.py web/backend/tests/test_health_route_conflicts.py web/backend/app/services/data_source_factory/__init__.py",
+      "OpenAPI smoke: routes, paths, operation IDs, duplicate operation IDs",
+      "route guard direct-call count: margin.py direct refs must move from 3 to 0 and total must move from 13 to 10",
+      "gitnexus.detect_changes(scope=staged)"
+    ]
+  },
+  "verification": {
+    "tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "114 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 121,
+      "env_note": "OpenAPI smoke used explicit non-secret test environment placeholders because this isolated worktree has no .env file."
+    },
+    "candidate_lint": {
+      "ruff": "7 E701 findings in kline.py and stocks.py; margin.py is clean",
+      "black": "would reformat kline.py, futures.py, lhb.py, and stocks.py; margin.py and market_data_request.py are unchanged"
+    }
+  },
+  "next_gate": "Human review / PR merge decision; if accepted, create G2.67 path-limited margin.py implementation branch. This packet itself authorizes no source edit."
+}

--- a/docs/reports/quality/backend-data-source-factory-route-candidate-authorization-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-route-candidate-authorization-2026-05-25.md
@@ -1,0 +1,121 @@
+# Backend DataSourceFactory Route Candidate Authorization - 2026-05-25
+
+Workline: G2.66 authorization-only packet
+
+Current HEAD: `d30f2c12d642fbc613689d85b39697999805bbb8`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This document is a governance evidence and authorization input
+only. It does not authorize source code changes, GitHub issue publication,
+OpenSpec proposal publication, OpenSpec implementation, production rollout, or
+promotion of this candidate selection into backend runtime truth.
+
+Boundary: this packet records current evidence and selects the next candidate.
+It does not authorize or perform backend source edits. A separate G2.67
+implementation branch is required before changing route code.
+
+## Prior Gate
+
+PR `#212` merged the G2.65 closeout for the `market.py` DataSourceFactory route
+migration. The closeout confirmed:
+
+- `market.py` direct `get_data_source_factory()` refs remain `0`
+- total remaining route/API direct factory refs remain `13`
+- health route conflict tests: `114 passed`
+- DataSourceFactory lifecycle DI tests: `4 passed`
+- OpenAPI smoke remains routes=`548`, paths=`500`, duplicate operation IDs=`0`
+
+## Current Candidate Matrix
+
+| Candidate | Direct refs | Routes | LOC | Ruff | Black | GitNexus upstream | Decision |
+|---|---:|---:|---:|---|---|---|---|
+| `web/backend/app/api/data/margin.py` | 3 | 3 | 155 | pass | unchanged | LOW/1 | Select for G2.67 |
+| `web/backend/app/api/data/lhb.py` | 2 | 2 | 128 | pass | would reformat | LOW/1 | Defer behind margin; same-file formatting debt exists |
+| `web/backend/app/api/market/market_data_request.py` | 2 | 11 | 645 | pass | unchanged | LOW/1 | Defer; broad route surface |
+| `web/backend/app/api/data/kline.py` | 2 | 4 | 252 | E701 | would reformat | LOW/1 | Defer; style cleanup must be bundled if touched |
+| `web/backend/app/api/data/stocks.py` | 2 | 5 | 417 | E701 | would reformat | LOW/1 | Defer; style cleanup and larger route surface |
+| `web/backend/app/api/data/futures.py` | 2 | 2 | 123 | pass | would reformat | CRITICAL/91 | Defer until a narrower impact pass explains the file-level GitNexus result |
+
+Selection rationale: `margin.py` is the cleanest next batch. It removes three
+direct factory calls, has only three route handlers, has no current ruff/black
+cleanup requirement, and has LOW/1 GitNexus upstream impact.
+
+## Selected G2.67 Scope
+
+If this packet is accepted, the next implementation packet may only touch:
+
+- `web/backend/app/api/data/margin.py`
+- `web/backend/tests/test_health_route_conflicts.py`
+
+The implementation should migrate these handlers to
+`get_data_source_factory_dependency`:
+
+- `get_margin_account_info`
+- `get_margin_detail_sse`
+- `get_margin_detail_szse`
+
+Expected route-guard result after G2.67 implementation:
+
+- `margin.py` direct refs: `3` -> `0`
+- total route/API direct refs: `13` -> `10`
+
+## Locked Scope
+
+This packet keeps the following locked:
+
+- `web/backend/app/api/data/kline.py`
+- `web/backend/app/api/data/futures.py`
+- `web/backend/app/api/data/lhb.py`
+- `web/backend/app/api/data/stocks.py`
+- `web/backend/app/api/market/market_data_request.py`
+- `web/frontend/**`
+- `src/**`
+- `openspec/changes/**`
+- `docs/api/**`
+
+No compatibility getter removal, OpenAPI contract edit, route path edit, frontend
+consumer edit, PM2/runtime stateful gate, or issue-label change is authorized by
+this packet.
+
+## Required G2.67 Gates
+
+Before source edits:
+
+1. Read `architecture/STANDARDS.md`.
+2. Run GitNexus impact/context for `margin.py` or the selected route handlers.
+3. Add failing dependency-injection wiring assertions for all three margin route
+   handlers.
+4. Stop if any HIGH or CRITICAL risk appears.
+
+Required verification:
+
+- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short`
+- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short`
+- `ruff check web/backend/app/api/data/margin.py web/backend/tests/test_health_route_conflicts.py web/backend/app/services/data_source_factory/__init__.py`
+- `black --check web/backend/app/api/data/margin.py web/backend/tests/test_health_route_conflicts.py web/backend/app/services/data_source_factory/__init__.py`
+- OpenAPI smoke with routes, paths, operation IDs, and duplicate operation IDs
+- route-guard direct-call count
+- `gitnexus.detect_changes(scope=staged)`
+
+## Current Evidence
+
+- Current HEAD: `d30f2c12d642fbc613689d85b39697999805bbb8`
+- Remaining direct refs: `13`
+- Candidate tests:
+  - `web/backend/tests/test_health_route_conflicts.py`: `114 passed`
+  - `web/backend/tests/test_data_source_factory_lifecycle_di.py`: `4 passed`
+- OpenAPI smoke: routes=`548`, paths=`500`, operation IDs=`536`, duplicate
+  operation IDs=`0`, duplicate operation ID warnings=`0`, warning count=`121`
+- Candidate lint:
+  - `margin.py`: ruff clean, black unchanged
+  - `kline.py` and `stocks.py`: existing E701 findings
+  - `kline.py`, `futures.py`, `lhb.py`, and `stocks.py`: black would reformat
+- Environment note: OpenAPI smoke used explicit non-secret test environment
+  placeholders because the isolated worktree has no `.env` file.
+
+## Review Gate
+
+Human review / PR merge decision. If accepted, create G2.67 as a separate
+path-limited `margin.py` implementation branch. This G2.66 packet itself
+authorizes no backend source edit.

--- a/governance/mainline/task-cards/pr-213.yaml
+++ b/governance/mainline/task-cards/pr-213.yaml
@@ -1,0 +1,119 @@
+version: "v0.2"
+
+task:
+  id: "pr-213"
+  title: "Authorize next DataSourceFactory route consumer"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-route-candidate-authorization"
+  objective: "select the next DataSourceFactory route migration candidate after G2.65 closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-route-candidate-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-route-candidate-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate authorization records evidence and future scope only; it does not change route behavior, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-route-candidate-authorization-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-route-candidate-authorization-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-213.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No G2.67 source implementation in this PR"
+  - "No compatibility getter cleanup in this PR"
+
+acceptance:
+  checks:
+    - id: "health-route-conflicts-current-head"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "data-source-factory-lifecycle-di"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "candidate-static-scan"
+      command: "scan remaining DataSourceFactory direct route calls and candidate route surfaces"
+      required: true
+    - id: "candidate-ruff-black-baseline"
+      command: "ruff/black checks over remaining candidate files"
+      required: true
+    - id: "openapi-smoke"
+      command: "app.openapi() smoke with route/path/operationId counts and duplicate operation ID warnings"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-route-candidate-authorization-2026-05-25.md"
+      required: true
+    - id: "json-yaml-parse"
+      command: "parse generated JSON artifact and this YAML task card"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-213.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source is edited, the PR exceeds the authorization-only boundary"
+    - "If G2.67 is started without human review, the route migration sequence bypasses the steward tree gate"
+    - "If futures.py is selected without resolving the GitNexus CRITICAL file-level anomaly, a future implementation may misclassify risk"
+  rollback_plan: "revert this governance-only authorization PR; no runtime behavior changes are introduced"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "select the next DataSourceFactory route migration candidate"
+    modified_scope: "authorization report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; all remaining route consumers and compatibility getter remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only PR if candidate selection is rejected"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T01:40:08+08:00"
+    approval_note: "human maintainer approved continuing after G2.65 closeout; this packet selects a future candidate only and authorizes no backend source edit"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Add the G2.66 DataSourceFactory route candidate comparison packet.
- Select `web/backend/app/api/data/margin.py` for a future G2.67 path-limited implementation because it is LOW/1, ruff clean, black unchanged, has 3 routes, and can clear 3 direct factory refs.
- Update the steward tree, generated artifact, authorization report, and mainline task card only.

## Verification
- `web/backend/tests/test_health_route_conflicts.py`: 114 passed.
- `web/backend/tests/test_data_source_factory_lifecycle_di.py`: 4 passed.
- Candidate scan: remaining direct route/API factory refs = 13.
- Candidate lint baseline: `margin.py` ruff clean and black unchanged; other candidates record known formatting or risk reasons for deferral.
- OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0.
- GitNexus: selected `margin.py` LOW/1; staged docs-only scope low/0.
- Post-commit mainline scope gate: pass=True.

## Boundary
Authorization-only. This PR does not edit backend source, does not start G2.67, and does not change route/OpenAPI/runtime behavior.