### PR TITLE
docs(governance): close out market request factory route migration

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1093,7 +1093,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                compatibility getter removal, frontend edit, PM2/runtime
 │   │                gate, OpenSpec change, or issue-label change is authorized
 │   ├── G2.71 Market data request DataSourceFactory route migration
-│   │   ├── State: ready for review; PR `#220` implementation packet
+│   │   ├── State: accepted; PR `#220` merged at
+│   │   │          `7f10db172b99b0d9d85fc740ffb00fa535bd4071`
 │   │   ├── Evidence: `backend-data-source-factory-market-data-request-route-migration-implementation-2026-05-25.md`
 │   │   ├── Current HEAD: `9060b455b7559ce21bc6f27975cce058be52cb96`
 │   │   ├── Result: migrates `get_fund_flow` and `get_market_quotes` from
@@ -1107,11 +1108,22 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: no route path, response model, response shape, OpenAPI,
 │   │                frontend, runtime/PM2, OpenSpec, issue-label, compatibility
 │   │                getter deletion, or other DataSourceFactory consumer change
-│   └── Next gate: Human review / PR merge decision for G2.71; if accepted,
-│                  create a separate closeout/current-head refresh before any
-│                  further DataSourceFactory route migration. Remaining
-│                  candidates (`kline.py`, `futures.py`, and `stocks.py`) stay
-│                  locked
+│   ├── G2.71 Closeout / current-head refresh
+│   │   ├── State: ready for review; PR `#221` closeout packet
+│   │   ├── Evidence: `backend-data-source-factory-market-data-request-route-migration-closeout-2026-05-25.md`
+│   │   ├── Current HEAD: `7f10db172b99b0d9d85fc740ffb00fa535bd4071`
+│   │   ├── Result: confirms PR `#220` merged, health route conflict tests
+│   │   │          remain `117 passed`, provider tests remain `4 passed`,
+│   │   │          route direct refs remain `6`, `market_data_request.py`
+│   │   │          direct refs remain `0`, OpenAPI paths remain `500`,
+│   │   │          duplicate operation IDs remain `0`, and GitNexus reports
+│   │   │          `market_data_request.py` LOW/1
+│   │   └── Boundary: closeout-only; no source edit or next consumer selection
+│   └── Next gate: Human review / PR merge decision for G2.71 closeout; if
+│                  accepted, create a separate candidate authorization packet
+│                  before any further DataSourceFactory route migration.
+│                  Remaining candidates (`kline.py`, `futures.py`, and
+│                  `stocks.py`) stay locked
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1164,6 +1176,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-lhb-route-migration-closeout-2026-05-25.md` | G | G2.69 closeout packet prepared at `d25803e93`: PR `#217` merge recorded, health tests remain `116 passed`, provider tests remain `4 passed`, total refs remain `8`, and `lhb.py` remains `0` | Human review / PR merge decision; if accepted, create G2.70 candidate authorization before further route migration |
 | `backend-data-source-factory-market-data-request-route-migration-authorization-2026-05-25.md` | G | G2.70 candidate packet prepared at `2670dba06`: selects `market_data_request.py` as the next route/API factory migration candidate; it is the only remaining ruff/black/GitNexus LOW candidate and can move total refs `8 -> 6` | Human review / PR merge decision; if accepted, create G2.71 path-limited implementation branch |
 | `backend-data-source-factory-market-data-request-route-migration-implementation-2026-05-25.md` | G | G2.71 implementation packet prepared at `9060b455`: market data request route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `8 -> 6`, and `market_data_request.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before selecting another DataSourceFactory route consumer |
+| `backend-data-source-factory-market-data-request-route-migration-closeout-2026-05-25.md` | G | G2.71 closeout packet prepared at `7f10db17`: PR `#220` merge recorded, health tests remain `117 passed`, provider tests remain `4 passed`, total refs remain `6`, and `market_data_request.py` remains `0` | Human review / PR merge decision; if accepted, create the next candidate authorization packet |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |
@@ -1401,6 +1414,8 @@ review, PR review, or OpenSpec archive review.
 | G2.70 DataSourceFactory route candidate authorization | Ready for review | `2670dba0` | Candidate comparison recorded after PR `#218`: selects `market_data_request.py` for future G2.71 because it is ruff clean, black unchanged, GitNexus LOW/1, and has two direct refs; this row authorizes no source edit until human review accepts the packet |
 
 | G2.71 market data request DataSourceFactory route migration | Ready for review | `9060b455` | Path-limited implementation migrates `get_fund_flow` and `get_market_quotes` to `get_data_source_factory_dependency`, adds focused dependency wiring coverage, moves total direct route/API factory refs `8 -> 6`, and keeps all other remaining consumers locked pending closeout |
+
+| G2.71 market data request DataSourceFactory route migration closeout | Ready for review | `7f10db17` | Current-head closeout records PR `#220` merged, keeps total direct route/API factory refs at `6`, keeps `market_data_request.py` at `0`, and requires a new authorization-only candidate comparison before any further route migration |
 
 ## Update Protocol
 

--- a/.planning/codebase/generated/data-source-factory-market-data-request-route-migration-closeout-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-market-data-request-route-migration-closeout-2026-05-25.json
@@ -1,0 +1,76 @@
+{
+  "artifact": "data-source-factory-market-data-request-route-migration-closeout-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-71-market-data-request-route-migration-closeout",
+  "current_head": "7f10db172b99b0d9d85fc740ffb00fa535bd4071",
+  "source_pr": {
+    "number": 220,
+    "merge_commit": "7f10db172b99b0d9d85fc740ffb00fa535bd4071",
+    "title": "refactor(api): inject data source factory into market request routes"
+  },
+  "scope": {
+    "files": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/data-source-factory-market-data-request-route-migration-closeout-2026-05-25.json",
+      "docs/reports/quality/backend-data-source-factory-market-data-request-route-migration-closeout-2026-05-25.md",
+      "governance/mainline/task-cards/pr-221.yaml"
+    ],
+    "excluded": [
+      "backend source edits",
+      "backend test edits",
+      "route path changes",
+      "OpenAPI exposure changes",
+      "frontend changes",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue label changes",
+      "next DataSourceFactory consumer migration"
+    ]
+  },
+  "verification": {
+    "tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "117 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "style": {
+      "ruff_market_request_and_health_test": "passed",
+      "black_market_request_and_health_test": "passed"
+    },
+    "route_api_factory_refs": {
+      "total_direct_refs": 6,
+      "market_data_request_py_direct_refs": 0,
+      "remaining_consumers": [
+        {
+          "file": "web/backend/app/api/data/kline.py",
+          "direct_refs": 2
+        },
+        {
+          "file": "web/backend/app/api/data/futures.py",
+          "direct_refs": 2
+        },
+        {
+          "file": "web/backend/app/api/data/stocks.py",
+          "direct_refs": 2
+        }
+      ]
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "warning_count": 0
+    },
+    "gitnexus": {
+      "market_data_request_py": {
+        "risk": "LOW",
+        "direct_impacted": 1,
+        "processes_affected": 0
+      }
+    }
+  },
+  "decision": "G2.71 implementation evidence remains valid at current HEAD. No additional source change is authorized by this closeout.",
+  "next_gate": "Human review / PR merge decision for this closeout, then a separate candidate authorization packet before any further DataSourceFactory route migration."
+}

--- a/docs/reports/quality/backend-data-source-factory-market-data-request-route-migration-closeout-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-market-data-request-route-migration-closeout-2026-05-25.md
@@ -1,0 +1,63 @@
+# Backend DataSourceFactory Market Data Request Route Migration Closeout - 2026-05-25
+
+Workline: G2.71 closeout / current-head refresh
+
+Current HEAD: `7f10db172b99b0d9d85fc740ffb00fa535bd4071`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This document records a closeout/current-head refresh for one
+already merged source implementation. It does not authorize backend source
+edits, route path changes, OpenAPI exposure changes, response shape changes,
+frontend edits, PM2/runtime operations, OpenSpec proposal publication,
+issue-label changes, or migration of any other DataSourceFactory route
+consumer.
+
+## Status
+
+Ready for review.
+
+PR `#220` has been merged at
+`7f10db172b99b0d9d85fc740ffb00fa535bd4071`. This closeout confirms the G2.71
+market data request route migration remains valid on current HEAD.
+
+## Current-Head Verification
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov` | 117 passed |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov` | 4 passed |
+| `ruff check web/backend/app/api/market/market_data_request.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| `black --check web/backend/app/api/market/market_data_request.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| OpenAPI smoke with `PYTHONPATH=web/backend` and root `.env` loaded | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0 |
+
+Route/API direct factory refs:
+
+| Metric | Current HEAD |
+| --- | ---: |
+| Total direct route/API `get_data_source_factory()` refs | 6 |
+| `web/backend/app/api/market/market_data_request.py` direct refs | 0 |
+
+Remaining consumers:
+
+- `web/backend/app/api/data/kline.py` — 2 direct refs
+- `web/backend/app/api/data/futures.py` — 2 direct refs
+- `web/backend/app/api/data/stocks.py` — 2 direct refs
+
+## GitNexus
+
+| Target | Result |
+| --- | --- |
+| `web/backend/app/api/market/market_data_request.py` | LOW risk, 1 direct import impact, 0 affected processes |
+
+## Decision
+
+G2.71 implementation evidence remains valid at current HEAD. No additional
+source change is authorized by this closeout.
+
+## Next Gate
+
+Human review / PR merge decision for this closeout. If accepted, create a
+separate candidate authorization packet before any further DataSourceFactory
+route migration. The remaining consumers stay locked until that packet is
+reviewed.

--- a/governance/mainline/task-cards/pr-221.yaml
+++ b/governance/mainline/task-cards/pr-221.yaml
@@ -1,0 +1,109 @@
+version: "v0.2"
+
+task:
+  id: "pr-221"
+  title: "Close out market data request DataSourceFactory route migration"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-market-data-request-route-migration-closeout"
+  objective: "record current-head verification for the merged market data request DataSourceFactory route migration"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-market-data-request-route-migration-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-market-data-request-route-migration-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout records current-head evidence only and does not alter runtime behavior"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-market-data-request-route-migration-closeout-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-market-data-request-route-migration-closeout-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-221.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source or test edit"
+  - "No route path, response model, response shape, OpenAPI exposure, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No DataSourceFactory consumer migration or compatibility getter cleanup"
+
+acceptance:
+  checks:
+    - id: "current-head-health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "current-head-provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-market-data-request-route-migration-closeout-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-market-data-request-route-migration-closeout-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-221.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-221.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If source files are edited, this closeout exceeds its approved evidence-only boundary"
+  rollback_plan: "revert this docs/governance-only closeout PR; merged G2.71 source implementation remains unaffected"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out the merged market data request DataSourceFactory route migration"
+    modified_scope: "closeout report, generated artifact, steward tree, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; compatibility getter and remaining route consumers are unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this closeout PR if current-head evidence is superseded or incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T03:40:20+08:00"
+    approval_note: "human maintainer accepted G2.71 implementation by merging PR #220; this packet records closeout evidence only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- close out merged G2.71 market data request DataSourceFactory route migration
- confirm current-head evidence remains stable after PR #220
- update steward tree and add closeout artifact plus mainline task card

## Evidence

- current HEAD: 7f10db172b99b0d9d85fc740ffb00fa535bd4071
- health route conflicts: 117 passed
- DataSourceFactory lifecycle DI: 4 passed
- ruff/black touched files: passed
- route/API direct factory refs: total 6; market_data_request.py 0
- OpenAPI smoke: 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0
- GitNexus market_data_request.py: LOW/1, 0 affected processes
- staged GitNexus detect_changes: low risk, 4 governance files, 0 changed symbols
- post-commit mainline scope gate: pass, 0 violations

## Boundary

Docs/governance only. No backend source/test edit, route contract change, OpenAPI exposure change, frontend edit, runtime/PM2 operation, OpenSpec change, issue-label change, or next consumer migration.