### PR TITLE
docs(governance): authorize market data request factory route candidate

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1068,7 +1068,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                frontend, runtime/PM2, OpenSpec, issue-label, compatibility
 │   │                getter deletion, or other DataSourceFactory consumer change
 │   ├── G2.69 Closeout / current-head refresh
-│   │   ├── State: ready for review; PR `#218` closeout packet
+│   │   ├── State: accepted; PR `#218` merged at
+│   │   │          `2670dba0661d9744372e834035027ac4de106fd0`
 │   │   ├── Evidence: `backend-data-source-factory-lhb-route-migration-closeout-2026-05-25.md`
 │   │   ├── Current HEAD: `d25803e93494b7115795a1922a84386b9daffb27`
 │   │   ├── Result: confirms PR `#217` merged, health route conflict tests
@@ -1077,11 +1078,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   │          `0`, OpenAPI paths remain `500`, duplicate operation IDs
 │   │   │          remain `0`, and GitNexus reports `lhb.py` LOW/1
 │   │   └── Boundary: closeout-only; no source edit or next consumer selection
-│   └── Next gate: Human review / PR merge decision for G2.69 closeout; if
-│                  accepted, create a separate G2.70 candidate authorization
-│                  packet before any further DataSourceFactory route migration.
-│                  Remaining candidates (`kline.py`, `futures.py`, `stocks.py`,
-│                  and `market/market_data_request.py`) stay locked
+│   ├── G2.70 DataSourceFactory route candidate authorization
+│   │   ├── State: ready for review; PR `#219` candidate packet
+│   │   ├── Evidence: `backend-data-source-factory-market-data-request-route-migration-authorization-2026-05-25.md`
+│   │   ├── Current HEAD: `2670dba0661d9744372e834035027ac4de106fd0`
+│   │   ├── Result: compares the remaining four route/API consumers and selects
+│   │   │          `web/backend/app/api/market/market_data_request.py` for future
+│   │   │          G2.71 because it is the only remaining candidate with ruff
+│   │   │          pass, black pass, GitNexus LOW/1, and exactly two direct refs
+│   │   │          that can move from `2` to `0`; expected total direct refs move
+│   │   │          `8 -> 6`
+│   │   └── Boundary: authorization-only; no source edit, route contract edit,
+│   │                compatibility getter removal, frontend edit, PM2/runtime
+│   │                gate, OpenSpec change, or issue-label change is authorized
+│   └── Next gate: Human review / PR merge decision for G2.70; if accepted,
+│                  create a separate G2.71 path-limited
+│                  `market_data_request.py` implementation branch. Remaining
+│                  candidates (`kline.py`, `futures.py`, and `stocks.py`) stay
+│                  locked
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1132,6 +1146,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `inject-technical-pattern-detection-service-di` task `5.3` closeout | D2.1a.1 | Final OpenSpec checklist governance merged in PR `#113`; issue `#92` received implementation and final governance closeout comments | D2.1a is 100% closed; future DI work requires a new approved child lane |
 | `backend-data-source-factory-lhb-route-migration-implementation-2026-05-25.md` | G | G2.69 implementation packet prepared at `a76f6dbdc`: LHB route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `10 -> 8`, and `lhb.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before selecting another DataSourceFactory route consumer |
 | `backend-data-source-factory-lhb-route-migration-closeout-2026-05-25.md` | G | G2.69 closeout packet prepared at `d25803e93`: PR `#217` merge recorded, health tests remain `116 passed`, provider tests remain `4 passed`, total refs remain `8`, and `lhb.py` remains `0` | Human review / PR merge decision; if accepted, create G2.70 candidate authorization before further route migration |
+| `backend-data-source-factory-market-data-request-route-migration-authorization-2026-05-25.md` | G | G2.70 candidate packet prepared at `2670dba06`: selects `market_data_request.py` as the next route/API factory migration candidate; it is the only remaining ruff/black/GitNexus LOW candidate and can move total refs `8 -> 6` | Human review / PR merge decision; if accepted, create G2.71 path-limited implementation branch |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |
@@ -1365,6 +1380,8 @@ review, PR review, or OpenSpec archive review.
 | G2.69 LHB DataSourceFactory route migration | Ready for review | `a76f6dbd` | Path-limited implementation migrates two LHB route handlers to `get_data_source_factory_dependency`, adds focused dependency wiring coverage, moves total direct route/API factory refs `10 -> 8`, and keeps all other remaining consumers locked pending closeout |
 
 | G2.69 LHB DataSourceFactory route migration closeout | Ready for review | `d25803e9` | Current-head closeout records PR `#217` merged, keeps total direct route/API factory refs at `8`, keeps `lhb.py` at `0`, and requires G2.70 authorization-only candidate comparison before any further route migration |
+
+| G2.70 DataSourceFactory route candidate authorization | Ready for review | `2670dba0` | Candidate comparison recorded after PR `#218`: selects `market_data_request.py` for future G2.71 because it is ruff clean, black unchanged, GitNexus LOW/1, and has two direct refs; this row authorizes no source edit until human review accepts the packet |
 
 ## Update Protocol
 

--- a/.planning/codebase/generated/data-source-factory-market-data-request-route-migration-authorization-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-market-data-request-route-migration-authorization-2026-05-25.json
@@ -1,0 +1,99 @@
+{
+  "artifact": "data-source-factory-market-data-request-route-migration-authorization-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-70-data-source-factory-route-candidate-authorization",
+  "current_head": "2670dba0661d9744372e834035027ac4de106fd0",
+  "scope": {
+    "type": "authorization_only",
+    "source_edits": false,
+    "allowed_future_candidate": "web/backend/app/api/market/market_data_request.py",
+    "excluded": [
+      "backend source edits in G2.70",
+      "route path changes",
+      "OpenAPI exposure changes",
+      "frontend changes",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue label changes",
+      "compatibility getter deletion"
+    ]
+  },
+  "baseline": {
+    "tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "116 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "route_api_factory_refs": {
+      "total_direct_refs": 8,
+      "rows": [
+        {
+          "file": "web/backend/app/api/data/kline.py",
+          "direct_refs": 2,
+          "route_count": 4,
+          "ruff": "fails E701",
+          "black": "would reformat",
+          "gitnexus": "LOW/1"
+        },
+        {
+          "file": "web/backend/app/api/data/futures.py",
+          "direct_refs": 2,
+          "route_count": 2,
+          "ruff": "passed",
+          "black": "would reformat",
+          "gitnexus": "CRITICAL/151"
+        },
+        {
+          "file": "web/backend/app/api/data/stocks.py",
+          "direct_refs": 2,
+          "route_count": 5,
+          "ruff": "fails E701",
+          "black": "would reformat",
+          "gitnexus": "LOW/1"
+        },
+        {
+          "file": "web/backend/app/api/market/market_data_request.py",
+          "direct_refs": 2,
+          "route_count": 11,
+          "ruff": "passed",
+          "black": "passed",
+          "gitnexus": "LOW/1"
+        }
+      ]
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 0
+    }
+  },
+  "decision": {
+    "selected_next_candidate": {
+      "file": "web/backend/app/api/market/market_data_request.py",
+      "future_branch": "G2.71",
+      "reason": "Only remaining candidate with ruff pass, black pass, GitNexus LOW/1, and exactly two direct DataSourceFactory getter refs. Although it has 11 route handlers, the direct migration surface is two refs and no formatting debt is expected.",
+      "expected_direct_ref_change": {
+        "total": "8 -> 6",
+        "market_data_request_py": "2 -> 0"
+      }
+    },
+    "deferred_candidates": [
+      {
+        "file": "web/backend/app/api/data/kline.py",
+        "reason": "LOW/1 but current ruff fails E701 and black would reformat; requires separate style-debt handling or explicit same-file normalization authorization."
+      },
+      {
+        "file": "web/backend/app/api/data/futures.py",
+        "reason": "ruff passes, but black would reformat and GitNexus file-level impact remains CRITICAL/151; requires narrower symbol impact or separate risk review."
+      },
+      {
+        "file": "web/backend/app/api/data/stocks.py",
+        "reason": "LOW/1 but current ruff fails E701 and black would reformat; larger file and route surface should remain deferred."
+      }
+    ]
+  },
+  "next_gate": "Human review / PR merge decision for G2.70; if accepted, create a separate G2.71 path-limited implementation branch for web/backend/app/api/market/market_data_request.py."
+}

--- a/docs/reports/quality/backend-data-source-factory-market-data-request-route-migration-authorization-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-market-data-request-route-migration-authorization-2026-05-25.md
@@ -1,0 +1,86 @@
+# Backend DataSourceFactory Market Data Request Route Migration Authorization - 2026-05-25
+
+Workline: G2.70 candidate authorization packet
+
+Current HEAD: `2670dba0661d9744372e834035027ac4de106fd0`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This document records a candidate-selection decision and its
+evidence. It does not authorize backend source edits, route path changes,
+OpenAPI exposure changes, response shape changes, frontend edits, PM2/runtime
+operations, OpenSpec proposal publication, issue-label changes, compatibility
+getter deletion, or migration of any DataSourceFactory consumer in this branch.
+
+## Status
+
+Ready for review.
+
+This packet compares the remaining direct route/API `get_data_source_factory()`
+consumers after G2.69 and selects one candidate for a future implementation
+branch. It is authorization-only.
+
+## Baseline Evidence
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov` | 116 passed |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov` | 4 passed |
+| OpenAPI smoke with `PYTHONPATH=web/backend` and root `.env` loaded | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0 |
+
+Current direct route/API refs: `8`.
+
+## Candidate Matrix
+
+| Candidate | Direct refs | Route count | Ruff | Black | GitNexus | Disposition |
+| --- | ---: | ---: | --- | --- | --- | --- |
+| `web/backend/app/api/market/market_data_request.py` | 2 | 11 | pass | pass | LOW/1 | Select for future G2.71 |
+| `web/backend/app/api/data/kline.py` | 2 | 4 | fails E701 | would reformat | LOW/1 | Defer |
+| `web/backend/app/api/data/futures.py` | 2 | 2 | pass | would reformat | CRITICAL/151 | Defer |
+| `web/backend/app/api/data/stocks.py` | 2 | 5 | fails E701 | would reformat | LOW/1 | Defer |
+
+`market_data_request.py` has the broadest route count, but the direct migration
+surface is exactly two getter refs, it has no ruff/black debt at current HEAD,
+and GitNexus reports LOW/1. That makes it the cleanest next implementation
+candidate.
+
+## Decision
+
+Select `web/backend/app/api/market/market_data_request.py` for future G2.71.
+
+Expected future direct ref movement:
+
+| Metric | Before future G2.71 | Expected after future G2.71 |
+| --- | ---: | ---: |
+| Total direct route/API `get_data_source_factory()` refs | 8 | 6 |
+| `web/backend/app/api/market/market_data_request.py` direct refs | 2 | 0 |
+
+## Deferred Candidates
+
+- `web/backend/app/api/data/kline.py`: LOW/1, but current ruff fails E701 and
+  black would reformat. It needs separate style-debt handling or explicit
+  same-file normalization authorization.
+- `web/backend/app/api/data/futures.py`: ruff passes, but black would reformat
+  and GitNexus file-level impact remains CRITICAL/151. It needs narrower symbol
+  impact or separate risk review.
+- `web/backend/app/api/data/stocks.py`: LOW/1, but current ruff fails E701 and
+  black would reformat. It also has a larger route/file surface than `kline.py`.
+
+## Authorized Future Scope
+
+If this packet is accepted, a future G2.71 implementation branch may be created
+with source scope limited to:
+
+- `web/backend/app/api/market/market_data_request.py`
+- a focused route dependency wiring test
+- implementation evidence
+- steward tree update
+- mainline task card
+
+No source edit is authorized by G2.70 itself.
+
+## Next Gate
+
+Human review / PR merge decision for G2.70. If accepted, create a separate
+G2.71 path-limited implementation branch for
+`web/backend/app/api/market/market_data_request.py`.

--- a/governance/mainline/task-cards/pr-219.yaml
+++ b/governance/mainline/task-cards/pr-219.yaml
@@ -1,0 +1,113 @@
+version: "v0.2"
+
+task:
+  id: "pr-219"
+  title: "Authorize market data request DataSourceFactory route candidate"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-market-data-request-route-authorization"
+  objective: "select the next DataSourceFactory route migration candidate after LHB closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-market-data-request-route-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-market-data-request-route-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization packet records evidence and future scope only; no runtime behavior changes"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-market-data-request-route-migration-authorization-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-market-data-request-route-migration-authorization-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-219.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source or test edit"
+  - "No route path, response model, response shape, OpenAPI exposure, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No DataSourceFactory consumer migration or compatibility getter cleanup"
+  - "No implementation work for market_data_request.py until a separate G2.71 branch is created after review"
+
+acceptance:
+  checks:
+    - id: "baseline-health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "baseline-provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "candidate-style-and-risk-scan"
+      command: "ruff/black/GitNexus candidate scan across remaining direct DataSourceFactory route consumers"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-market-data-request-route-migration-authorization-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-market-data-request-route-migration-authorization-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-219.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-219.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If source files are edited, this authorization packet exceeds its approved evidence-only boundary"
+  rollback_plan: "revert this docs/governance-only authorization PR; no runtime code is affected"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize the next DataSourceFactory route migration candidate"
+    modified_scope: "authorization report, generated artifact, steward tree, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; compatibility getter and all source files are unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this authorization PR if candidate evidence is superseded or incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T03:09:23+08:00"
+    approval_note: "human maintainer accepted G2.69 closeout by merging PR #218; this packet selects the next candidate only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- add G2.70 DataSourceFactory route candidate authorization packet
- select `web/backend/app/api/market/market_data_request.py` for future G2.71 migration
- update steward tree and add generated artifact plus mainline task card

## Evidence

- baseline tests: health route conflicts 116 passed; DataSourceFactory lifecycle DI 4 passed
- OpenAPI smoke: 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0
- remaining direct route/API factory refs: 8 across kline.py, futures.py, stocks.py, market_data_request.py
- selected candidate: `market_data_request.py`, 2 direct refs, 11 routes, ruff pass, black pass, GitNexus LOW/1
- deferred: `kline.py` and `stocks.py` due E701/black debt; `futures.py` due black debt plus GitNexus CRITICAL/151
- staged GitNexus detect_changes: low risk, 4 governance files, 0 changed symbols
- post-commit mainline scope gate: pass, 0 violations

## Boundary

Docs/governance only. No backend source/test edit, route contract change, OpenAPI exposure change, frontend edit, runtime/PM2 operation, OpenSpec change, issue-label change, compatibility getter deletion, or implementation work in this branch.