### PR TITLE
docs(governance): close out lhb factory route migration

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1052,7 +1052,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                compatibility getter removal, frontend edit, PM2/runtime
 │   │                gate, or issue-label change is authorized
 │   ├── G2.69 LHB DataSourceFactory route migration
-│   │   ├── State: ready for review; PR `#217` implementation packet
+│   │   ├── State: accepted; PR `#217` merged at
+│   │   │          `d25803e93494b7115795a1922a84386b9daffb27`
 │   │   ├── Evidence: `backend-data-source-factory-lhb-route-migration-implementation-2026-05-25.md`
 │   │   ├── Current HEAD: `a76f6dbdc700738e4d07977ae3808f75b2103fe3`
 │   │   ├── Result: migrates `get_dragon_tiger_detail` and
@@ -1066,12 +1067,21 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: no route path, response model, response shape, OpenAPI,
 │   │                frontend, runtime/PM2, OpenSpec, issue-label, compatibility
 │   │                getter deletion, or other DataSourceFactory consumer change
-│   └── Next gate: Human review / PR merge decision for G2.69; if accepted,
-│                  create a separate closeout/current-head refresh and then a
-│                  new candidate authorization packet before any further
-│                  DataSourceFactory route migration. Remaining candidates
-│                  (`kline.py`, `futures.py`, `stocks.py`, and
-│                  `market/market_data_request.py`) stay locked
+│   ├── G2.69 Closeout / current-head refresh
+│   │   ├── State: ready for review; PR `#218` closeout packet
+│   │   ├── Evidence: `backend-data-source-factory-lhb-route-migration-closeout-2026-05-25.md`
+│   │   ├── Current HEAD: `d25803e93494b7115795a1922a84386b9daffb27`
+│   │   ├── Result: confirms PR `#217` merged, health route conflict tests
+│   │   │          remain `116 passed`, provider tests remain `4 passed`,
+│   │   │          route direct refs remain `8`, `lhb.py` direct refs remain
+│   │   │          `0`, OpenAPI paths remain `500`, duplicate operation IDs
+│   │   │          remain `0`, and GitNexus reports `lhb.py` LOW/1
+│   │   └── Boundary: closeout-only; no source edit or next consumer selection
+│   └── Next gate: Human review / PR merge decision for G2.69 closeout; if
+│                  accepted, create a separate G2.70 candidate authorization
+│                  packet before any further DataSourceFactory route migration.
+│                  Remaining candidates (`kline.py`, `futures.py`, `stocks.py`,
+│                  and `market/market_data_request.py`) stay locked
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1121,6 +1131,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-technical-pattern-di-pilot-implementation-2026-05-21.md` | D2.1a.1 | First DI lifecycle pilot implementation merged in PR `#112`; route-level provider and dependency override test seam are in place | D2.1a implementation closed; do not infer a second DI pilot from this evidence |
 | `inject-technical-pattern-detection-service-di` task `5.3` closeout | D2.1a.1 | Final OpenSpec checklist governance merged in PR `#113`; issue `#92` received implementation and final governance closeout comments | D2.1a is 100% closed; future DI work requires a new approved child lane |
 | `backend-data-source-factory-lhb-route-migration-implementation-2026-05-25.md` | G | G2.69 implementation packet prepared at `a76f6dbdc`: LHB route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `10 -> 8`, and `lhb.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before selecting another DataSourceFactory route consumer |
+| `backend-data-source-factory-lhb-route-migration-closeout-2026-05-25.md` | G | G2.69 closeout packet prepared at `d25803e93`: PR `#217` merge recorded, health tests remain `116 passed`, provider tests remain `4 passed`, total refs remain `8`, and `lhb.py` remains `0` | Human review / PR merge decision; if accepted, create G2.70 candidate authorization before further route migration |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |
@@ -1352,6 +1363,8 @@ review, PR review, or OpenSpec archive review.
 | G2.68 DataSourceFactory route candidate authorization | Ready for review | `d5a0ef78` | Candidate comparison recorded after PR `#215`: selects `lhb.py` for future G2.69 because it has the smallest low-risk route surface; this row authorizes no source edit until human review accepts the packet |
 
 | G2.69 LHB DataSourceFactory route migration | Ready for review | `a76f6dbd` | Path-limited implementation migrates two LHB route handlers to `get_data_source_factory_dependency`, adds focused dependency wiring coverage, moves total direct route/API factory refs `10 -> 8`, and keeps all other remaining consumers locked pending closeout |
+
+| G2.69 LHB DataSourceFactory route migration closeout | Ready for review | `d25803e9` | Current-head closeout records PR `#217` merged, keeps total direct route/API factory refs at `8`, keeps `lhb.py` at `0`, and requires G2.70 authorization-only candidate comparison before any further route migration |
 
 ## Update Protocol
 

--- a/.planning/codebase/generated/data-source-factory-lhb-route-migration-closeout-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-lhb-route-migration-closeout-2026-05-25.json
@@ -1,0 +1,78 @@
+{
+  "artifact": "data-source-factory-lhb-route-migration-closeout-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-69-lhb-route-migration-closeout",
+  "current_head": "d25803e93494b7115795a1922a84386b9daffb27",
+  "source_pr": {
+    "number": 217,
+    "merge_commit": "d25803e93494b7115795a1922a84386b9daffb27",
+    "title": "refactor(api): inject data source factory into lhb routes"
+  },
+  "scope": {
+    "files": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/data-source-factory-lhb-route-migration-closeout-2026-05-25.json",
+      "docs/reports/quality/backend-data-source-factory-lhb-route-migration-closeout-2026-05-25.md",
+      "governance/mainline/task-cards/pr-218.yaml"
+    ],
+    "excluded": [
+      "backend source edits",
+      "backend test edits",
+      "route path changes",
+      "OpenAPI exposure changes",
+      "frontend changes",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue label changes",
+      "next DataSourceFactory consumer migration"
+    ]
+  },
+  "verification": {
+    "tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "116 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "style": {
+      "ruff_lhb_and_health_test": "passed",
+      "black_lhb_and_health_test": "passed"
+    },
+    "route_api_factory_refs": {
+      "total_direct_refs": 8,
+      "lhb_py_direct_refs": 0,
+      "remaining_data_route_consumers": [
+        {
+          "file": "web/backend/app/api/data/kline.py",
+          "direct_refs": 2
+        },
+        {
+          "file": "web/backend/app/api/data/futures.py",
+          "direct_refs": 2
+        },
+        {
+          "file": "web/backend/app/api/data/stocks.py",
+          "direct_refs": 2
+        }
+      ]
+    },
+    "openapi_smoke": {
+      "command_context": "PYTHONPATH=web/backend with root .env loaded",
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 0
+    },
+    "gitnexus": {
+      "lhb_py": {
+        "risk": "LOW",
+        "direct_impacted": 1,
+        "processes_affected": 0
+      },
+      "provider_package_lookup": "target web/backend/app/services/data_source_factory was not indexed as a package target in this check"
+    }
+  },
+  "decision": "G2.69 implementation evidence remains valid at current HEAD. No additional source change is authorized by this closeout.",
+  "next_gate": "Human review / PR merge decision for this closeout, then a separate G2.70 candidate authorization packet before any further DataSourceFactory route migration."
+}

--- a/docs/reports/quality/backend-data-source-factory-lhb-route-migration-closeout-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-lhb-route-migration-closeout-2026-05-25.md
@@ -1,0 +1,69 @@
+# Backend DataSourceFactory LHB Route Migration Closeout - 2026-05-25
+
+Workline: G2.69 closeout / current-head refresh
+
+Current HEAD: `d25803e93494b7115795a1922a84386b9daffb27`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This document records a closeout/current-head refresh for one
+already merged source implementation. It does not authorize backend source
+edits, route path changes, OpenAPI exposure changes, response shape changes,
+frontend edits, PM2/runtime operations, OpenSpec proposal publication,
+issue-label changes, or migration of any other DataSourceFactory route
+consumer.
+
+## Status
+
+Ready for review.
+
+PR `#217` has been merged at
+`d25803e93494b7115795a1922a84386b9daffb27`. This closeout confirms the
+G2.69 LHB route migration remains valid on current HEAD and records the next
+gate.
+
+## Current-Head Verification
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov` | 116 passed |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov` | 4 passed |
+| `ruff check web/backend/app/api/data/lhb.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| `black --check web/backend/app/api/data/lhb.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| OpenAPI smoke with `PYTHONPATH=web/backend` and root `.env` loaded | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0 |
+
+Route/API direct factory refs:
+
+| Metric | Current HEAD |
+| --- | ---: |
+| Total direct route/API `get_data_source_factory()` refs | 8 |
+| `web/backend/app/api/data/lhb.py` direct refs | 0 |
+
+Remaining data route consumers:
+
+- `web/backend/app/api/data/kline.py` — 2 direct refs
+- `web/backend/app/api/data/futures.py` — 2 direct refs
+- `web/backend/app/api/data/stocks.py` — 2 direct refs
+
+## GitNexus
+
+| Target | Result |
+| --- | --- |
+| `web/backend/app/api/data/lhb.py` | LOW risk, 1 direct import impact, 0 affected processes |
+| `web/backend/app/services/data_source_factory` | package target lookup not indexed in this check |
+
+The provider package lookup miss is recorded as tool/indexing scope, not as a
+code contradiction. The closeout does not depend on changing provider package
+code.
+
+## Decision
+
+G2.69 implementation evidence remains valid at current HEAD. No additional
+source change is authorized by this closeout.
+
+## Next Gate
+
+Human review / PR merge decision for this closeout. If accepted, create a
+separate G2.70 candidate authorization packet before any further
+DataSourceFactory route migration. Remaining candidates stay locked until that
+authorization packet is reviewed.

--- a/governance/mainline/task-cards/pr-218.yaml
+++ b/governance/mainline/task-cards/pr-218.yaml
@@ -1,0 +1,113 @@
+version: "v0.2"
+
+task:
+  id: "pr-218"
+  title: "Close out LHB DataSourceFactory route migration"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-lhb-route-migration-closeout"
+  objective: "record current-head verification for the merged LHB DataSourceFactory route migration"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-lhb-route-migration-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-lhb-route-migration-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout records current-head evidence only and does not alter runtime behavior"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-lhb-route-migration-closeout-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-lhb-route-migration-closeout-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-218.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source or test edit"
+  - "No route path, response model, response shape, OpenAPI exposure, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No DataSourceFactory consumer migration or compatibility getter cleanup"
+  - "No selection of the next route consumer beyond requiring a separate candidate authorization packet"
+
+acceptance:
+  checks:
+    - id: "current-head-health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "current-head-provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "current-head-openapi-smoke"
+      command: "PYTHONPATH=web/backend python -c 'from dotenv import load_dotenv; load_dotenv(...) ; from app.main import app; schema=app.openapi(); ...'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-lhb-route-migration-closeout-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-lhb-route-migration-closeout-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-218.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-218.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If source files are edited, this closeout exceeds its approved evidence-only boundary"
+  rollback_plan: "revert this docs/governance-only closeout PR; merged G2.69 source implementation remains unaffected"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out the merged LHB DataSourceFactory route migration"
+    modified_scope: "closeout report, generated artifact, steward tree, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; compatibility getter and remaining route consumers are unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this closeout PR if current-head evidence is superseded or incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T02:59:42+08:00"
+    approval_note: "human maintainer accepted G2.69 implementation by merging PR #217; this packet records closeout evidence only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- record G2.69 current-head closeout for the merged LHB DataSourceFactory route migration
- confirm PR #217 merge evidence remains valid at current HEAD
- update steward tree and add closeout artifact plus mainline task card

## Evidence

- current HEAD: d25803e93494b7115795a1922a84386b9daffb27
- `web/backend/tests/test_health_route_conflicts.py`: 116 passed
- `web/backend/tests/test_data_source_factory_lifecycle_di.py`: 4 passed
- ruff/black on LHB route and focused test: passed
- route/API direct factory refs: total 8; `lhb.py` 0
- OpenAPI smoke: 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0
- GitNexus `lhb.py`: LOW/1, 0 affected processes
- staged GitNexus detect_changes: low risk, 4 governance files, 0 changed symbols
- post-commit mainline scope gate: pass, 0 violations

## Boundary

Docs/governance only. No backend source/test edit, route contract change, OpenAPI exposure change, frontend edit, runtime/PM2 operation, OpenSpec change, issue-label change, or next consumer migration.