### PR TITLE
docs(governance): retain data source factory compatibility getter

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1254,9 +1254,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                compatibility getter deletion, other route consumer, or
 │   │                formatting outside `futures.py`
 │   ├── G2.78 Closeout / current-head refresh
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#231` merged at
+│   │   │          `b3aefed2648a3ec19dede187e4ca04a096dd0a7c`
 │   │   ├── Evidence: `backend-data-source-factory-futures-route-migration-closeout-2026-05-25.md`
-│   │   ├── Current HEAD: `e7a2a436b157dc32d5675e89e4f8c16505b07629`
+│   │   ├── Current HEAD: `b3aefed2648a3ec19dede187e4ca04a096dd0a7c`
 │   │   ├── Result: records PR `#230` merge, confirms health route conflict tests
 │   │   │          pass `120`, provider lifecycle tests pass `4`, ruff and black
 │   │   │          pass for `futures.py` plus the health test, OpenAPI remains
@@ -1266,9 +1267,23 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                shape, OpenAPI exposure, frontend, runtime/PM2, OpenSpec,
 │   │                issue-label, compatibility getter deletion, or retained-shim
 │   │                retirement change is authorized
-│   └── Next gate: Human review / PR merge decision for G2.78 closeout; if
-│                  accepted, prepare a separate compatibility getter retirement
-│                  / retained-shim decision packet before any
+│   ├── G2.79 DataSourceFactory compatibility getter retained-shim decision
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-data-source-factory-compat-getter-retained-shim-decision-2026-05-25.md`
+│   │   ├── Current HEAD: `b3aefed2648a3ec19dede187e4ca04a096dd0a7c`
+│   │   ├── Result: decides to retain `get_data_source_factory()` for now:
+│   │   │          route/API direct calls are `0`, but the compatibility getter
+│   │   │          remains package-exported, is covered by lifecycle tests, and
+│   │   │          is still used by service-internal helper fallback paths;
+│   │   │          current GitNexus impact reports CRITICAL and must be treated
+│   │   │          as a high-risk/stale-index warning, not deletion approval
+│   │   └── Boundary: no source, test, route path, response model, response
+│   │                shape, OpenAPI exposure, frontend, runtime/PM2, OpenSpec,
+│   │                issue-label, compatibility getter deletion, package export
+│   │                removal, or retained-shim retirement change is authorized
+│   └── Next gate: Human review / PR merge decision for G2.79 decision; if
+│                  accepted, create a separate source-capable retirement
+│                  authorization packet before any
 │                  `get_data_source_factory()` compatibility API removal
 │
 ├── H. Decision-Only Track: CSRF composition root
@@ -1333,6 +1348,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-futures-route-migration-implementation-authorization-2026-05-25.md` | G | G2.77 authorization packet prepared at `5fab3e8f`: future G2.78 may edit only `futures.py` and `test_health_route_conflicts.py`, must run TDD red/green, must keep route/OpenAPI/response/frontend/runtime/OpenSpec/issue-label/compatibility-getter scope locked, and is expected to move final route/API factory refs `2 -> 0` | Human review / PR merge decision; if accepted, create G2.78 path-limited implementation branch |
 | `backend-data-source-factory-futures-route-migration-implementation-2026-05-25.md` | G | G2.78 implementation packet prepared at `5169da56`: futures route handlers now use `get_data_source_factory_dependency`, direct route/API factory refs move `2 -> 0`, health route conflicts pass `120`, provider tests pass `4`, OpenAPI paths remain `500`, and compatibility getter remains unchanged | Human review / PR merge decision; if accepted, create closeout/current-head refresh before compatibility getter retirement or retained-shim decision |
 | `backend-data-source-factory-futures-route-migration-closeout-2026-05-25.md` | G | G2.78 closeout packet prepared at `e7a2a436`: PR `#230` merge recorded, health tests remain `120 passed`, provider tests remain `4 passed`, total route/API direct factory refs remain `0`, OpenAPI paths remain `500`, and compatibility getter remains unchanged | Human review / PR merge decision; if accepted, prepare a separate compatibility getter retirement / retained-shim decision packet |
+| `backend-data-source-factory-compat-getter-retained-shim-decision-2026-05-25.md` | G | G2.79 decision packet prepared at `b3aefed2`: route/API direct `get_data_source_factory()` calls are `0`, but the compatibility getter remains package-exported, lifecycle-tested, and used by service-internal helper fallback paths; decision is retain shim for now | Human review / PR merge decision; if accepted, create a separate source-capable retirement authorization packet before any compatibility API removal |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-compat-getter-retained-shim-decision-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-compat-getter-retained-shim-decision-2026-05-25.json
@@ -1,0 +1,72 @@
+{
+  "artifact": "data-source-factory-compat-getter-retained-shim-decision-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-79-data-source-factory-compat-getter-decision",
+  "current_head": "b3aefed2648a3ec19dede187e4ca04a096dd0a7c",
+  "scope": {
+    "type": "decision_only_retained_shim",
+    "source_edits": false,
+    "closed_prerequisite_pr": 231,
+    "excluded": [
+      "backend source edits",
+      "test source edits",
+      "route path changes",
+      "OpenAPI exposure changes",
+      "response model or response shape changes",
+      "frontend changes",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue label changes",
+      "compatibility getter deletion",
+      "package export removal",
+      "retained-shim retirement"
+    ]
+  },
+  "decision": "Retain get_data_source_factory() as a compatibility shim for now. Route/API direct consumers are closed, but service-internal helper and package export dependencies remain.",
+  "inventory": {
+    "route_api_direct_get_data_source_factory_refs": 0,
+    "exact_parenthesized_refs": 10,
+    "definition": "web/backend/app/services/data_source_factory/data_source_factory.py:300",
+    "service_internal_parenthesized_refs": [
+      "web/backend/app/services/data_source_factory/data_source_factory.py:300",
+      "web/backend/app/services/data_source_factory/data_source_factory.py:310",
+      "web/backend/app/services/data_source_factory/data_source_factory.py:324",
+      "web/backend/app/services/data_source_factory/data_source_factory.py:330",
+      "web/backend/app/services/data_source_factory/data_source_factory.py:336",
+      "web/backend/app/services/data_source_factory/data_source_factory.py:342"
+    ],
+    "package_export_refs": [
+      "web/backend/app/services/data_source_factory/__init__.py:12",
+      "web/backend/app/services/data_source_factory/__init__.py:31"
+    ],
+    "compatibility_test_ref": "web/backend/tests/test_data_source_factory_lifecycle_di.py:70"
+  },
+  "verification": {
+    "tests": {
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed",
+      "web/backend/tests/test_health_route_conflicts.py": "120 passed"
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "generic_python_warning_count": 121
+    },
+    "gitnexus": {
+      "impact": "CRITICAL, 22 impacted symbols, 21 direct dependents, 12 affected processes",
+      "note": "index still lists historical route handlers that textual current-head scans show as migrated; treat as stale-index/high-risk warning, not deletion authorization"
+    }
+  },
+  "required_preconditions_before_retirement": [
+    "fresh GitNexus reanalysis or explicit stale-index waiver",
+    "current textual scan confirming route/API direct calls remain 0",
+    "service-internal helper migration plan",
+    "package export compatibility decision",
+    "TDD red/green compatibility coverage",
+    "OpenAPI smoke and route-conflict regression checks"
+  ],
+  "next_gate": "Human review / PR merge decision for G2.79 retained-shim decision. If accepted, create a separate retirement authorization packet before any source-capable removal."
+}

--- a/docs/reports/quality/backend-data-source-factory-compat-getter-retained-shim-decision-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-compat-getter-retained-shim-decision-2026-05-25.md
@@ -1,0 +1,93 @@
+# Backend DataSourceFactory Compatibility Getter Retained-Shim Decision - 2026-05-25
+
+Workline: G2.79 decision-only compatibility API governance
+
+Current HEAD: `b3aefed2648a3ec19dede187e4ca04a096dd0a7c`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This decision packet records the current status of the
+`get_data_source_factory()` compatibility getter after the G2.78 futures route
+migration. It does not authorize backend source edits, test edits, route path
+changes, OpenAPI exposure changes, response shape changes, frontend edits,
+PM2/runtime operations, OpenSpec proposal publication, issue-label changes,
+compatibility getter deletion, package export removal, or retained-shim
+retirement.
+
+## Status
+
+Ready for review.
+
+## Decision
+
+Retain `get_data_source_factory()` as a compatibility shim for now.
+
+The route/API direct consumer migration is closed: current textual scan reports
+0 direct `get_data_source_factory()` calls under `web/backend/app/api`. That is
+not the same as deletion readiness. The function remains package-exported and is
+still used by service-internal convenience helpers and the dependency fallback
+path in `web/backend/app/services/data_source_factory/data_source_factory.py`.
+
+## Evidence
+
+| Metric | Current HEAD |
+| --- | ---: |
+| Route/API direct `get_data_source_factory()` calls | 0 |
+| Exact Python `get_data_source_factory()` parenthesized refs | 10 |
+| Function definitions | 1 |
+| Package export lines | 2 |
+| Service-internal parenthesized refs | 6 |
+
+Key locations:
+
+| Location | Role |
+| --- | --- |
+| `web/backend/app/services/data_source_factory/data_source_factory.py:300` | compatibility getter definition |
+| `web/backend/app/services/data_source_factory/data_source_factory.py:310` | dependency fallback uses the getter when app state has no factory |
+| `web/backend/app/services/data_source_factory/data_source_factory.py:324` | `get_data_source` convenience helper fallback |
+| `web/backend/app/services/data_source_factory/data_source_factory.py:330` | `get_market_data` convenience helper fallback |
+| `web/backend/app/services/data_source_factory/data_source_factory.py:336` | `get_dashboard_data` convenience helper fallback |
+| `web/backend/app/services/data_source_factory/data_source_factory.py:342` | `get_technical_analysis_data` convenience helper fallback |
+| `web/backend/app/services/data_source_factory/__init__.py:12` | package re-export |
+| `web/backend/app/services/data_source_factory/__init__.py:31` | package `__all__` export |
+| `web/backend/tests/test_data_source_factory_lifecycle_di.py:70` | explicit compatibility getter test |
+
+GitNexus impact against the current index reports CRITICAL risk, 22 impacted
+symbols, 21 direct dependents, and 12 affected processes. The graph still lists
+historical route handlers that textual current-head scans show as migrated, so
+the impact result should be treated as a high-risk/stale-index warning and not
+as deletion authorization.
+
+## Verification
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov` | 4 passed |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov` | 120 passed |
+| OpenAPI smoke with `PYTHONPATH=web/backend` and root `.env` loaded | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0 |
+
+The OpenAPI import captured 121 generic Python warnings. Duplicate operation ID
+warnings remain 0.
+
+## Required Preconditions Before Any Future Retirement
+
+Any future removal or export retirement needs a separate authorization packet
+and must include:
+
+1. Fresh GitNexus reanalysis or an explicit stale-index waiver.
+2. Current textual scan confirming route/API direct calls remain 0.
+3. A service-internal helper migration plan for `get_data_source`,
+   `get_market_data`, `get_dashboard_data`, and
+   `get_technical_analysis_data`.
+4. A package export compatibility decision for
+   `web/backend/app/services/data_source_factory/__init__.py`.
+5. TDD red/green coverage proving external compatibility behavior is either
+   preserved or intentionally retired.
+6. OpenAPI smoke and route-conflict regression checks after implementation.
+
+## Next Gate
+
+Human review / PR merge decision for this retained-shim decision packet. If
+accepted, the next source-capable step must be a separate retirement
+authorization packet; this packet itself keeps the compatibility getter in
+place.

--- a/governance/mainline/task-cards/pr-232.yaml
+++ b/governance/mainline/task-cards/pr-232.yaml
@@ -1,0 +1,113 @@
+version: "v0.2"
+
+task:
+  id: "pr-232"
+  title: "Decide DataSourceFactory compatibility getter retained shim"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-compat-getter-retained-shim-decision"
+  objective: "record retained-shim decision for get_data_source_factory compatibility API"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-compat-getter-retained-shim"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-compat-getter-retained-shim-decision"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision packet records compatibility getter governance only and does not alter runtime behavior"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-compat-getter-retained-shim-decision-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-compat-getter-retained-shim-decision-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-232.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source or test edit"
+  - "No route path, response model, response shape, OpenAPI exposure, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No compatibility getter deletion, package export removal, retained-shim retirement, or source-capable retirement authorization"
+
+acceptance:
+  checks:
+    - id: "current-head-provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov"
+      required: true
+    - id: "current-head-health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov"
+      required: true
+    - id: "current-head-openapi-smoke"
+      command: "PYTHONPATH=web/backend python -c 'from app.main import app; app.openapi()'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-compat-getter-retained-shim-decision-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-compat-getter-retained-shim-decision-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-232.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-232.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If source files are edited, this decision packet exceeds its evidence-only boundary"
+    - "If this packet is misread as deletion approval, service-internal helper fallback and package export compatibility may break"
+  rollback_plan: "revert this docs/governance-only decision PR; no runtime code is affected"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record retained-shim decision for get_data_source_factory compatibility API"
+    modified_scope: "decision report, generated artifact, steward tree, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; compatibility getter remains unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this decision PR if inventory evidence is superseded or incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T11:52:02+08:00"
+    approval_note: "human maintainer asked to continue after G2.78 closeout; this packet records retained-shim decision evidence only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record G2.79 retained-shim decision for get_data_source_factory()
- confirm route/API direct get_data_source_factory() calls are 0 while package export and service-internal fallback helpers remain
- keep compatibility getter deletion, package export removal, and source-capable retirement out of scope

## Verification
- pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov: 4 passed
- pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov: 120 passed
- OpenAPI smoke: 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0
- route/API direct get_data_source_factory() refs: 0
- exact parenthesized refs: 10, all service/test scope
- GitNexus impact: CRITICAL/stale-index warning recorded, not deletion authorization
- markdown governance: 2 checked, 0 errors
- JSON/YAML parse: passed
- git diff --cached --check: passed
- GitNexus detect_changes staged: LOW, 0 changed symbols, 0 affected processes
- post-commit mainline scope gate: pass=True