### PR TITLE
refactor(api): migrate kline factory dependency

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1121,7 +1121,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   │          `market_data_request.py` LOW/1
 │   │   └── Boundary: closeout-only; no source edit or next consumer selection
 │   ├── G2.72 DataSourceFactory route candidate authorization
-│   │   ├── State: ready for review; PR `#222` candidate packet
+│   │   ├── State: accepted; PR `#222` merged at
+│   │   │          `68ff82a9257fb7bee7bbb7aefe4c7a82c4cb76af`
 │   │   ├── Evidence: `backend-data-source-factory-kline-route-migration-authorization-2026-05-25.md`
 │   │   ├── Current HEAD: `f4e3db66effa63ce37c94ad0f2b687a606ff8396`
 │   │   ├── Result: compares the remaining three route/API consumers and selects
@@ -1134,10 +1135,26 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                gate, OpenSpec change, or issue-label change is authorized;
 │   │                a future G2.73 may normalize same-file E701/black style in
 │   │                `kline.py` only if the implementation diff requires it
-│   └── Next gate: Human review / PR merge decision for G2.72 authorization; if
-│                  accepted, create a separate G2.73 path-limited implementation
-│                  branch for `kline.py`. Remaining candidates (`futures.py`
-│                  and `stocks.py`) stay locked
+│   ├── G2.73 Kline DataSourceFactory route migration
+│   │   ├── State: ready for review; PR `#223` implementation packet
+│   │   ├── Evidence: `backend-data-source-factory-kline-route-migration-implementation-2026-05-25.md`
+│   │   ├── Current HEAD: `68ff82a9257fb7bee7bbb7aefe4c7a82c4cb76af`
+│   │   ├── Result: migrates `get_daily_kline`, `get_kline`, and
+│   │   │          `get_intraday_data` from direct `get_data_source_factory()`
+│   │   │          calls to `Depends(get_data_source_factory_dependency)`;
+│   │   │          total route/API direct refs move `6 -> 4`, `kline.py` direct
+│   │   │          refs move `2 -> 0`, health route conflict tests move to
+│   │   │          `118 passed`, provider tests remain `4 passed`, OpenAPI paths
+│   │   │          remain `500`, duplicate operation IDs remain `0`, and staged
+│   │   │          GitNexus reports low risk / 0 affected processes
+│   │   └── Boundary: no route path, response model, response shape, OpenAPI,
+│   │                frontend, runtime/PM2, OpenSpec, issue-label, compatibility
+│   │                getter deletion, `stocks.py`, `futures.py`, or broad
+│   │                formatting cleanup outside `kline.py` and the focused test
+│   └── Next gate: Human review / PR merge decision for G2.73 implementation; if
+│                  accepted, create closeout/current-head refresh before another
+│                  DataSourceFactory route consumer selection. Remaining
+│                  candidates (`futures.py` and `stocks.py`) stay locked
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1192,6 +1209,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-market-data-request-route-migration-implementation-2026-05-25.md` | G | G2.71 implementation packet prepared at `9060b455`: market data request route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `8 -> 6`, and `market_data_request.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before selecting another DataSourceFactory route consumer |
 | `backend-data-source-factory-market-data-request-route-migration-closeout-2026-05-25.md` | G | G2.71 closeout packet prepared at `7f10db17`: PR `#220` merge recorded, health tests remain `117 passed`, provider tests remain `4 passed`, total refs remain `6`, and `market_data_request.py` remains `0` | Human review / PR merge decision; if accepted, create the next candidate authorization packet |
 | `backend-data-source-factory-kline-route-migration-authorization-2026-05-25.md` | G | G2.72 candidate packet prepared at `f4e3db66`: selects `kline.py` as the next route/API factory migration candidate; it has GitNexus LOW/1, four routes, two direct refs, and scoped same-file E701/black debt, and can move total refs `6 -> 4` | Human review / PR merge decision; if accepted, create G2.73 path-limited implementation branch for `kline.py` only |
+| `backend-data-source-factory-kline-route-migration-implementation-2026-05-25.md` | G | G2.73 implementation packet prepared at `68ff82a9`: kline route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `6 -> 4`, and `kline.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before selecting another DataSourceFactory route consumer |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-kline-route-migration-implementation-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-kline-route-migration-implementation-2026-05-25.json
@@ -1,0 +1,136 @@
+{
+  "artifact": "data-source-factory-kline-route-migration-implementation-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-73-data-source-factory-kline-route-migration",
+  "base_head": "68ff82a9257fb7bee7bbb7aefe4c7a82c4cb76af",
+  "scope": {
+    "source_files": [
+      "web/backend/app/api/data/kline.py",
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "governance_files": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/data-source-factory-kline-route-migration-implementation-2026-05-25.json",
+      "docs/reports/quality/backend-data-source-factory-kline-route-migration-implementation-2026-05-25.md",
+      "governance/mainline/task-cards/pr-223.yaml"
+    ],
+    "excluded": [
+      "route paths",
+      "response models",
+      "response shape",
+      "OpenAPI exposure policy",
+      "frontend",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue labels",
+      "other DataSourceFactory consumers",
+      "DataSourceFactory compatibility getter removal",
+      "formatting outside web/backend/app/api/data/kline.py and the focused test file"
+    ]
+  },
+  "pre_edit_evidence": {
+    "authorization": {
+      "source": "backend-data-source-factory-kline-route-migration-authorization-2026-05-25.md",
+      "pr": 222,
+      "merge_commit": "68ff82a9257fb7bee7bbb7aefe4c7a82c4cb76af"
+    },
+    "gitnexus": {
+      "file": {
+        "target": "web/backend/app/api/data/kline.py",
+        "risk": "LOW",
+        "direct_impacted": 1,
+        "processes_affected": 0
+      },
+      "functions": [
+        {
+          "target": "get_intraday_data",
+          "risk": "LOW",
+          "direct_impacted": 0,
+          "processes_affected": 0
+        },
+        {
+          "target": "get_daily_kline",
+          "note": "Function name is ambiguous in GitNexus impact; path-specific context/cypher for web/backend/app/api/data/kline.py:get_daily_kline reported one in-file caller, get_kline, and no affected execution processes."
+        }
+      ]
+    },
+    "baseline": {
+      "direct_route_api_factory_refs_total": 6,
+      "kline_py_direct_refs": 2,
+      "health_route_conflicts": "117 passed",
+      "provider_lifecycle": "4 passed",
+      "openapi": {
+        "routes": 548,
+        "paths": 500,
+        "operation_ids": 536,
+        "duplicate_operation_ids": 0
+      }
+    }
+  },
+  "tdd": {
+    "red": {
+      "command": "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_kline_routes_use_data_source_factory_dependency -q --no-cov --tb=short",
+      "result": "failed as expected",
+      "failure": "KeyError: 'factory'"
+    },
+    "green": {
+      "command": "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_kline_routes_use_data_source_factory_dependency -q --no-cov --tb=short",
+      "result": "1 passed"
+    }
+  },
+  "implementation": {
+    "migrated_route_handlers": [
+      "get_daily_kline",
+      "get_kline",
+      "get_intraday_data"
+    ],
+    "dependency": "Depends(get_data_source_factory_dependency)",
+    "style_normalization": [
+      "same-file kline.py E701 cleanup",
+      "same-file kline.py black normalization"
+    ],
+    "unchanged": [
+      "route paths",
+      "response shape",
+      "OpenAPI exposure",
+      "DataSourceFactory compatibility getter",
+      "stocks.py",
+      "futures.py"
+    ]
+  },
+  "verification": {
+    "focused_tdd_green": "1 passed",
+    "web/backend/tests/test_health_route_conflicts.py": "118 passed",
+    "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed",
+    "ruff_touched_files": "passed",
+    "black_check_touched_files": "passed",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "warning_count": 0
+    },
+    "route_api_factory_refs": {
+      "total_direct_refs": {
+        "before": 6,
+        "after": 4
+      },
+      "kline_py_direct_refs": {
+        "before": 2,
+        "after": 0
+      },
+      "remaining_files": [
+        "web/backend/app/api/data/stocks.py",
+        "web/backend/app/api/data/futures.py"
+      ]
+    },
+    "staged_gitnexus": {
+      "risk": "low",
+      "changed_symbols": 26,
+      "affected_processes": 0
+    }
+  },
+  "next_gate": "Human review / PR merge decision for G2.73. If accepted, create a closeout/current-head refresh before selecting another DataSourceFactory route consumer."
+}

--- a/docs/reports/quality/backend-data-source-factory-kline-route-migration-implementation-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-kline-route-migration-implementation-2026-05-25.md
@@ -1,0 +1,123 @@
+# Backend DataSourceFactory Kline Route Migration Implementation - 2026-05-25
+
+Workline: G2.73 implementation packet
+
+Base HEAD: `68ff82a9257fb7bee7bbb7aefe4c7a82c4cb76af`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This implementation follows the G2.72 authorization packet and
+changes only `web/backend/app/api/data/kline.py`, the focused route dependency
+test, and governance evidence files. It does not change route paths, response
+models, response shapes, OpenAPI exposure policy, frontend code, runtime/PM2
+state, OpenSpec state, issue labels, or DataSourceFactory compatibility getter
+surfaces.
+
+## Status
+
+Ready for review.
+
+PR `#222` merged the G2.72 authorization packet at
+`68ff82a9257fb7bee7bbb7aefe4c7a82c4cb76af`, selecting
+`web/backend/app/api/data/kline.py` for this path-limited implementation.
+
+## Pre-Edit Evidence
+
+| Target | Result |
+| --- | --- |
+| `web/backend/app/api/data/kline.py` | GitNexus LOW/1, 0 affected processes |
+| `get_intraday_data` | GitNexus LOW/0 |
+| `get_daily_kline` | Name ambiguous in GitNexus impact; path-specific context/cypher reported one in-file caller, `get_kline`, and no affected execution processes |
+
+Baseline verification from G2.72:
+
+| Check | Result |
+| --- | --- |
+| `web/backend/tests/test_health_route_conflicts.py` | 117 passed |
+| `web/backend/tests/test_data_source_factory_lifecycle_di.py` | 4 passed |
+| Route/API direct `await get_data_source_factory()` refs | total `6`, `kline.py` `2` |
+| OpenAPI smoke | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0 |
+
+## TDD Evidence
+
+Red test:
+
+```text
+pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_kline_routes_use_data_source_factory_dependency -q --no-cov --tb=short
+```
+
+Result: failed as expected with `KeyError: 'factory'`.
+
+Green test:
+
+```text
+pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_kline_routes_use_data_source_factory_dependency -q --no-cov --tb=short
+```
+
+Result: `1 passed`.
+
+## Implementation
+
+Changed `web/backend/app/api/data/kline.py`:
+
+- Added `DataSourceFactory` and `get_data_source_factory_dependency` import.
+- Migrated `get_daily_kline` from route-local `await get_data_source_factory()`
+  to `factory: DataSourceFactory = Depends(get_data_source_factory_dependency)`.
+- Migrated `get_kline` to accept the same dependency and pass the factory into
+  `get_daily_kline`.
+- Migrated `get_intraday_data` from route-local `await get_data_source_factory()`
+  to the same dependency.
+- Normalized same-file `E701` and black formatting debt in `kline.py`, as
+  explicitly allowed by G2.72.
+
+Changed `web/backend/tests/test_health_route_conflicts.py`:
+
+- Added `test_kline_routes_use_data_source_factory_dependency`.
+
+## Verification
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_kline_routes_use_data_source_factory_dependency -q --no-cov --tb=short` | 1 passed |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | 118 passed |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | 4 passed |
+| `ruff check web/backend/app/api/data/kline.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| `black --check web/backend/app/api/data/kline.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| OpenAPI smoke with `PYTHONPATH=web/backend` and root `.env` loaded | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0 |
+| staged GitNexus `detect_changes(scope=staged)` | low risk, 26 changed symbols, 0 affected processes |
+
+Route/API direct factory refs:
+
+| Metric | Before | After |
+| --- | ---: | ---: |
+| Total direct route/API `get_data_source_factory()` refs | 6 | 4 |
+| `web/backend/app/api/data/kline.py` direct refs | 2 | 0 |
+
+Remaining route consumers stay locked for future authorization:
+
+- `web/backend/app/api/data/stocks.py`
+- `web/backend/app/api/data/futures.py`
+
+GitNexus reports 26 changed symbols because black normalization and the shared
+test file cause broad same-file symbol attribution. The staged risk level is
+`low`, and no affected execution processes are reported.
+
+## Boundary
+
+This PR does not authorize:
+
+- route path changes
+- response model or response shape changes
+- OpenAPI exposure changes
+- frontend edits
+- runtime/PM2 operations
+- OpenSpec changes
+- issue-label changes
+- DataSourceFactory compatibility getter deletion
+- `stocks.py` or `futures.py` migration
+- formatting outside `kline.py` and the focused test file
+
+## Next Gate
+
+Human review / PR merge decision for G2.73. If accepted, create a closeout /
+current-head refresh before selecting another DataSourceFactory route consumer.

--- a/governance/mainline/task-cards/pr-223.yaml
+++ b/governance/mainline/task-cards/pr-223.yaml
@@ -1,0 +1,127 @@
+version: "v0.2"
+
+task:
+  id: "pr-223"
+  title: "Migrate kline routes to DataSourceFactory dependency injection"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-kline-route-migration"
+  objective: "move kline route DataSourceFactory access from compatibility getter calls to FastAPI dependency injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-kline-route-migration"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-kline-route-migration"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Implementation changes dependency acquisition only and preserves route paths, OpenAPI exposure, response shape, and runtime semantics"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/api/data/kline.py"
+    - "web/backend/tests/test_health_route_conflicts.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-kline-route-migration-implementation-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-kline-route-migration-implementation-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-223.yaml"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+    - "web/backend/app/api/data/futures.py"
+    - "web/backend/app/api/data/stocks.py"
+
+non_goals:
+  - "No route path, response model, response shape, OpenAPI exposure, docs/API, generated client, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No non-kline.py DataSourceFactory route consumer migration"
+  - "No deletion of get_data_source_factory() or _global_factory compatibility surfaces"
+  - "No broad formatting cleanup outside web/backend/app/api/data/kline.py and the focused test file"
+
+acceptance:
+  checks:
+    - id: "pre-edit-gitnexus-impact"
+      command: "MCP gitnexus.impact(target=web/backend/app/api/data/kline.py,direction=upstream)"
+      required: true
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_kline_routes_use_data_source_factory_dependency -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-files"
+      command: "ruff check web/backend/app/api/data/kline.py web/backend/tests/test_health_route_conflicts.py"
+      required: true
+    - id: "black-touched-files"
+      command: "black --check web/backend/app/api/data/kline.py web/backend/tests/test_health_route_conflicts.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-kline-route-migration-implementation-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-kline-route-migration-implementation-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-223.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-223.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If response shape or route paths change, the PR exceeds the approved G2.73 boundary"
+    - "If another route consumer is edited, the PR bypasses G2.72 candidate sequencing"
+    - "If formatting cleanup escapes kline.py and the focused test file, the scoped style authorization is exceeded"
+  rollback_plan: "revert this path-limited PR; compatibility getter surfaces remain available and no route contract changes are introduced"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "migrate kline route DataSourceFactory access to dependency injection"
+    modified_scope: "kline route file, focused route-conflict test, implementation report, generated artifact, steward tree, and task card"
+    dependency_changes: "uses existing get_data_source_factory_dependency provider"
+    legacy_logic_impact: "compatibility getter and _global_factory remain unchanged for remaining consumers"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if dependency wiring or route guard verification fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T08:25:37+08:00"
+    approval_note: "human maintainer accepted G2.72 candidate selection by merging PR #222; this packet implements only the approved kline.py route migration"
+    secondary_approved: false

--- a/web/backend/app/api/data/kline.py
+++ b/web/backend/app/api/data/kline.py
@@ -1,6 +1,7 @@
 """
 K线与行情数据路由 (KLine Data)
 """
+
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
@@ -11,6 +12,7 @@ from app.core.database import db_service
 from app.core.exceptions import BusinessException
 from app.core.security import User, get_current_user
 from app.openapi_config import COMMON_RESPONSES
+from app.services.data_source_factory import DataSourceFactory, get_data_source_factory_dependency
 
 router = APIRouter()
 
@@ -138,27 +140,30 @@ async def get_daily_kline(
     end_date: Optional[str] = Query(None, description="返回结果的结束日期，格式为 YYYY-MM-DD。"),
     limit: int = Query(100, description="单次请求返回的最大日线记录数。"),
     current_user: User = Depends(get_current_user),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
 ) -> Dict[str, Any]:
     """获取股票日线数据"""
     try:
-        from app.services.data_source_factory import get_data_source_factory
-        factory = await get_data_source_factory()
-
-        if not end_date: end_date = datetime.now().strftime("%Y-%m-%d")
-        if not start_date: start_date = (datetime.now() - timedelta(days=90)).strftime("%Y-%m-%d")
+        if not end_date:
+            end_date = datetime.now().strftime("%Y-%m-%d")
+        if not start_date:
+            start_date = (datetime.now() - timedelta(days=90)).strftime("%Y-%m-%d")
 
         params = {"symbol": symbol, "start_date": start_date, "end_date": end_date, "limit": limit}
         result = await factory.get_data("data", "stocks/daily", params)
 
         if result.get("status") == "success":
             return {
-                "success": True, "data": result.get("data", []),
-                "symbol": symbol, "total": result.get("total", 0),
+                "success": True,
+                "data": result.get("data", []),
+                "symbol": symbol,
+                "total": result.get("total", 0),
                 "timestamp": datetime.now().isoformat(),
             }
         raise BusinessException(detail="获取失败", status_code=500)
     except Exception as e:
         raise BusinessException(detail=str(e), status_code=500)
+
 
 @router.get(
     "/kline",
@@ -172,9 +177,11 @@ async def get_kline(
     end_date: Optional[str] = Query(None, description="返回结果的结束日期，格式为 YYYY-MM-DD。"),
     limit: int = Query(100, description="单次请求返回的最大 K 线记录数。"),
     current_user: User = Depends(get_current_user),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
 ) -> Dict[str, Any]:
     """获取股票K线数据（日线别名）"""
-    return await get_daily_kline(symbol, start_date, end_date, limit, current_user)
+    return await get_daily_kline(symbol, start_date, end_date, limit, current_user, factory)
+
 
 @router.get(
     "/stocks/kline",
@@ -228,6 +235,7 @@ async def get_kline_data(
     except Exception as e:
         raise BusinessException(detail=f"获取标准化K线数据失败: {str(e)}", status_code=500, error_code="DATABASE_ERROR")
 
+
 @router.get(
     "/stocks/intraday",
     summary="查询股票分时行情",
@@ -238,14 +246,15 @@ async def get_intraday_data(
     symbol: str = Query(..., description="股票代码。"),
     date: Optional[str] = Query(None, description="交易日期，格式为 YYYY-MM-DD；不传时默认取当天。"),
     current_user: User = Depends(get_current_user),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
 ) -> Dict[str, Any]:
     """获取股票分时数据"""
     try:
-        from app.services.data_source_factory import get_data_source_factory
-        factory = await get_data_source_factory()
         if not date:
             date = datetime.now().strftime("%Y-%m-%d")
         result = await factory.get_data("data", "stocks/intraday", {"symbol": symbol, "date": date})
         return {"success": True, "data": result.get("data", []), "symbol": symbol, "date": date}
     except Exception as e:
-        raise BusinessException(detail=f"获取分时行情失败: {str(e)}", status_code=500, error_code="DATA_RETRIEVAL_FAILED")
+        raise BusinessException(
+            detail=f"获取分时行情失败: {str(e)}", status_code=500, error_code="DATA_RETRIEVAL_FAILED"
+        )

--- a/web/backend/tests/test_health_route_conflicts.py
+++ b/web/backend/tests/test_health_route_conflicts.py
@@ -6,6 +6,7 @@ import inspect
 from fastapi.routing import APIRoute
 
 from app.api.data import financial as financial_module
+from app.api.data import kline as kline_module
 from app.api.data import lhb as lhb_module
 from app.api.data import margin as margin_module
 from app.api.data import market as market_module
@@ -88,6 +89,17 @@ def test_market_data_request_routes_use_data_source_factory_dependency() -> None
             getattr(factory_param.default, "dependency", None)
             is market_data_request_module.get_data_source_factory_dependency
         )
+
+
+def test_kline_routes_use_data_source_factory_dependency() -> None:
+    for route_handler in [
+        kline_module.get_daily_kline,
+        kline_module.get_kline,
+        kline_module.get_intraday_data,
+    ]:
+        factory_param = inspect.signature(route_handler).parameters["factory"]
+
+        assert getattr(factory_param.default, "dependency", None) is kline_module.get_data_source_factory_dependency
 
 
 def test_root_and_socketio_status_have_documented_examples_and_errors() -> None:


### PR DESCRIPTION
## Summary
- migrate kline DataSourceFactory route access to FastAPI dependency injection
- add focused route dependency wiring test
- record G2.73 implementation evidence and update steward tree

## Evidence
- TDD red: focused test failed with KeyError: 'factory'
- TDD green: focused test 1 passed
- health route conflicts: 118 passed
- provider lifecycle tests: 4 passed
- ruff touched files: passed
- black --check touched files: passed
- OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0
- direct route/API factory refs: total 6 -> 4; kline.py 2 -> 0
- staged GitNexus scope: low risk, 26 changed symbols, 0 affected processes
- post-commit mainline scope gate: pass=True

## Boundary
- Scope is limited to kline.py, the focused test, implementation evidence, steward tree, and task card
- No route path, response model, response shape, OpenAPI exposure, frontend, runtime, PM2, OpenSpec, issue-label, compatibility getter, stocks.py, or futures.py change
- Same-file E701/black normalization is limited to kline.py as authorized by G2.72
