### PR TITLE
docs(governance): close out kline factory route migration

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1136,7 +1136,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                a future G2.73 may normalize same-file E701/black style in
 │   │                `kline.py` only if the implementation diff requires it
 │   ├── G2.73 Kline DataSourceFactory route migration
-│   │   ├── State: ready for review; PR `#223` implementation packet
+│   │   ├── State: accepted; PR `#223` merged at
+│   │   │          `6ece7f1367d3e4c1fcd881bc5596ec37942c79e4`
 │   │   ├── Evidence: `backend-data-source-factory-kline-route-migration-implementation-2026-05-25.md`
 │   │   ├── Current HEAD: `68ff82a9257fb7bee7bbb7aefe4c7a82c4cb76af`
 │   │   ├── Result: migrates `get_daily_kline`, `get_kline`, and
@@ -1151,10 +1152,21 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                frontend, runtime/PM2, OpenSpec, issue-label, compatibility
 │   │                getter deletion, `stocks.py`, `futures.py`, or broad
 │   │                formatting cleanup outside `kline.py` and the focused test
-│   └── Next gate: Human review / PR merge decision for G2.73 implementation; if
-│                  accepted, create closeout/current-head refresh before another
-│                  DataSourceFactory route consumer selection. Remaining
-│                  candidates (`futures.py` and `stocks.py`) stay locked
+│   ├── G2.73 Closeout / current-head refresh
+│   │   ├── State: ready for review; PR `#224` closeout packet
+│   │   ├── Evidence: `backend-data-source-factory-kline-route-migration-closeout-2026-05-25.md`
+│   │   ├── Current HEAD: `6ece7f1367d3e4c1fcd881bc5596ec37942c79e4`
+│   │   ├── Result: confirms PR `#223` merged, health route conflict tests
+│   │   │          remain `118 passed`, provider tests remain `4 passed`,
+│   │   │          route direct refs remain `4`, `kline.py` direct refs remain
+│   │   │          `0`, OpenAPI paths remain `500`, duplicate operation IDs
+│   │   │          remain `0`, and GitNexus reports `kline.py` LOW/1
+│   │   └── Boundary: closeout-only; no source edit or next consumer selection
+│   └── Next gate: Human review / PR merge decision for G2.73 closeout; if
+│                  accepted, create the next candidate authorization packet
+│                  before any further DataSourceFactory route migration.
+│                  Remaining candidates (`futures.py` and `stocks.py`) stay
+│                  locked
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1210,6 +1222,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-market-data-request-route-migration-closeout-2026-05-25.md` | G | G2.71 closeout packet prepared at `7f10db17`: PR `#220` merge recorded, health tests remain `117 passed`, provider tests remain `4 passed`, total refs remain `6`, and `market_data_request.py` remains `0` | Human review / PR merge decision; if accepted, create the next candidate authorization packet |
 | `backend-data-source-factory-kline-route-migration-authorization-2026-05-25.md` | G | G2.72 candidate packet prepared at `f4e3db66`: selects `kline.py` as the next route/API factory migration candidate; it has GitNexus LOW/1, four routes, two direct refs, and scoped same-file E701/black debt, and can move total refs `6 -> 4` | Human review / PR merge decision; if accepted, create G2.73 path-limited implementation branch for `kline.py` only |
 | `backend-data-source-factory-kline-route-migration-implementation-2026-05-25.md` | G | G2.73 implementation packet prepared at `68ff82a9`: kline route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `6 -> 4`, and `kline.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before selecting another DataSourceFactory route consumer |
+| `backend-data-source-factory-kline-route-migration-closeout-2026-05-25.md` | G | G2.73 closeout packet prepared at `6ece7f13`: PR `#223` merge recorded, health tests remain `118 passed`, provider tests remain `4 passed`, total refs remain `4`, and `kline.py` remains `0` | Human review / PR merge decision; if accepted, create the next candidate authorization packet |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-kline-route-migration-closeout-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-kline-route-migration-closeout-2026-05-25.json
@@ -1,0 +1,58 @@
+{
+  "artifact": "data-source-factory-kline-route-migration-closeout-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-73-data-source-factory-kline-route-migration-closeout",
+  "current_head": "6ece7f1367d3e4c1fcd881bc5596ec37942c79e4",
+  "scope": {
+    "type": "closeout_current_head_refresh",
+    "source_edits": false,
+    "closed_pr": 223,
+    "closed_merge_commit": "6ece7f1367d3e4c1fcd881bc5596ec37942c79e4",
+    "excluded": [
+      "backend source edits",
+      "test source edits",
+      "route path changes",
+      "OpenAPI exposure changes",
+      "response model or response shape changes",
+      "frontend changes",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue label changes",
+      "compatibility getter deletion",
+      "next consumer selection"
+    ]
+  },
+  "current_head_verification": {
+    "tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "118 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "style": {
+      "ruff_kline_and_health_route_conflicts": "passed",
+      "black_check_kline_and_health_route_conflicts": "passed"
+    },
+    "route_api_factory_refs": {
+      "total_direct_refs": 4,
+      "kline_py_direct_refs": 0,
+      "remaining_locations": [
+        "web/backend/app/api/data/stocks.py:269",
+        "web/backend/app/api/data/stocks.py:371",
+        "web/backend/app/api/data/futures.py:91",
+        "web/backend/app/api/data/futures.py:114"
+      ]
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "warning_count": 0
+    },
+    "gitnexus": {
+      "kline_py": "LOW/1, 0 affected processes"
+    }
+  },
+  "decision": "G2.73 implementation evidence remains valid at current HEAD. No additional source change is authorized by this closeout.",
+  "next_gate": "Human review / PR merge decision for G2.73 closeout. If accepted, create the next candidate authorization packet before any further DataSourceFactory route migration."
+}

--- a/docs/reports/quality/backend-data-source-factory-kline-route-migration-closeout-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-kline-route-migration-closeout-2026-05-25.md
@@ -1,0 +1,60 @@
+# Backend DataSourceFactory Kline Route Migration Closeout - 2026-05-25
+
+Workline: G2.73 closeout / current-head refresh
+
+Current HEAD: `6ece7f1367d3e4c1fcd881bc5596ec37942c79e4`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This closeout records current-head evidence for the merged G2.73
+kline DataSourceFactory route migration. It does not authorize backend source
+edits, test edits, route path changes, OpenAPI exposure changes, response shape
+changes, frontend edits, PM2/runtime operations, OpenSpec proposal publication,
+issue-label changes, compatibility getter deletion, or next-consumer selection.
+
+## Status
+
+Ready for review.
+
+PR `#223` has been merged at
+`6ece7f1367d3e4c1fcd881bc5596ec37942c79e4`. This closeout confirms the G2.73
+kline route migration remains valid on current HEAD.
+
+## Current-Head Verification
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | 118 passed |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | 4 passed |
+| `ruff check web/backend/app/api/data/kline.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| `black --check web/backend/app/api/data/kline.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| OpenAPI smoke with `PYTHONPATH=web/backend` and root `.env` loaded | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0 |
+
+Route/API direct factory refs:
+
+| Metric | Current HEAD |
+| --- | ---: |
+| Total direct route/API `get_data_source_factory()` refs | 4 |
+| `web/backend/app/api/data/kline.py` direct refs | 0 |
+
+Remaining direct route/API refs:
+
+- `web/backend/app/api/data/stocks.py:269`
+- `web/backend/app/api/data/stocks.py:371`
+- `web/backend/app/api/data/futures.py:91`
+- `web/backend/app/api/data/futures.py:114`
+
+## GitNexus
+
+`web/backend/app/api/data/kline.py`: LOW/1, 0 affected processes.
+
+## Decision
+
+G2.73 implementation evidence remains valid at current HEAD. No additional
+source change is authorized by this closeout.
+
+## Next Gate
+
+Human review / PR merge decision for this closeout. If accepted, create the next
+candidate authorization packet before any further DataSourceFactory route
+migration. `stocks.py` and `futures.py` remain locked until then.

--- a/governance/mainline/task-cards/pr-224.yaml
+++ b/governance/mainline/task-cards/pr-224.yaml
@@ -1,0 +1,116 @@
+version: "v0.2"
+
+task:
+  id: "pr-224"
+  title: "Close out kline DataSourceFactory route migration"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-kline-route-migration-closeout"
+  objective: "record current-head verification for the merged kline DataSourceFactory route migration"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-kline-route-migration-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-kline-route-migration-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout records current-head evidence only and does not alter runtime behavior"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-kline-route-migration-closeout-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-kline-route-migration-closeout-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-224.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source or test edit"
+  - "No route path, response model, response shape, OpenAPI exposure, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No DataSourceFactory consumer migration or compatibility getter cleanup"
+  - "No next-consumer selection until this closeout is accepted"
+
+acceptance:
+  checks:
+    - id: "current-head-health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "current-head-provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "current-head-style"
+      command: "ruff check web/backend/app/api/data/kline.py web/backend/tests/test_health_route_conflicts.py && black --check web/backend/app/api/data/kline.py web/backend/tests/test_health_route_conflicts.py"
+      required: true
+    - id: "current-head-openapi-smoke"
+      command: "PYTHONPATH=web/backend python -c 'from app.main import app; app.openapi()'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-kline-route-migration-closeout-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-kline-route-migration-closeout-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-224.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-224.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If source files are edited, this closeout exceeds its evidence-only boundary"
+  rollback_plan: "revert this docs/governance-only closeout PR; no runtime code is affected"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out the merged kline DataSourceFactory route migration"
+    modified_scope: "closeout report, generated artifact, steward tree, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; compatibility getter and remaining route consumers are unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this closeout PR if current-head evidence is superseded or incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T08:25:37+08:00"
+    approval_note: "human maintainer accepted G2.73 implementation by merging PR #223; this packet records closeout evidence only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record G2.73 closeout/current-head refresh for the merged kline DataSourceFactory route migration
- confirm PR #223 remains valid on current HEAD
- keep next consumer selection locked until this closeout is accepted

## Evidence
- current HEAD: 6ece7f1367d3e4c1fcd881bc5596ec37942c79e4
- health route conflicts: 118 passed
- provider lifecycle tests: 4 passed
- ruff/black kline + focused test: passed
- OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0
- direct route/API factory refs: total 4; kline.py 0
- kline.py GitNexus: LOW/1, 0 affected processes
- staged GitNexus scope: low risk, 0 changed symbols / 0 affected processes
- post-commit mainline scope gate: pass=True

## Boundary
- Docs/governance closeout only
- No backend source/test edits, next-consumer selection, route path, response shape, OpenAPI, frontend, runtime, PM2, OpenSpec, issue-label, or compatibility getter change
