### PR TITLE
refactor(api): migrate futures factory dependency

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1225,7 +1225,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                label change; recommends a future G2.77 path-limited
 │   │                implementation authorization packet if accepted
 │   ├── G2.77 Futures DataSourceFactory implementation authorization
-│   │   ├── State: ready for review; authorization packet for PR `#229`
+│   │   ├── State: accepted; PR `#229` merged at
+│   │   │          `5169da563b883fe0d883b25a09ed0d599952df0d`
 │   │   ├── Evidence: `backend-data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.md`
 │   │   ├── Current HEAD: `5fab3e8f6b0ebfb660f0cae1010cd59dfb30f039`
 │   │   ├── Result: authorizes a future G2.78 implementation to edit only
@@ -1236,8 +1237,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route contract edit, OpenSpec change, issue-label change,
 │   │                runtime/PM2 action, compatibility getter deletion, or
 │   │                formatting outside `futures.py`
-│   └── Next gate: Human review / PR merge decision for G2.77 authorization; if
-│                  accepted, create G2.78 path-limited implementation branch
+│   ├── G2.78 Futures DataSourceFactory route migration
+│   │   ├── State: ready for review; implementation packet for PR `#230`
+│   │   ├── Evidence: `backend-data-source-factory-futures-route-migration-implementation-2026-05-25.md`
+│   │   ├── Current HEAD: `5169da563b883fe0d883b25a09ed0d599952df0d`
+│   │   ├── Result: migrates `get_futures_index_daily` and
+│   │   │          `get_futures_index_realtime` to
+│   │   │          `Depends(get_data_source_factory_dependency)`, removes the
+│   │   │          final two route/API direct `get_data_source_factory()` calls,
+│   │   │          moves direct refs `2 -> 0`, health tests to `120 passed`,
+│   │   │          provider tests stay `4 passed`, OpenAPI paths stay `500`, and
+│   │   │          duplicate operation IDs stay `0`
+│   │   └── Boundary: no route path, response model, response shape, OpenAPI,
+│   │                frontend, runtime/PM2, OpenSpec, issue-label,
+│   │                compatibility getter deletion, other route consumer, or
+│   │                formatting outside `futures.py`
+│   └── Next gate: Human review / PR merge decision for G2.78 implementation; if
+│                  accepted, create closeout/current-head refresh before any
+│                  compatibility getter retirement or retained-shim decision
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1299,6 +1316,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-stocks-route-migration-closeout-2026-05-25.md` | G | G2.75 closeout packet prepared at `02518742f`: PR `#226` merge recorded, health tests remain `119 passed`, provider tests remain `4 passed`, total refs remain `2`, `stocks.py` remains `0`, and remaining direct refs are only `futures.py:91` and `futures.py:114` | Human review / PR merge decision; if accepted, prepare a `futures.py` risk packet before any remaining DataSourceFactory route/API migration |
 | `backend-data-source-factory-futures-route-migration-risk-packet-2026-05-25.md` | G | G2.76 risk packet prepared at `53f365b55`: confirms `futures.py` owns the final two direct route/API factory refs, records file-level GitNexus HIGH risk with exact endpoint caller count 0, and recommends a separate G2.77 path-limited implementation authorization before any source edit | Human review / PR merge decision; if accepted, create G2.77 implementation authorization for `futures.py` only |
 | `backend-data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.md` | G | G2.77 authorization packet prepared at `5fab3e8f`: future G2.78 may edit only `futures.py` and `test_health_route_conflicts.py`, must run TDD red/green, must keep route/OpenAPI/response/frontend/runtime/OpenSpec/issue-label/compatibility-getter scope locked, and is expected to move final route/API factory refs `2 -> 0` | Human review / PR merge decision; if accepted, create G2.78 path-limited implementation branch |
+| `backend-data-source-factory-futures-route-migration-implementation-2026-05-25.md` | G | G2.78 implementation packet prepared at `5169da56`: futures route handlers now use `get_data_source_factory_dependency`, direct route/API factory refs move `2 -> 0`, health route conflicts pass `120`, provider tests pass `4`, OpenAPI paths remain `500`, and compatibility getter remains unchanged | Human review / PR merge decision; if accepted, create closeout/current-head refresh before compatibility getter retirement or retained-shim decision |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-futures-route-migration-implementation-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-futures-route-migration-implementation-2026-05-25.json
@@ -1,0 +1,88 @@
+{
+  "artifact": "data-source-factory-futures-route-migration-implementation-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-78-data-source-factory-futures-route-migration",
+  "current_head_before_commit": "5169da563b883fe0d883b25a09ed0d599952df0d",
+  "parent_authorization": {
+    "workline": "G2.77",
+    "report": "docs/reports/quality/backend-data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.md",
+    "merged_pr": 229,
+    "merge_commit": "5169da563b883fe0d883b25a09ed0d599952df0d"
+  },
+  "scope": {
+    "type": "path_limited_implementation",
+    "source_paths": [
+      "web/backend/app/api/data/futures.py",
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "governance_paths": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/data-source-factory-futures-route-migration-implementation-2026-05-25.json",
+      "docs/reports/quality/backend-data-source-factory-futures-route-migration-implementation-2026-05-25.md",
+      "governance/mainline/task-cards/pr-230.yaml"
+    ],
+    "excluded": [
+      "route path changes",
+      "response model or response shape changes",
+      "OpenAPI exposure changes",
+      "frontend changes",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue label changes",
+      "compatibility getter deletion",
+      "other DataSourceFactory consumers",
+      "formatting outside futures.py"
+    ]
+  },
+  "implementation": {
+    "route_handlers": [
+      "get_futures_index_daily",
+      "get_futures_index_realtime"
+    ],
+    "changes": [
+      "added DataSourceFactory and get_data_source_factory_dependency import",
+      "added factory dependency parameter to both futures route handlers",
+      "removed two function-local get_data_source_factory imports and awaits",
+      "added test_futures_routes_use_data_source_factory_dependency",
+      "normalized same-file futures.py black formatting"
+    ],
+    "direct_route_api_factory_refs": {
+      "before": 2,
+      "after": 0
+    }
+  },
+  "verification": {
+    "tdd_red": "test_futures_routes_use_data_source_factory_dependency failed with KeyError: 'factory'",
+    "tdd_green": "1 passed",
+    "health_route_conflicts": "120 passed",
+    "data_source_factory_lifecycle_di": "4 passed",
+    "ruff": "passed",
+    "black_check": "passed",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0
+    },
+    "direct_ref_scan": {
+      "total_direct_refs": 0,
+      "remaining_locations": []
+    },
+    "pre_edit_gitnexus": {
+      "route_handler_context": "both handlers have no incoming callers and call get_data_source_factory",
+      "file_level_impact": "CRITICAL, impactedCount=151, direct=31, processes_affected=0",
+      "provider_dependency_impact": "not found in current GitNexus index; code scan confirms export and implementation exist"
+    },
+    "staged_gitnexus_code_batch": {
+      "risk_level": "low",
+      "changed_count": 0,
+      "affected_count": 0,
+      "changed_files": 2,
+      "affected_processes": []
+    }
+  },
+  "decision": "G2.78 implementation is ready for review. It removes the final route/API get_data_source_factory() direct refs without route, OpenAPI, response, frontend, runtime, OpenSpec, issue-label, or compatibility getter changes.",
+  "next_gate": "Human review / PR merge decision for G2.78 implementation. If accepted, create closeout/current-head refresh before any compatibility getter retirement decision."
+}

--- a/docs/reports/quality/backend-data-source-factory-futures-route-migration-implementation-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-futures-route-migration-implementation-2026-05-25.md
@@ -1,0 +1,92 @@
+# Backend DataSourceFactory Futures Route Migration Implementation - 2026-05-25
+
+Workline: G2.78 path-limited implementation
+
+Current HEAD before commit: `5169da563b883fe0d883b25a09ed0d599952df0d`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This implementation follows G2.77 authorization. It only changes
+`web/backend/app/api/data/futures.py`,
+`web/backend/tests/test_health_route_conflicts.py`, this implementation report,
+the generated evidence artifact, the steward tree, and the mainline task-card.
+It does not change route paths, response models, response shapes, OpenAPI
+exposure policy, frontend code, PM2/runtime state, OpenSpec tasks, issue labels,
+or the `get_data_source_factory()` compatibility getter.
+
+## Status
+
+Ready for review.
+
+Parent authorization: G2.77, PR `#229`, merged at
+`5169da563b883fe0d883b25a09ed0d599952df0d`.
+
+## Pre-Edit GitNexus
+
+Known accepted risk from G2.77 was restated before editing:
+
+| Target | Result |
+| --- | --- |
+| `get_futures_index_daily` context | no incoming callers; outgoing call to `get_data_source_factory` |
+| `get_futures_index_realtime` context | no incoming callers; outgoing call to `get_data_source_factory` |
+| `web/backend/app/api/data/futures.py` file-level upstream impact | CRITICAL, impactedCount 151, direct 31, processes affected 0 |
+| `get_data_source_factory_dependency` impact | not found in current GitNexus index |
+
+The provider dependency symbol is present in code:
+
+- `web/backend/app/services/data_source_factory/data_source_factory.py:315`
+- `web/backend/app/services/data_source_factory/__init__.py:13`
+
+No new HIGH/CRITICAL risk outside the accepted `futures.py` file-level import
+fan-out was identified before editing.
+
+## TDD
+
+RED:
+
+- Added `test_futures_routes_use_data_source_factory_dependency`.
+- Focused test failed as expected with `KeyError: 'factory'`.
+
+GREEN:
+
+- Added `DataSourceFactory` and `get_data_source_factory_dependency` import in
+  `futures.py`.
+- Added `factory: DataSourceFactory = Depends(get_data_source_factory_dependency)`
+  to both futures route handlers.
+- Removed both function-local `get_data_source_factory` imports and direct awaits.
+- Focused test passed: 1 passed.
+
+## Verification
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_futures_routes_use_data_source_factory_dependency -q --no-cov --tb=short` before implementation | failed with `KeyError: 'factory'` |
+| Same focused test after implementation | 1 passed |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | 120 passed |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | 4 passed |
+| `ruff check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| `black --check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| OpenAPI smoke with root `.env` loaded | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0, duplicate operation ID warnings 0 |
+| Staged GitNexus for code/test batch | LOW, changed files 2, changed symbols 0, affected processes 0 |
+
+Route/API direct factory refs:
+
+| Metric | Before | After |
+| --- | ---: | ---: |
+| Total direct route/API `get_data_source_factory()` refs | 2 | 0 |
+| `web/backend/app/api/data/futures.py` direct refs | 2 | 0 |
+
+## Result
+
+The final route/API direct `get_data_source_factory()` calls have been removed.
+All active route/API consumers now use `get_data_source_factory_dependency` for
+DataSourceFactory access.
+
+The compatibility getter itself remains in place. Its retirement or continued
+retention must be handled by a separate decision packet.
+
+## Next Gate
+
+Human review / PR merge decision for this implementation. If accepted, create a
+G2.78 closeout/current-head refresh before any compatibility getter retirement
+or retained-shim decision.

--- a/governance/mainline/task-cards/pr-230.yaml
+++ b/governance/mainline/task-cards/pr-230.yaml
@@ -1,0 +1,127 @@
+version: "v0.2"
+
+task:
+  id: "pr-230"
+  title: "Migrate futures DataSourceFactory route dependency"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-futures-route-migration-implementation"
+  objective: "migrate final futures route DataSourceFactory direct calls to FastAPI dependency injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-futures-route-migration"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-futures-route-migration"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "Route entrypoints and behavior are unchanged; only provider acquisition changes"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-futures-route-migration-implementation-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-futures-route-migration-implementation-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-230.yaml"
+    - "web/backend/app/api/data/futures.py"
+    - "web/backend/tests/test_health_route_conflicts.py"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No route path, response model, response shape, OpenAPI exposure, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No compatibility getter cleanup"
+  - "No edits to route/API consumers other than futures.py"
+  - "No formatting outside futures.py"
+
+acceptance:
+  checks:
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_futures_routes_use_data_source_factory_dependency -q --no-cov --tb=short before implementation"
+      required: true
+    - id: "focused-green"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_futures_routes_use_data_source_factory_dependency -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "style"
+      command: "ruff check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py && black --check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py"
+      required: true
+    - id: "openapi-smoke"
+      command: "PYTHONPATH=web/backend python -c 'from app.main import app; app.openapi()'"
+      required: true
+    - id: "direct-ref-scan"
+      command: "scan web/backend/app/api for get_data_source_factory() excluding get_data_source_factory_dependency"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-futures-route-migration-implementation-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-futures-route-migration-implementation-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-230.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-230.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "File-level GitNexus impact is CRITICAL due accepted futures.py import fan-out"
+    - "If route paths, response shape, OpenAPI exposure, compatibility getter, or other route consumers change, this PR exceeds authorization"
+  rollback_plan: "revert this implementation PR; direct factory calls would return only in futures.py"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "migrate final futures route direct DataSourceFactory calls to dependency injection"
+    modified_scope: "futures.py, health route conflict dependency guard, implementation report, generated artifact, steward tree, and task card"
+    dependency_changes: "route handlers now receive DataSourceFactory through get_data_source_factory_dependency"
+    legacy_logic_impact: "compatibility getter remains unchanged; direct route/API calls move 2 -> 0"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if route/OpenAPI/response or provider behavior regresses"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T11:08:57+08:00"
+    approval_note: "human maintainer accepted G2.77 implementation authorization by merging PR #229"
+    secondary_approved: false

--- a/web/backend/app/api/data/futures.py
+++ b/web/backend/app/api/data/futures.py
@@ -1,6 +1,7 @@
 """
 股指期货数据路由 (Futures)
 """
+
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, Query
@@ -8,6 +9,7 @@ from fastapi import APIRouter, Depends, Query
 from app.core.exceptions import BusinessException
 from app.core.security import User, get_current_user
 from app.openapi_config import COMMON_RESPONSES
+from app.services.data_source_factory import DataSourceFactory, get_data_source_factory_dependency
 
 router = APIRouter()
 
@@ -84,11 +86,9 @@ async def get_futures_index_daily(
     start_date: str = Query(..., description="查询开始日期，格式为 YYYY-MM-DD。"),
     end_date: str = Query(..., description="查询结束日期，格式为 YYYY-MM-DD。"),
     current_user: User = Depends(get_current_user),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
 ) -> Dict[str, Any]:
     try:
-        from app.services.data_source_factory import get_data_source_factory
-
-        factory = await get_data_source_factory()
         result = await factory.get_data(
             "data",
             "futures/index/daily",
@@ -96,7 +96,10 @@ async def get_futures_index_daily(
         )
         return {"success": True, "data": result.get("data", []), "symbol": symbol}
     except Exception as e:
-        raise BusinessException(detail=f"获取股指期货日线失败: {str(e)}", status_code=500, error_code="DATA_RETRIEVAL_FAILED")
+        raise BusinessException(
+            detail=f"获取股指期货日线失败: {str(e)}", status_code=500, error_code="DATA_RETRIEVAL_FAILED"
+        )
+
 
 @router.get(
     "/futures/index/realtime",
@@ -107,11 +110,9 @@ async def get_futures_index_daily(
 async def get_futures_index_realtime(
     symbol: str = Query(..., description="股指期货合约代码，例如 IF2404、IH2404 或 IC2404。"),
     current_user: User = Depends(get_current_user),
+    factory: DataSourceFactory = Depends(get_data_source_factory_dependency),
 ) -> Dict[str, Any]:
     try:
-        from app.services.data_source_factory import get_data_source_factory
-
-        factory = await get_data_source_factory()
         result = await factory.get_data("data", "futures/index/realtime", {"symbol": symbol})
         return {"success": True, "data": result.get("data", []), "symbol": symbol}
     except Exception as e:

--- a/web/backend/tests/test_health_route_conflicts.py
+++ b/web/backend/tests/test_health_route_conflicts.py
@@ -6,6 +6,7 @@ import inspect
 from fastapi.routing import APIRoute
 
 from app.api.data import financial as financial_module
+from app.api.data import futures as futures_module
 from app.api.data import kline as kline_module
 from app.api.data import lhb as lhb_module
 from app.api.data import margin as margin_module
@@ -111,6 +112,16 @@ def test_stocks_routes_use_data_source_factory_dependency() -> None:
         factory_param = inspect.signature(route_handler).parameters["factory"]
 
         assert getattr(factory_param.default, "dependency", None) is stocks_module.get_data_source_factory_dependency
+
+
+def test_futures_routes_use_data_source_factory_dependency() -> None:
+    for route_handler in [
+        futures_module.get_futures_index_daily,
+        futures_module.get_futures_index_realtime,
+    ]:
+        factory_param = inspect.signature(route_handler).parameters["factory"]
+
+        assert getattr(factory_param.default, "dependency", None) is futures_module.get_data_source_factory_dependency
 
 
 def test_root_and_socketio_status_have_documented_examples_and_errors() -> None:


### PR DESCRIPTION
## Summary

G2.78 migrates the final route/API direct `get_data_source_factory()` calls in `web/backend/app/api/data/futures.py` to FastAPI dependency injection.

Changed route handlers:

- `get_futures_index_daily`
- `get_futures_index_realtime`

## Scope

- `web/backend/app/api/data/futures.py`
- `web/backend/tests/test_health_route_conflicts.py`
- steward tree, generated evidence artifact, report, task-card

No route paths, response shape, OpenAPI exposure, frontend, runtime/PM2, OpenSpec, issue labels, or compatibility getter changes.

## Verification

- Pre-edit GitNexus: futures.py file-level impact CRITICAL/151/direct 31/processes 0, accepted by G2.77; route handler contexts had no incoming callers and outgoing calls to `get_data_source_factory`
- Provider dependency GitNexus impact: symbol not found in current index; code scan confirmed implementation/export
- TDD red: `test_futures_routes_use_data_source_factory_dependency` failed with `KeyError: factory`
- TDD green: focused test 1 passed
- `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short`: 120 passed
- `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short`: 4 passed
- `ruff check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py`: passed
- `black --check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py`: passed
- OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0, duplicate_operation_id_warnings=0
- Direct route/API factory refs: 2 -> 0
- Staged GitNexus: LOW, changed_files=6, changed_symbols=0, affected_processes=0
- Post-commit mainline scope gate: pass, changed files limited to the six intended paths

## Next gate

If accepted, create G2.78 closeout/current-head refresh before any compatibility getter retirement or retained-shim decision.
