### PR TITLE
docs(governance): authorize stocks factory route candidate

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1153,7 +1153,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, `stocks.py`, `futures.py`, or broad
 │   │                formatting cleanup outside `kline.py` and the focused test
 │   ├── G2.73 Closeout / current-head refresh
-│   │   ├── State: ready for review; PR `#224` closeout packet
+│   │   ├── State: accepted; PR `#224` merged at
+│   │   │          `f7d370cd91f3c28a6f11fdbcb42b8241cfd43be6`
 │   │   ├── Evidence: `backend-data-source-factory-kline-route-migration-closeout-2026-05-25.md`
 │   │   ├── Current HEAD: `6ece7f1367d3e4c1fcd881bc5596ec37942c79e4`
 │   │   ├── Result: confirms PR `#223` merged, health route conflict tests
@@ -1162,11 +1163,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   │          `0`, OpenAPI paths remain `500`, duplicate operation IDs
 │   │   │          remain `0`, and GitNexus reports `kline.py` LOW/1
 │   │   └── Boundary: closeout-only; no source edit or next consumer selection
-│   └── Next gate: Human review / PR merge decision for G2.73 closeout; if
-│                  accepted, create the next candidate authorization packet
-│                  before any further DataSourceFactory route migration.
-│                  Remaining candidates (`futures.py` and `stocks.py`) stay
-│                  locked
+│   ├── G2.74 DataSourceFactory route candidate authorization
+│   │   ├── State: ready for review; PR `#225` candidate packet
+│   │   ├── Evidence: `backend-data-source-factory-stocks-route-migration-authorization-2026-05-25.md`
+│   │   ├── Current HEAD: `f7d370cd91f3c28a6f11fdbcb42b8241cfd43be6`
+│   │   ├── Result: compares the remaining two route/API consumers and selects
+│   │   │          `web/backend/app/api/data/stocks.py` for future G2.75 because
+│   │   │          it is the only LOW-risk remaining candidate; expected total
+│   │   │          direct refs move `4 -> 2`, while `stocks.py` direct refs move
+│   │   │          `2 -> 0`; same-file E701/black debt is explicitly scoped
+│   │   └── Boundary: authorization-only; no source edit, route contract edit,
+│   │                compatibility getter removal, frontend edit, PM2/runtime
+│   │                gate, OpenSpec change, or issue-label change is authorized;
+│   │                a future G2.75 may normalize same-file E701/black style in
+│   │                `stocks.py` only if the implementation diff requires it
+│   └── Next gate: Human review / PR merge decision for G2.74 authorization; if
+│                  accepted, create a separate G2.75 path-limited implementation
+│                  branch for `stocks.py`. Remaining candidate `futures.py`
+│                  stays locked
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1223,6 +1237,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-kline-route-migration-authorization-2026-05-25.md` | G | G2.72 candidate packet prepared at `f4e3db66`: selects `kline.py` as the next route/API factory migration candidate; it has GitNexus LOW/1, four routes, two direct refs, and scoped same-file E701/black debt, and can move total refs `6 -> 4` | Human review / PR merge decision; if accepted, create G2.73 path-limited implementation branch for `kline.py` only |
 | `backend-data-source-factory-kline-route-migration-implementation-2026-05-25.md` | G | G2.73 implementation packet prepared at `68ff82a9`: kline route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `6 -> 4`, and `kline.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before selecting another DataSourceFactory route consumer |
 | `backend-data-source-factory-kline-route-migration-closeout-2026-05-25.md` | G | G2.73 closeout packet prepared at `6ece7f13`: PR `#223` merge recorded, health tests remain `118 passed`, provider tests remain `4 passed`, total refs remain `4`, and `kline.py` remains `0` | Human review / PR merge decision; if accepted, create the next candidate authorization packet |
+| `backend-data-source-factory-stocks-route-migration-authorization-2026-05-25.md` | G | G2.74 candidate packet prepared at `f7d370cd`: selects `stocks.py` as the next route/API factory migration candidate; it is the only remaining LOW-risk candidate and can move total refs `4 -> 2` | Human review / PR merge decision; if accepted, create G2.75 path-limited implementation branch for `stocks.py` only |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-stocks-route-migration-authorization-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-stocks-route-migration-authorization-2026-05-25.json
@@ -1,0 +1,99 @@
+{
+  "artifact": "data-source-factory-stocks-route-migration-authorization-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-74-data-source-factory-route-candidate-authorization",
+  "current_head": "f7d370cd91f3c28a6f11fdbcb42b8241cfd43be6",
+  "scope": {
+    "type": "authorization_only",
+    "source_edits": false,
+    "allowed_future_candidate": "web/backend/app/api/data/stocks.py",
+    "allowed_future_style_normalization": [
+      "same-file E701 cleanup in web/backend/app/api/data/stocks.py",
+      "same-file black normalization in web/backend/app/api/data/stocks.py if required by the future implementation diff"
+    ],
+    "excluded": [
+      "backend source edits in G2.74",
+      "route path changes",
+      "OpenAPI exposure changes",
+      "response model or response shape changes",
+      "frontend changes",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue label changes",
+      "compatibility getter deletion",
+      "formatting or lint cleanup outside web/backend/app/api/data/stocks.py in the future implementation branch"
+    ]
+  },
+  "baseline": {
+    "tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "118 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "direct_route_api_factory_refs": {
+      "total": 4,
+      "locations": [
+        "web/backend/app/api/data/stocks.py:269",
+        "web/backend/app/api/data/stocks.py:371",
+        "web/backend/app/api/data/futures.py:91",
+        "web/backend/app/api/data/futures.py:114"
+      ]
+    },
+    "candidate_matrix": {
+      "rows": [
+        {
+          "file": "web/backend/app/api/data/stocks.py",
+          "loc": 417,
+          "route_count": 5,
+          "direct_refs": 2,
+          "direct_ref_lines": [
+            269,
+            371
+          ],
+          "ruff": "fails E701 x5",
+          "black": "would reformat",
+          "gitnexus": "LOW/1"
+        },
+        {
+          "file": "web/backend/app/api/data/futures.py",
+          "loc": 123,
+          "route_count": 2,
+          "direct_refs": 2,
+          "direct_ref_lines": [
+            91,
+            114
+          ],
+          "ruff": "passed",
+          "black": "would reformat",
+          "gitnexus": "CRITICAL/31 at maxDepth=1"
+        }
+      ]
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "warning_count": 0,
+      "env_note": "OpenAPI smoke loaded the root .env into the isolated worktree without recording secret values."
+    }
+  },
+  "decision": {
+    "selected_next_candidate": {
+      "file": "web/backend/app/api/data/stocks.py",
+      "future_branch": "G2.75",
+      "reason": "Among the two remaining direct route/API DataSourceFactory consumers, stocks.py is the only LOW-risk candidate. It has same-file E701/black debt, but futures.py remains CRITICAL/31 and requires separate risk review.",
+      "expected_direct_ref_change": {
+        "total": "4 -> 2",
+        "stocks_py": "2 -> 0"
+      }
+    },
+    "deferred_candidates": [
+      {
+        "file": "web/backend/app/api/data/futures.py",
+        "reason": "ruff passes, but black would reformat and GitNexus file-level impact is CRITICAL/31; requires a narrower risk packet before source migration."
+      }
+    ]
+  },
+  "next_gate": "Human review / PR merge decision for G2.74. If accepted, create a separate G2.75 path-limited implementation branch for stocks.py only."
+}

--- a/docs/reports/quality/backend-data-source-factory-stocks-route-migration-authorization-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-stocks-route-migration-authorization-2026-05-25.md
@@ -1,0 +1,91 @@
+# Backend DataSourceFactory Stocks Route Migration Authorization - 2026-05-25
+
+Workline: G2.74 candidate authorization packet
+
+Current HEAD: `f7d370cd91f3c28a6f11fdbcb42b8241cfd43be6`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This document records a candidate-selection decision and its
+evidence. It does not authorize backend source edits, route path changes,
+OpenAPI exposure changes, response shape changes, frontend edits, PM2/runtime
+operations, OpenSpec proposal publication, issue-label changes, compatibility
+getter deletion, or migration of any DataSourceFactory consumer in this branch.
+
+## Status
+
+Ready for review.
+
+G2.73 closeout has been accepted by PR `#224`, merged at
+`f7d370cd91f3c28a6f11fdbcb42b8241cfd43be6`. This packet selects the next
+route/API DataSourceFactory direct consumer candidate before any further source
+edit.
+
+## Baseline Evidence
+
+| Check | Result |
+| --- | --- |
+| `web/backend/tests/test_health_route_conflicts.py` | `118 passed` |
+| `web/backend/tests/test_data_source_factory_lifecycle_di.py` | `4 passed` |
+| Route/API direct `await get_data_source_factory()` refs | `4` |
+| OpenAPI smoke | `routes=548`, `paths=500`, `operation_ids=536`, `duplicate_operation_ids=0`, `warning_count=0` |
+| Git status before docs edits | clean |
+
+OpenAPI smoke loaded the root `.env` into the isolated worktree without
+recording any secret values.
+
+## Candidate Matrix
+
+| Candidate | LOC | Routes | Direct refs | Ruff | Black | GitNexus |
+| --- | ---: | ---: | ---: | --- | --- | --- |
+| `web/backend/app/api/data/stocks.py` | 417 | 5 | 2 at lines `269`, `371` | `E701 x5` | would reformat | `LOW/1` |
+| `web/backend/app/api/data/futures.py` | 123 | 2 | 2 at lines `91`, `114` | passed | would reformat | `CRITICAL/31` at `maxDepth=1` |
+
+The remaining direct route/API refs are:
+
+- `web/backend/app/api/data/stocks.py:269`
+- `web/backend/app/api/data/stocks.py:371`
+- `web/backend/app/api/data/futures.py:91`
+- `web/backend/app/api/data/futures.py:114`
+
+## Decision
+
+Select `web/backend/app/api/data/stocks.py` for the future G2.75
+DataSourceFactory route migration.
+
+Rationale:
+
+- It is the only remaining LOW-risk route/API candidate.
+- It can move total route/API direct refs from `4 -> 2` and `stocks.py` refs
+  from `2 -> 0`.
+- Its style debt is same-file and bounded: `E701 x5` plus black normalization.
+- `futures.py` remains `CRITICAL/31`, so it must not be selected without a
+  separate narrower risk packet.
+
+## Deferred Candidates
+
+`futures.py` remains locked. It is small and ruff-clean, but file-level
+GitNexus impact is `CRITICAL/31`; it requires a separate narrower risk packet
+before any source migration.
+
+## Authorized Future Scope
+
+If this packet is accepted, a future G2.75 implementation branch may be created
+with source scope limited to:
+
+- `web/backend/app/api/data/stocks.py`
+- a focused route dependency wiring test
+- implementation evidence
+- steward tree update
+- mainline task card
+
+The future G2.75 branch may normalize same-file `E701` and black formatting in
+`web/backend/app/api/data/stocks.py` only, if that normalization is required by
+the route dependency migration diff.
+
+No source edit is authorized by G2.74 itself.
+
+## Next Gate
+
+Human review / PR merge decision for this authorization packet. If accepted,
+create a separate G2.75 path-limited implementation branch for `stocks.py` only.

--- a/governance/mainline/task-cards/pr-225.yaml
+++ b/governance/mainline/task-cards/pr-225.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-225"
+  title: "Authorize stocks DataSourceFactory route candidate"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-stocks-route-authorization"
+  objective: "select the next DataSourceFactory route migration candidate after kline closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-stocks-route-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-stocks-route-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization packet records evidence and future scope only; no runtime behavior changes"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-stocks-route-migration-authorization-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-stocks-route-migration-authorization-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-225.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source or test edit"
+  - "No route path, response model, response shape, OpenAPI exposure, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No DataSourceFactory consumer migration or compatibility getter cleanup"
+  - "No implementation work for stocks.py until a separate G2.75 branch is created after review"
+  - "No formatting or lint cleanup outside stocks.py in the future implementation branch"
+
+acceptance:
+  checks:
+    - id: "baseline-health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "baseline-provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "baseline-openapi-smoke"
+      command: "PYTHONPATH=web/backend python -c 'from app.main import app; app.openapi()'"
+      required: true
+    - id: "candidate-style-and-risk-scan"
+      command: "ruff/black/GitNexus candidate scan across remaining direct DataSourceFactory route consumers"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-stocks-route-migration-authorization-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-stocks-route-migration-authorization-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-225.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-225.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If source files are edited, this authorization packet exceeds its approved evidence-only boundary"
+    - "If future G2.75 normalizes style outside stocks.py, the scoped authorization is exceeded"
+  rollback_plan: "revert this docs/governance-only authorization PR; no runtime code is affected"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize the next DataSourceFactory route migration candidate"
+    modified_scope: "authorization report, generated artifact, steward tree, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; compatibility getter and all source files are unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this authorization PR if candidate evidence is superseded or incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T09:30:41+08:00"
+    approval_note: "human maintainer accepted G2.73 closeout by merging PR #224; this packet selects the next candidate only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record G2.74 DataSourceFactory route candidate authorization
- select web/backend/app/api/data/stocks.py for a future G2.75 implementation branch
- keep futures.py locked pending separate risk packet

## Evidence
- health route conflicts: 118 passed
- provider lifecycle tests: 4 passed
- OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0
- candidate scan: stocks.py LOW/1 with E701 x5 + black debt; futures.py CRITICAL/31
- direct route/API factory refs: total 4; stocks.py 2; futures.py 2
- staged GitNexus scope: low risk, 0 changed symbols / 0 affected processes
- post-commit mainline scope gate: pass=True

## Boundary
- No backend source or test edits in G2.74
- No route path, response shape, OpenAPI exposure, frontend, runtime, PM2, OpenSpec, issue-label, or compatibility getter change
- Future G2.75 may normalize same-file E701/black style in stocks.py only if required by the implementation diff
