### PR TITLE
docs(governance): authorize lhb factory route candidate

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1037,10 +1037,23 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   │          `0`, and GitNexus reports `margin.py` LOW/1 plus provider
 │   │   │          package LOW/0
 │   │   └── Boundary: closeout-only; no source edit or next consumer selection
-│   └── Next gate: Create a separate G2.68 authorization-only candidate
-│                  comparison packet before any next DataSourceFactory route
-│                  consumer edit. Remaining candidates (`kline.py`,
-│                  `futures.py`, `lhb.py`, `stocks.py`, and
+│   ├── G2.68 DataSourceFactory route candidate authorization
+│   │   ├── State: ready for review; PR `#216` candidate packet
+│   │   ├── Evidence: `backend-data-source-factory-lhb-route-migration-authorization-2026-05-25.md`
+│   │   ├── Current HEAD: `d5a0ef78718a070180be0428573530081945c943`
+│   │   ├── Result: compares the remaining five route/API consumers and selects
+│   │   │          `web/backend/app/api/data/lhb.py` for future G2.69 because it
+│   │   │          has LOW/1 GitNexus impact, ruff clean, two route handlers, and
+│   │   │          two direct refs that can move from `2` to `0`; same-file black
+│   │   │          normalization is allowed only inside the future authorized
+│   │   │          implementation if black reformats `lhb.py`
+│   │   └── Boundary: authorization-only; no source edit, route contract edit,
+│   │                compatibility getter removal, frontend edit, PM2/runtime
+│   │                gate, or issue-label change is authorized
+│   └── Next gate: Human review / PR merge decision for G2.68; if accepted,
+│                  create a separate G2.69 path-limited `lhb.py`
+│                  implementation branch. Other remaining candidates
+│                  (`kline.py`, `futures.py`, `stocks.py`, and
 │                  `market/market_data_request.py`) stay locked
 │
 ├── H. Decision-Only Track: CSRF composition root
@@ -1158,6 +1171,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-margin-route-migration-implementation-2026-05-25.md` | G | G2.67 implementation prepared at current HEAD `7b817debccfba1c82efc5a9c71f23f0b775434c0`: records PR `#213` as `MERGED`, verifies pre-edit GitNexus `margin.py` LOW/1 and three route-handler contexts, follows TDD red=`1 failed: KeyError factory` then green=`1 passed`, migrates `get_margin_account_info`, `get_margin_detail_sse`, and `get_margin_detail_szse` to `get_data_source_factory_dependency`, removes three inline compatibility getter calls, moves `margin.py` direct refs `3 -> 0`, total direct refs `13 -> 10`, verifies health route conflict tests=`115 passed`, provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, and staged GitNexus detect changes risk=`low`, affected count=`0`; remaining `10` route/API consumers stay locked | Human review / PR merge decision; if accepted, run G2.67 closeout/current-head refresh before selecting another DataSourceFactory route consumer packet |
 
 | `backend-data-source-factory-margin-route-migration-closeout-2026-05-25.md` | G | G2.67 closeout prepared at current HEAD `3f1a737a5cc62f0424951931581e410d1dd14975`: records PR `#214` as `MERGED`, confirms current-head route guard direct API calls=`10`, `margin.py` direct refs=`0`, provider dependency API refs=`8`, health route conflict tests=`115 passed`, provider lifecycle tests=`4 passed`, ruff/black touched files=`passed`, app/OpenAPI smoke routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, file-level `margin.py` LOW/1 upstream impact and provider package LOW/0; recommends G2.68 authorization-only candidate comparison before any next route consumer edit | Human review / PR merge decision; if accepted, create G2.68 consumer-selection authorization packet; all remaining `10` route/API consumers stay locked |
+
+| `backend-data-source-factory-lhb-route-migration-authorization-2026-05-25.md` | G | G2.68 authorization prepared at current HEAD `d5a0ef78718a070180be0428573530081945c943`: records PR `#215` as `MERGED`, confirms remaining route/API direct factory calls=`10`, compares five candidates, selects `web/backend/app/api/data/lhb.py` for future G2.69 because it has direct refs=`2`, route handlers=`2`, LOC=`128`, ruff=`pass`, black=`would_reformat`, GitNexus=`LOW/1`, and expected post-implementation direct refs `2 -> 0` / total direct refs `10 -> 8`; defers `market_data_request.py` due broad 11-route surface, `kline.py` and `stocks.py` due E701/black debt, and `futures.py` due a CRITICAL/91 file-level GitNexus anomaly requiring narrower impact analysis | Human review / PR merge decision; if accepted, create G2.69 path-limited `lhb.py` implementation branch; all other remaining consumers stay locked |
 
 ## Completed And Reviewed Ledger
 
@@ -1315,6 +1330,8 @@ review, PR review, or OpenSpec archive review.
 | G2.67 margin DataSourceFactory route migration | Ready for review | `7b817deb` | Path-limited implementation migrates three margin route handlers to `get_data_source_factory_dependency`, adds focused dependency wiring coverage, moves total direct route/API factory refs `13 -> 10`, and keeps all other remaining consumers locked pending closeout |
 
 | G2.67 margin DataSourceFactory route migration closeout | Ready for review | `3f1a737a` | Current-head closeout records PR `#214` merged, keeps total direct route/API factory refs at `10`, keeps `margin.py` at `0`, and requires G2.68 authorization-only candidate comparison before any further route migration |
+
+| G2.68 DataSourceFactory route candidate authorization | Ready for review | `d5a0ef78` | Candidate comparison recorded after PR `#215`: selects `lhb.py` for future G2.69 because it has the smallest low-risk route surface; this row authorizes no source edit until human review accepts the packet |
 
 ## Update Protocol
 

--- a/.planning/codebase/generated/data-source-factory-lhb-route-migration-authorization-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-lhb-route-migration-authorization-2026-05-25.json
@@ -1,0 +1,99 @@
+{
+  "artifact": "data-source-factory-lhb-route-migration-authorization-2026-05-25",
+  "workline": "G2.68",
+  "status": "ready_for_review",
+  "generated_at": "2026-05-25T02:27:06+08:00",
+  "current_head": "d5a0ef78718a070180be0428573530081945c943",
+  "previous_gate": {
+    "workline": "G2.67-closeout",
+    "merged_pr": 215,
+    "merge_commit": "d5a0ef78718a070180be0428573530081945c943",
+    "remaining_direct_factory_refs": 10
+  },
+  "candidate_matrix": [
+    {
+      "file": "web/backend/app/api/data/lhb.py",
+      "direct_calls": 2,
+      "direct_call_lines": [90, 115],
+      "route_count": 2,
+      "loc": 128,
+      "ruff_status": "passed",
+      "black_status": "would_reformat",
+      "gitnexus_upstream": "LOW/1",
+      "decision": "selected_for_G2.69",
+      "note": "smallest low-risk route surface; future implementation may include same-file black normalization only"
+    },
+    {
+      "file": "web/backend/app/api/market/market_data_request.py",
+      "direct_calls": 2,
+      "direct_call_lines": [134, 427],
+      "route_count": 11,
+      "loc": 645,
+      "ruff_status": "passed",
+      "black_status": "unchanged",
+      "gitnexus_upstream": "LOW/1",
+      "decision": "defer_broad_route_surface"
+    },
+    {
+      "file": "web/backend/app/api/data/kline.py",
+      "direct_calls": 2,
+      "direct_call_lines": [145, 245],
+      "route_count": 4,
+      "loc": 252,
+      "ruff_status": "fails_E701",
+      "black_status": "would_reformat",
+      "gitnexus_upstream": "LOW/1",
+      "decision": "defer_style_debt"
+    },
+    {
+      "file": "web/backend/app/api/data/stocks.py",
+      "direct_calls": 2,
+      "direct_call_lines": [269, 371],
+      "route_count": 5,
+      "loc": 417,
+      "ruff_status": "fails_E701",
+      "black_status": "would_reformat",
+      "gitnexus_upstream": "LOW/1",
+      "decision": "defer_style_debt"
+    },
+    {
+      "file": "web/backend/app/api/data/futures.py",
+      "direct_calls": 2,
+      "direct_call_lines": [91, 114],
+      "route_count": 2,
+      "loc": 123,
+      "ruff_status": "passed",
+      "black_status": "would_reformat",
+      "gitnexus_upstream": "CRITICAL/91_file_level_anomaly",
+      "decision": "defer_until_narrower_impact_analysis"
+    }
+  ],
+  "selected_next_candidate": {
+    "workline": "G2.69",
+    "file": "web/backend/app/api/data/lhb.py",
+    "allowed_future_source_scope": [
+      "web/backend/app/api/data/lhb.py",
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "expected_route_guard": {
+      "lhb_direct_refs": "2 -> 0",
+      "total_direct_refs": "10 -> 8"
+    },
+    "formatting_boundary": "same-file black normalization in lhb.py is allowed only if black reformats the authorized file during implementation"
+  },
+  "verification": {
+    "tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "115 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 121
+    }
+  },
+  "next_gate": "Human review / PR merge decision; if accepted, create G2.69 path-limited lhb.py implementation branch. This packet itself authorizes no source edit."
+}

--- a/docs/reports/quality/backend-data-source-factory-lhb-route-migration-authorization-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-lhb-route-migration-authorization-2026-05-25.md
@@ -1,0 +1,78 @@
+# Backend DataSourceFactory LHB Route Migration Authorization - 2026-05-25
+
+Workline: G2.68 authorization-only packet
+
+Current HEAD: `d5a0ef78718a070180be0428573530081945c943`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This document is a governance evidence and authorization input
+only. It does not authorize source code changes, GitHub issue publication,
+OpenSpec proposal publication, OpenSpec implementation, production rollout, or
+promotion of this candidate selection into backend runtime truth.
+
+## Prior Gate
+
+PR `#215` merged the G2.67 closeout for the `margin.py` DataSourceFactory route
+migration. Remaining route/API direct factory refs are `10`.
+
+## Candidate Matrix
+
+| Candidate | Direct refs | Routes | LOC | Ruff | Black | GitNexus upstream | Decision |
+|---|---:|---:|---:|---|---|---|---|
+| `web/backend/app/api/data/lhb.py` | 2 | 2 | 128 | pass | would reformat | LOW/1 | Select for G2.69 |
+| `web/backend/app/api/market/market_data_request.py` | 2 | 11 | 645 | pass | unchanged | LOW/1 | Defer; broad route surface |
+| `web/backend/app/api/data/kline.py` | 2 | 4 | 252 | E701 | would reformat | LOW/1 | Defer; style debt |
+| `web/backend/app/api/data/stocks.py` | 2 | 5 | 417 | E701 | would reformat | LOW/1 | Defer; style debt |
+| `web/backend/app/api/data/futures.py` | 2 | 2 | 123 | pass | would reformat | CRITICAL/91 | Defer until narrower impact analysis |
+
+Selection rationale: `lhb.py` has the smallest low-risk route surface after
+`margin.py`: two route handlers, two direct factory refs, ruff clean, and LOW/1
+GitNexus impact. Although black would reformat the file, that formatting debt is
+same-file and can be bundled with the future path-limited implementation if
+G2.69 is accepted.
+
+## Selected G2.69 Scope
+
+If accepted, the next implementation packet may only touch:
+
+- `web/backend/app/api/data/lhb.py`
+- `web/backend/tests/test_health_route_conflicts.py`
+
+Expected route-guard result after G2.69 implementation:
+
+- `lhb.py` direct refs: `2 -> 0`
+- total route/API direct refs: `10 -> 8`
+
+Same-file black normalization in `lhb.py` is allowed only if black reformats the
+authorized file during implementation. No other formatting cleanup is
+authorized.
+
+## Locked Scope
+
+- `web/backend/app/api/data/kline.py`
+- `web/backend/app/api/data/futures.py`
+- `web/backend/app/api/data/stocks.py`
+- `web/backend/app/api/market/market_data_request.py`
+- `web/frontend/**`
+- `src/**`
+- `openspec/changes/**`
+- `docs/api/**`
+
+No compatibility getter removal, route path edit, OpenAPI contract edit,
+frontend edit, PM2/runtime stateful gate, or issue-label change is authorized by
+this packet.
+
+## Current Evidence
+
+- `web/backend/tests/test_health_route_conflicts.py`: `115 passed`
+- `web/backend/tests/test_data_source_factory_lifecycle_di.py`: `4 passed`
+- OpenAPI smoke: routes=`548`, paths=`500`, operation IDs=`536`, duplicate
+  operation IDs=`0`, duplicate operation ID warnings=`0`, warning count=`121`
+- Candidate direct refs: total=`10`
+
+## Review Gate
+
+Human review / PR merge decision. If accepted, create G2.69 as a separate
+path-limited `lhb.py` implementation branch. This G2.68 packet itself
+authorizes no backend source edit.

--- a/governance/mainline/task-cards/pr-216.yaml
+++ b/governance/mainline/task-cards/pr-216.yaml
@@ -1,0 +1,121 @@
+version: "v0.2"
+
+task:
+  id: "pr-216"
+  title: "Authorize LHB as next DataSourceFactory route consumer"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-lhb-route-migration-authorization"
+  objective: "select the next DataSourceFactory route migration candidate after G2.67 closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-lhb-route-migration-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-lhb-route-migration-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate authorization records evidence and future scope only; it does not change route behavior, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-lhb-route-migration-authorization-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-lhb-route-migration-authorization-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-216.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source, test, route, OpenAPI, response contract, docs/API, generated client, frontend, PM2, or runtime process change in this PR"
+  - "No OpenSpec change/spec creation, modification, or archive execution"
+  - "No issue label changes or ready-for-agent movement"
+  - "No G2.69 source implementation in this PR"
+  - "No compatibility getter cleanup in this PR"
+
+acceptance:
+  checks:
+    - id: "health-route-conflicts-current-head"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "data-source-factory-lifecycle-di"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "candidate-static-scan"
+      command: "scan remaining DataSourceFactory direct route calls and candidate route surfaces"
+      required: true
+    - id: "candidate-ruff-black-baseline"
+      command: "ruff/black checks over remaining candidate files"
+      required: true
+    - id: "openapi-smoke"
+      command: "app.openapi() smoke with route/path/operationId counts and duplicate operation ID warnings"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-lhb-route-migration-authorization-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-lhb-route-migration-authorization-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-216.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-216.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If backend source is edited, the PR exceeds the authorization-only boundary"
+    - "If G2.69 is started without human review, the route migration sequence bypasses the steward tree gate"
+  rollback_plan: "revert this governance-only authorization PR; no runtime behavior changes are introduced"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "select LHB as the next DataSourceFactory route migration candidate"
+    modified_scope: "authorization report, generated artifact, steward tree, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; all remaining route consumers and compatibility getter remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this docs-only PR if candidate selection is rejected"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T02:27:06+08:00"
+    approval_note: "human maintainer approved continuing after G2.67 closeout; this packet selects a future candidate only and authorizes no backend source edit"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- add G2.68 DataSourceFactory route candidate authorization packet
- select `web/backend/app/api/data/lhb.py` for future G2.69 migration
- update steward tree and add mainline governance task card for PR #216

## Evidence

- current direct route/API factory refs: 10
- selected candidate: `lhb.py`, 2 direct refs, 2 routes, GitNexus LOW/1
- expected future reduction after implementation: 10 -> 8 total direct refs, lhb 2 -> 0
- baseline tests: `web/backend/tests/test_health_route_conflicts.py` 115 passed; `test_data_source_factory_lifecycle_di.py` 4 passed
- OpenAPI smoke: 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0
- staged GitNexus detect_changes: low risk, 4 governance files, 0 changed symbols
- post-commit mainline scope gate: pass, 0 violations

## Boundary

Docs/governance only. No backend source, test source, OpenSpec runtime spec, or issue-label changes are included.