### PR TITLE
docs(governance): prepare futures factory route risk packet

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1196,7 +1196,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, `futures.py`, or broad formatting cleanup
 │   │                outside `stocks.py` and the focused test
 │   ├── G2.75 Closeout / current-head refresh
-│   │   ├── State: ready for review; closeout packet for PR `#227`
+│   │   ├── State: accepted; PR `#227` merged at
+│   │   │          `53f365b55b37a03334ea25f083c8ef453fbb2db8`
 │   │   ├── Evidence: `backend-data-source-factory-stocks-route-migration-closeout-2026-05-25.md`
 │   │   ├── Current HEAD: `02518742fb1169ced7f2aa34daaff0dc9dc8b47b`
 │   │   ├── Result: records PR `#226` merge, confirms health route conflict tests
@@ -1208,9 +1209,23 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: closeout-only; no source edit, compatibility getter
 │   │                deletion, `futures.py` migration, or implementation
 │   │                authorization
-│   └── Next gate: Human review / PR merge decision for G2.75 closeout; if
-│                  accepted, prepare a `futures.py` risk packet before any
-│                  remaining DataSourceFactory route/API migration
+│   ├── G2.76 Futures DataSourceFactory route migration risk packet
+│   │   ├── State: ready for review; risk packet for PR `#228`
+│   │   ├── Evidence: `backend-data-source-factory-futures-route-migration-risk-packet-2026-05-25.md`
+│   │   ├── Current HEAD: `53f365b55b37a03334ea25f083c8ef453fbb2db8`
+│   │   ├── Result: confirms `futures.py` owns the final two direct route/API
+│   │   │          `get_data_source_factory()` refs at lines `91` and `114`;
+│   │   │          records two OpenAPI-visible futures endpoints, ruff pass,
+│   │   │          black reformat debt, focused futures docs guard `1 passed`,
+│   │   │          provider tests `4 passed`, file-level GitNexus HIGH risk,
+│   │   │          and exact route-handler caller count `0`
+│   │   └── Boundary: decision-only; no source edit, route contract edit,
+│   │                compatibility getter deletion, OpenSpec change, or issue
+│   │                label change; recommends a future G2.77 path-limited
+│   │                implementation authorization packet if accepted
+│   └── Next gate: Human review / PR merge decision for G2.76 risk packet; if
+│                  accepted, create G2.77 path-limited implementation
+│                  authorization for `futures.py`
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1270,6 +1285,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-stocks-route-migration-authorization-2026-05-25.md` | G | G2.74 candidate packet prepared at `f7d370cd`: selects `stocks.py` as the next route/API factory migration candidate; it is the only remaining LOW-risk candidate and can move total refs `4 -> 2` | Human review / PR merge decision; if accepted, create G2.75 path-limited implementation branch for `stocks.py` only |
 | `backend-data-source-factory-stocks-route-migration-implementation-2026-05-25.md` | G | G2.75 implementation packet prepared at `2a04b019`: stocks route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `4 -> 2`, and `stocks.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before preparing the futures.py risk packet |
 | `backend-data-source-factory-stocks-route-migration-closeout-2026-05-25.md` | G | G2.75 closeout packet prepared at `02518742f`: PR `#226` merge recorded, health tests remain `119 passed`, provider tests remain `4 passed`, total refs remain `2`, `stocks.py` remains `0`, and remaining direct refs are only `futures.py:91` and `futures.py:114` | Human review / PR merge decision; if accepted, prepare a `futures.py` risk packet before any remaining DataSourceFactory route/API migration |
+| `backend-data-source-factory-futures-route-migration-risk-packet-2026-05-25.md` | G | G2.76 risk packet prepared at `53f365b55`: confirms `futures.py` owns the final two direct route/API factory refs, records file-level GitNexus HIGH risk with exact endpoint caller count 0, and recommends a separate G2.77 path-limited implementation authorization before any source edit | Human review / PR merge decision; if accepted, create G2.77 implementation authorization for `futures.py` only |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-futures-route-migration-risk-packet-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-futures-route-migration-risk-packet-2026-05-25.json
@@ -1,0 +1,84 @@
+{
+  "artifact": "data-source-factory-futures-route-migration-risk-packet-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-76-data-source-factory-futures-risk-packet",
+  "current_head": "53f365b55b37a03334ea25f083c8ef453fbb2db8",
+  "scope": {
+    "type": "risk_packet",
+    "source_edits": false,
+    "purpose": "decide whether the final futures.py DataSourceFactory direct route/API refs can enter a future path-limited implementation lane",
+    "excluded": [
+      "backend source edits",
+      "test source edits",
+      "route path changes",
+      "OpenAPI exposure changes",
+      "response model or response shape changes",
+      "frontend changes",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue label changes",
+      "compatibility getter deletion",
+      "futures.py implementation"
+    ]
+  },
+  "current_head_evidence": {
+    "route_api_factory_refs": {
+      "total_direct_refs": 2,
+      "futures_py_direct_refs": 2,
+      "remaining_locations": [
+        "web/backend/app/api/data/futures.py:91",
+        "web/backend/app/api/data/futures.py:114"
+      ]
+    },
+    "futures_py": {
+      "loc": 123,
+      "route_handlers": [
+        "get_futures_index_daily",
+        "get_futures_index_realtime"
+      ],
+      "routes": [
+        "GET /api/v1/data/futures/index/daily",
+        "GET /api/v1/data/futures/index/realtime"
+      ],
+      "include_in_schema": true,
+      "direct_factory_pattern": "function-local import plus await get_data_source_factory()",
+      "ruff": "passed",
+      "black_check": "would reformat",
+      "black_diff": "2 hunks, 6 added diff lines, 2 removed diff lines"
+    },
+    "tests_and_openapi": {
+      "futures_docs_guard": "1 passed",
+      "data_source_factory_lifecycle_di": "4 passed",
+      "openapi_routes": 548,
+      "openapi_paths": 500,
+      "futures_openapi_operations": [
+        "get_futures_index_daily_api_v1_data_futures_index_daily_get",
+        "get_futures_index_realtime_api_v1_data_futures_index_realtime_get"
+      ],
+      "duplicate_operation_id_warnings": 0
+    },
+    "gitnexus": {
+      "analyze_default": "failed in git worktree with ENOTDIR on .git/info because .git is a worktree pointer file",
+      "analyze_no_gitignore_no_register": "status 0, Already up to date",
+      "file_level_impact": "HIGH, impactedCount=141, direct=27, processes_affected=0",
+      "endpoint_cypher_incoming_callers": 0,
+      "endpoint_cypher_outgoing_calls": [
+        "get_futures_index_daily -> get_data_source_factory",
+        "get_futures_index_realtime -> get_data_source_factory"
+      ],
+      "interpretation": "file-level impact is treated as a risk signal and not as implementation approval; endpoint-specific evidence shows the migration surface is two FastAPI route handlers"
+    }
+  },
+  "decision": {
+    "recommendation": "approve a future G2.77 path-limited implementation authorization packet for futures.py only",
+    "implementation_preconditions": [
+      "do not edit source code in this G2.76 packet",
+      "future implementation must run TDD red on a futures dependency-injection guard before source edits",
+      "future implementation may normalize same-file futures.py black formatting only if included in the authorized diff",
+      "future implementation must keep route paths, OpenAPI operation IDs, response shape, frontend consumers, PM2/runtime, OpenSpec, issue labels, and compatibility getter unchanged",
+      "future implementation must rerun health route conflicts, DataSourceFactory lifecycle tests, ruff/black, OpenAPI smoke, direct-ref scan, staged GitNexus, and post-commit mainline scope gate"
+    ]
+  },
+  "next_gate": "Human review / PR merge decision for G2.76 risk packet. If accepted, create G2.77 path-limited implementation authorization for futures.py."
+}

--- a/docs/reports/quality/backend-data-source-factory-futures-route-migration-risk-packet-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-futures-route-migration-risk-packet-2026-05-25.md
@@ -1,0 +1,114 @@
+# Backend DataSourceFactory Futures Route Migration Risk Packet - 2026-05-25
+
+Workline: G2.76 risk packet / final route consumer decision
+
+Current HEAD: `53f365b55b37a03334ea25f083c8ef453fbb2db8`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This packet is decision-only. It does not authorize backend
+source edits, test edits, route path changes, OpenAPI exposure changes, response
+shape changes, frontend edits, PM2/runtime operations, OpenSpec proposal
+publication, issue-label changes, compatibility getter deletion, or a
+`futures.py` implementation.
+
+## Status
+
+Ready for review.
+
+G2.75 closeout was merged in PR `#227`. The only remaining route/API direct
+`get_data_source_factory()` calls are now in `web/backend/app/api/data/futures.py`.
+
+## Current-Head Evidence
+
+Route/API direct factory refs:
+
+| Metric | Current HEAD |
+| --- | ---: |
+| Total direct route/API `get_data_source_factory()` refs | 2 |
+| `web/backend/app/api/data/futures.py` direct refs | 2 |
+| Other route/API direct refs | 0 |
+
+Remaining direct refs:
+
+- `web/backend/app/api/data/futures.py:91`
+- `web/backend/app/api/data/futures.py:114`
+
+`futures.py` shape:
+
+| Fact | Value |
+| --- | --- |
+| LOC | 123 |
+| Route handlers | `get_futures_index_daily`, `get_futures_index_realtime` |
+| Runtime paths | `GET /api/v1/data/futures/index/daily`, `GET /api/v1/data/futures/index/realtime` |
+| OpenAPI schema exposure | both included |
+| Direct factory pattern | function-local import plus `await get_data_source_factory()` |
+| `ruff check web/backend/app/api/data/futures.py` | passed |
+| `black --check web/backend/app/api/data/futures.py` | would reformat |
+| `black --diff web/backend/app/api/data/futures.py` | 2 hunks; 6 added diff lines; 2 removed diff lines |
+
+OpenAPI and focused tests:
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_futures_index_endpoints_have_docs_examples_and_error_responses -q --no-cov --tb=short` | 1 passed |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | 4 passed |
+| OpenAPI route table with root `.env` loaded | 548 routes, 500 paths |
+| Futures OpenAPI operation IDs | `get_futures_index_daily_api_v1_data_futures_index_daily_get`, `get_futures_index_realtime_api_v1_data_futures_index_realtime_get` |
+| Duplicate operation ID warnings | 0 |
+
+## GitNexus Risk
+
+Default `gitnexus analyze` failed in this Git worktree because `.git` is a
+worktree pointer file and GitNexus attempted to create `.git/info`. Running
+`gitnexus analyze --no-gitignore --no-register` exited 0 with `Already up to
+date`.
+
+Risk readings:
+
+| Target | Result | Interpretation |
+| --- | --- | --- |
+| `web/backend/app/api/data/futures.py` file-level upstream impact | HIGH, impactedCount 141, direct 27, processes affected 0 | Treat as a risk signal from file-level import fan-out. Do not use this as implementation approval. |
+| Exact route-handler incoming callers via Cypher | 0 | The two functions are FastAPI route entrypoints rather than ordinary call-chain functions. |
+| Exact route-handler outgoing calls via Cypher | both call `get_data_source_factory` | Confirms the migration surface is two route handlers. |
+
+The file-level HIGH result is why this packet exists. The next implementation
+must stay path-limited and must not fold in compatibility getter deletion,
+response contract edits, or broad route governance changes.
+
+## Decision Recommendation
+
+Approve a future G2.77 path-limited implementation authorization packet for
+`web/backend/app/api/data/futures.py` only.
+
+The future implementation packet should authorize only:
+
+1. Add a TDD guard that proves both futures route handlers expose a `factory`
+   dependency wired to `get_data_source_factory_dependency`.
+2. Add `DataSourceFactory` / `get_data_source_factory_dependency` imports in
+   `futures.py`.
+3. Add a `factory: DataSourceFactory = Depends(get_data_source_factory_dependency)`
+   parameter to both route handlers.
+4. Remove the two function-local `get_data_source_factory` imports and awaits.
+5. Normalize same-file `futures.py` black formatting only if included in the
+   authorized implementation diff.
+
+## Required Future Verification
+
+The future G2.77 implementation must rerun:
+
+- TDD red before any source edit.
+- Focused futures dependency-injection test.
+- Full `web/backend/tests/test_health_route_conflicts.py`.
+- `web/backend/tests/test_data_source_factory_lifecycle_di.py`.
+- `ruff check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py`.
+- `black --check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py`.
+- OpenAPI smoke with route/path/operation ID duplicate checks.
+- Direct route/API factory ref scan, expected `2 -> 0`.
+- Staged GitNexus detect_changes.
+- Post-commit mainline scope gate.
+
+## Next Gate
+
+Human review / PR merge decision for this risk packet. If accepted, create a
+separate G2.77 path-limited implementation authorization packet for `futures.py`.

--- a/governance/mainline/task-cards/pr-228.yaml
+++ b/governance/mainline/task-cards/pr-228.yaml
@@ -1,0 +1,119 @@
+version: "v0.2"
+
+task:
+  id: "pr-228"
+  title: "Prepare futures DataSourceFactory route migration risk packet"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-futures-route-migration-risk-packet"
+  objective: "record current-head risk evidence and next-gate constraints for the final futures.py DataSourceFactory route consumer"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-futures-risk-packet"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-futures-risk-packet"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Risk packet records evidence and does not alter runtime behavior"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-futures-route-migration-risk-packet-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-futures-route-migration-risk-packet-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-228.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source or test edit"
+  - "No route path, response model, response shape, OpenAPI exposure, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No DataSourceFactory consumer migration or compatibility getter cleanup"
+  - "No futures.py implementation authorization beyond recommending the next packet"
+
+acceptance:
+  checks:
+    - id: "current-head-futures-docs-guard"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_futures_index_endpoints_have_docs_examples_and_error_responses -q --no-cov --tb=short"
+      required: true
+    - id: "current-head-provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "current-head-futures-ruff"
+      command: "ruff check web/backend/app/api/data/futures.py"
+      required: true
+    - id: "current-head-futures-black-diff"
+      command: "black --diff web/backend/app/api/data/futures.py"
+      required: true
+    - id: "current-head-openapi-futures-smoke"
+      command: "PYTHONPATH=web/backend python -c 'from app.main import app; app.openapi()'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-futures-route-migration-risk-packet-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-futures-route-migration-risk-packet-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-228.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-228.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If source files are edited, this risk packet exceeds its evidence-only boundary"
+  rollback_plan: "revert this docs/governance-only risk packet PR; no runtime code is affected"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "prepare the futures.py DataSourceFactory route migration risk packet"
+    modified_scope: "risk report, generated artifact, steward tree, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; compatibility getter and futures.py runtime code are unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this risk packet PR if current-head evidence is superseded or incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T10:37:41+08:00"
+    approval_note: "human maintainer accepted G2.75 closeout by merging PR #227; this packet records futures.py risk evidence only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

G2.76 prepares the decision-only risk packet for the final DataSourceFactory direct route/API consumer: `web/backend/app/api/data/futures.py`.

This PR does not edit backend source or tests. It updates the steward tree, generated evidence artifact, quality report, and mainline task-card only.

## Evidence

- Current HEAD: `53f365b55b37a03334ea25f083c8ef453fbb2db8`
- Direct route/API `get_data_source_factory()` refs: total=2, both in `futures.py` at lines 91 and 114
- Futures runtime paths: `GET /api/v1/data/futures/index/daily`, `GET /api/v1/data/futures/index/realtime`
- OpenAPI: 548 routes, 500 paths, futures ops included, duplicate operation ID warnings=0
- Focused futures docs guard: 1 passed
- DataSourceFactory lifecycle tests: 4 passed
- `ruff check web/backend/app/api/data/futures.py`: passed
- `black --check web/backend/app/api/data/futures.py`: would reformat; recorded as same-file risk/debt
- File-level GitNexus: HIGH, impactedCount=141, direct=27, processes_affected=0
- Exact route-handler caller count via Cypher: 0
- Staged GitNexus for this docs-only PR: LOW, changed_symbols=0, affected_processes=0
- Post-commit mainline scope gate: pass, changed files limited to 4 governance paths

## Recommendation

If accepted, create a separate G2.77 path-limited implementation authorization packet for `futures.py` only.

## Boundary

- No backend source or test edits
- No route path / response shape / OpenAPI policy changes
- No frontend / PM2 / runtime operations
- No OpenSpec changes or issue label changes
- No compatibility getter deletion
- No implementation authorization inside this PR beyond recommending the next packet
