### PR TITLE
refactor(api): inject data source factory into lhb routes

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1038,7 +1038,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   │          package LOW/0
 │   │   └── Boundary: closeout-only; no source edit or next consumer selection
 │   ├── G2.68 DataSourceFactory route candidate authorization
-│   │   ├── State: ready for review; PR `#216` candidate packet
+│   │   ├── State: accepted; PR `#216` merged at
+│   │   │          `a76f6dbdc700738e4d07977ae3808f75b2103fe3`
 │   │   ├── Evidence: `backend-data-source-factory-lhb-route-migration-authorization-2026-05-25.md`
 │   │   ├── Current HEAD: `d5a0ef78718a070180be0428573530081945c943`
 │   │   ├── Result: compares the remaining five route/API consumers and selects
@@ -1050,9 +1051,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: authorization-only; no source edit, route contract edit,
 │   │                compatibility getter removal, frontend edit, PM2/runtime
 │   │                gate, or issue-label change is authorized
-│   └── Next gate: Human review / PR merge decision for G2.68; if accepted,
-│                  create a separate G2.69 path-limited `lhb.py`
-│                  implementation branch. Other remaining candidates
+│   ├── G2.69 LHB DataSourceFactory route migration
+│   │   ├── State: ready for review; PR `#217` implementation packet
+│   │   ├── Evidence: `backend-data-source-factory-lhb-route-migration-implementation-2026-05-25.md`
+│   │   ├── Current HEAD: `a76f6dbdc700738e4d07977ae3808f75b2103fe3`
+│   │   ├── Result: migrates `get_dragon_tiger_detail` and
+│   │   │          `get_dragon_tiger_institution_stats` from direct
+│   │   │          `get_data_source_factory()` calls to
+│   │   │          `Depends(get_data_source_factory_dependency)`; total route/API
+│   │   │          direct refs move `10 -> 8`, `lhb.py` direct refs move
+│   │   │          `2 -> 0`, health route conflict tests move to `116 passed`,
+│   │   │          provider tests remain `4 passed`, OpenAPI paths remain `500`,
+│   │   │          and duplicate operation IDs remain `0`
+│   │   └── Boundary: no route path, response model, response shape, OpenAPI,
+│   │                frontend, runtime/PM2, OpenSpec, issue-label, compatibility
+│   │                getter deletion, or other DataSourceFactory consumer change
+│   └── Next gate: Human review / PR merge decision for G2.69; if accepted,
+│                  create a separate closeout/current-head refresh and then a
+│                  new candidate authorization packet before any further
+│                  DataSourceFactory route migration. Remaining candidates
 │                  (`kline.py`, `futures.py`, `stocks.py`, and
 │                  `market/market_data_request.py`) stay locked
 │
@@ -1103,6 +1120,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-error-contract-completion-verification-2026-05-19.md` | I | P3-C5 / #77 main migration resolved | Do not reopen old live-count backlog without current-head contradiction |
 | `backend-technical-pattern-di-pilot-implementation-2026-05-21.md` | D2.1a.1 | First DI lifecycle pilot implementation merged in PR `#112`; route-level provider and dependency override test seam are in place | D2.1a implementation closed; do not infer a second DI pilot from this evidence |
 | `inject-technical-pattern-detection-service-di` task `5.3` closeout | D2.1a.1 | Final OpenSpec checklist governance merged in PR `#113`; issue `#92` received implementation and final governance closeout comments | D2.1a is 100% closed; future DI work requires a new approved child lane |
+| `backend-data-source-factory-lhb-route-migration-implementation-2026-05-25.md` | G | G2.69 implementation packet prepared at `a76f6dbdc`: LHB route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `10 -> 8`, and `lhb.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before selecting another DataSourceFactory route consumer |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |
@@ -1332,6 +1350,8 @@ review, PR review, or OpenSpec archive review.
 | G2.67 margin DataSourceFactory route migration closeout | Ready for review | `3f1a737a` | Current-head closeout records PR `#214` merged, keeps total direct route/API factory refs at `10`, keeps `margin.py` at `0`, and requires G2.68 authorization-only candidate comparison before any further route migration |
 
 | G2.68 DataSourceFactory route candidate authorization | Ready for review | `d5a0ef78` | Candidate comparison recorded after PR `#215`: selects `lhb.py` for future G2.69 because it has the smallest low-risk route surface; this row authorizes no source edit until human review accepts the packet |
+
+| G2.69 LHB DataSourceFactory route migration | Ready for review | `a76f6dbd` | Path-limited implementation migrates two LHB route handlers to `get_data_source_factory_dependency`, adds focused dependency wiring coverage, moves total direct route/API factory refs `10 -> 8`, and keeps all other remaining consumers locked pending closeout |
 
 ## Update Protocol
 

--- a/.planning/codebase/generated/data-source-factory-lhb-route-migration-implementation-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-lhb-route-migration-implementation-2026-05-25.json
@@ -1,0 +1,133 @@
+{
+  "artifact": "data-source-factory-lhb-route-migration-implementation-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-69-lhb-route-factory-migration",
+  "base_head": "a76f6dbdc700738e4d07977ae3808f75b2103fe3",
+  "scope": {
+    "source_files": [
+      "web/backend/app/api/data/lhb.py",
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "governance_files": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/data-source-factory-lhb-route-migration-implementation-2026-05-25.json",
+      "docs/reports/quality/backend-data-source-factory-lhb-route-migration-implementation-2026-05-25.md",
+      "governance/mainline/task-cards/pr-217.yaml"
+    ],
+    "excluded": [
+      "route paths",
+      "response models",
+      "response shape",
+      "OpenAPI exposure policy",
+      "frontend",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue labels",
+      "other DataSourceFactory consumers",
+      "DataSourceFactory compatibility getter removal"
+    ]
+  },
+  "pre_edit_evidence": {
+    "gitnexus": {
+      "file": {
+        "target": "web/backend/app/api/data/lhb.py",
+        "risk": "LOW",
+        "direct_impacted": 1,
+        "processes_affected": 0
+      },
+      "functions": [
+        {
+          "target": "get_dragon_tiger_detail",
+          "risk": "LOW",
+          "direct_impacted": 0,
+          "processes_affected": 0
+        },
+        {
+          "target": "get_dragon_tiger_institution_stats",
+          "risk": "LOW",
+          "direct_impacted": 0,
+          "processes_affected": 0
+        }
+      ]
+    },
+    "baseline_tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "115 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "baseline_style": {
+      "ruff_lhb": "passed",
+      "black_lhb": "would reformat; same-file normalization allowed by G2.68 authorization"
+    },
+    "baseline_route_api_factory_refs": {
+      "total_direct_refs": 10,
+      "lhb_py_direct_refs": 2
+    }
+  },
+  "tdd": {
+    "red": {
+      "command": "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_lhb_routes_use_data_source_factory_dependency -q --no-cov --tb=short",
+      "result": "failed as expected",
+      "failure": "KeyError: 'factory'"
+    },
+    "green": {
+      "command": "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_lhb_routes_use_data_source_factory_dependency -q --no-cov --tb=short",
+      "result": "1 passed"
+    }
+  },
+  "implementation": {
+    "migrated_route_handlers": [
+      "get_dragon_tiger_detail",
+      "get_dragon_tiger_institution_stats"
+    ],
+    "dependency": "Depends(get_data_source_factory_dependency)",
+    "factory_type": "DataSourceFactory",
+    "removed_inline_calls": [
+      "await get_data_source_factory() in get_dragon_tiger_detail",
+      "await get_data_source_factory() in get_dragon_tiger_institution_stats"
+    ],
+    "compatibility_surfaces_retained": [
+      "get_data_source_factory()",
+      "_global_factory",
+      "get_data_source_factory_dependency"
+    ]
+  },
+  "post_change_evidence": {
+    "tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "116 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "style": {
+      "ruff_touched_files": "passed",
+      "black_touched_files": "passed"
+    },
+    "route_api_factory_refs": {
+      "total_direct_refs": 8,
+      "lhb_py_direct_refs": 0,
+      "remaining_data_route_consumers": [
+        {
+          "file": "web/backend/app/api/data/kline.py",
+          "direct_refs": 2
+        },
+        {
+          "file": "web/backend/app/api/data/futures.py",
+          "direct_refs": 2
+        },
+        {
+          "file": "web/backend/app/api/data/stocks.py",
+          "direct_refs": 2
+        }
+      ]
+    },
+    "openapi_smoke": {
+      "command_context": "PYTHONPATH=web/backend with root .env loaded",
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 0
+    }
+  },
+  "next_gate": "Human review / PR merge decision for G2.69, then a separate closeout and next-candidate authorization packet before any further DataSourceFactory route migration."
+}

--- a/docs/reports/quality/backend-data-source-factory-lhb-route-migration-implementation-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-lhb-route-migration-implementation-2026-05-25.md
@@ -1,0 +1,139 @@
+# Backend DataSourceFactory LHB Route Migration Implementation - 2026-05-25
+
+Workline: G2.69 implementation packet
+
+Current HEAD: `a76f6dbdc700738e4d07977ae3808f75b2103fe3`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This document records one path-limited source implementation and
+its evidence. It does not authorize route path changes, OpenAPI exposure
+changes, response shape changes, frontend edits, PM2/runtime operations,
+OpenSpec proposal publication, issue-label changes, or migration of any other
+DataSourceFactory route consumer.
+
+## Status
+
+Ready for review.
+
+This is the G2.69 implementation packet authorized by the G2.68 LHB candidate
+selection. It is path-limited to `web/backend/app/api/data/lhb.py`, one focused
+route-conflict test, and governance evidence. It does not change route paths,
+response contracts, OpenAPI exposure policy, frontend code, runtime/PM2 gates,
+OpenSpec files, issue labels, or other DataSourceFactory consumers.
+
+## Scope
+
+Changed source/test files:
+
+- `web/backend/app/api/data/lhb.py`
+- `web/backend/tests/test_health_route_conflicts.py`
+
+Governance artifacts:
+
+- `.planning/codebase/generated/data-source-factory-lhb-route-migration-implementation-2026-05-25.json`
+- `docs/reports/quality/backend-data-source-factory-lhb-route-migration-implementation-2026-05-25.md`
+- `governance/mainline/task-cards/pr-217.yaml`
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+
+## Pre-Edit Evidence
+
+GitNexus impact before editing:
+
+| Target | Risk | Direct impact | Processes affected |
+| --- | --- | ---: | ---: |
+| `web/backend/app/api/data/lhb.py` | LOW | 1 | 0 |
+| `get_dragon_tiger_detail` | LOW | 0 | 0 |
+| `get_dragon_tiger_institution_stats` | LOW | 0 | 0 |
+
+Baseline verification:
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov` | 115 passed |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov` | 4 passed |
+| `ruff check web/backend/app/api/data/lhb.py` | passed |
+| `black --check web/backend/app/api/data/lhb.py` | would reformat |
+
+The black finding was known from G2.68. Same-file normalization was explicitly
+allowed for the future authorized `lhb.py` implementation branch.
+
+## TDD Evidence
+
+Red test:
+
+```text
+pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_lhb_routes_use_data_source_factory_dependency -q --no-cov --tb=short
+```
+
+Result: failed as expected with `KeyError: 'factory'`.
+
+Green test:
+
+```text
+pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_lhb_routes_use_data_source_factory_dependency -q --no-cov --tb=short
+```
+
+Result: `1 passed`.
+
+## Implementation
+
+Migrated route handlers:
+
+- `get_dragon_tiger_detail`
+- `get_dragon_tiger_institution_stats`
+
+Both handlers now receive:
+
+```python
+factory: DataSourceFactory = Depends(get_data_source_factory_dependency)
+```
+
+The route-local `from app.services.data_source_factory import get_data_source_factory`
+imports and `await get_data_source_factory()` calls were removed from both
+handlers. Compatibility surfaces remain intact:
+
+- `get_data_source_factory()`
+- `_global_factory`
+- `get_data_source_factory_dependency`
+
+## Verification
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov` | 116 passed |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov` | 4 passed |
+| `ruff check web/backend/app/api/data/lhb.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| `black --check web/backend/app/api/data/lhb.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| OpenAPI smoke with `PYTHONPATH=web/backend` and root `.env` loaded | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0 |
+
+Route/API direct factory refs:
+
+| Metric | Before | After |
+| --- | ---: | ---: |
+| Total direct route/API `get_data_source_factory()` refs | 10 | 8 |
+| `web/backend/app/api/data/lhb.py` direct refs | 2 | 0 |
+
+Remaining data route consumers stay locked for future authorization:
+
+- `web/backend/app/api/data/kline.py`
+- `web/backend/app/api/data/futures.py`
+- `web/backend/app/api/data/stocks.py`
+
+## Boundary
+
+This packet does not authorize:
+
+- route path, response model, response shape, or OpenAPI exposure changes
+- frontend edits
+- runtime/PM2 stateful gates
+- OpenSpec changes
+- issue label changes
+- `get_data_source_factory()` or `_global_factory` deletion
+- migration of `kline.py`, `futures.py`, `stocks.py`, or any market package consumer
+
+## Next Gate
+
+Human review / PR merge decision for G2.69. After merge, create a separate
+closeout/current-head refresh and then a new candidate authorization packet
+before any additional DataSourceFactory route migration.

--- a/governance/mainline/task-cards/pr-217.yaml
+++ b/governance/mainline/task-cards/pr-217.yaml
@@ -1,0 +1,129 @@
+version: "v0.2"
+
+task:
+  id: "pr-217"
+  title: "Migrate LHB routes to DataSourceFactory dependency injection"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-lhb-route-migration"
+  objective: "move LHB route DataSourceFactory access from compatibility getter calls to FastAPI dependency injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-lhb-route-migration"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-lhb-route-migration"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Implementation changes dependency acquisition only and preserves route paths, OpenAPI exposure, response shape, and runtime semantics"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/api/data/lhb.py"
+    - "web/backend/tests/test_health_route_conflicts.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-lhb-route-migration-implementation-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-lhb-route-migration-implementation-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-217.yaml"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+    - "web/backend/app/api/data/futures.py"
+    - "web/backend/app/api/data/kline.py"
+    - "web/backend/app/api/data/margin.py"
+    - "web/backend/app/api/data/stocks.py"
+    - "web/backend/app/api/market/**"
+
+non_goals:
+  - "No route path, response model, response shape, OpenAPI exposure, docs/API, generated client, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No non-lhb.py DataSourceFactory route consumer migration"
+  - "No deletion of get_data_source_factory() or _global_factory compatibility surfaces"
+  - "No broad formatting cleanup outside web/backend/app/api/data/lhb.py and the focused test file"
+
+acceptance:
+  checks:
+    - id: "pre-edit-gitnexus-impact"
+      command: "MCP gitnexus.impact(target=web/backend/app/api/data/lhb.py,direction=upstream)"
+      required: true
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_lhb_routes_use_data_source_factory_dependency -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-files"
+      command: "ruff check web/backend/app/api/data/lhb.py web/backend/tests/test_health_route_conflicts.py"
+      required: true
+    - id: "black-touched-files"
+      command: "black --check web/backend/app/api/data/lhb.py web/backend/tests/test_health_route_conflicts.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-lhb-route-migration-implementation-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-lhb-route-migration-implementation-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-217.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-217.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If response shape or route paths change, the PR exceeds the approved G2.69 boundary"
+    - "If another route consumer is edited, the PR bypasses G2.68 candidate sequencing"
+  rollback_plan: "revert this path-limited PR; compatibility getter surfaces remain available and no route contract changes are introduced"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "migrate LHB route DataSourceFactory access to dependency injection"
+    modified_scope: "LHB route file, focused route-conflict test, implementation report, generated artifact, steward tree, and task card"
+    dependency_changes: "uses existing get_data_source_factory_dependency provider"
+    legacy_logic_impact: "compatibility getter and _global_factory remain unchanged for other consumers"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if LHB dependency wiring or route guard verification fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T02:37:34+08:00"
+    approval_note: "human maintainer accepted G2.68 candidate selection by merging PR #216; this packet implements only the approved lhb.py route migration"
+    secondary_approved: false

--- a/web/backend/app/api/data/lhb.py
+++ b/web/backend/app/api/data/lhb.py
@@ -1,6 +1,7 @@
 """
 龙虎榜数据路由 (Dragon Tiger)
 """
+
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, Query
@@ -9,6 +10,7 @@ from app.core.exceptions import BusinessException
 from app.core.security import User, get_current_user
 from app.core.responses import UnifiedResponse, ok
 from app.openapi_config import COMMON_RESPONSES
+from app.services.data_source_factory import DataSourceFactory, get_data_source_factory_dependency
 
 router = APIRouter()
 
@@ -62,9 +64,7 @@ DRAGON_TIGER_INSTITUTION_RESPONSES = {
         "龙虎榜机构统计结果",
         {
             "success": True,
-            "data": [
-                {"trade_date": "2026-04-03", "buy_count": 12, "sell_count": 7, "net_amount": 486000000.0}
-            ],
+            "data": [{"trade_date": "2026-04-03", "buy_count": 12, "sell_count": 7, "net_amount": 486000000.0}],
             "period": "近一月",
         },
     ),
@@ -83,11 +83,9 @@ async def get_dragon_tiger_detail(
     end_date: str = Query(..., description="查询结束日期，格式为 YYYY-MM-DD。"),
     limit: int = Query(100, description="单次请求返回的最大龙虎榜记录数。"),
     current_user: User = Depends(get_current_user),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
 ) -> UnifiedResponse:
     try:
-        from app.services.data_source_factory import get_data_source_factory
-
-        factory = await get_data_source_factory()
         result = await factory.get_data(
             "data",
             "dragon-tiger/detail",
@@ -95,7 +93,9 @@ async def get_dragon_tiger_detail(
         )
         return ok(data=result.get("data", []))
     except Exception as e:
-        raise BusinessException(detail=f"获取龙虎榜明细失败: {str(e)}", status_code=500, error_code="DATA_RETRIEVAL_FAILED")
+        raise BusinessException(
+            detail=f"获取龙虎榜明细失败: {str(e)}", status_code=500, error_code="DATA_RETRIEVAL_FAILED"
+        )
 
 
 @router.get(
@@ -108,11 +108,9 @@ async def get_dragon_tiger_institution_stats(
     period: str = Query("近一月", description="统计周期，例如近一周、近一月或近三月。"),
     limit: int = Query(50, description="返回的最大统计记录数。"),
     current_user: User = Depends(get_current_user),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
 ) -> Dict[str, Any]:
     try:
-        from app.services.data_source_factory import get_data_source_factory
-
-        factory = await get_data_source_factory()
         result = await factory.get_data(
             "data",
             "dragon-tiger/institution-stats",

--- a/web/backend/tests/test_health_route_conflicts.py
+++ b/web/backend/tests/test_health_route_conflicts.py
@@ -6,6 +6,7 @@ import inspect
 from fastapi.routing import APIRoute
 
 from app.api.data import financial as financial_module
+from app.api.data import lhb as lhb_module
 from app.api.data import margin as margin_module
 from app.api.data import market as market_module
 from app.main import app
@@ -63,6 +64,16 @@ def test_margin_routes_use_data_source_factory_dependency() -> None:
         factory_param = inspect.signature(route_handler).parameters["factory"]
 
         assert getattr(factory_param.default, "dependency", None) is margin_module.get_data_source_factory_dependency
+
+
+def test_lhb_routes_use_data_source_factory_dependency() -> None:
+    for route_handler in [
+        lhb_module.get_dragon_tiger_detail,
+        lhb_module.get_dragon_tiger_institution_stats,
+    ]:
+        factory_param = inspect.signature(route_handler).parameters["factory"]
+
+        assert getattr(factory_param.default, "dependency", None) is lhb_module.get_data_source_factory_dependency
 
 
 def test_root_and_socketio_status_have_documented_examples_and_errors() -> None:


### PR DESCRIPTION
## Summary

- migrate `web/backend/app/api/data/lhb.py` route-local DataSourceFactory access to `Depends(get_data_source_factory_dependency)`
- add focused route wiring coverage for both LHB handlers
- update steward tree, generated evidence artifact, implementation report, and mainline task card

## Evidence

- pre-edit GitNexus: `lhb.py` LOW/1; `get_dragon_tiger_detail` LOW/0; `get_dragon_tiger_institution_stats` LOW/0
- TDD red: focused test failed with `KeyError: 'factory'`
- TDD green: focused test 1 passed
- `web/backend/tests/test_health_route_conflicts.py`: 116 passed
- `web/backend/tests/test_data_source_factory_lifecycle_di.py`: 4 passed
- ruff touched files: passed
- black touched files: passed
- route/API direct factory refs: total 10 -> 8; `lhb.py` 2 -> 0
- OpenAPI smoke: 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0
- staged GitNexus detect_changes: low risk, 6 files, 0 changed symbols, 0 affected processes
- post-commit mainline scope gate: pass, 0 violations

## Boundary

No route path, response model, response shape, OpenAPI exposure, frontend, runtime/PM2, OpenSpec, issue-label, compatibility getter deletion, or other DataSourceFactory consumer changes.