### PR TITLE
docs(governance): authorize futures factory route migration

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1210,7 +1210,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                deletion, `futures.py` migration, or implementation
 │   │                authorization
 │   ├── G2.76 Futures DataSourceFactory route migration risk packet
-│   │   ├── State: ready for review; risk packet for PR `#228`
+│   │   ├── State: accepted; PR `#228` merged at
+│   │   │          `5fab3e8f6b0ebfb660f0cae1010cd59dfb30f039`
 │   │   ├── Evidence: `backend-data-source-factory-futures-route-migration-risk-packet-2026-05-25.md`
 │   │   ├── Current HEAD: `53f365b55b37a03334ea25f083c8ef453fbb2db8`
 │   │   ├── Result: confirms `futures.py` owns the final two direct route/API
@@ -1223,9 +1224,20 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                compatibility getter deletion, OpenSpec change, or issue
 │   │                label change; recommends a future G2.77 path-limited
 │   │                implementation authorization packet if accepted
-│   └── Next gate: Human review / PR merge decision for G2.76 risk packet; if
-│                  accepted, create G2.77 path-limited implementation
-│                  authorization for `futures.py`
+│   ├── G2.77 Futures DataSourceFactory implementation authorization
+│   │   ├── State: ready for review; authorization packet for PR `#229`
+│   │   ├── Evidence: `backend-data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.md`
+│   │   ├── Current HEAD: `5fab3e8f6b0ebfb660f0cae1010cd59dfb30f039`
+│   │   ├── Result: authorizes a future G2.78 implementation to edit only
+│   │   │          `web/backend/app/api/data/futures.py` and
+│   │   │          `web/backend/tests/test_health_route_conflicts.py`, using TDD
+│   │   │          to move the final direct route/API factory refs `2 -> 0`
+│   │   └── Boundary: authorization-only; no source edit in this packet, no
+│   │                route contract edit, OpenSpec change, issue-label change,
+│   │                runtime/PM2 action, compatibility getter deletion, or
+│   │                formatting outside `futures.py`
+│   └── Next gate: Human review / PR merge decision for G2.77 authorization; if
+│                  accepted, create G2.78 path-limited implementation branch
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1286,6 +1298,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-stocks-route-migration-implementation-2026-05-25.md` | G | G2.75 implementation packet prepared at `2a04b019`: stocks route handlers now use `get_data_source_factory_dependency`, total route/API factory refs move `4 -> 2`, and `stocks.py` refs move `2 -> 0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before preparing the futures.py risk packet |
 | `backend-data-source-factory-stocks-route-migration-closeout-2026-05-25.md` | G | G2.75 closeout packet prepared at `02518742f`: PR `#226` merge recorded, health tests remain `119 passed`, provider tests remain `4 passed`, total refs remain `2`, `stocks.py` remains `0`, and remaining direct refs are only `futures.py:91` and `futures.py:114` | Human review / PR merge decision; if accepted, prepare a `futures.py` risk packet before any remaining DataSourceFactory route/API migration |
 | `backend-data-source-factory-futures-route-migration-risk-packet-2026-05-25.md` | G | G2.76 risk packet prepared at `53f365b55`: confirms `futures.py` owns the final two direct route/API factory refs, records file-level GitNexus HIGH risk with exact endpoint caller count 0, and recommends a separate G2.77 path-limited implementation authorization before any source edit | Human review / PR merge decision; if accepted, create G2.77 implementation authorization for `futures.py` only |
+| `backend-data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.md` | G | G2.77 authorization packet prepared at `5fab3e8f`: future G2.78 may edit only `futures.py` and `test_health_route_conflicts.py`, must run TDD red/green, must keep route/OpenAPI/response/frontend/runtime/OpenSpec/issue-label/compatibility-getter scope locked, and is expected to move final route/API factory refs `2 -> 0` | Human review / PR merge decision; if accepted, create G2.78 path-limited implementation branch |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.json
@@ -1,0 +1,69 @@
+{
+  "artifact": "data-source-factory-futures-route-migration-implementation-authorization-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-77-data-source-factory-futures-implementation-authorization",
+  "current_head": "5fab3e8f6b0ebfb660f0cae1010cd59dfb30f039",
+  "parent_risk_packet": {
+    "workline": "G2.76",
+    "report": "docs/reports/quality/backend-data-source-factory-futures-route-migration-risk-packet-2026-05-25.md",
+    "merged_pr": 228,
+    "merge_commit": "5fab3e8f6b0ebfb660f0cae1010cd59dfb30f039"
+  },
+  "scope": {
+    "type": "implementation_authorization",
+    "source_edits_in_this_packet": false,
+    "future_implementation_workline": "G2.78",
+    "future_allowed_source_paths": [
+      "web/backend/app/api/data/futures.py",
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "future_allowed_governance_paths": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/data-source-factory-futures-route-migration-implementation-2026-05-25.json",
+      "docs/reports/quality/backend-data-source-factory-futures-route-migration-implementation-2026-05-25.md",
+      "governance/mainline/task-cards/pr-230.yaml"
+    ],
+    "excluded": [
+      "route path changes",
+      "response model or response shape changes",
+      "OpenAPI exposure changes",
+      "frontend changes",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue label changes",
+      "compatibility getter deletion",
+      "other DataSourceFactory consumers",
+      "broad formatting outside futures.py"
+    ]
+  },
+  "future_implementation_steps": [
+    "run GitNexus context/impact for futures.py, get_futures_index_daily, get_futures_index_realtime, and get_data_source_factory_dependency before editing",
+    "write TDD guard test_futures_routes_use_data_source_factory_dependency in web/backend/tests/test_health_route_conflicts.py",
+    "verify the TDD guard fails before source edits because factory is absent",
+    "add DataSourceFactory and get_data_source_factory_dependency import in futures.py",
+    "add factory: DataSourceFactory = Depends(get_data_source_factory_dependency) to get_futures_index_daily and get_futures_index_realtime",
+    "remove the two function-local get_data_source_factory imports and awaits",
+    "normalize same-file futures.py black formatting if required by the implementation diff",
+    "verify direct route/API get_data_source_factory() refs move 2 -> 0"
+  ],
+  "required_future_verification": [
+    "focused TDD guard green",
+    "full web/backend/tests/test_health_route_conflicts.py",
+    "web/backend/tests/test_data_source_factory_lifecycle_di.py",
+    "ruff check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py",
+    "black --check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py",
+    "OpenAPI smoke with routes, paths, operation IDs, and duplicate operation ID warnings",
+    "direct route/API factory ref scan",
+    "staged GitNexus detect_changes",
+    "post-commit mainline scope gate"
+  ],
+  "known_risk": {
+    "file_level_gitnexus": "HIGH at G2.76, impactedCount=141, direct=27, processes_affected=0",
+    "route_handler_cypher_callers": 0,
+    "black_debt": "futures.py would reformat before implementation",
+    "risk_handling": "Future G2.78 must restate the known HIGH file-level risk before editing and stop if new HIGH/CRITICAL findings appear outside the accepted futures.py file-level import fan-out."
+  },
+  "decision": "If this authorization packet is accepted, G2.78 may implement the path-limited futures.py DataSourceFactory route migration under the constraints above.",
+  "next_gate": "Human review / PR merge decision for G2.77 authorization. If accepted, create G2.78 path-limited implementation branch."
+}

--- a/docs/reports/quality/backend-data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.md
@@ -1,0 +1,110 @@
+# Backend DataSourceFactory Futures Route Migration Implementation Authorization - 2026-05-25
+
+Workline: G2.77 implementation authorization
+
+Current HEAD: `5fab3e8f6b0ebfb660f0cae1010cd59dfb30f039`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This packet authorizes a future path-limited implementation
+branch only if reviewed and accepted. It does not itself edit backend source,
+tests, route paths, OpenAPI exposure, response shapes, frontend code, PM2/runtime
+state, OpenSpec changes, issue labels, or compatibility getter behavior.
+
+## Status
+
+Ready for review.
+
+Parent packet: G2.76, PR `#228`, merged at
+`5fab3e8f6b0ebfb660f0cae1010cd59dfb30f039`.
+
+## Authorized Future Implementation
+
+If this authorization is accepted, future G2.78 may edit only:
+
+- `web/backend/app/api/data/futures.py`
+- `web/backend/tests/test_health_route_conflicts.py`
+
+The future implementation may also add its implementation report, generated
+artifact, steward-tree update, and task-card.
+
+Authorized implementation goal:
+
+1. Add `test_futures_routes_use_data_source_factory_dependency`.
+2. Prove the test fails before source edits because `factory` is absent.
+3. Add `DataSourceFactory` and `get_data_source_factory_dependency` imports in
+   `futures.py`.
+4. Add `factory: DataSourceFactory = Depends(get_data_source_factory_dependency)`
+   to `get_futures_index_daily` and `get_futures_index_realtime`.
+5. Remove both function-local `get_data_source_factory` imports and direct awaits.
+6. Normalize same-file `futures.py` black formatting if required by the
+   implementation diff.
+
+Expected result:
+
+| Metric | Before G2.78 | After G2.78 |
+| --- | ---: | ---: |
+| Total direct route/API `get_data_source_factory()` refs | 2 | 0 |
+| `web/backend/app/api/data/futures.py` direct refs | 2 | 0 |
+
+## Locked Scope
+
+G2.78 must not change:
+
+- Route paths or HTTP methods.
+- OpenAPI exposure policy or operation IDs except changes inherently caused by
+  adding a dependency parameter that must remain non-request-visible.
+- Response models, response body shape, examples, or error contract.
+- Frontend consumers.
+- Runtime/PM2 state.
+- OpenSpec tasks or issue labels.
+- `get_data_source_factory()` compatibility getter.
+- Any route/API file other than `futures.py`.
+- Formatting outside `futures.py`.
+
+## Required Pre-Edit Gates
+
+Before source edits, G2.78 must run and record:
+
+- GitNexus context for `get_futures_index_daily`.
+- GitNexus context for `get_futures_index_realtime`.
+- GitNexus impact for `web/backend/app/api/data/futures.py`.
+- GitNexus impact or context for `get_data_source_factory_dependency`.
+
+Known accepted risk from G2.76:
+
+| Signal | Value |
+| --- | --- |
+| File-level `futures.py` impact | HIGH, impactedCount 141, direct 27, processes affected 0 |
+| Exact route-handler caller count | 0 |
+| Route-handler outgoing calls | both call `get_data_source_factory` |
+| Existing style debt | `black --check futures.py` would reformat |
+
+If G2.78 sees a new HIGH/CRITICAL risk outside this known file-level
+`futures.py` import fan-out, it must stop and return to review before editing.
+
+## Required TDD And Verification
+
+G2.78 must run:
+
+- TDD red for `test_futures_routes_use_data_source_factory_dependency`.
+- Focused TDD green for the same test.
+- Full `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short`.
+- `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short`.
+- `ruff check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py`.
+- `black --check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py`.
+- OpenAPI smoke with route count, path count, operation ID count, and duplicate
+  operation ID warnings.
+- Direct route/API factory ref scan, expected `2 -> 0`.
+- Staged GitNexus detect_changes.
+- Post-commit mainline scope gate.
+
+## Decision
+
+If this packet is accepted, G2.78 may perform the path-limited `futures.py`
+DataSourceFactory route migration under the constraints above.
+
+## Next Gate
+
+Human review / PR merge decision for this authorization. If accepted, create the
+G2.78 path-limited implementation branch.

--- a/governance/mainline/task-cards/pr-229.yaml
+++ b/governance/mainline/task-cards/pr-229.yaml
@@ -1,0 +1,104 @@
+version: "v0.2"
+
+task:
+  id: "pr-229"
+  title: "Authorize futures DataSourceFactory route migration implementation"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-futures-route-migration-implementation-authorization"
+  objective: "authorize a future path-limited implementation for the final futures.py DataSourceFactory route consumer"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-futures-implementation-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-futures-implementation-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization packet records future implementation constraints and does not alter runtime behavior"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-229.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source or test edit in this authorization packet"
+  - "No route path, response model, response shape, OpenAPI exposure, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No compatibility getter cleanup"
+  - "No implementation before this authorization is reviewed and accepted"
+
+acceptance:
+  checks:
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-229.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-229.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If source files are edited, this authorization packet exceeds its evidence-only boundary"
+  rollback_plan: "revert this docs/governance-only authorization PR; no runtime code is affected"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize the future futures.py DataSourceFactory route migration implementation"
+    modified_scope: "authorization report, generated artifact, steward tree, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; compatibility getter and futures.py runtime code are unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this authorization PR if its future implementation scope is incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T10:48:43+08:00"
+    approval_note: "human maintainer accepted G2.76 risk packet by merging PR #228; this packet authorizes only a future path-limited implementation packet"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

G2.77 authorizes a future G2.78 path-limited implementation for the final `futures.py` DataSourceFactory direct route/API refs.

This PR is docs/governance only and does not edit backend source or tests.

## Authorization

If accepted, future G2.78 may edit only:

- `web/backend/app/api/data/futures.py`
- `web/backend/tests/test_health_route_conflicts.py`

Expected future result: direct route/API `get_data_source_factory()` refs move total 2 -> 0, all from `futures.py`.

## Required future implementation gates

- Run GitNexus context/impact before editing and restate known file-level HIGH risk from G2.76
- TDD red on `test_futures_routes_use_data_source_factory_dependency` before source edits
- Migrate both route handlers to `DataSourceFactory = Depends(get_data_source_factory_dependency)`
- Remove the two function-local compatibility getter calls
- Same-file `futures.py` black formatting may be normalized if included in the authorized diff
- Run full health-route conflicts, provider lifecycle tests, ruff/black, OpenAPI smoke, direct-ref scan, staged GitNexus, and post-commit mainline gate

## Boundary

- No source/test edits in this PR
- No route path / response shape / OpenAPI policy changes
- No frontend / PM2 / runtime operations
- No OpenSpec changes or issue label changes
- No compatibility getter deletion
- No implementation before this authorization is accepted

## Verification for this PR

- Markdown governance: passed
- JSON parse: passed
- YAML parse: passed
- `git diff --cached --check`: passed
- Staged GitNexus: LOW, changed_symbols=0, affected_processes=0
- Post-commit mainline scope gate: pass, changed files limited to 4 governance paths
