### PR TITLE
refactor(api): inject factory dependency in margin routes

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1011,9 +1011,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: authorization-only; no source edit, route contract edit,
 │   │                compatibility getter removal, frontend edit, PM2/runtime
 │   │                gate, or issue-label change is authorized
-│   └── Next gate: Human review / PR merge decision for G2.66; if accepted,
-│                  create a separate G2.67 path-limited `margin.py`
-│                  implementation branch. Other remaining candidates
+│   ├── G2.67 Margin DataSourceFactory route migration
+│   │   ├── State: ready for review; PR `#214` implementation packet
+│   │   ├── Evidence: `backend-data-source-factory-margin-route-migration-implementation-2026-05-25.md`
+│   │   ├── Current HEAD: `7b817debccfba1c82efc5a9c71f23f0b775434c0`
+│   │   ├── Result: migrates `get_margin_account_info`,
+│   │   │          `get_margin_detail_sse`, and `get_margin_detail_szse` from
+│   │   │          direct `get_data_source_factory()` calls to
+│   │   │          `Depends(get_data_source_factory_dependency)`; total route/API
+│   │   │          direct refs move `13 -> 10`, `margin.py` direct refs move
+│   │   │          `3 -> 0`, health route conflict tests move to `115 passed`,
+│   │   │          provider tests remain `4 passed`, OpenAPI paths remain `500`,
+│   │   │          and duplicate operation IDs remain `0`
+│   │   └── Boundary: no route path, response model, response shape, OpenAPI,
+│   │                frontend, runtime/PM2, OpenSpec, issue-label, or other
+│   │                DataSourceFactory consumer change
+│   └── Next gate: Human review / PR merge decision for G2.67; if accepted,
+│                  run G2.67 closeout/current-head refresh before selecting
+│                  another route consumer. Remaining candidates
 │                  (`kline.py`, `futures.py`, `lhb.py`, `stocks.py`, and
 │                  `market/market_data_request.py`) stay locked
 │
@@ -1128,6 +1143,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-market-route-migration-closeout-2026-05-24.md` | G | G2.65 closeout prepared at current HEAD `277fdd412b2bbf68b64c5186fee943dc50080480`: records PR `#211` as `MERGED`, confirms current-head route guard direct API calls=`13`, `market.py` direct refs=`0`, provider dependency API refs=`7`, health route conflict tests=`114 passed`, provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, and refreshed non-linked GitNexus at `277fdd412` with analyze exit=`0`, nodes=`62667`, edges=`145820`, flows=`300`, file-level `market.py` LOW/1 upstream impact and provider dependency LOW/0; recommends G2.66 authorization-only candidate comparison before any next route consumer edit | Human review / PR merge decision; if accepted, create G2.66 consumer-selection authorization packet; all remaining `13` route/API consumers stay locked |
 
 | `backend-data-source-factory-route-candidate-authorization-2026-05-25.md` | G | G2.66 authorization prepared at current HEAD `d30f2c12d642fbc613689d85b39697999805bbb8`: records PR `#212` as `MERGED`, confirms remaining route/API direct factory calls=`13`, compares six candidates, selects `web/backend/app/api/data/margin.py` for future G2.67 because it has direct refs=`3`, route handlers=`3`, LOC=`155`, ruff=`pass`, black=`unchanged`, GitNexus=`LOW/1`, and expected post-implementation direct refs `3 -> 0` / total direct refs `13 -> 10`; defers `lhb.py` due black reformat debt, `market_data_request.py` due broad 11-route surface, `kline.py` and `stocks.py` due E701/black debt, and `futures.py` due a CRITICAL/91 file-level GitNexus anomaly requiring narrower impact analysis | Human review / PR merge decision; if accepted, create G2.67 path-limited `margin.py` implementation branch; all other remaining consumers stay locked |
+
+| `backend-data-source-factory-margin-route-migration-implementation-2026-05-25.md` | G | G2.67 implementation prepared at current HEAD `7b817debccfba1c82efc5a9c71f23f0b775434c0`: records PR `#213` as `MERGED`, verifies pre-edit GitNexus `margin.py` LOW/1 and three route-handler contexts, follows TDD red=`1 failed: KeyError factory` then green=`1 passed`, migrates `get_margin_account_info`, `get_margin_detail_sse`, and `get_margin_detail_szse` to `get_data_source_factory_dependency`, removes three inline compatibility getter calls, moves `margin.py` direct refs `3 -> 0`, total direct refs `13 -> 10`, verifies health route conflict tests=`115 passed`, provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, and staged GitNexus detect changes risk=`low`, affected count=`0`; remaining `10` route/API consumers stay locked | Human review / PR merge decision; if accepted, run G2.67 closeout/current-head refresh before selecting another DataSourceFactory route consumer packet |
 
 ## Completed And Reviewed Ledger
 
@@ -1281,6 +1298,8 @@ review, PR review, or OpenSpec archive review.
 | G2.63 financial DataSourceFactory route migration closeout | Merged implementation closeout | `229cd7fe0` | PR `#208` merged and closeout evidence is recorded: `financial.py` direct factory refs remain `0`, total API direct factory calls remain `14`, health route conflict tests pass `113`, provider lifecycle tests pass `4`, OpenAPI stays paths=`500` with duplicate operation IDs=`0`, and next movement requires a separate G2.64 authorization packet for `market.py` or another selected remaining consumer |
 
 | G2.66 DataSourceFactory route candidate authorization | Ready for review | `d30f2c12` | Candidate comparison recorded after PR `#212`: selects `margin.py` for future G2.67 because it is ruff clean, black unchanged, GitNexus LOW/1, three routes, and three direct refs; this row authorizes no source edit until human review accepts the packet |
+
+| G2.67 margin DataSourceFactory route migration | Ready for review | `7b817deb` | Path-limited implementation migrates three margin route handlers to `get_data_source_factory_dependency`, adds focused dependency wiring coverage, moves total direct route/API factory refs `13 -> 10`, and keeps all other remaining consumers locked pending closeout |
 
 ## Update Protocol
 

--- a/.planning/codebase/generated/data-source-factory-margin-route-migration-implementation-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-margin-route-migration-implementation-2026-05-25.json
@@ -1,0 +1,125 @@
+{
+  "artifact": "data-source-factory-margin-route-migration-implementation-2026-05-25",
+  "workline": "G2.67",
+  "status": "ready_for_review",
+  "generated_at": "2026-05-25T01:57:47+08:00",
+  "current_head": "7b817debccfba1c82efc5a9c71f23f0b775434c0",
+  "authorization_source": {
+    "workline": "G2.66",
+    "merged_pr": 213,
+    "merge_commit": "7b817debccfba1c82efc5a9c71f23f0b775434c0",
+    "selected_candidate": "web/backend/app/api/data/margin.py"
+  },
+  "scope": {
+    "source_files": [
+      "web/backend/app/api/data/margin.py",
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "governance_files": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/data-source-factory-margin-route-migration-implementation-2026-05-25.json",
+      "docs/reports/quality/backend-data-source-factory-margin-route-migration-implementation-2026-05-25.md",
+      "governance/mainline/task-cards/pr-214.yaml"
+    ],
+    "out_of_scope": [
+      "web/backend/app/api/data/kline.py",
+      "web/backend/app/api/data/futures.py",
+      "web/backend/app/api/data/lhb.py",
+      "web/backend/app/api/data/stocks.py",
+      "web/backend/app/api/market/market_data_request.py",
+      "web/frontend/**",
+      "src/**",
+      "openspec/changes/**",
+      "docs/api/**"
+    ]
+  },
+  "pre_edit_gate": {
+    "standards_read": "architecture/STANDARDS.md relevant governance and migration sections reviewed",
+    "gitnexus_impact": {
+      "target": "web/backend/app/api/data/margin.py",
+      "risk": "LOW",
+      "impacted_count": 1,
+      "direct": 1,
+      "processes_affected": 0
+    },
+    "gitnexus_context": [
+      {
+        "symbol": "get_margin_account_info",
+        "outgoing_before": ["get_data_source_factory", "server_error"],
+        "incoming": 0
+      },
+      {
+        "symbol": "get_margin_detail_sse",
+        "outgoing_before": ["get_data_source_factory", "server_error"],
+        "incoming": 0
+      },
+      {
+        "symbol": "get_margin_detail_szse",
+        "outgoing_before": ["get_data_source_factory", "server_error"],
+        "incoming": 0
+      }
+    ]
+  },
+  "tdd": {
+    "red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_margin_routes_use_data_source_factory_dependency -q --no-cov --tb=short",
+      "result": "1 failed",
+      "failure": "KeyError: 'factory'"
+    },
+    "green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_margin_routes_use_data_source_factory_dependency -q --no-cov --tb=short",
+      "result": "1 passed"
+    }
+  },
+  "implementation": {
+    "margin_py": {
+      "import_added": "DataSourceFactory, get_data_source_factory_dependency",
+      "handlers_migrated": [
+        "get_margin_account_info",
+        "get_margin_detail_sse",
+        "get_margin_detail_szse"
+      ],
+      "inline_getter_imports_removed": 3,
+      "direct_factory_calls_before": 3,
+      "direct_factory_calls_after": 0
+    },
+    "test_health_route_conflicts_py": {
+      "import_added": "margin_module",
+      "test_added": "test_margin_routes_use_data_source_factory_dependency"
+    }
+  },
+  "verification": {
+    "tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "115 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "lint_format": {
+      "ruff_touched_files": "passed",
+      "black_check_touched_files": "3 files would be left unchanged"
+    },
+    "route_guard": {
+      "total_direct_before": 13,
+      "total_direct_after": 10,
+      "margin_direct_before": 3,
+      "margin_direct_after": 0,
+      "provider_dependency_refs_after": 8
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 121,
+      "env_note": "OpenAPI smoke used explicit non-secret test environment placeholders because this isolated worktree has no .env file."
+    },
+    "gitnexus_detect_changes_staged": {
+      "risk_level": "low",
+      "changed_count": 26,
+      "affected_count": 0,
+      "changed_files": 6,
+      "affected_processes": 0
+    }
+  },
+  "next_gate": "Human review / PR merge decision; if accepted, run G2.67 closeout/current-head refresh before selecting another DataSourceFactory route consumer."
+}

--- a/docs/reports/quality/backend-data-source-factory-margin-route-migration-implementation-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-margin-route-migration-implementation-2026-05-25.md
@@ -1,0 +1,119 @@
+# Backend DataSourceFactory Margin Route Migration Implementation - 2026-05-25
+
+Workline: G2.67 implementation packet
+
+Current HEAD: `7b817debccfba1c82efc5a9c71f23f0b775434c0`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This document records one path-limited source implementation and
+its evidence. It does not authorize route path changes, OpenAPI exposure
+changes, response shape changes, frontend edits, PM2/runtime operations,
+OpenSpec proposal publication, issue-label changes, or migration of any other
+DataSourceFactory route consumer.
+
+## Authorization
+
+G2.66 selected `web/backend/app/api/data/margin.py` for this source packet after
+PR `#213` merged at `7b817debccfba1c82efc5a9c71f23f0b775434c0`.
+
+Allowed source scope:
+
+- `web/backend/app/api/data/margin.py`
+- `web/backend/tests/test_health_route_conflicts.py`
+
+All other remaining DataSourceFactory route consumers stayed locked.
+
+## Pre-Edit Gate
+
+- `architecture/STANDARDS.md` relevant governance and migration sections were
+  reviewed before source edits.
+- GitNexus upstream impact for `web/backend/app/api/data/margin.py`:
+  LOW, impacted count=`1`, direct=`1`, affected processes=`0`.
+- GitNexus context was checked for:
+  - `get_margin_account_info`
+  - `get_margin_detail_sse`
+  - `get_margin_detail_szse`
+- All three route handlers had no incoming callers/processes and called
+  `get_data_source_factory` before migration.
+
+## TDD Evidence
+
+Red:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_margin_routes_use_data_source_factory_dependency -q --no-cov --tb=short
+1 failed
+KeyError: 'factory'
+```
+
+Green:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_margin_routes_use_data_source_factory_dependency -q --no-cov --tb=short
+1 passed
+```
+
+## Implementation
+
+`web/backend/app/api/data/margin.py` now imports and uses:
+
+- `DataSourceFactory`
+- `get_data_source_factory_dependency`
+
+The following handlers now receive `factory` via FastAPI `Depends`:
+
+- `get_margin_account_info`
+- `get_margin_detail_sse`
+- `get_margin_detail_szse`
+
+The function-local compatibility getter imports and awaits were removed from
+those handlers. No route path, response model, response shape, OpenAPI exposure,
+or compatibility getter definition was changed.
+
+`web/backend/tests/test_health_route_conflicts.py` now imports `margin_module`
+and asserts all three margin route handlers are wired to
+`margin_module.get_data_source_factory_dependency`.
+
+## Verification
+
+- `web/backend/tests/test_health_route_conflicts.py`: `115 passed`
+- `web/backend/tests/test_data_source_factory_lifecycle_di.py`: `4 passed`
+- `ruff check` touched files: passed
+- `black --check` touched files: `3 files would be left unchanged`
+- `git diff --check`: no output
+- Route guard:
+  - total route/API direct factory refs: `13 -> 10`
+  - `margin.py` direct factory refs: `3 -> 0`
+  - provider dependency refs after migration: `8`
+- OpenAPI smoke:
+  - routes=`548`
+  - paths=`500`
+  - operation IDs=`536`
+  - duplicate operation IDs=`0`
+  - duplicate operation ID warnings=`0`
+  - warning count=`121`
+- GitNexus staged detect changes:
+  - risk level=`low`
+  - changed files=`6`
+  - affected count=`0`
+  - affected processes=`0`
+
+Environment note: OpenAPI smoke used explicit non-secret test environment
+placeholders because the isolated worktree has no `.env` file.
+
+## Remaining Consumers
+
+After this implementation, remaining direct route/API factory refs are `10`.
+The still-locked candidates remain:
+
+- `web/backend/app/api/data/kline.py`
+- `web/backend/app/api/data/futures.py`
+- `web/backend/app/api/data/lhb.py`
+- `web/backend/app/api/data/stocks.py`
+- `web/backend/app/api/market/market_data_request.py`
+
+## Next Gate
+
+Human review / PR merge decision. If accepted, run G2.67 closeout/current-head
+refresh before selecting another DataSourceFactory route consumer.

--- a/governance/mainline/task-cards/pr-214.yaml
+++ b/governance/mainline/task-cards/pr-214.yaml
@@ -1,0 +1,129 @@
+version: "v0.2"
+
+task:
+  id: "pr-214"
+  title: "Migrate margin routes to DataSourceFactory dependency injection"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-margin-route-migration"
+  objective: "move margin route DataSourceFactory access from compatibility getter calls to FastAPI dependency injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-margin-route-migration"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-margin-route-migration"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Implementation changes dependency acquisition only and preserves route paths, OpenAPI exposure, response shape, and runtime semantics"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/api/data/margin.py"
+    - "web/backend/tests/test_health_route_conflicts.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-margin-route-migration-implementation-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-margin-route-migration-implementation-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-214.yaml"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+    - "web/backend/app/api/data/futures.py"
+    - "web/backend/app/api/data/kline.py"
+    - "web/backend/app/api/data/lhb.py"
+    - "web/backend/app/api/data/stocks.py"
+    - "web/backend/app/api/market/**"
+
+non_goals:
+  - "No route path, response model, response shape, OpenAPI exposure, docs/API, generated client, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No non-margin.py DataSourceFactory route consumer migration"
+  - "No deletion of get_data_source_factory() or _global_factory compatibility surfaces"
+  - "No broad formatting cleanup outside web/backend/app/api/data/margin.py and the focused test file"
+
+acceptance:
+  checks:
+    - id: "pre-edit-gitnexus-impact"
+      command: "MCP gitnexus.impact(target=web/backend/app/api/data/margin.py,direction=upstream)"
+      required: true
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_margin_routes_use_data_source_factory_dependency -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-files"
+      command: "ruff check web/backend/app/api/data/margin.py web/backend/tests/test_health_route_conflicts.py web/backend/app/services/data_source_factory/__init__.py"
+      required: true
+    - id: "black-touched-files"
+      command: "black --check web/backend/app/api/data/margin.py web/backend/tests/test_health_route_conflicts.py web/backend/app/services/data_source_factory/__init__.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-margin-route-migration-implementation-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-margin-route-migration-implementation-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-214.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-214.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If response shape or route paths change, the PR exceeds the approved G2.67 boundary"
+    - "If another route consumer is edited, the PR bypasses G2.66 candidate sequencing"
+  rollback_plan: "revert this path-limited PR; compatibility getter surfaces remain available and no route contract changes are introduced"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "migrate margin route DataSourceFactory access to dependency injection"
+    modified_scope: "margin route file, focused route-conflict test, implementation report, generated artifact, steward tree, and task card"
+    dependency_changes: "uses existing get_data_source_factory_dependency provider"
+    legacy_logic_impact: "compatibility getter and _global_factory remain unchanged for other consumers"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if margin dependency wiring or route guard verification fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T01:57:47+08:00"
+    approval_note: "human maintainer accepted G2.66 candidate selection by merging PR #213; this packet implements only the approved margin.py route migration"
+    secondary_approved: false

--- a/web/backend/app/api/data/margin.py
+++ b/web/backend/app/api/data/margin.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, Query
 
 from app.core.security import User, get_current_user
 from app.core.responses import UnifiedResponse, ok, server_error
+from app.services.data_source_factory import DataSourceFactory, get_data_source_factory_dependency
 
 router = APIRouter()
 
@@ -96,12 +97,12 @@ MARGIN_DETAIL_RESPONSES = {
     description="查询全市场融资融券账户汇总指标，返回融资余额、融券余额和当日融资买入额等统计信息。",
     responses=MARGIN_ACCOUNT_INFO_RESPONSES,
 )
-async def get_margin_account_info(current_user: User = Depends(get_current_user)) -> UnifiedResponse:
+async def get_margin_account_info(
+    current_user: User = Depends(get_current_user),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
+) -> UnifiedResponse:
     """获取全市场融资融券账户统计信息"""
     try:
-        from app.services.data_source_factory import get_data_source_factory
-
-        factory = await get_data_source_factory()
         result = await factory.get_data("data", "margin/account-info", {})
         if result.get("status") == "success":
             return ok(data=result.get("data", []))
@@ -120,12 +121,10 @@ async def get_margin_account_info(current_user: User = Depends(get_current_user)
 async def get_margin_detail_sse(
     date: str = Query(..., description="需要查询的交易日期，格式为 YYYY-MM-DD。"),
     current_user: User = Depends(get_current_user),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
 ) -> UnifiedResponse:
     """获取上证所融资融券明细数据"""
     try:
-        from app.services.data_source_factory import get_data_source_factory
-
-        factory = await get_data_source_factory()
         result = await factory.get_data("data", "margin/detail/sse", {"date": date})
         return ok(data=result.get("data", []))
     except Exception as e:
@@ -142,12 +141,10 @@ async def get_margin_detail_sse(
 async def get_margin_detail_szse(
     date: str = Query(..., description="需要查询的交易日期，格式为 YYYY-MM-DD。"),
     current_user: User = Depends(get_current_user),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
 ) -> UnifiedResponse:
     """获取深证所融资融券明细数据"""
     try:
-        from app.services.data_source_factory import get_data_source_factory
-
-        factory = await get_data_source_factory()
         result = await factory.get_data("data", "margin/detail/szse", {"date": date})
         return ok(data=result.get("data", []))
     except Exception as e:

--- a/web/backend/tests/test_health_route_conflicts.py
+++ b/web/backend/tests/test_health_route_conflicts.py
@@ -6,6 +6,7 @@ import inspect
 from fastapi.routing import APIRoute
 
 from app.api.data import financial as financial_module
+from app.api.data import margin as margin_module
 from app.api.data import market as market_module
 from app.main import app
 
@@ -51,6 +52,17 @@ def test_market_overview_route_uses_data_source_factory_dependency() -> None:
     factory_param = inspect.signature(market_module.get_market_overview).parameters["factory"]
 
     assert getattr(factory_param.default, "dependency", None) is market_module.get_data_source_factory_dependency
+
+
+def test_margin_routes_use_data_source_factory_dependency() -> None:
+    for route_handler in [
+        margin_module.get_margin_account_info,
+        margin_module.get_margin_detail_sse,
+        margin_module.get_margin_detail_szse,
+    ]:
+        factory_param = inspect.signature(route_handler).parameters["factory"]
+
+        assert getattr(factory_param.default, "dependency", None) is margin_module.get_data_source_factory_dependency
 
 
 def test_root_and_socketio_status_have_documented_examples_and_errors() -> None:


### PR DESCRIPTION
## Summary
- Migrate the three margin route handlers from direct `get_data_source_factory()` calls to `Depends(get_data_source_factory_dependency)`.
- Add focused dependency wiring coverage for `get_margin_account_info`, `get_margin_detail_sse`, and `get_margin_detail_szse`.
- Update steward tree, implementation evidence artifact, implementation report, and task card.

## Verification
- TDD red: `test_margin_routes_use_data_source_factory_dependency` failed with `KeyError: 'factory'`.
- TDD green: focused test passed.
- `web/backend/tests/test_health_route_conflicts.py`: 115 passed.
- `web/backend/tests/test_data_source_factory_lifecycle_di.py`: 4 passed.
- ruff / black touched files: passed.
- route guard: total direct refs 13 -> 10, `margin.py` 3 -> 0.
- OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0.
- GitNexus staged detect changes: low risk, affected_count=0.
- Post-commit mainline scope gate: pass=True.

## Boundary
Path-limited G2.67 implementation only. No route path, response shape, OpenAPI exposure, frontend, runtime/PM2, OpenSpec, issue-label, or other DataSourceFactory route consumer change.