### PR TITLE
docs(governance): close out stocks factory route migration

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1179,7 +1179,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                a future G2.75 may normalize same-file E701/black style in
 │   │                `stocks.py` only if the implementation diff requires it
 │   ├── G2.75 Stocks DataSourceFactory route migration
-│   │   ├── State: ready for review; PR `#226` implementation packet
+│   │   ├── State: accepted; PR `#226` merged at
+│   │   │          `02518742fb1169ced7f2aa34daaff0dc9dc8b47b`
 │   │   ├── Evidence: `backend-data-source-factory-stocks-route-migration-implementation-2026-05-25.md`
 │   │   ├── Current HEAD: `2a04b019965801084822e132c99690f97f8299b5`
 │   │   ├── Result: migrates `get_stocks_basic` and `search_stocks` from direct
@@ -1194,10 +1195,22 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                frontend, runtime/PM2, OpenSpec, issue-label, compatibility
 │   │                getter deletion, `futures.py`, or broad formatting cleanup
 │   │                outside `stocks.py` and the focused test
-│   └── Next gate: Human review / PR merge decision for G2.75 implementation; if
-│                  accepted, create closeout/current-head refresh before the
-│                  `futures.py` risk packet. Remaining candidate `futures.py`
-│                  stays locked
+│   ├── G2.75 Closeout / current-head refresh
+│   │   ├── State: ready for review; closeout packet for PR `#227`
+│   │   ├── Evidence: `backend-data-source-factory-stocks-route-migration-closeout-2026-05-25.md`
+│   │   ├── Current HEAD: `02518742fb1169ced7f2aa34daaff0dc9dc8b47b`
+│   │   ├── Result: records PR `#226` merge, confirms health route conflict tests
+│   │   │          remain `119 passed`, provider tests remain `4 passed`,
+│   │   │          route direct refs remain `2`, `stocks.py` direct refs remain
+│   │   │          `0`, OpenAPI paths remain `500`, duplicate operation IDs
+│   │   │          remain `0`, and the only remaining direct route/API refs are
+│   │   │          `web/backend/app/api/data/futures.py:91` and `:114`
+│   │   └── Boundary: closeout-only; no source edit, compatibility getter
+│   │                deletion, `futures.py` migration, or implementation
+│   │                authorization
+│   └── Next gate: Human review / PR merge decision for G2.75 closeout; if
+│                  accepted, prepare a `futures.py` risk packet before any
+│                  remaining DataSourceFactory route/API migration
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1256,6 +1269,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-kline-route-migration-closeout-2026-05-25.md` | G | G2.73 closeout packet prepared at `6ece7f13`: PR `#223` merge recorded, health tests remain `118 passed`, provider tests remain `4 passed`, total refs remain `4`, and `kline.py` remains `0` | Human review / PR merge decision; if accepted, create the next candidate authorization packet |
 | `backend-data-source-factory-stocks-route-migration-authorization-2026-05-25.md` | G | G2.74 candidate packet prepared at `f7d370cd`: selects `stocks.py` as the next route/API factory migration candidate; it is the only remaining LOW-risk candidate and can move total refs `4 -> 2` | Human review / PR merge decision; if accepted, create G2.75 path-limited implementation branch for `stocks.py` only |
 | `backend-data-source-factory-stocks-route-migration-implementation-2026-05-25.md` | G | G2.75 implementation packet prepared at `2a04b019`: stocks route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `4 -> 2`, and `stocks.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before preparing the futures.py risk packet |
+| `backend-data-source-factory-stocks-route-migration-closeout-2026-05-25.md` | G | G2.75 closeout packet prepared at `02518742f`: PR `#226` merge recorded, health tests remain `119 passed`, provider tests remain `4 passed`, total refs remain `2`, `stocks.py` remains `0`, and remaining direct refs are only `futures.py:91` and `futures.py:114` | Human review / PR merge decision; if accepted, prepare a `futures.py` risk packet before any remaining DataSourceFactory route/API migration |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-stocks-route-migration-closeout-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-stocks-route-migration-closeout-2026-05-25.json
@@ -1,0 +1,63 @@
+{
+  "artifact": "data-source-factory-stocks-route-migration-closeout-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-75-data-source-factory-stocks-route-migration-closeout",
+  "current_head": "02518742fb1169ced7f2aa34daaff0dc9dc8b47b",
+  "scope": {
+    "type": "closeout_current_head_refresh",
+    "source_edits": false,
+    "closed_pr": 226,
+    "closed_merge_commit": "02518742fb1169ced7f2aa34daaff0dc9dc8b47b",
+    "excluded": [
+      "backend source edits",
+      "test source edits",
+      "route path changes",
+      "OpenAPI exposure changes",
+      "response model or response shape changes",
+      "frontend changes",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue label changes",
+      "compatibility getter deletion",
+      "futures.py migration"
+    ]
+  },
+  "current_head_verification": {
+    "tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "119 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "style": {
+      "ruff_stocks_and_health_route_conflicts": "passed",
+      "black_check_stocks_and_health_route_conflicts": "passed"
+    },
+    "route_api_factory_refs": {
+      "total_direct_refs": 2,
+      "stocks_py_direct_refs": 0,
+      "remaining_locations": [
+        "web/backend/app/api/data/futures.py:91",
+        "web/backend/app/api/data/futures.py:114"
+      ]
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "generic_python_warning_count": 121,
+      "warning_note": "generic warnings are existing datetime/Pydantic deprecation warnings captured during app import; duplicate operation ID warnings remain 0"
+    },
+    "github": {
+      "pr": 226,
+      "checks": "9 success, 4 skipped",
+      "merge_state": "MERGED"
+    },
+    "gitnexus": {
+      "staged_pr_226": "LOW, 30 changed symbols, 0 affected processes"
+    }
+  },
+  "decision": "G2.75 implementation evidence remains valid at current HEAD. No additional source change is authorized by this closeout.",
+  "next_gate": "Human review / PR merge decision for G2.75 closeout. If accepted, prepare a futures.py risk packet before any remaining DataSourceFactory route/API migration."
+}

--- a/docs/reports/quality/backend-data-source-factory-stocks-route-migration-closeout-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-stocks-route-migration-closeout-2026-05-25.md
@@ -1,0 +1,68 @@
+# Backend DataSourceFactory Stocks Route Migration Closeout - 2026-05-25
+
+Workline: G2.75 closeout / current-head refresh
+
+Current HEAD: `02518742fb1169ced7f2aa34daaff0dc9dc8b47b`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This closeout records current-head evidence for the merged G2.75
+stocks DataSourceFactory route migration. It does not authorize backend source
+edits, test edits, route path changes, OpenAPI exposure changes, response shape
+changes, frontend edits, PM2/runtime operations, OpenSpec proposal publication,
+issue-label changes, compatibility getter deletion, or the remaining `futures.py`
+migration.
+
+## Status
+
+Ready for review.
+
+PR `#226` has been merged at
+`02518742fb1169ced7f2aa34daaff0dc9dc8b47b`. This closeout confirms the G2.75
+stocks route migration remains valid on current HEAD.
+
+## Current-Head Verification
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | 119 passed |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | 4 passed |
+| `ruff check web/backend/app/api/data/stocks.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| `black --check web/backend/app/api/data/stocks.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| OpenAPI smoke with `PYTHONPATH=web/backend` and root `.env` loaded | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0 |
+
+The OpenAPI import captured 121 generic Python warnings, all sampled warnings
+were existing datetime or Pydantic deprecation warnings. Duplicate operation ID
+warnings remain 0.
+
+Route/API direct factory refs:
+
+| Metric | Current HEAD |
+| --- | ---: |
+| Total direct route/API `get_data_source_factory()` refs | 2 |
+| `web/backend/app/api/data/stocks.py` direct refs | 0 |
+
+Remaining direct route/API refs:
+
+- `web/backend/app/api/data/futures.py:91`
+- `web/backend/app/api/data/futures.py:114`
+
+## GitHub And GitNexus
+
+PR `#226` reached CLEAN before merge: 9 checks succeeded and 4 were skipped.
+
+PR `#226` staged GitNexus detect_changes reported LOW risk, 30 changed symbols,
+and 0 affected processes. No new GitNexus source-edit gate is required by this
+docs/governance-only closeout.
+
+## Decision
+
+G2.75 implementation evidence remains valid at current HEAD. No additional
+source change is authorized by this closeout.
+
+## Next Gate
+
+Human review / PR merge decision for this closeout. If accepted, prepare a
+`futures.py` risk packet before any remaining DataSourceFactory route/API
+migration. The remaining `futures.py` direct refs stay locked until that packet
+is reviewed and accepted.

--- a/governance/mainline/task-cards/pr-227.yaml
+++ b/governance/mainline/task-cards/pr-227.yaml
@@ -1,0 +1,116 @@
+version: "v0.2"
+
+task:
+  id: "pr-227"
+  title: "Close out stocks DataSourceFactory route migration"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-stocks-route-migration-closeout"
+  objective: "record current-head verification for the merged stocks DataSourceFactory route migration"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-stocks-route-migration-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-stocks-route-migration-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout records current-head evidence only and does not alter runtime behavior"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-stocks-route-migration-closeout-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-stocks-route-migration-closeout-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-227.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source or test edit"
+  - "No route path, response model, response shape, OpenAPI exposure, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No DataSourceFactory consumer migration or compatibility getter cleanup"
+  - "No futures.py migration or next source implementation authorization"
+
+acceptance:
+  checks:
+    - id: "current-head-health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "current-head-provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "current-head-style"
+      command: "ruff check web/backend/app/api/data/stocks.py web/backend/tests/test_health_route_conflicts.py && black --check web/backend/app/api/data/stocks.py web/backend/tests/test_health_route_conflicts.py"
+      required: true
+    - id: "current-head-openapi-smoke"
+      command: "PYTHONPATH=web/backend python -c 'from app.main import app; app.openapi()'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-stocks-route-migration-closeout-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-stocks-route-migration-closeout-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-227.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-227.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If source files are edited, this closeout exceeds its evidence-only boundary"
+  rollback_plan: "revert this docs/governance-only closeout PR; no runtime code is affected"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out the merged stocks DataSourceFactory route migration"
+    modified_scope: "closeout report, generated artifact, steward tree, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; compatibility getter and remaining futures.py route consumer are unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this closeout PR if current-head evidence is superseded or incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T10:09:45+08:00"
+    approval_note: "human maintainer accepted G2.75 implementation by merging PR #226; this packet records closeout evidence only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

G2.75 closeout/current-head refresh for the merged stocks DataSourceFactory route migration.

This is docs/governance only. It records PR #226 as merged and updates the steward tree, generated artifact, closeout report, and mainline task-card.

## Current-head evidence

- Current HEAD: `02518742fb1169ced7f2aa34daaff0dc9dc8b47b`
- PR #226: merged
- `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short`: 119 passed
- `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short`: 4 passed
- `ruff check web/backend/app/api/data/stocks.py web/backend/tests/test_health_route_conflicts.py`: passed
- `black --check web/backend/app/api/data/stocks.py web/backend/tests/test_health_route_conflicts.py`: passed
- OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0, duplicate_operation_id_warnings=0
- Direct route/API factory refs: total=2, stocks.py=0, remaining only futures.py:91 and futures.py:114
- Staged GitNexus scope for this closeout: LOW, changed_symbols=0, affected_processes=0
- Post-commit mainline scope gate: pass, changed files limited to 4 governance paths

## Boundary

- No backend source or test edits
- No route path / response shape / OpenAPI policy changes
- No frontend / PM2 / runtime operations
- No OpenSpec changes or issue label changes
- No compatibility getter deletion
- No futures.py migration or implementation authorization

## Next gate

If this closeout is accepted, prepare a separate futures.py risk packet before any remaining DataSourceFactory route/API migration.
