### PR TITLE
refactor(api): migrate stocks factory dependency

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1164,7 +1164,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   │          remain `0`, and GitNexus reports `kline.py` LOW/1
 │   │   └── Boundary: closeout-only; no source edit or next consumer selection
 │   ├── G2.74 DataSourceFactory route candidate authorization
-│   │   ├── State: ready for review; PR `#225` candidate packet
+│   │   ├── State: accepted; PR `#225` merged at
+│   │   │          `2a04b019965801084822e132c99690f97f8299b5`
 │   │   ├── Evidence: `backend-data-source-factory-stocks-route-migration-authorization-2026-05-25.md`
 │   │   ├── Current HEAD: `f7d370cd91f3c28a6f11fdbcb42b8241cfd43be6`
 │   │   ├── Result: compares the remaining two route/API consumers and selects
@@ -1177,9 +1178,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                gate, OpenSpec change, or issue-label change is authorized;
 │   │                a future G2.75 may normalize same-file E701/black style in
 │   │                `stocks.py` only if the implementation diff requires it
-│   └── Next gate: Human review / PR merge decision for G2.74 authorization; if
-│                  accepted, create a separate G2.75 path-limited implementation
-│                  branch for `stocks.py`. Remaining candidate `futures.py`
+│   ├── G2.75 Stocks DataSourceFactory route migration
+│   │   ├── State: ready for review; PR `#226` implementation packet
+│   │   ├── Evidence: `backend-data-source-factory-stocks-route-migration-implementation-2026-05-25.md`
+│   │   ├── Current HEAD: `2a04b019965801084822e132c99690f97f8299b5`
+│   │   ├── Result: migrates `get_stocks_basic` and `search_stocks` from direct
+│   │   │          `get_data_source_factory()` calls to
+│   │   │          `Depends(get_data_source_factory_dependency)`; total route/API
+│   │   │          direct refs move `4 -> 2`, `stocks.py` direct refs move
+│   │   │          `2 -> 0`, health route conflict tests move to `119 passed`,
+│   │   │          provider tests remain `4 passed`, OpenAPI paths remain `500`,
+│   │   │          duplicate operation IDs remain `0`, and staged GitNexus
+│   │   │          reports low risk / 0 affected processes
+│   │   └── Boundary: no route path, response model, response shape, OpenAPI,
+│   │                frontend, runtime/PM2, OpenSpec, issue-label, compatibility
+│   │                getter deletion, `futures.py`, or broad formatting cleanup
+│   │                outside `stocks.py` and the focused test
+│   └── Next gate: Human review / PR merge decision for G2.75 implementation; if
+│                  accepted, create closeout/current-head refresh before the
+│                  `futures.py` risk packet. Remaining candidate `futures.py`
 │                  stays locked
 │
 ├── H. Decision-Only Track: CSRF composition root
@@ -1238,6 +1255,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-kline-route-migration-implementation-2026-05-25.md` | G | G2.73 implementation packet prepared at `68ff82a9`: kline route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `6 -> 4`, and `kline.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before selecting another DataSourceFactory route consumer |
 | `backend-data-source-factory-kline-route-migration-closeout-2026-05-25.md` | G | G2.73 closeout packet prepared at `6ece7f13`: PR `#223` merge recorded, health tests remain `118 passed`, provider tests remain `4 passed`, total refs remain `4`, and `kline.py` remains `0` | Human review / PR merge decision; if accepted, create the next candidate authorization packet |
 | `backend-data-source-factory-stocks-route-migration-authorization-2026-05-25.md` | G | G2.74 candidate packet prepared at `f7d370cd`: selects `stocks.py` as the next route/API factory migration candidate; it is the only remaining LOW-risk candidate and can move total refs `4 -> 2` | Human review / PR merge decision; if accepted, create G2.75 path-limited implementation branch for `stocks.py` only |
+| `backend-data-source-factory-stocks-route-migration-implementation-2026-05-25.md` | G | G2.75 implementation packet prepared at `2a04b019`: stocks route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `4 -> 2`, and `stocks.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before preparing the futures.py risk packet |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-stocks-route-migration-implementation-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-stocks-route-migration-implementation-2026-05-25.json
@@ -1,0 +1,133 @@
+{
+  "artifact": "data-source-factory-stocks-route-migration-implementation-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-75-data-source-factory-stocks-route-migration",
+  "base_head": "2a04b019965801084822e132c99690f97f8299b5",
+  "scope": {
+    "source_files": [
+      "web/backend/app/api/data/stocks.py",
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "governance_files": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/data-source-factory-stocks-route-migration-implementation-2026-05-25.json",
+      "docs/reports/quality/backend-data-source-factory-stocks-route-migration-implementation-2026-05-25.md",
+      "governance/mainline/task-cards/pr-226.yaml"
+    ],
+    "excluded": [
+      "route paths",
+      "response models",
+      "response shape",
+      "OpenAPI exposure policy",
+      "frontend",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue labels",
+      "other DataSourceFactory consumers",
+      "DataSourceFactory compatibility getter removal",
+      "formatting outside web/backend/app/api/data/stocks.py and the focused test file"
+    ]
+  },
+  "pre_edit_evidence": {
+    "authorization": {
+      "source": "backend-data-source-factory-stocks-route-migration-authorization-2026-05-25.md",
+      "pr": 225,
+      "merge_commit": "2a04b019965801084822e132c99690f97f8299b5"
+    },
+    "gitnexus": {
+      "file": {
+        "target": "web/backend/app/api/data/stocks.py",
+        "risk": "LOW",
+        "direct_impacted": 1,
+        "processes_affected": 0
+      },
+      "functions": [
+        {
+          "target": "get_stocks_industries",
+          "risk": "LOW",
+          "direct_impacted": 0,
+          "processes_affected": 0
+        },
+        {
+          "target": "search_stocks",
+          "note": "Function name is ambiguous in GitNexus impact; path-specific context for web/backend/app/api/data/stocks.py:search_stocks reported no incoming references and the outgoing get_data_source_factory call."
+        }
+      ]
+    },
+    "baseline": {
+      "direct_route_api_factory_refs_total": 4,
+      "stocks_py_direct_refs": 2,
+      "health_route_conflicts": "118 passed",
+      "provider_lifecycle": "4 passed",
+      "openapi": {
+        "routes": 548,
+        "paths": 500,
+        "operation_ids": 536,
+        "duplicate_operation_ids": 0
+      }
+    }
+  },
+  "tdd": {
+    "red": {
+      "command": "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_stocks_routes_use_data_source_factory_dependency -q --no-cov --tb=short",
+      "result": "failed as expected",
+      "failure": "KeyError: 'factory'"
+    },
+    "green": {
+      "command": "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_stocks_routes_use_data_source_factory_dependency -q --no-cov --tb=short",
+      "result": "1 passed"
+    }
+  },
+  "implementation": {
+    "migrated_route_handlers": [
+      "get_stocks_basic",
+      "search_stocks"
+    ],
+    "dependency": "Depends(get_data_source_factory_dependency)",
+    "style_normalization": [
+      "same-file stocks.py E701 cleanup",
+      "same-file stocks.py black normalization"
+    ],
+    "unchanged": [
+      "route paths",
+      "response shape",
+      "OpenAPI exposure",
+      "DataSourceFactory compatibility getter",
+      "futures.py"
+    ]
+  },
+  "verification": {
+    "focused_tdd_green": "1 passed",
+    "web/backend/tests/test_health_route_conflicts.py": "119 passed",
+    "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed",
+    "ruff_touched_files": "passed",
+    "black_check_touched_files": "passed",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "warning_count": 0
+    },
+    "route_api_factory_refs": {
+      "total_direct_refs": {
+        "before": 4,
+        "after": 2
+      },
+      "stocks_py_direct_refs": {
+        "before": 2,
+        "after": 0
+      },
+      "remaining_files": [
+        "web/backend/app/api/data/futures.py"
+      ]
+    },
+    "staged_gitnexus": {
+      "risk": "low",
+      "changed_symbols": 30,
+      "affected_processes": 0
+    }
+  },
+  "next_gate": "Human review / PR merge decision for G2.75. If accepted, create a closeout/current-head refresh before preparing the futures.py risk packet."
+}

--- a/docs/reports/quality/backend-data-source-factory-stocks-route-migration-implementation-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-stocks-route-migration-implementation-2026-05-25.md
@@ -1,0 +1,120 @@
+# Backend DataSourceFactory Stocks Route Migration Implementation - 2026-05-25
+
+Workline: G2.75 implementation packet
+
+Base HEAD: `2a04b019965801084822e132c99690f97f8299b5`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This implementation follows the G2.74 authorization packet and
+changes only `web/backend/app/api/data/stocks.py`, the focused route dependency
+test, and governance evidence files. It does not change route paths, response
+models, response shapes, OpenAPI exposure policy, frontend code, runtime/PM2
+state, OpenSpec state, issue labels, or DataSourceFactory compatibility getter
+surfaces.
+
+## Status
+
+Ready for review.
+
+PR `#225` merged the G2.74 authorization packet at
+`2a04b019965801084822e132c99690f97f8299b5`, selecting
+`web/backend/app/api/data/stocks.py` for this path-limited implementation.
+
+## Pre-Edit Evidence
+
+| Target | Result |
+| --- | --- |
+| `web/backend/app/api/data/stocks.py` | GitNexus LOW/1, 0 affected processes |
+| `get_stocks_industries` | GitNexus LOW/0 |
+| `search_stocks` | Name ambiguous in GitNexus impact; path-specific context reported no incoming refs |
+
+Baseline verification from G2.74:
+
+| Check | Result |
+| --- | --- |
+| `web/backend/tests/test_health_route_conflicts.py` | 118 passed |
+| `web/backend/tests/test_data_source_factory_lifecycle_di.py` | 4 passed |
+| Route/API direct `await get_data_source_factory()` refs | total `4`, `stocks.py` `2` |
+| OpenAPI smoke | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0 |
+
+## TDD Evidence
+
+Red test:
+
+```text
+pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_stocks_routes_use_data_source_factory_dependency -q --no-cov --tb=short
+```
+
+Result: failed as expected with `KeyError: 'factory'`.
+
+Green test:
+
+```text
+pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_stocks_routes_use_data_source_factory_dependency -q --no-cov --tb=short
+```
+
+Result: `1 passed`.
+
+## Implementation
+
+Changed `web/backend/app/api/data/stocks.py`:
+
+- Added `DataSourceFactory` and `get_data_source_factory_dependency` import.
+- Migrated `get_stocks_basic` from route-local `await get_data_source_factory()`
+  to `factory: DataSourceFactory = Depends(get_data_source_factory_dependency)`.
+- Migrated `search_stocks` from route-local `await get_data_source_factory()`
+  to the same dependency.
+- Normalized same-file `E701` and black formatting debt in `stocks.py`, as
+  explicitly allowed by G2.74.
+
+Changed `web/backend/tests/test_health_route_conflicts.py`:
+
+- Added `test_stocks_routes_use_data_source_factory_dependency`.
+
+## Verification
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_stocks_routes_use_data_source_factory_dependency -q --no-cov --tb=short` | 1 passed |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | 119 passed |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | 4 passed |
+| `ruff check web/backend/app/api/data/stocks.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| `black --check web/backend/app/api/data/stocks.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| OpenAPI smoke with `PYTHONPATH=web/backend` and root `.env` loaded | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0 |
+| staged GitNexus `detect_changes(scope=staged)` | low risk, 30 changed symbols, 0 affected processes |
+
+Route/API direct factory refs:
+
+| Metric | Before | After |
+| --- | ---: | ---: |
+| Total direct route/API `get_data_source_factory()` refs | 4 | 2 |
+| `web/backend/app/api/data/stocks.py` direct refs | 2 | 0 |
+
+Remaining route consumer stays locked for future authorization:
+
+- `web/backend/app/api/data/futures.py`
+
+GitNexus reports 30 changed symbols because black normalization and the shared
+test file cause broad same-file symbol attribution. The staged risk level is
+`low`, and no affected execution processes are reported.
+
+## Boundary
+
+This PR does not authorize:
+
+- route path changes
+- response model or response shape changes
+- OpenAPI exposure changes
+- frontend edits
+- runtime/PM2 operations
+- OpenSpec changes
+- issue-label changes
+- DataSourceFactory compatibility getter deletion
+- `futures.py` migration
+- formatting outside `stocks.py` and the focused test file
+
+## Next Gate
+
+Human review / PR merge decision for G2.75. If accepted, create a closeout /
+current-head refresh before preparing the `futures.py` risk packet.

--- a/governance/mainline/task-cards/pr-226.yaml
+++ b/governance/mainline/task-cards/pr-226.yaml
@@ -1,0 +1,126 @@
+version: "v0.2"
+
+task:
+  id: "pr-226"
+  title: "Migrate stocks routes to DataSourceFactory dependency injection"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-stocks-route-migration"
+  objective: "move stocks route DataSourceFactory access from compatibility getter calls to FastAPI dependency injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-stocks-route-migration"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-stocks-route-migration"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Implementation changes dependency acquisition only and preserves route paths, OpenAPI exposure, response shape, and runtime semantics"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/api/data/stocks.py"
+    - "web/backend/tests/test_health_route_conflicts.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-stocks-route-migration-implementation-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-stocks-route-migration-implementation-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-226.yaml"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+    - "web/backend/app/api/data/futures.py"
+
+non_goals:
+  - "No route path, response model, response shape, OpenAPI exposure, docs/API, generated client, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No non-stocks.py DataSourceFactory route consumer migration"
+  - "No deletion of get_data_source_factory() or _global_factory compatibility surfaces"
+  - "No broad formatting cleanup outside web/backend/app/api/data/stocks.py and the focused test file"
+
+acceptance:
+  checks:
+    - id: "pre-edit-gitnexus-impact"
+      command: "MCP gitnexus.impact(target=web/backend/app/api/data/stocks.py,direction=upstream)"
+      required: true
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_stocks_routes_use_data_source_factory_dependency -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-files"
+      command: "ruff check web/backend/app/api/data/stocks.py web/backend/tests/test_health_route_conflicts.py"
+      required: true
+    - id: "black-touched-files"
+      command: "black --check web/backend/app/api/data/stocks.py web/backend/tests/test_health_route_conflicts.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-stocks-route-migration-implementation-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-stocks-route-migration-implementation-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-226.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-226.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If response shape or route paths change, the PR exceeds the approved G2.75 boundary"
+    - "If another route consumer is edited, the PR bypasses G2.74 candidate sequencing"
+    - "If formatting cleanup escapes stocks.py and the focused test file, the scoped style authorization is exceeded"
+  rollback_plan: "revert this path-limited PR; compatibility getter surfaces remain available and no route contract changes are introduced"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "migrate stocks route DataSourceFactory access to dependency injection"
+    modified_scope: "stocks route file, focused route-conflict test, implementation report, generated artifact, steward tree, and task card"
+    dependency_changes: "uses existing get_data_source_factory_dependency provider"
+    legacy_logic_impact: "compatibility getter and _global_factory remain unchanged for remaining consumer"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if dependency wiring or route guard verification fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T09:42:21+08:00"
+    approval_note: "human maintainer accepted G2.74 candidate selection by merging PR #225; this packet implements only the approved stocks.py route migration"
+    secondary_approved: false

--- a/web/backend/app/api/data/stocks.py
+++ b/web/backend/app/api/data/stocks.py
@@ -1,6 +1,7 @@
 """
 股票基础信息路由 (Stocks Basic Info)
 """
+
 import os
 from datetime import datetime
 from typing import Any, Dict, Optional
@@ -10,6 +11,7 @@ from app.core.database import db_service
 from app.core.exceptions import BusinessException
 from app.core.security import User, get_current_user
 from app.openapi_config import COMMON_RESPONSES
+from app.services.data_source_factory import DataSourceFactory, get_data_source_factory_dependency
 
 router = APIRouter()
 
@@ -142,10 +144,7 @@ STOCK_DETAIL_RESPONSES = {
 
 
 def _runtime_fallback_enabled() -> bool:
-    return (
-        os.getenv("TESTING", "false").lower() == "true"
-        or os.getenv("DEVELOPMENT_MODE", "false").lower() == "true"
-    )
+    return os.getenv("TESTING", "false").lower() == "true" or os.getenv("DEVELOPMENT_MODE", "false").lower() == "true"
 
 
 def _normalize_market_code(symbol: str, raw_market: str) -> str:
@@ -208,10 +207,7 @@ def _build_runtime_stocks_basic_result(params: Dict[str, Any]) -> Dict[str, Any]
         rows.append(normalized)
 
     if search:
-        rows = [
-            row for row in rows
-            if search in str(row["symbol"]).lower() or search in str(row["name"]).lower()
-        ]
+        rows = [row for row in rows if search in str(row["symbol"]).lower() or search in str(row["name"]).lower()]
 
     if industry:
         rows = [row for row in rows if str(row.get("industry", "")) == industry]
@@ -233,6 +229,7 @@ def _build_runtime_stocks_basic_result(params: Dict[str, Any]) -> Dict[str, Any]
         "source": "runtime_fallback",
     }
 
+
 @router.get(
     "/stocks/basic",
     summary="查询股票基础信息",
@@ -251,6 +248,7 @@ async def get_stocks_basic(
     ),
     sort_order: Optional[str] = Query(None, description="排序方向: asc,desc"),
     current_user: User = Depends(get_current_user),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
 ):
     """获取股票基本信息列表"""
     params = {
@@ -264,9 +262,6 @@ async def get_stocks_basic(
         "sort_order": sort_order,
     }
     try:
-        from app.services.data_source_factory import get_data_source_factory
-
-        factory = await get_data_source_factory()
         result = await factory.get_data("data", "stocks/basic", params)
         if result.get("status") == "success":
             return {
@@ -307,6 +302,7 @@ async def get_stocks_basic(
             }
         raise BusinessException(detail=f"查询失败: {str(e)}", status_code=500)
 
+
 @router.get(
     "/stocks/industries",
     summary="查询股票行业分类",
@@ -318,18 +314,26 @@ async def get_stocks_industries(current_user: User = Depends(get_current_user)) 
     try:
         cache_key = "stocks:industries:list"
         cached_data = db_service.get_cache_data(cache_key)
-        if cached_data: return cached_data
+        if cached_data:
+            return cached_data
 
         df = db_service.query_stocks_basic(limit=10000)
-        if df.empty: return {"success": True, "data": [], "total": 0}
+        if df.empty:
+            return {"success": True, "data": [], "total": 0}
 
         industries = sorted(df["industry"].dropna().unique().tolist())
         industry_list = [{"industry_name": ind, "industry_code": f"IND_{i+1:03d}"} for i, ind in enumerate(industries)]
-        result = {"success": True, "data": industry_list, "total": len(industry_list), "timestamp": datetime.now().isoformat()}
+        result = {
+            "success": True,
+            "data": industry_list,
+            "total": len(industry_list),
+            "timestamp": datetime.now().isoformat(),
+        }
         db_service.set_cache_data(cache_key, result, ttl=3600)
         return result
     except Exception as e:
         raise BusinessException(detail=f"获取行业分类失败: {str(e)}", status_code=500, error_code="DATABASE_ERROR")
+
 
 @router.get(
     "/stocks/concepts",
@@ -342,17 +346,25 @@ async def get_stocks_concepts(current_user: User = Depends(get_current_user)) ->
     try:
         cache_key = "stocks:concepts:list"
         cached_data = db_service.get_cache_data(cache_key)
-        if cached_data: return cached_data
+        if cached_data:
+            return cached_data
 
         df = db_service.query_concepts(limit=10000)
-        if df.empty: return {"success": True, "data": [], "total": 0}
+        if df.empty:
+            return {"success": True, "data": [], "total": 0}
 
         concept_list = [{"concept_name": row["name"], "concept_code": row["code"]} for _, row in df.iterrows()]
-        result = {"success": True, "data": concept_list, "total": len(concept_list), "timestamp": datetime.now().isoformat()}
+        result = {
+            "success": True,
+            "data": concept_list,
+            "total": len(concept_list),
+            "timestamp": datetime.now().isoformat(),
+        }
         db_service.set_cache_data(cache_key, result, ttl=3600)
         return result
     except Exception as e:
         raise BusinessException(detail=f"获取概念分类失败: {str(e)}", status_code=500, error_code="DATABASE_ERROR")
+
 
 @router.get(
     "/stocks/search",
@@ -364,11 +376,10 @@ async def search_stocks(
     keyword: str = Query(..., description="搜索关键词"),
     limit: int = Query(20, ge=1, le=100, description="单次返回的最大匹配结果数。"),
     current_user: User = Depends(get_current_user),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
 ) -> Dict[str, Any]:
     """股票搜索接口"""
     try:
-        from app.services.data_source_factory import get_data_source_factory
-        factory = await get_data_source_factory()
         result = await factory.get_data("data", "stocks/search", {"keyword": keyword, "limit": limit})
         if result.get("status") == "success":
             return {
@@ -384,6 +395,7 @@ async def search_stocks(
     except Exception as e:
         raise BusinessException(detail=str(e), status_code=500)
 
+
 @router.get(
     "/stocks/{symbol}/detail",
     summary="查询股票详情",
@@ -398,15 +410,20 @@ async def get_stock_detail(
     try:
         cache_key = f"stock:detail:{symbol}"
         cached_data = db_service.get_cache_data(cache_key)
-        if cached_data: return cached_data
+        if cached_data:
+            return cached_data
 
         # Simplified for refactoring, usually queries DB
         import random
+
         random.seed(hash(symbol))
         market = "SH" if symbol.startswith("6") else "SZ"
         stock_detail = {
-            "symbol": symbol, "name": f"股票{symbol[-3:]}", "market": market,
-            "industry": "银行", "price": round(random.uniform(5, 100), 2),
+            "symbol": symbol,
+            "name": f"股票{symbol[-3:]}",
+            "market": market,
+            "industry": "银行",
+            "price": round(random.uniform(5, 100), 2),
             "change_pct": round(random.uniform(-10, 10), 2),
         }
         result = {"success": True, "data": stock_detail, "timestamp": datetime.now().isoformat()}

--- a/web/backend/tests/test_health_route_conflicts.py
+++ b/web/backend/tests/test_health_route_conflicts.py
@@ -10,6 +10,7 @@ from app.api.data import kline as kline_module
 from app.api.data import lhb as lhb_module
 from app.api.data import margin as margin_module
 from app.api.data import market as market_module
+from app.api.data import stocks as stocks_module
 from app.api.market import market_data_request as market_data_request_module
 from app.main import app
 
@@ -100,6 +101,16 @@ def test_kline_routes_use_data_source_factory_dependency() -> None:
         factory_param = inspect.signature(route_handler).parameters["factory"]
 
         assert getattr(factory_param.default, "dependency", None) is kline_module.get_data_source_factory_dependency
+
+
+def test_stocks_routes_use_data_source_factory_dependency() -> None:
+    for route_handler in [
+        stocks_module.get_stocks_basic,
+        stocks_module.search_stocks,
+    ]:
+        factory_param = inspect.signature(route_handler).parameters["factory"]
+
+        assert getattr(factory_param.default, "dependency", None) is stocks_module.get_data_source_factory_dependency
 
 
 def test_root_and_socketio_status_have_documented_examples_and_errors() -> None:


### PR DESCRIPTION
## Summary

G2.75 migrates the `web/backend/app/api/data/stocks.py` direct `get_data_source_factory()` route calls into FastAPI dependency injection.

Changed endpoints:

- `get_stocks_basic`
- `search_stocks`

This follows the G2.74 authorization packet and keeps `web/backend/app/api/data/futures.py` locked pending a separate high-risk decision packet.

## Verification

- TDD red: `test_stocks_routes_use_data_source_factory_dependency` failed with `KeyError: factory` before implementation
- TDD green: focused test passed after adding `DataSourceFactory = Depends(get_data_source_factory_dependency)`
- `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short`: 119 passed
- `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short`: 4 passed
- `ruff check web/backend/app/api/data/stocks.py web/backend/tests/test_health_route_conflicts.py`: passed
- `black --check web/backend/app/api/data/stocks.py web/backend/tests/test_health_route_conflicts.py`: passed
- OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0, warnings=0
- Direct route/API refs: total 4 -> 2; `stocks.py` 2 -> 0
- GitNexus staged detect_changes: LOW, changed_symbols=30, affected_processes=0
- Post-commit mainline scope gate: pass, changed files limited to the six intended paths

## Scope boundary

- No route path changes
- No response shape changes
- No OpenAPI exposure policy changes
- No frontend changes
- No PM2/runtime state changes
- No OpenSpec task status or issue label changes
- No `futures.py` migration
- No compatibility getter removal
- Same-file `stocks.py` formatting only, limited to the touched route source file
