### PR TITLE
docs(governance): authorize factory getter retirement phase one

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1268,9 +1268,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                issue-label, compatibility getter deletion, or retained-shim
 │   │                retirement change is authorized
 │   ├── G2.79 DataSourceFactory compatibility getter retained-shim decision
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#232` merged at
+│   │   │          `ac0fa318aa30262092d00219de18bd670bab26b2`
 │   │   ├── Evidence: `backend-data-source-factory-compat-getter-retained-shim-decision-2026-05-25.md`
-│   │   ├── Current HEAD: `b3aefed2648a3ec19dede187e4ca04a096dd0a7c`
+│   │   ├── Current HEAD: `ac0fa318aa30262092d00219de18bd670bab26b2`
 │   │   ├── Result: decides to retain `get_data_source_factory()` for now:
 │   │   │          route/API direct calls are `0`, but the compatibility getter
 │   │   │          remains package-exported, is covered by lifecycle tests, and
@@ -1281,10 +1282,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                shape, OpenAPI exposure, frontend, runtime/PM2, OpenSpec,
 │   │                issue-label, compatibility getter deletion, package export
 │   │                removal, or retained-shim retirement change is authorized
-│   └── Next gate: Human review / PR merge decision for G2.79 decision; if
-│                  accepted, create a separate source-capable retirement
-│                  authorization packet before any
-│                  `get_data_source_factory()` compatibility API removal
+│   ├── G2.80 DataSourceFactory compatibility getter retirement authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-data-source-factory-compat-getter-retirement-authorization-2026-05-25.md`
+│   │   ├── Current HEAD: `ac0fa318aa30262092d00219de18bd670bab26b2`
+│   │   ├── Result: authorizes only a future G2.81 Phase 1 service-internal
+│   │   │          decoupling step: internal helper fallback paths may stop
+│   │   │          calling public `get_data_source_factory()`, while the public
+│   │   │          getter and package exports must remain; route/API direct calls
+│   │   │          are still `0`, focused lifecycle tests pass `4`, health route
+│   │   │          conflicts pass `120`, and OpenAPI remains paths=`500` with
+│   │   │          duplicate operation IDs=`0`
+│   │   └── Boundary: this packet makes no source changes and does not authorize
+│   │                public getter deletion, package export removal, route/API
+│   │                edits, OpenAPI exposure changes, frontend changes,
+│   │                runtime/PM2 changes, OpenSpec changes, or issue-label changes
+│   └── Next gate: Human review / PR merge decision for G2.80 authorization; if
+│                  accepted, create a G2.81 implementation branch for Phase 1
+│                  service-internal decoupling only
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1349,6 +1364,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-futures-route-migration-implementation-2026-05-25.md` | G | G2.78 implementation packet prepared at `5169da56`: futures route handlers now use `get_data_source_factory_dependency`, direct route/API factory refs move `2 -> 0`, health route conflicts pass `120`, provider tests pass `4`, OpenAPI paths remain `500`, and compatibility getter remains unchanged | Human review / PR merge decision; if accepted, create closeout/current-head refresh before compatibility getter retirement or retained-shim decision |
 | `backend-data-source-factory-futures-route-migration-closeout-2026-05-25.md` | G | G2.78 closeout packet prepared at `e7a2a436`: PR `#230` merge recorded, health tests remain `120 passed`, provider tests remain `4 passed`, total route/API direct factory refs remain `0`, OpenAPI paths remain `500`, and compatibility getter remains unchanged | Human review / PR merge decision; if accepted, prepare a separate compatibility getter retirement / retained-shim decision packet |
 | `backend-data-source-factory-compat-getter-retained-shim-decision-2026-05-25.md` | G | G2.79 decision packet prepared at `b3aefed2`: route/API direct `get_data_source_factory()` calls are `0`, but the compatibility getter remains package-exported, lifecycle-tested, and used by service-internal helper fallback paths; decision is retain shim for now | Human review / PR merge decision; if accepted, create a separate source-capable retirement authorization packet before any compatibility API removal |
+| `backend-data-source-factory-compat-getter-retirement-authorization-2026-05-25.md` | G | G2.80 authorization packet prepared at `ac0fa318`: authorizes only a future G2.81 Phase 1 service-internal decoupling step; public getter and package exports must remain, route/API direct calls stay `0`, lifecycle tests pass `4`, health route conflicts pass `120`, and OpenAPI paths remain `500` | Human review / PR merge decision; if accepted, create a G2.81 implementation branch for Phase 1 service-internal decoupling only |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-compat-getter-retirement-authorization-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-compat-getter-retirement-authorization-2026-05-25.json
@@ -1,0 +1,77 @@
+{
+  "artifact": "data-source-factory-compat-getter-retirement-authorization-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25",
+  "branch": "g2-80-data-source-factory-compat-getter-retirement-authorization",
+  "current_head": "ac0fa318aa30262092d00219de18bd670bab26b2",
+  "scope": {
+    "type": "source_capable_authorization_packet",
+    "source_edits_in_this_packet": false,
+    "future_authorized_stage": "G2.81 Phase 1 service-internal decoupling only",
+    "excluded_from_this_packet": [
+      "backend source edits",
+      "test source edits",
+      "route path changes",
+      "OpenAPI exposure changes",
+      "response model or response shape changes",
+      "frontend changes",
+      "runtime or PM2 gates",
+      "OpenSpec changes",
+      "issue label changes",
+      "compatibility getter deletion",
+      "package export removal"
+    ]
+  },
+  "decision": "Authorize a future G2.81 implementation to decouple service-internal helper fallback paths from the public get_data_source_factory() compatibility getter. Do not delete the public getter or remove package exports in G2.81.",
+  "current_evidence": {
+    "route_api_direct_get_data_source_factory_refs": 0,
+    "python_mentions": 61,
+    "exact_parenthesized_refs": 10,
+    "service_module_exact_refs": 6,
+    "package_export_mentions": 4,
+    "tests": {
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py": "4 passed",
+      "web/backend/tests/test_health_route_conflicts.py": "120 passed"
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "generic_python_warning_count": 121
+    },
+    "gitnexus": {
+      "impact": "CRITICAL, 22 impacted symbols, 21 direct dependents, 12 affected processes",
+      "waiver": "scoped stale-index waiver for Phase 1 service-internal decoupling only; no full getter or package export deletion waiver"
+    }
+  },
+  "future_g2_81_allowed_source_files": [
+    "web/backend/app/services/data_source_factory/data_source_factory.py",
+    "web/backend/tests/test_data_source_factory_lifecycle_di.py"
+  ],
+  "future_g2_81_forbidden": [
+    "delete get_data_source_factory()",
+    "remove package exports from web/backend/app/services/data_source_factory/__init__.py",
+    "edit route modules under web/backend/app/api/**",
+    "edit frontend files",
+    "edit route paths, response models, response shapes, or OpenAPI exposure",
+    "change DATA_SOURCE_FACTORY_STATE_KEY",
+    "runtime or PM2 script changes",
+    "OpenSpec changes",
+    "GitHub issue label changes"
+  ],
+  "future_g2_81_required_gates": [
+    "read architecture/STANDARDS.md before source edits",
+    "GitNexus impact/context for get_data_source_factory, install_data_source_factory, get_data_source, get_market_data, get_dashboard_data, get_technical_analysis_data",
+    "TDD red test for internal helper fallback not depending on public getter",
+    "focused lifecycle test",
+    "health route conflicts test",
+    "ruff and black on allowed source/test files",
+    "OpenAPI smoke",
+    "route/API direct get_data_source_factory() refs remain 0",
+    "service-module helper direct calls to public getter are removed while public getter definition remains",
+    "staged GitNexus detect_changes"
+  ],
+  "next_gate": "Human review / PR merge decision for G2.80 authorization. If accepted, create G2.81 implementation branch for Phase 1 service-internal decoupling only."
+}

--- a/docs/reports/quality/backend-data-source-factory-compat-getter-retirement-authorization-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-compat-getter-retirement-authorization-2026-05-25.md
@@ -1,0 +1,161 @@
+# Backend DataSourceFactory Compatibility Getter Retirement Authorization - 2026-05-25
+
+Workline: G2.80 source-capable authorization packet
+
+Current HEAD: `ac0fa318aa30262092d00219de18bd670bab26b2`
+
+> **历史索引说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: This packet authorizes only a future, separate implementation
+branch. It does not itself edit backend source, tests, routes, OpenAPI exposure,
+frontend code, runtime processes, OpenSpec changes, issue labels, package
+exports, or the `get_data_source_factory()` compatibility API.
+
+## Status
+
+Ready for review.
+
+## Authorization Decision
+
+Authorize a future G2.81 Phase 1 implementation to decouple service-internal
+helper fallback paths from the public `get_data_source_factory()` compatibility
+getter.
+
+This is not deletion authorization. G2.81 may make the public getter delegate to
+a private/internal initializer, and may move internal helper calls to that
+private/internal initializer. G2.81 must keep the public function and package
+exports in place.
+
+## Current Evidence
+
+| Metric | Current HEAD |
+| --- | ---: |
+| Route/API direct `get_data_source_factory()` calls | 0 |
+| Python mentions of `get_data_source_factory` | 61 |
+| Exact Python `get_data_source_factory()` parenthesized refs | 10 |
+| Service-module exact refs | 6 |
+| Package export mentions | 4 |
+| OpenAPI routes | 548 |
+| OpenAPI paths | 500 |
+| Duplicate operation IDs | 0 |
+| Duplicate operation ID warnings | 0 |
+
+Focused verification:
+
+| Check | Result |
+| --- | --- |
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov` | 4 passed |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov` | 120 passed |
+| OpenAPI smoke with `PYTHONPATH=web/backend` and root `.env` loaded | 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0 |
+
+Current service-module call sites:
+
+| Location | Current role |
+| --- | --- |
+| `web/backend/app/services/data_source_factory/data_source_factory.py:300` | public compatibility getter definition |
+| `web/backend/app/services/data_source_factory/data_source_factory.py:310` | `install_data_source_factory` fallback calls public getter |
+| `web/backend/app/services/data_source_factory/data_source_factory.py:324` | `get_data_source` fallback calls public getter |
+| `web/backend/app/services/data_source_factory/data_source_factory.py:330` | `get_market_data` fallback calls public getter |
+| `web/backend/app/services/data_source_factory/data_source_factory.py:336` | `get_dashboard_data` fallback calls public getter |
+| `web/backend/app/services/data_source_factory/data_source_factory.py:342` | `get_technical_analysis_data` fallback calls public getter |
+
+Package export locations:
+
+| Location | Current role |
+| --- | --- |
+| `web/backend/app/services/data_source_factory/__init__.py:12` | package re-export |
+| `web/backend/app/services/data_source_factory/__init__.py:31` | package `__all__` export |
+
+GitNexus currently reports CRITICAL impact for `get_data_source_factory()`: 22
+impacted symbols, 21 direct dependents, 12 affected processes. The current graph
+still lists historical route handlers that textual current-head scans show as
+migrated. G2.80 therefore grants only a scoped stale-index waiver for Phase 1
+service-internal decoupling; it does not waive full getter or package export
+deletion risk.
+
+## Future G2.81 Allowed Scope
+
+Allowed source files:
+
+- `web/backend/app/services/data_source_factory/data_source_factory.py`
+- `web/backend/tests/test_data_source_factory_lifecycle_di.py`
+
+Allowed governance files:
+
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/data-source-factory-compat-getter-retirement-phase1-implementation-*.json`
+- `docs/reports/quality/backend-data-source-factory-compat-getter-retirement-phase1-implementation-*.md`
+- `governance/mainline/task-cards/pr-*.yaml`
+
+Allowed implementation intent:
+
+1. Add or reuse a private/internal helper that owns lazy DataSourceFactory
+   initialization.
+2. Keep `get_data_source_factory()` as a compatibility wrapper.
+3. Make `install_data_source_factory()` use the private/internal initializer
+   when no explicit factory is provided.
+4. Make `get_data_source`, `get_market_data`, `get_dashboard_data`, and
+   `get_technical_analysis_data` stop calling the public compatibility getter
+   directly.
+5. Add TDD coverage proving service-internal helper fallback no longer depends
+   on the public compatibility getter while the public getter still initializes
+   correctly.
+
+## Future G2.81 Forbidden Scope
+
+The future implementation must not:
+
+- delete `get_data_source_factory()`;
+- remove package exports from
+  `web/backend/app/services/data_source_factory/__init__.py`;
+- edit route modules under `web/backend/app/api/**`;
+- edit frontend files;
+- edit route paths, response models, response shapes, or OpenAPI exposure;
+- change app-state key `DATA_SOURCE_FACTORY_STATE_KEY`;
+- change runtime/PM2 scripts or run stateful PM2 gates;
+- create or archive OpenSpec changes;
+- change GitHub issue labels.
+
+## Future G2.81 Required Gates
+
+Before source edits:
+
+1. Read `architecture/STANDARDS.md`.
+2. Run GitNexus impact/context for `get_data_source_factory`,
+   `install_data_source_factory`, `get_data_source`, `get_market_data`,
+   `get_dashboard_data`, and `get_technical_analysis_data`.
+3. Record that this G2.80 packet is the stale-index waiver only for Phase 1
+   service-internal decoupling.
+
+Implementation gates:
+
+1. TDD red test for internal helper fallback not depending on the public getter.
+2. Green implementation.
+3. `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov`.
+4. `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov`.
+5. `ruff check web/backend/app/services/data_source_factory/data_source_factory.py web/backend/tests/test_data_source_factory_lifecycle_di.py`.
+6. `black --check web/backend/app/services/data_source_factory/data_source_factory.py web/backend/tests/test_data_source_factory_lifecycle_di.py`.
+7. OpenAPI smoke: paths remain 500 and duplicate operation IDs remain 0.
+8. Textual scan: route/API direct `get_data_source_factory()` calls remain 0.
+9. Textual scan: service-module direct calls from helper functions to public
+   `get_data_source_factory()` are removed, while the public getter definition
+   remains.
+10. Staged GitNexus `detect_changes(scope=staged)`.
+
+## Stop Conditions
+
+Stop and return to review if any of these occur:
+
+- source edits need files outside the allowed source scope;
+- deletion of the public getter or package export appears necessary;
+- route/OpenAPI changes appear;
+- GitNexus reports new HIGH/CRITICAL impact outside the known service-internal
+  helper and stale-index route-handler set;
+- focused tests or OpenAPI smoke fail for reasons unrelated to the planned
+  helper decoupling.
+
+## Next Gate
+
+Human review / PR merge decision for this authorization packet. If accepted,
+create a separate G2.81 implementation branch for Phase 1 service-internal
+decoupling only.

--- a/governance/mainline/task-cards/pr-233.yaml
+++ b/governance/mainline/task-cards/pr-233.yaml
@@ -1,0 +1,114 @@
+version: "v0.2"
+
+task:
+  id: "pr-233"
+  title: "Authorize DataSourceFactory compatibility getter retirement phase 1"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-compat-getter-retirement-authorization"
+  objective: "authorize a future phase-1 service-internal decoupling step for get_data_source_factory compatibility getter retirement"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-compat-getter-retirement-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-compat-getter-retirement-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization packet records future allowed implementation scope only and does not alter runtime behavior"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-compat-getter-retirement-authorization-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-compat-getter-retirement-authorization-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-233.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source or test edit in this packet"
+  - "No route path, response model, response shape, OpenAPI exposure, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No compatibility getter deletion or package export removal"
+  - "No authorization for a full public API retirement; only future Phase 1 service-internal decoupling is authorized"
+
+acceptance:
+  checks:
+    - id: "current-head-provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov"
+      required: true
+    - id: "current-head-health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov"
+      required: true
+    - id: "current-head-openapi-smoke"
+      command: "PYTHONPATH=web/backend python -c 'from app.main import app; app.openapi()'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-compat-getter-retirement-authorization-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-compat-getter-retirement-authorization-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-233.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-233.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If source files are edited, this authorization packet exceeds its evidence-only boundary"
+    - "If this packet is misread as getter deletion approval, public compatibility and package exports may break"
+  rollback_plan: "revert this docs/governance-only authorization PR; no runtime code is affected"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize future Phase 1 internal decoupling for get_data_source_factory compatibility getter retirement"
+    modified_scope: "authorization report, generated artifact, steward tree, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none in this packet; future G2.81 must keep public getter and package exports"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this authorization PR if the future scope or evidence is incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T12:20:00+08:00"
+    approval_note: "human maintainer accepted continuing from G2.79; this packet authorizes future Phase 1 service-internal decoupling only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- add G2.80 authorization packet for future DataSourceFactory compatibility getter retirement Phase 1
- authorize only future service-internal helper decoupling; keep public get_data_source_factory() and package exports in place
- record current evidence, stale-index waiver boundary, future G2.81 allowed files, gates, and stop conditions

## Verification
- pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov: 4 passed
- pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov: 120 passed
- OpenAPI smoke: 548 routes, 500 paths, 536 operation IDs, duplicate operation IDs 0
- route/API direct get_data_source_factory() refs: 0
- exact parenthesized refs: 10; service-module exact refs: 6; package export mentions: 4
- GitNexus impact on getter: CRITICAL/stale-index warning recorded as Phase 1 scoped waiver only
- markdown governance: 2 checked, 0 errors
- JSON/YAML parse: passed
- git diff --cached --check: passed
- GitNexus detect_changes staged: LOW, 0 changed symbols, 0 affected processes
- post-commit mainline scope gate: pass=True