### PR TITLE
docs(governance): close out futures factory route migration

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1238,9 +1238,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                runtime/PM2 action, compatibility getter deletion, or
 │   │                formatting outside `futures.py`
 │   ├── G2.78 Futures DataSourceFactory route migration
-│   │   ├── State: ready for review; implementation packet for PR `#230`
+│   │   ├── State: accepted; PR `#230` merged at
+│   │   │          `e7a2a436b157dc32d5675e89e4f8c16505b07629`
 │   │   ├── Evidence: `backend-data-source-factory-futures-route-migration-implementation-2026-05-25.md`
-│   │   ├── Current HEAD: `5169da563b883fe0d883b25a09ed0d599952df0d`
+│   │   ├── Current HEAD: `e7a2a436b157dc32d5675e89e4f8c16505b07629`
 │   │   ├── Result: migrates `get_futures_index_daily` and
 │   │   │          `get_futures_index_realtime` to
 │   │   │          `Depends(get_data_source_factory_dependency)`, removes the
@@ -1252,9 +1253,23 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                frontend, runtime/PM2, OpenSpec, issue-label,
 │   │                compatibility getter deletion, other route consumer, or
 │   │                formatting outside `futures.py`
-│   └── Next gate: Human review / PR merge decision for G2.78 implementation; if
-│                  accepted, create closeout/current-head refresh before any
-│                  compatibility getter retirement or retained-shim decision
+│   ├── G2.78 Closeout / current-head refresh
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-data-source-factory-futures-route-migration-closeout-2026-05-25.md`
+│   │   ├── Current HEAD: `e7a2a436b157dc32d5675e89e4f8c16505b07629`
+│   │   ├── Result: records PR `#230` merge, confirms health route conflict tests
+│   │   │          pass `120`, provider lifecycle tests pass `4`, ruff and black
+│   │   │          pass for `futures.py` plus the health test, OpenAPI remains
+│   │   │          routes=`548`, paths=`500`, duplicate operation IDs=`0`, and
+│   │   │          total route/API direct factory refs remain `0`
+│   │   └── Boundary: no source, test, route path, response model, response
+│   │                shape, OpenAPI exposure, frontend, runtime/PM2, OpenSpec,
+│   │                issue-label, compatibility getter deletion, or retained-shim
+│   │                retirement change is authorized
+│   └── Next gate: Human review / PR merge decision for G2.78 closeout; if
+│                  accepted, prepare a separate compatibility getter retirement
+│                  / retained-shim decision packet before any
+│                  `get_data_source_factory()` compatibility API removal
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1317,6 +1332,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-futures-route-migration-risk-packet-2026-05-25.md` | G | G2.76 risk packet prepared at `53f365b55`: confirms `futures.py` owns the final two direct route/API factory refs, records file-level GitNexus HIGH risk with exact endpoint caller count 0, and recommends a separate G2.77 path-limited implementation authorization before any source edit | Human review / PR merge decision; if accepted, create G2.77 implementation authorization for `futures.py` only |
 | `backend-data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.md` | G | G2.77 authorization packet prepared at `5fab3e8f`: future G2.78 may edit only `futures.py` and `test_health_route_conflicts.py`, must run TDD red/green, must keep route/OpenAPI/response/frontend/runtime/OpenSpec/issue-label/compatibility-getter scope locked, and is expected to move final route/API factory refs `2 -> 0` | Human review / PR merge decision; if accepted, create G2.78 path-limited implementation branch |
 | `backend-data-source-factory-futures-route-migration-implementation-2026-05-25.md` | G | G2.78 implementation packet prepared at `5169da56`: futures route handlers now use `get_data_source_factory_dependency`, direct route/API factory refs move `2 -> 0`, health route conflicts pass `120`, provider tests pass `4`, OpenAPI paths remain `500`, and compatibility getter remains unchanged | Human review / PR merge decision; if accepted, create closeout/current-head refresh before compatibility getter retirement or retained-shim decision |
+| `backend-data-source-factory-futures-route-migration-closeout-2026-05-25.md` | G | G2.78 closeout packet prepared at `e7a2a436`: PR `#230` merge recorded, health tests remain `120 passed`, provider tests remain `4 passed`, total route/API direct factory refs remain `0`, OpenAPI paths remain `500`, and compatibility getter remains unchanged | Human review / PR merge decision; if accepted, prepare a separate compatibility getter retirement / retained-shim decision packet |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-futures-route-migration-closeout-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-futures-route-migration-closeout-2026-05-25.json
@@ -1,0 +1,60 @@
+{
+  "artifact": "data-source-factory-futures-route-migration-closeout-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-78-data-source-factory-futures-route-migration-closeout",
+  "current_head": "e7a2a436b157dc32d5675e89e4f8c16505b07629",
+  "scope": {
+    "type": "closeout_current_head_refresh",
+    "source_edits": false,
+    "closed_pr": 230,
+    "closed_merge_commit": "e7a2a436b157dc32d5675e89e4f8c16505b07629",
+    "excluded": [
+      "backend source edits",
+      "test source edits",
+      "route path changes",
+      "OpenAPI exposure changes",
+      "response model or response shape changes",
+      "frontend changes",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue label changes",
+      "compatibility getter deletion",
+      "retained-shim retirement"
+    ]
+  },
+  "current_head_verification": {
+    "tests": {
+      "web/backend/tests/test_health_route_conflicts.py": "120 passed",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed"
+    },
+    "style": {
+      "ruff_futures_and_health_route_conflicts": "passed",
+      "black_check_futures_and_health_route_conflicts": "passed"
+    },
+    "route_api_factory_refs": {
+      "total_direct_refs": 0,
+      "futures_py_direct_refs": 0,
+      "remaining_locations": []
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "generic_python_warning_count": 121,
+      "warning_note": "generic warnings are existing app import warnings captured during OpenAPI generation; duplicate operation ID warnings remain 0"
+    },
+    "github": {
+      "pr": 230,
+      "checks": "9 success, 4 skipped",
+      "merge_state": "MERGED"
+    },
+    "gitnexus": {
+      "staged_pr_230": "LOW, 0 changed symbols, 0 affected processes after documentation artifacts were staged"
+    }
+  },
+  "decision": "G2.78 implementation evidence remains valid at current HEAD. Route/API direct get_data_source_factory() consumer migration is closed for the scanned web/backend/app/api scope. No additional source change is authorized by this closeout.",
+  "next_gate": "Human review / PR merge decision for G2.78 closeout. If accepted, prepare a separate compatibility getter retirement / retained-shim decision packet before any get_data_source_factory() compatibility API removal."
+}

--- a/docs/reports/quality/backend-data-source-factory-futures-route-migration-closeout-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-futures-route-migration-closeout-2026-05-25.md
@@ -1,0 +1,68 @@
+# Backend DataSourceFactory Futures Route Migration Closeout - 2026-05-25
+
+Workline: G2.78 closeout / current-head refresh
+
+Current HEAD: `e7a2a436b157dc32d5675e89e4f8c16505b07629`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This closeout records current-head evidence for the merged G2.78
+futures DataSourceFactory route migration. It does not authorize backend source
+edits, test edits, route path changes, OpenAPI exposure changes, response shape
+changes, frontend edits, PM2/runtime operations, OpenSpec proposal publication,
+issue-label changes, compatibility getter deletion, or retained-shim retirement.
+
+## Status
+
+Ready for review.
+
+PR `#230` has been merged at
+`e7a2a436b157dc32d5675e89e4f8c16505b07629`. This closeout confirms the G2.78
+futures route migration remains valid on current HEAD.
+
+## Current-Head Verification
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov` | 120 passed |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov` | 4 passed |
+| `ruff check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| `black --check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py` | passed |
+| OpenAPI smoke with `PYTHONPATH=web/backend` and root `.env` loaded | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0 |
+
+The OpenAPI import captured 121 generic Python warnings. Duplicate operation ID
+warnings remain 0.
+
+Route/API direct factory refs:
+
+| Metric | Current HEAD |
+| --- | ---: |
+| Total direct route/API `get_data_source_factory()` refs | 0 |
+| `web/backend/app/api/data/futures.py` direct refs | 0 |
+
+Remaining direct route/API refs:
+
+- None.
+
+## GitHub And GitNexus
+
+PR `#230` reached CLEAN before merge: 9 checks succeeded and 4 were skipped.
+
+PR `#230` staged GitNexus detect_changes reported LOW risk, 0 changed symbols,
+and 0 affected processes after documentation artifacts were staged. No new
+GitNexus source-edit gate is required by this docs/governance-only closeout.
+
+## Decision
+
+G2.78 implementation evidence remains valid at current HEAD. The route/API
+direct `get_data_source_factory()` consumer migration is closed for the scanned
+`web/backend/app/api` scope.
+
+No additional source change is authorized by this closeout.
+
+## Next Gate
+
+Human review / PR merge decision for this closeout. If accepted, prepare a
+separate compatibility getter retirement / retained-shim decision packet before
+any `get_data_source_factory()` compatibility API removal, service package export
+change, or downstream consumer rewrite.

--- a/governance/mainline/task-cards/pr-231.yaml
+++ b/governance/mainline/task-cards/pr-231.yaml
@@ -1,0 +1,116 @@
+version: "v0.2"
+
+task:
+  id: "pr-231"
+  title: "Close out futures DataSourceFactory route migration"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-futures-route-migration-closeout"
+  objective: "record current-head verification for the merged futures DataSourceFactory route migration"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-futures-route-migration-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-futures-route-migration-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout records current-head evidence only and does not alter runtime behavior"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-futures-route-migration-closeout-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-futures-route-migration-closeout-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-231.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source or test edit"
+  - "No route path, response model, response shape, OpenAPI exposure, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No DataSourceFactory consumer migration or compatibility getter cleanup"
+  - "No compatibility getter deletion or retained-shim retirement"
+
+acceptance:
+  checks:
+    - id: "current-head-health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov"
+      required: true
+    - id: "current-head-provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov"
+      required: true
+    - id: "current-head-style"
+      command: "ruff check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py && black --check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py"
+      required: true
+    - id: "current-head-openapi-smoke"
+      command: "PYTHONPATH=web/backend python -c 'from app.main import app; app.openapi()'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-futures-route-migration-closeout-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-futures-route-migration-closeout-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-231.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-231.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If source files are edited, this closeout exceeds its evidence-only boundary"
+  rollback_plan: "revert this docs/governance-only closeout PR; no runtime code is affected"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out the merged futures DataSourceFactory route migration"
+    modified_scope: "closeout report, generated artifact, steward tree, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; compatibility getter remains unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this closeout PR if current-head evidence is superseded or incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T11:35:47+08:00"
+    approval_note: "human maintainer accepted G2.78 implementation by merging PR #230; this packet records closeout evidence only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record G2.78 futures DataSourceFactory route migration closeout at current HEAD e7a2a436
- add current-head evidence report, generated JSON artifact, task card, and steward tree update
- keep source/runtime/OpenSpec/issue-label/compatibility getter changes out of scope

## Verification
- pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov: 120 passed
- pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov: 4 passed
- ruff check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py: passed
- black --check web/backend/app/api/data/futures.py web/backend/tests/test_health_route_conflicts.py: passed
- OpenAPI smoke: 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0
- direct route/API get_data_source_factory() refs: 0
- markdown governance: 2 checked, 0 errors
- JSON/YAML parse: passed
- git diff --cached --check: passed
- GitNexus detect_changes staged: LOW, 0 changed symbols, 0 affected processes
- post-commit mainline scope gate: pass=True