### PR TITLE
docs(governance): close out margin factory route migration

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1026,10 +1026,21 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: no route path, response model, response shape, OpenAPI,
 │   │                frontend, runtime/PM2, OpenSpec, issue-label, or other
 │   │                DataSourceFactory consumer change
-│   └── Next gate: Human review / PR merge decision for G2.67; if accepted,
-│                  run G2.67 closeout/current-head refresh before selecting
-│                  another route consumer. Remaining candidates
-│                  (`kline.py`, `futures.py`, `lhb.py`, `stocks.py`, and
+│   ├── G2.67 Closeout / current-head refresh
+│   │   ├── State: ready for review; PR `#215` closeout packet
+│   │   ├── Evidence: `backend-data-source-factory-margin-route-migration-closeout-2026-05-25.md`
+│   │   ├── Current HEAD: `3f1a737a5cc62f0424951931581e410d1dd14975`
+│   │   ├── Result: confirms PR `#214` merged, health route conflict tests
+│   │   │          remain `115 passed`, provider tests remain `4 passed`,
+│   │   │          route direct refs remain `10`, `margin.py` direct refs remain
+│   │   │          `0`, OpenAPI paths remain `500`, duplicate operation IDs remain
+│   │   │          `0`, and GitNexus reports `margin.py` LOW/1 plus provider
+│   │   │          package LOW/0
+│   │   └── Boundary: closeout-only; no source edit or next consumer selection
+│   └── Next gate: Create a separate G2.68 authorization-only candidate
+│                  comparison packet before any next DataSourceFactory route
+│                  consumer edit. Remaining candidates (`kline.py`,
+│                  `futures.py`, `lhb.py`, `stocks.py`, and
 │                  `market/market_data_request.py`) stay locked
 │
 ├── H. Decision-Only Track: CSRF composition root
@@ -1145,6 +1156,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-route-candidate-authorization-2026-05-25.md` | G | G2.66 authorization prepared at current HEAD `d30f2c12d642fbc613689d85b39697999805bbb8`: records PR `#212` as `MERGED`, confirms remaining route/API direct factory calls=`13`, compares six candidates, selects `web/backend/app/api/data/margin.py` for future G2.67 because it has direct refs=`3`, route handlers=`3`, LOC=`155`, ruff=`pass`, black=`unchanged`, GitNexus=`LOW/1`, and expected post-implementation direct refs `3 -> 0` / total direct refs `13 -> 10`; defers `lhb.py` due black reformat debt, `market_data_request.py` due broad 11-route surface, `kline.py` and `stocks.py` due E701/black debt, and `futures.py` due a CRITICAL/91 file-level GitNexus anomaly requiring narrower impact analysis | Human review / PR merge decision; if accepted, create G2.67 path-limited `margin.py` implementation branch; all other remaining consumers stay locked |
 
 | `backend-data-source-factory-margin-route-migration-implementation-2026-05-25.md` | G | G2.67 implementation prepared at current HEAD `7b817debccfba1c82efc5a9c71f23f0b775434c0`: records PR `#213` as `MERGED`, verifies pre-edit GitNexus `margin.py` LOW/1 and three route-handler contexts, follows TDD red=`1 failed: KeyError factory` then green=`1 passed`, migrates `get_margin_account_info`, `get_margin_detail_sse`, and `get_margin_detail_szse` to `get_data_source_factory_dependency`, removes three inline compatibility getter calls, moves `margin.py` direct refs `3 -> 0`, total direct refs `13 -> 10`, verifies health route conflict tests=`115 passed`, provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, and staged GitNexus detect changes risk=`low`, affected count=`0`; remaining `10` route/API consumers stay locked | Human review / PR merge decision; if accepted, run G2.67 closeout/current-head refresh before selecting another DataSourceFactory route consumer packet |
+
+| `backend-data-source-factory-margin-route-migration-closeout-2026-05-25.md` | G | G2.67 closeout prepared at current HEAD `3f1a737a5cc62f0424951931581e410d1dd14975`: records PR `#214` as `MERGED`, confirms current-head route guard direct API calls=`10`, `margin.py` direct refs=`0`, provider dependency API refs=`8`, health route conflict tests=`115 passed`, provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, file-level `margin.py` LOW/1 upstream impact and provider package LOW/0; recommends G2.68 authorization-only candidate comparison before any next route consumer edit | Human review / PR merge decision; if accepted, create G2.68 consumer-selection authorization packet; all remaining `10` route/API consumers stay locked |
 
 ## Completed And Reviewed Ledger
 
@@ -1300,6 +1313,8 @@ review, PR review, or OpenSpec archive review.
 | G2.66 DataSourceFactory route candidate authorization | Ready for review | `d30f2c12` | Candidate comparison recorded after PR `#212`: selects `margin.py` for future G2.67 because it is ruff clean, black unchanged, GitNexus LOW/1, three routes, and three direct refs; this row authorizes no source edit until human review accepts the packet |
 
 | G2.67 margin DataSourceFactory route migration | Ready for review | `7b817deb` | Path-limited implementation migrates three margin route handlers to `get_data_source_factory_dependency`, adds focused dependency wiring coverage, moves total direct route/API factory refs `13 -> 10`, and keeps all other remaining consumers locked pending closeout |
+
+| G2.67 margin DataSourceFactory route migration closeout | Ready for review | `3f1a737a` | Current-head closeout records PR `#214` merged, keeps total direct route/API factory refs at `10`, keeps `margin.py` at `0`, and requires G2.68 authorization-only candidate comparison before any further route migration |
 
 ## Update Protocol
 

--- a/.planning/codebase/generated/data-source-factory-margin-route-migration-closeout-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-margin-route-migration-closeout-2026-05-25.json
@@ -1,0 +1,61 @@
+{
+  "artifact": "data-source-factory-margin-route-migration-closeout-2026-05-25",
+  "workline": "G2.67-closeout",
+  "status": "ready_for_review",
+  "generated_at": "2026-05-25T02:16:55+08:00",
+  "current_head": "3f1a737a5cc62f0424951931581e410d1dd14975",
+  "merged_implementation": {
+    "workline": "G2.67",
+    "merged_pr": 214,
+    "merge_commit": "3f1a737a5cc62f0424951931581e410d1dd14975",
+    "summary": "margin.py DataSourceFactory route migration merged"
+  },
+  "current_head_verification": {
+    "tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "115 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "lint_format": {
+      "ruff_touched_files": "passed",
+      "black_check_touched_files": "3 files would be left unchanged"
+    },
+    "route_guard": {
+      "total_direct_factory_refs": 10,
+      "margin_direct_factory_refs": 0,
+      "provider_dependency_refs": 8,
+      "remaining_files": [
+        "web/backend/app/api/data/kline.py",
+        "web/backend/app/api/data/futures.py",
+        "web/backend/app/api/data/lhb.py",
+        "web/backend/app/api/data/stocks.py",
+        "web/backend/app/api/market/market_data_request.py"
+      ]
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 121,
+      "env_note": "OpenAPI smoke used explicit non-secret test environment placeholders because this isolated worktree has no .env file."
+    },
+    "gitnexus": {
+      "margin_py_upstream": "LOW/1",
+      "data_source_factory_package_upstream": "LOW/0",
+      "provider_symbol_note": "get_data_source_factory_dependency was not directly addressable by current GitNexus symbol lookup; package file impact was used for closeout."
+    }
+  },
+  "next_gate": {
+    "workline": "G2.68",
+    "type": "authorization-only candidate comparison",
+    "boundary": "no source edit before a separate accepted G2.68 packet",
+    "candidate_pool": [
+      "web/backend/app/api/data/kline.py",
+      "web/backend/app/api/data/futures.py",
+      "web/backend/app/api/data/lhb.py",
+      "web/backend/app/api/data/stocks.py",
+      "web/backend/app/api/market/market_data_request.py"
+    ]
+  }
+}

--- a/docs/reports/quality/backend-data-source-factory-margin-route-migration-closeout-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-margin-route-migration-closeout-2026-05-25.md
@@ -1,0 +1,73 @@
+# Backend DataSourceFactory Margin Route Migration Closeout - 2026-05-25
+
+Workline: G2.67 closeout/current-head refresh
+
+Current HEAD: `3f1a737a5cc62f0424951931581e410d1dd14975`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This document records closeout evidence only. It does not
+authorize source code changes, route/OpenAPI changes, frontend changes,
+runtime/PM2 operations, OpenSpec publication, issue-label changes, or selection
+of the next DataSourceFactory route consumer without a separate authorization
+packet.
+
+## Merged Implementation
+
+PR `#214` merged G2.67 at
+`3f1a737a5cc62f0424951931581e410d1dd14975`.
+
+Merged result:
+
+- `get_margin_account_info`
+- `get_margin_detail_sse`
+- `get_margin_detail_szse`
+
+now receive `DataSourceFactory` through
+`Depends(get_data_source_factory_dependency)`.
+
+## Current-Head Verification
+
+- `web/backend/tests/test_health_route_conflicts.py`: `115 passed`
+- `web/backend/tests/test_data_source_factory_lifecycle_di.py`: `4 passed`
+- `ruff check` touched files: passed
+- `black --check` touched files: `3 files would be left unchanged`
+- route guard:
+  - total route/API direct factory refs=`10`
+  - `margin.py` direct factory refs=`0`
+  - provider dependency refs=`8`
+- OpenAPI smoke:
+  - routes=`548`
+  - paths=`500`
+  - operation IDs=`536`
+  - duplicate operation IDs=`0`
+  - duplicate operation ID warnings=`0`
+  - warning count=`121`
+- GitNexus:
+  - `margin.py` upstream impact=`LOW/1`
+  - `web/backend/app/services/data_source_factory/__init__.py` upstream impact=`LOW/0`
+
+GitNexus note: `get_data_source_factory_dependency` was not directly addressable
+by current symbol lookup in this closeout pass, so the package file impact was
+used as the provider-side closeout check.
+
+Environment note: OpenAPI smoke used explicit non-secret test environment
+placeholders because the isolated worktree has no `.env` file.
+
+## Remaining Route Consumers
+
+Remaining direct route/API factory refs: `10`.
+
+Remaining locked candidates:
+
+- `web/backend/app/api/data/kline.py`
+- `web/backend/app/api/data/futures.py`
+- `web/backend/app/api/data/lhb.py`
+- `web/backend/app/api/data/stocks.py`
+- `web/backend/app/api/market/market_data_request.py`
+
+## Next Gate
+
+Create a separate G2.68 authorization-only candidate comparison packet before
+any next DataSourceFactory route consumer edit. This closeout does not select or
+authorize the next source file.

--- a/governance/mainline/task-cards/pr-215.yaml
+++ b/governance/mainline/task-cards/pr-215.yaml
@@ -1,0 +1,124 @@
+version: "v0.2"
+
+task:
+  id: "pr-215"
+  title: "Close out margin DataSourceFactory route migration"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-margin-route-migration-closeout"
+  objective: "record current-head closeout evidence for the merged margin.py DataSourceFactory route migration"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-margin-route-migration-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-margin-route-migration-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout records merged route migration evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-margin-route-migration-closeout-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-margin-route-migration-closeout-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-215.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No next route consumer migration in this PR"
+  - "No compatibility getter cleanup in this PR"
+
+acceptance:
+  checks:
+    - id: "health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-files"
+      command: "ruff check web/backend/app/api/data/margin.py web/backend/tests/test_health_route_conflicts.py web/backend/app/services/data_source_factory/__init__.py"
+      required: true
+    - id: "black-touched-files"
+      command: "black --check web/backend/app/api/data/margin.py web/backend/tests/test_health_route_conflicts.py web/backend/app/services/data_source_factory/__init__.py"
+      required: true
+    - id: "route-guard"
+      command: "confirm total direct route/API factory refs=10 and margin.py direct refs=0"
+      required: true
+    - id: "openapi-smoke"
+      command: "app.openapi() smoke with routes, paths, operation IDs, and duplicate operation IDs"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-margin-route-migration-closeout-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-margin-route-migration-closeout-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-215.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-215.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source or tests are edited, the PR exceeds the closeout-only boundary"
+    - "If this PR selects or migrates the next consumer, it bypasses the next authorization review gate"
+  rollback_plan: "revert this governance-only closeout PR; PR #214 remains the implementation source of truth unless separately reverted"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out the merged margin.py DataSourceFactory route migration"
+    modified_scope: "closeout report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none in this PR"
+    legacy_logic_impact: "none; remaining route consumers and compatibility getter remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only closeout PR if governance validation fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T02:16:55+08:00"
+    approval_note: "human maintainer approved continuing after G2.67 implementation; this packet records closeout evidence only and authorizes no backend source edit"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Close out merged PR #214 at current HEAD 3f1a737a5cc6 for the margin.py DataSourceFactory route migration.
- Record current-head evidence: total direct refs=10, margin.py direct refs=0, provider dependency refs=8.
- Update the steward tree, generated closeout artifact, closeout report, and task card only.

## Verification
- `web/backend/tests/test_health_route_conflicts.py`: 115 passed.
- `web/backend/tests/test_data_source_factory_lifecycle_di.py`: 4 passed.
- ruff / black touched files: passed.
- route guard: total direct refs=10, margin.py=0.
- OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0.
- GitNexus: margin.py LOW/1, provider package LOW/0; staged docs-only scope low/0.
- Post-commit mainline scope gate: pass=True.

## Boundary
Closeout only. This PR does not edit backend source and does not select or migrate the next route consumer. Next gate is G2.68 authorization-only candidate comparison.