### PR TITLE
refactor(api): inject data source factory into market request routes

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1079,7 +1079,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   │          remain `0`, and GitNexus reports `lhb.py` LOW/1
 │   │   └── Boundary: closeout-only; no source edit or next consumer selection
 │   ├── G2.70 DataSourceFactory route candidate authorization
-│   │   ├── State: ready for review; PR `#219` candidate packet
+│   │   ├── State: accepted; PR `#219` merged at
+│   │   │          `9060b455b7559ce21bc6f27975cce058be52cb96`
 │   │   ├── Evidence: `backend-data-source-factory-market-data-request-route-migration-authorization-2026-05-25.md`
 │   │   ├── Current HEAD: `2670dba0661d9744372e834035027ac4de106fd0`
 │   │   ├── Result: compares the remaining four route/API consumers and selects
@@ -1091,9 +1092,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: authorization-only; no source edit, route contract edit,
 │   │                compatibility getter removal, frontend edit, PM2/runtime
 │   │                gate, OpenSpec change, or issue-label change is authorized
-│   └── Next gate: Human review / PR merge decision for G2.70; if accepted,
-│                  create a separate G2.71 path-limited
-│                  `market_data_request.py` implementation branch. Remaining
+│   ├── G2.71 Market data request DataSourceFactory route migration
+│   │   ├── State: ready for review; PR `#220` implementation packet
+│   │   ├── Evidence: `backend-data-source-factory-market-data-request-route-migration-implementation-2026-05-25.md`
+│   │   ├── Current HEAD: `9060b455b7559ce21bc6f27975cce058be52cb96`
+│   │   ├── Result: migrates `get_fund_flow` and `get_market_quotes` from
+│   │   │          direct `get_data_source_factory()` calls to
+│   │   │          `Depends(get_data_source_factory_dependency)`; total route/API
+│   │   │          direct refs move `8 -> 6`,
+│   │   │          `market_data_request.py` direct refs move `2 -> 0`, health
+│   │   │          route conflict tests move to `117 passed`, provider tests
+│   │   │          remain `4 passed`, OpenAPI paths remain `500`, and duplicate
+│   │   │          operation IDs remain `0`
+│   │   └── Boundary: no route path, response model, response shape, OpenAPI,
+│   │                frontend, runtime/PM2, OpenSpec, issue-label, compatibility
+│   │                getter deletion, or other DataSourceFactory consumer change
+│   └── Next gate: Human review / PR merge decision for G2.71; if accepted,
+│                  create a separate closeout/current-head refresh before any
+│                  further DataSourceFactory route migration. Remaining
 │                  candidates (`kline.py`, `futures.py`, and `stocks.py`) stay
 │                  locked
 │
@@ -1147,6 +1163,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-lhb-route-migration-implementation-2026-05-25.md` | G | G2.69 implementation packet prepared at `a76f6dbdc`: LHB route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `10 -> 8`, and `lhb.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before selecting another DataSourceFactory route consumer |
 | `backend-data-source-factory-lhb-route-migration-closeout-2026-05-25.md` | G | G2.69 closeout packet prepared at `d25803e93`: PR `#217` merge recorded, health tests remain `116 passed`, provider tests remain `4 passed`, total refs remain `8`, and `lhb.py` remains `0` | Human review / PR merge decision; if accepted, create G2.70 candidate authorization before further route migration |
 | `backend-data-source-factory-market-data-request-route-migration-authorization-2026-05-25.md` | G | G2.70 candidate packet prepared at `2670dba06`: selects `market_data_request.py` as the next route/API factory migration candidate; it is the only remaining ruff/black/GitNexus LOW candidate and can move total refs `8 -> 6` | Human review / PR merge decision; if accepted, create G2.71 path-limited implementation branch |
+| `backend-data-source-factory-market-data-request-route-migration-implementation-2026-05-25.md` | G | G2.71 implementation packet prepared at `9060b455`: market data request route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `8 -> 6`, and `market_data_request.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before selecting another DataSourceFactory route consumer |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |
@@ -1382,6 +1399,8 @@ review, PR review, or OpenSpec archive review.
 | G2.69 LHB DataSourceFactory route migration closeout | Ready for review | `d25803e9` | Current-head closeout records PR `#217` merged, keeps total direct route/API factory refs at `8`, keeps `lhb.py` at `0`, and requires G2.70 authorization-only candidate comparison before any further route migration |
 
 | G2.70 DataSourceFactory route candidate authorization | Ready for review | `2670dba0` | Candidate comparison recorded after PR `#218`: selects `market_data_request.py` for future G2.71 because it is ruff clean, black unchanged, GitNexus LOW/1, and has two direct refs; this row authorizes no source edit until human review accepts the packet |
+
+| G2.71 market data request DataSourceFactory route migration | Ready for review | `9060b455` | Path-limited implementation migrates `get_fund_flow` and `get_market_quotes` to `get_data_source_factory_dependency`, adds focused dependency wiring coverage, moves total direct route/API factory refs `8 -> 6`, and keeps all other remaining consumers locked pending closeout |
 
 ## Update Protocol
 

--- a/.planning/codebase/generated/data-source-factory-market-data-request-route-migration-implementation-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-market-data-request-route-migration-implementation-2026-05-25.json
@@ -1,0 +1,137 @@
+{
+  "artifact": "data-source-factory-market-data-request-route-migration-implementation-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-71-market-data-request-route-factory-migration",
+  "base_head": "9060b455b7559ce21bc6f27975cce058be52cb96",
+  "scope": {
+    "source_files": [
+      "web/backend/app/api/market/market_data_request.py",
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "governance_files": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/data-source-factory-market-data-request-route-migration-implementation-2026-05-25.json",
+      "docs/reports/quality/backend-data-source-factory-market-data-request-route-migration-implementation-2026-05-25.md",
+      "governance/mainline/task-cards/pr-220.yaml"
+    ],
+    "excluded": [
+      "route paths",
+      "response models",
+      "response shape",
+      "OpenAPI exposure policy",
+      "frontend",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue labels",
+      "other DataSourceFactory consumers",
+      "DataSourceFactory compatibility getter removal"
+    ]
+  },
+  "pre_edit_evidence": {
+    "gitnexus": {
+      "file": {
+        "target": "web/backend/app/api/market/market_data_request.py",
+        "risk": "LOW",
+        "direct_impacted": 1,
+        "processes_affected": 0
+      },
+      "functions": [
+        {
+          "target": "get_market_quotes",
+          "risk": "LOW",
+          "direct_impacted": 0,
+          "processes_affected": 0
+        },
+        {
+          "target": "get_fund_flow",
+          "note": "Function name is ambiguous in GitNexus impact; path-specific context for web/backend/app/api/market/market_data_request.py:get_fund_flow reported no incoming references and the outgoing get_data_source_factory call."
+        }
+      ]
+    },
+    "baseline_tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "116 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "baseline_style": {
+      "ruff_market_data_request": "passed",
+      "black_market_data_request": "passed"
+    },
+    "baseline_route_api_factory_refs": {
+      "total_direct_refs": 8,
+      "market_data_request_py_direct_refs": 2
+    }
+  },
+  "tdd": {
+    "red": {
+      "command": "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_market_data_request_routes_use_data_source_factory_dependency -q --no-cov --tb=short",
+      "result": "failed as expected",
+      "failure": "KeyError: 'factory'"
+    },
+    "green": {
+      "command": "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_market_data_request_routes_use_data_source_factory_dependency -q --no-cov --tb=short",
+      "result": "1 passed"
+    }
+  },
+  "implementation": {
+    "migrated_route_handlers": [
+      "get_fund_flow",
+      "get_market_quotes"
+    ],
+    "dependency": "Depends(get_data_source_factory_dependency)",
+    "factory_type": "DataSourceFactory",
+    "removed_inline_calls": [
+      "await get_data_source_factory() in get_fund_flow",
+      "await get_data_source_factory() in get_market_quotes"
+    ],
+    "compatibility_surfaces_retained": [
+      "get_data_source_factory()",
+      "_global_factory",
+      "get_data_source_factory_dependency"
+    ]
+  },
+  "post_change_evidence": {
+    "tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "117 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "style": {
+      "ruff_touched_files": "passed",
+      "black_touched_files": "passed"
+    },
+    "route_api_factory_refs": {
+      "total_direct_refs": 6,
+      "market_data_request_py_direct_refs": 0,
+      "remaining_data_route_consumers": [
+        {
+          "file": "web/backend/app/api/data/kline.py",
+          "direct_refs": 2
+        },
+        {
+          "file": "web/backend/app/api/data/futures.py",
+          "direct_refs": 2
+        },
+        {
+          "file": "web/backend/app/api/data/stocks.py",
+          "direct_refs": 2
+        }
+      ]
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 0
+    },
+    "staged_gitnexus": {
+      "risk_level": "high",
+      "changed_files": 6,
+      "changed_symbols": 36,
+      "affected_processes": 6,
+      "interpretation": "The staged diff itself is limited to import wiring, get_fund_flow, get_market_quotes, and one focused test. GitNexus marked same-file functions and get_kline_data flows as changed because the parser attributed the file edit broadly; no get_kline_data hunk is present in git diff."
+    }
+  },
+  "next_gate": "Human review / PR merge decision for G2.71, then a separate closeout/current-head refresh before any further DataSourceFactory route migration."
+}

--- a/docs/reports/quality/backend-data-source-factory-market-data-request-route-migration-implementation-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-market-data-request-route-migration-implementation-2026-05-25.md
@@ -1,0 +1,125 @@
+# Backend DataSourceFactory Market Data Request Route Migration Implementation - 2026-05-25
+
+Workline: G2.71 implementation packet
+
+Current HEAD: `9060b455b7559ce21bc6f27975cce058be52cb96`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This document records one path-limited source implementation and
+its evidence. It does not authorize route path changes, OpenAPI exposure
+changes, response shape changes, frontend edits, PM2/runtime operations,
+OpenSpec proposal publication, issue-label changes, or migration of any other
+DataSourceFactory route consumer.
+
+## Status
+
+Ready for review.
+
+This is the G2.71 implementation packet authorized by the G2.70
+`market_data_request.py` candidate selection.
+
+## Pre-Edit Evidence
+
+| Target | Result |
+| --- | --- |
+| `web/backend/app/api/market/market_data_request.py` | GitNexus LOW/1, 0 affected processes |
+| `get_market_quotes` | GitNexus LOW/0 |
+| `get_fund_flow` | Name ambiguous in GitNexus impact; path-specific context reported no incoming refs |
+
+Baseline verification:
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov` | 116 passed |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov` | 4 passed |
+| `ruff check web/backend/app/api/market/market_data_request.py` | passed |
+| `black --check web/backend/app/api/market/market_data_request.py` | passed |
+
+## TDD Evidence
+
+Red test:
+
+```text
+pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_market_data_request_routes_use_data_source_factory_dependency -q --no-cov --tb=short
+```
+
+Result: failed as expected with `KeyError: 'factory'`.
+
+Green test:
+
+```text
+pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_market_data_request_routes_use_data_source_factory_dependency -q --no-cov --tb=short
+```
+
+Result: `1 passed`.
+
+## Implementation
+
+Migrated route handlers:
+
+- `get_fund_flow`
+- `get_market_quotes`
+
+Both handlers now receive:
+
+```python
+factory: DataSourceFactory = Depends(get_data_source_factory_dependency)
+```
+
+The route-local `from app.services.data_source_factory import get_data_source_factory`
+imports and `await get_data_source_factory()` calls were removed from both
+handlers. Compatibility surfaces remain intact:
+
+- `get_data_source_factory()`
+- `_global_factory`
+- `get_data_source_factory_dependency`
+
+## Verification
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov` | 117 passed |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov` | 4 passed |
+| `ruff check web/backend/app/api/market/market_data_request.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| `black --check web/backend/app/api/market/market_data_request.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| OpenAPI smoke with `PYTHONPATH=web/backend` and root `.env` loaded | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0 |
+| staged GitNexus `detect_changes(scope=staged)` | HIGH, 36 changed symbols, 6 affected processes |
+
+Route/API direct factory refs:
+
+| Metric | Before | After |
+| --- | ---: | ---: |
+| Total direct route/API `get_data_source_factory()` refs | 8 | 6 |
+| `web/backend/app/api/market/market_data_request.py` direct refs | 2 | 0 |
+
+Remaining route consumers stay locked for future authorization:
+
+- `web/backend/app/api/data/kline.py`
+- `web/backend/app/api/data/futures.py`
+- `web/backend/app/api/data/stocks.py`
+
+Staged GitNexus reports HIGH because the parser attributed the
+`market_data_request.py` file edit broadly and listed same-file functions plus
+`get_kline_data` processes as changed. The reviewed staged diff is limited to
+one import, the `get_fund_flow` and `get_market_quotes` dependency parameters,
+removal of their two route-local getter calls, and one focused test. There is
+no `get_kline_data` hunk in `git diff --cached`.
+
+## Boundary
+
+This packet does not authorize:
+
+- route path, response model, response shape, or OpenAPI exposure changes
+- frontend edits
+- runtime/PM2 stateful gates
+- OpenSpec changes
+- issue label changes
+- `get_data_source_factory()` or `_global_factory` deletion
+- migration of `kline.py`, `futures.py`, `stocks.py`, or any other consumer
+
+## Next Gate
+
+Human review / PR merge decision for G2.71. After merge, create a separate
+closeout/current-head refresh before any additional DataSourceFactory route
+migration.

--- a/governance/mainline/task-cards/pr-220.yaml
+++ b/governance/mainline/task-cards/pr-220.yaml
@@ -1,0 +1,127 @@
+version: "v0.2"
+
+task:
+  id: "pr-220"
+  title: "Migrate market data request routes to DataSourceFactory dependency injection"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-market-data-request-route-migration"
+  objective: "move market data request route DataSourceFactory access from compatibility getter calls to FastAPI dependency injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-market-data-request-route-migration"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-market-data-request-route-migration"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Implementation changes dependency acquisition only and preserves route paths, OpenAPI exposure, response shape, and runtime semantics"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/api/market/market_data_request.py"
+    - "web/backend/tests/test_health_route_conflicts.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-market-data-request-route-migration-implementation-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-market-data-request-route-migration-implementation-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-220.yaml"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+    - "web/backend/app/api/data/futures.py"
+    - "web/backend/app/api/data/kline.py"
+    - "web/backend/app/api/data/stocks.py"
+
+non_goals:
+  - "No route path, response model, response shape, OpenAPI exposure, docs/API, generated client, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No non-market_data_request.py DataSourceFactory route consumer migration"
+  - "No deletion of get_data_source_factory() or _global_factory compatibility surfaces"
+  - "No broad formatting cleanup outside web/backend/app/api/market/market_data_request.py and the focused test file"
+
+acceptance:
+  checks:
+    - id: "pre-edit-gitnexus-impact"
+      command: "MCP gitnexus.impact(target=web/backend/app/api/market/market_data_request.py,direction=upstream)"
+      required: true
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_market_data_request_routes_use_data_source_factory_dependency -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-files"
+      command: "ruff check web/backend/app/api/market/market_data_request.py web/backend/tests/test_health_route_conflicts.py"
+      required: true
+    - id: "black-touched-files"
+      command: "black --check web/backend/app/api/market/market_data_request.py web/backend/tests/test_health_route_conflicts.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-market-data-request-route-migration-implementation-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-market-data-request-route-migration-implementation-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-220.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-220.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If response shape or route paths change, the PR exceeds the approved G2.71 boundary"
+    - "If another route consumer is edited, the PR bypasses G2.70 candidate sequencing"
+  rollback_plan: "revert this path-limited PR; compatibility getter surfaces remain available and no route contract changes are introduced"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "migrate market data request route DataSourceFactory access to dependency injection"
+    modified_scope: "market data request route file, focused route-conflict test, implementation report, generated artifact, steward tree, and task card"
+    dependency_changes: "uses existing get_data_source_factory_dependency provider"
+    legacy_logic_impact: "compatibility getter and _global_factory remain unchanged for other consumers"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if dependency wiring or route guard verification fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T03:19:13+08:00"
+    approval_note: "human maintainer accepted G2.70 candidate selection by merging PR #219; this packet implements only the approved market_data_request.py route migration"
+    secondary_approved: false

--- a/web/backend/app/api/market/market_data_request.py
+++ b/web/backend/app/api/market/market_data_request.py
@@ -34,6 +34,7 @@ from app.schemas.market_schemas import (
     LongHuBangResponse,
     MessageResponse,
 )
+from app.services.data_source_factory import DataSourceFactory, get_data_source_factory_dependency
 from app.services.market_data_service import MarketDataService, get_market_data_service_dependency
 from app.services.stock_search_service import StockSearchService, get_stock_search_service_dependency
 
@@ -79,6 +80,7 @@ async def get_fund_flow(
     start_date: Optional[str] = Query(None, description="开始日期 YYYY-MM-DD"),
     end_date: Optional[str] = Query(None, description="结束日期 YYYY-MM-DD"),
     # current_user: User = Depends(get_current_user),  # Temporarily disable auth for debugging
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
 ):
     """
     查询个股资金流向历史数据（使用数据源工厂）
@@ -127,11 +129,6 @@ async def get_fund_flow(
             return create_success_response(
                 data={"fund_flow": [], "total": 0}, message="市场数据服务暂不可用，请稍后重试"
             )
-
-        # 使用数据源工厂获取市场数据
-        from app.services.data_source_factory import get_data_source_factory
-
-        factory = await get_data_source_factory()
 
         # 调用数据源工厂获取fund-flow数据
         try:
@@ -409,6 +406,7 @@ async def refresh_lhb_detail(
 @cache_response("real_time_quotes", ttl=10)  # 🚀 添加10秒缓存（平衡实时性）
 async def get_market_quotes(
     symbols: Optional[str] = Query(None, description="股票代码列表，逗号分隔，如: 000001,600519"),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
 ):
     """
     获取实时市场行情数据（使用数据源工厂）
@@ -421,11 +419,6 @@ async def get_market_quotes(
     **返回**: 实时行情列表
     """
     try:
-        # 使用数据源工厂获取市场数据
-        from app.services.data_source_factory import get_data_source_factory
-
-        factory = await get_data_source_factory()
-
         # 如果未指定股票代码，返回热门股票
         if not symbols:
             symbols = "000001,600519,000858,601318,600036"  # 平安、茅台、五粮液、平安保险、招商银行

--- a/web/backend/tests/test_health_route_conflicts.py
+++ b/web/backend/tests/test_health_route_conflicts.py
@@ -9,6 +9,7 @@ from app.api.data import financial as financial_module
 from app.api.data import lhb as lhb_module
 from app.api.data import margin as margin_module
 from app.api.data import market as market_module
+from app.api.market import market_data_request as market_data_request_module
 from app.main import app
 
 
@@ -74,6 +75,19 @@ def test_lhb_routes_use_data_source_factory_dependency() -> None:
         factory_param = inspect.signature(route_handler).parameters["factory"]
 
         assert getattr(factory_param.default, "dependency", None) is lhb_module.get_data_source_factory_dependency
+
+
+def test_market_data_request_routes_use_data_source_factory_dependency() -> None:
+    for route_handler in [
+        market_data_request_module.get_fund_flow,
+        market_data_request_module.get_market_quotes,
+    ]:
+        factory_param = inspect.signature(route_handler).parameters["factory"]
+
+        assert (
+            getattr(factory_param.default, "dependency", None)
+            is market_data_request_module.get_data_source_factory_dependency
+        )
 
 
 def test_root_and_socketio_status_have_documented_examples_and_errors() -> None:


### PR DESCRIPTION
## Summary

- migrate `get_fund_flow` and `get_market_quotes` in `market_data_request.py` to `Depends(get_data_source_factory_dependency)`
- add focused dependency wiring coverage
- update steward tree, generated evidence artifact, implementation report, and mainline task card

## Evidence

- pre-edit GitNexus: `market_data_request.py` LOW/1; `get_market_quotes` LOW/0; path-specific `get_fund_flow` context had no incoming refs
- TDD red: focused test failed with `KeyError: 'factory'`
- TDD green: focused test 1 passed
- `web/backend/tests/test_health_route_conflicts.py`: 117 passed
- `web/backend/tests/test_data_source_factory_lifecycle_di.py`: 4 passed
- ruff/black touched files: passed
- route/API direct factory refs: total 8 -> 6; `market_data_request.py` 2 -> 0
- OpenAPI smoke: 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0
- staged GitNexus detect_changes: HIGH due broad file-level attribution; cached diff contains only import wiring, two target handlers, and one focused test, with no `get_kline_data` hunk
- post-commit mainline scope gate: pass, 0 violations

## Boundary

No route path, response model, response shape, OpenAPI exposure, frontend, runtime/PM2, OpenSpec, issue-label, compatibility getter deletion, or other DataSourceFactory consumer changes.