### PR TITLE
refactor(services): decouple factory helpers from compat getter

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1283,9 +1283,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                issue-label, compatibility getter deletion, package export
 │   │                removal, or retained-shim retirement change is authorized
 │   ├── G2.80 DataSourceFactory compatibility getter retirement authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#233` merged at
+│   │   │          `b922db6b672f1084dcefb9ecba953b780ac8dbe3`
 │   │   ├── Evidence: `backend-data-source-factory-compat-getter-retirement-authorization-2026-05-25.md`
-│   │   ├── Current HEAD: `ac0fa318aa30262092d00219de18bd670bab26b2`
+│   │   ├── Current HEAD: `b922db6b672f1084dcefb9ecba953b780ac8dbe3`
 │   │   ├── Result: authorizes only a future G2.81 Phase 1 service-internal
 │   │   │          decoupling step: internal helper fallback paths may stop
 │   │   │          calling public `get_data_source_factory()`, while the public
@@ -1297,9 +1298,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                public getter deletion, package export removal, route/API
 │   │                edits, OpenAPI exposure changes, frontend changes,
 │   │                runtime/PM2 changes, OpenSpec changes, or issue-label changes
-│   └── Next gate: Human review / PR merge decision for G2.80 authorization; if
-│                  accepted, create a G2.81 implementation branch for Phase 1
-│                  service-internal decoupling only
+│   ├── G2.81 DataSourceFactory compatibility getter retirement Phase 1 implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.md`
+│   │   ├── Current HEAD: `b922db6b672f1084dcefb9ecba953b780ac8dbe3`
+│   │   ├── Result: introduces private `_get_or_create_data_source_factory()`,
+│   │   │          keeps public `get_data_source_factory()` as a compatibility
+│   │   │          wrapper, decouples service-internal helper fallback calls from
+│   │   │          the public getter, keeps package exports unchanged, moves
+│   │   │          service helper public getter calls to `0`, keeps route/API
+│   │   │          direct calls at `0`, expands lifecycle tests to `5 passed`,
+│   │   │          keeps health route conflicts at `120 passed`, and keeps
+│   │   │          OpenAPI paths=`500` with duplicate operation IDs=`0`
+│   │   └── Boundary: no public getter deletion, package export removal, route/API
+│   │                edit, OpenAPI exposure change, frontend change, runtime/PM2
+│   │                change, OpenSpec change, or issue-label change is authorized
+│   └── Next gate: Human review / PR merge decision for G2.81 implementation; if
+│                  accepted, create a separate closeout/current-head refresh
+│                  before any public getter or package export retirement decision
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1364,7 +1380,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-futures-route-migration-implementation-2026-05-25.md` | G | G2.78 implementation packet prepared at `5169da56`: futures route handlers now use `get_data_source_factory_dependency`, direct route/API factory refs move `2 -> 0`, health route conflicts pass `120`, provider tests pass `4`, OpenAPI paths remain `500`, and compatibility getter remains unchanged | Human review / PR merge decision; if accepted, create closeout/current-head refresh before compatibility getter retirement or retained-shim decision |
 | `backend-data-source-factory-futures-route-migration-closeout-2026-05-25.md` | G | G2.78 closeout packet prepared at `e7a2a436`: PR `#230` merge recorded, health tests remain `120 passed`, provider tests remain `4 passed`, total route/API direct factory refs remain `0`, OpenAPI paths remain `500`, and compatibility getter remains unchanged | Human review / PR merge decision; if accepted, prepare a separate compatibility getter retirement / retained-shim decision packet |
 | `backend-data-source-factory-compat-getter-retained-shim-decision-2026-05-25.md` | G | G2.79 decision packet prepared at `b3aefed2`: route/API direct `get_data_source_factory()` calls are `0`, but the compatibility getter remains package-exported, lifecycle-tested, and used by service-internal helper fallback paths; decision is retain shim for now | Human review / PR merge decision; if accepted, create a separate source-capable retirement authorization packet before any compatibility API removal |
-| `backend-data-source-factory-compat-getter-retirement-authorization-2026-05-25.md` | G | G2.80 authorization packet prepared at `ac0fa318`: authorizes only a future G2.81 Phase 1 service-internal decoupling step; public getter and package exports must remain, route/API direct calls stay `0`, lifecycle tests pass `4`, health route conflicts pass `120`, and OpenAPI paths remain `500` | Human review / PR merge decision; if accepted, create a G2.81 implementation branch for Phase 1 service-internal decoupling only |
+| `backend-data-source-factory-compat-getter-retirement-authorization-2026-05-25.md` | G | G2.80 authorization packet accepted in PR `#233` at `b922db6b`: authorizes only a future G2.81 Phase 1 service-internal decoupling step; public getter and package exports must remain, route/API direct calls stay `0`, lifecycle tests pass `4`, health route conflicts pass `120`, and OpenAPI paths remain `500` | G2.81 implementation branch may perform Phase 1 service-internal decoupling only |
+| `backend-data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.md` | G | G2.81 implementation packet prepared at `b922db6b`: adds private `_get_or_create_data_source_factory()`, keeps public `get_data_source_factory()` and package exports, removes service helper public getter calls, expands lifecycle tests to `5 passed`, keeps health route conflicts at `120 passed`, and keeps OpenAPI paths=`500` with duplicate operation IDs=`0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before any public getter or package export retirement decision |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.json
@@ -1,0 +1,94 @@
+{
+  "artifact": "data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T12:48:57+08:00",
+  "branch": "g2-81-data-source-factory-compat-getter-phase1-implementation",
+  "baseline_head": "b922db6b672f1084dcefb9ecba953b780ac8dbe3",
+  "authorization": {
+    "source": "backend-data-source-factory-compat-getter-retirement-authorization-2026-05-25.md",
+    "merged_pr": 233,
+    "merged_head": "b922db6b672f1084dcefb9ecba953b780ac8dbe3",
+    "allowed_stage": "G2.81 Phase 1 service-internal decoupling only"
+  },
+  "scope": {
+    "type": "source_implementation_packet",
+    "allowed_source_files": [
+      "web/backend/app/services/data_source_factory/data_source_factory.py",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py"
+    ],
+    "forbidden_changes": [
+      "delete get_data_source_factory()",
+      "remove package exports from web/backend/app/services/data_source_factory/__init__.py",
+      "edit route modules under web/backend/app/api/**",
+      "edit frontend files",
+      "edit route paths, response models, response shapes, or OpenAPI exposure",
+      "change DATA_SOURCE_FACTORY_STATE_KEY",
+      "runtime or PM2 script changes",
+      "OpenSpec changes",
+      "GitHub issue label changes"
+    ]
+  },
+  "implementation": {
+    "private_initializer_added": "_get_or_create_data_source_factory",
+    "public_getter_kept": true,
+    "public_getter_role": "compatibility wrapper around _get_or_create_data_source_factory()",
+    "package_exports_kept": true,
+    "service_internal_helpers_decoupled_from_public_getter": [
+      "install_data_source_factory",
+      "get_data_source",
+      "get_market_data",
+      "get_dashboard_data",
+      "get_technical_analysis_data"
+    ]
+  },
+  "tdd": {
+    "red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short",
+      "result": "2 failed, 3 passed",
+      "expected_failure": "AttributeError for missing _get_or_create_data_source_factory"
+    },
+    "green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short",
+      "result": "5 passed in 1.69s"
+    }
+  },
+  "verification": {
+    "lifecycle_tests": "5 passed",
+    "health_route_conflicts": "120 passed",
+    "ruff": "passed",
+    "black_check": "passed",
+    "openapi_smoke": {
+      "env_source": "/opt/claude/mystocks_spec/.env",
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "generic_python_warning_count": 121
+    },
+    "reference_scan": {
+      "route_api_direct_get_data_source_factory_calls": 0,
+      "exact_parenthesized_refs": 4,
+      "service_module_exact_refs": 1,
+      "service_helper_public_getter_calls": 0,
+      "package_export_mentions": 4,
+      "private_initializer_refs": 11
+    }
+  },
+  "gitnexus": {
+    "pre_edit_get_data_source_factory_impact": "CRITICAL, 22 impacted symbols, 21 direct dependents, 12 affected processes",
+    "waiver": "G2.80 scoped stale-index waiver for Phase 1 service-internal decoupling only",
+    "staged_detect_changes": {
+      "changed_files": 6,
+      "changed_symbols": 20,
+      "affected_symbols": 12,
+      "risk_level": "high",
+      "affected_process_families": [
+        "Get_system_status_overview",
+        "Get_sources_health"
+      ],
+      "interpretation": "Expected DataSourceFactory initialization blast radius; no public getter deletion or package export removal."
+    }
+  },
+  "next_gate": "Human review / PR merge decision for G2.81. If accepted, create closeout/current-head refresh before any public getter or package export retirement decision."
+}

--- a/docs/reports/quality/backend-data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.md
@@ -1,0 +1,178 @@
+# Backend DataSourceFactory Compatibility Getter Retirement Phase 1 Implementation - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.81 source implementation packet
+
+Status: ready for review
+
+Branch: `g2-81-data-source-factory-compat-getter-phase1-implementation`
+
+Baseline HEAD: `b922db6b672f1084dcefb9ecba953b780ac8dbe3`
+
+Prepared at: `2026-05-25T12:48:57+08:00`
+
+## Purpose
+
+Implement the G2.80 authorization boundary for Phase 1 retirement of the
+`get_data_source_factory()` compatibility getter.
+
+This packet decouples service-internal fallback helper paths from the public
+compatibility getter while keeping the public getter and package exports intact.
+It does not retire the compatibility API.
+
+## Authorization Source
+
+G2.80 was merged in PR `#233` at
+`b922db6b672f1084dcefb9ecba953b780ac8dbe3`.
+
+G2.80 authorized only this Phase 1 service-internal decoupling:
+
+- source edits limited to
+  `web/backend/app/services/data_source_factory/data_source_factory.py`;
+- test edits limited to
+  `web/backend/tests/test_data_source_factory_lifecycle_di.py`;
+- public `get_data_source_factory()` must remain;
+- package exports in `web/backend/app/services/data_source_factory/__init__.py`
+  must remain;
+- route/API modules, OpenAPI exposure, frontend, runtime/PM2, OpenSpec, and
+  issue labels remain out of scope.
+
+## Implementation Summary
+
+Changed
+`web/backend/app/services/data_source_factory/data_source_factory.py`:
+
+- introduced private `_get_or_create_data_source_factory()`;
+- changed public `get_data_source_factory()` into a compatibility wrapper around
+  the private initializer;
+- changed `install_data_source_factory()` fallback to call the private
+  initializer;
+- changed service convenience helpers to call the private initializer:
+  - `get_data_source()`;
+  - `get_market_data()`;
+  - `get_dashboard_data()`;
+  - `get_technical_analysis_data()`.
+
+Changed
+`web/backend/tests/test_data_source_factory_lifecycle_di.py`:
+
+- updated the fallback dependency test to patch the private initializer;
+- added coverage proving service convenience helpers no longer call the public
+  compatibility getter;
+- kept coverage proving the public compatibility getter still initializes a
+  factory.
+
+## TDD Evidence
+
+RED:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short
+2 failed, 3 passed
+```
+
+Expected failures:
+
+- `AttributeError: ... has no attribute '_get_or_create_data_source_factory'`
+  in `test_data_source_factory_dependency_installs_fallback_factory`;
+- `AttributeError: ... has no attribute '_get_or_create_data_source_factory'`
+  in `test_convenience_helpers_use_internal_factory_initializer`.
+
+GREEN after implementation and formatting:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short
+5 passed in 1.69s
+```
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | 5 passed |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | 120 passed |
+| `ruff check web/backend/app/services/data_source_factory/data_source_factory.py web/backend/tests/test_data_source_factory_lifecycle_di.py` | passed |
+| `black --check web/backend/app/services/data_source_factory/data_source_factory.py web/backend/tests/test_data_source_factory_lifecycle_di.py` | passed |
+| OpenAPI smoke with root `.env` loaded | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, duplicate operation ID warnings=`0` |
+
+Reference scan after implementation:
+
+| Metric | Result |
+|---|---:|
+| Route/API direct `get_data_source_factory()` calls | 0 |
+| Exact parenthesized `get_data_source_factory(` refs | 4 |
+| Service-module exact refs | 1 |
+| Service helper public getter calls | 0 |
+| Package export mentions | 4 |
+| Private initializer refs | 11 |
+
+The remaining service-module exact ref is the public compatibility getter
+definition itself. Package exports intentionally remain unchanged.
+
+## GitNexus Evidence
+
+Pre-edit GitNexus checks were run before source modification:
+
+| Target | Result |
+|---|---|
+| `get_data_source_factory` impact | CRITICAL, 22 impacted symbols, 21 direct dependents, 12 affected processes |
+| `get_data_source_factory` context | confirms public compatibility getter and historical/stale route-handler references |
+| `get_data_source` impact | LOW, 0 impacted symbols |
+| `get_market_data` context | exact service function located in `data_source_factory.py` |
+| `get_dashboard_data` context | exact service function located in `data_source_factory.py` |
+| `get_technical_analysis_data` impact | LOW, 0 impacted symbols |
+| `install_data_source_factory` | not found in current GitNexus index |
+
+The CRITICAL impact for `get_data_source_factory()` is handled under the G2.80
+scoped stale-index waiver for Phase 1 service-internal decoupling only. This
+packet does not rely on that waiver for public getter deletion or package export
+removal.
+
+Staged GitNexus `detect_changes(scope=staged)` result:
+
+| Metric | Result |
+|---|---|
+| Changed files | 6 |
+| Changed symbols | 20 |
+| Affected symbols | 12 |
+| Risk level | HIGH |
+| Affected process families | `Get_system_status_overview`, `Get_sources_health` |
+
+This matches the expected DataSourceFactory initialization blast radius and
+does not introduce a new public getter deletion or package export removal path.
+
+## Boundary Confirmation
+
+This packet did not:
+
+- delete public `get_data_source_factory()`;
+- remove package exports from
+  `web/backend/app/services/data_source_factory/__init__.py`;
+- edit route modules under `web/backend/app/api/**`;
+- edit route paths, response models, response shapes, or OpenAPI exposure;
+- edit frontend files;
+- edit runtime or PM2 scripts;
+- edit OpenSpec changes;
+- change GitHub issue labels;
+- change `DATA_SOURCE_FACTORY_STATE_KEY`.
+
+## Risk And Rollback
+
+Risk level: MEDIUM because the public compatibility getter has a known
+GitNexus CRITICAL/stale-index warning, but the implementation keeps the public
+API and narrows only service-internal fallback calls.
+
+Rollback: revert this packet to restore service helpers calling the public
+compatibility getter directly. The rollback does not require route, OpenAPI,
+frontend, runtime, or package export changes.
+
+## Next Gate
+
+Human review / PR merge decision for G2.81.
+
+If accepted, create a separate closeout/current-head refresh before any further
+retained-shim retirement decision. Full public getter deletion and package
+export removal remain unauthorized.

--- a/governance/mainline/task-cards/pr-234.yaml
+++ b/governance/mainline/task-cards/pr-234.yaml
@@ -1,0 +1,127 @@
+version: "v0.2"
+
+task:
+  id: "pr-234"
+  title: "Implement DataSourceFactory compatibility getter phase 1 decoupling"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-compat-getter-phase1-decoupling"
+  objective: "decouple DataSourceFactory service-internal helpers from the public compatibility getter while keeping the public compatibility API intact"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-compat-getter-phase1-decoupling"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-234.yaml"
+    - "web/backend/app/services/data_source_factory/data_source_factory.py"
+    - "web/backend/tests/test_data_source_factory_lifecycle_di.py"
+  forbidden_paths:
+    - "web/backend/app/api/**"
+    - "web/backend/app/services/data_source_factory/__init__.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-compat-getter-phase1-decoupling"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Implementation changes service-internal fallback acquisition only and preserves route paths, OpenAPI exposure, response shape, public compatibility getter, and package exports"
+
+non_goals:
+  - "No deletion of public get_data_source_factory()"
+  - "No package export removal from web/backend/app/services/data_source_factory/__init__.py"
+  - "No route path, response model, response shape, OpenAPI exposure, docs/API, generated client, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No DataSourceFactory route/API consumer migration"
+  - "No broad formatting cleanup outside the allowed service and lifecycle test files"
+
+acceptance:
+  checks:
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short before implementation"
+      required: true
+    - id: "focused-green"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "style"
+      command: "ruff check web/backend/app/services/data_source_factory/data_source_factory.py web/backend/tests/test_data_source_factory_lifecycle_di.py && black --check web/backend/app/services/data_source_factory/data_source_factory.py web/backend/tests/test_data_source_factory_lifecycle_di.py"
+      required: true
+    - id: "openapi-smoke"
+      command: "PYTHONPATH=web/backend python -c \"from dotenv import load_dotenv; load_dotenv('/opt/claude/mystocks_spec/.env'); from app.main import app; app.openapi()\""
+      required: true
+    - id: "direct-ref-scan"
+      command: "scan route/API direct get_data_source_factory() refs, service helper calls, package export mentions, and private initializer refs"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-234.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-234.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If public get_data_source_factory() is deleted, the PR exceeds the G2.80 authorization boundary"
+    - "If package exports are removed, downstream compatibility consumers may break outside this Phase 1 scope"
+    - "If route/API or OpenAPI surfaces change, the PR turns an internal compatibility cleanup into a contract change"
+  rollback_plan: "revert this path-limited PR; the public compatibility getter and package exports remain available and no route contract changes are introduced"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "decouple DataSourceFactory service-internal helpers from the public compatibility getter"
+    modified_scope: "one service module, one lifecycle test module, implementation report, generated artifact, steward tree, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "public get_data_source_factory() and package exports remain intact; service helpers use a private initializer internally"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this implementation PR to restore helper calls through the public compatibility getter"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T12:48:57+08:00"
+    approval_note: "human maintainer accepted continuing after G2.80; G2.80 PR #233 authorizes this Phase 1 service-internal decoupling only"
+    secondary_approved: false

--- a/web/backend/app/services/data_source_factory/data_source_factory.py
+++ b/web/backend/app/services/data_source_factory/data_source_factory.py
@@ -297,8 +297,7 @@ DATA_SOURCE_FACTORY_STATE_KEY = "data_source_factory"
 _global_factory: Optional[DataSourceFactory] = None
 
 
-async def get_data_source_factory() -> DataSourceFactory:
-    """获取全局数据源工厂实例"""
+async def _get_or_create_data_source_factory() -> DataSourceFactory:
     global _global_factory
     if _global_factory is None:
         _global_factory = DataSourceFactory()
@@ -306,8 +305,13 @@ async def get_data_source_factory() -> DataSourceFactory:
     return _global_factory
 
 
+async def get_data_source_factory() -> DataSourceFactory:
+    """获取全局数据源工厂实例"""
+    return await _get_or_create_data_source_factory()
+
+
 async def install_data_source_factory(app: Any, factory: Optional[DataSourceFactory] = None) -> DataSourceFactory:
-    selected_factory = factory if factory is not None else await get_data_source_factory()
+    selected_factory = factory if factory is not None else await _get_or_create_data_source_factory()
     setattr(app.state, DATA_SOURCE_FACTORY_STATE_KEY, selected_factory)
     return selected_factory
 
@@ -321,25 +325,25 @@ async def get_data_source_factory_dependency(request: Request) -> DataSourceFact
 
 async def get_data_source(source_name: str) -> Optional[IDataSource]:
     """便捷函数：获取数据源"""
-    factory = await get_data_source_factory()
+    factory = await _get_or_create_data_source_factory()
     return await factory.get_data_source(source_name)
 
 
 async def get_market_data(endpoint: str, params: Dict[str, Any] = None) -> Dict[str, Any]:
     """便捷函数：获取市场数据"""
-    factory = await get_data_source_factory()
+    factory = await _get_or_create_data_source_factory()
     return await factory.get_data("market", endpoint, params)
 
 
 async def get_dashboard_data(endpoint: str, params: Dict[str, Any] = None) -> Dict[str, Any]:
     """便捷函数：获取仪表盘数据"""
-    factory = await get_data_source_factory()
+    factory = await _get_or_create_data_source_factory()
     return await factory.get_data("dashboard", endpoint, params)
 
 
 async def get_technical_analysis_data(endpoint: str, params: Dict[str, Any] = None) -> Dict[str, Any]:
     """便捷函数：获取技术分析数据"""
-    factory = await get_data_source_factory()
+    factory = await _get_or_create_data_source_factory()
     return await factory.get_data("technical_analysis", endpoint, params)
 
 

--- a/web/backend/tests/test_data_source_factory_lifecycle_di.py
+++ b/web/backend/tests/test_data_source_factory_lifecycle_di.py
@@ -42,11 +42,13 @@ async def test_data_source_factory_dependency_installs_fallback_factory(monkeypa
     request = SimpleNamespace(app=fake_app)
     calls = []
 
-    async def fake_get_data_source_factory():
+    async def fake_get_or_create_data_source_factory():
         calls.append("fallback")
         return fake_factory
 
-    monkeypatch.setattr(data_source_factory_module, "get_data_source_factory", fake_get_data_source_factory)
+    monkeypatch.setattr(
+        data_source_factory_module, "_get_or_create_data_source_factory", fake_get_or_create_data_source_factory
+    )
 
     result = await data_source_factory_module.get_data_source_factory_dependency(request)
 
@@ -72,3 +74,46 @@ async def test_get_data_source_factory_compatibility_getter_still_initializes(mo
     assert isinstance(result, FakeDataSourceFactory)
     assert result.initialized is True
     assert data_source_factory_module._global_factory is result
+
+
+@pytest.mark.asyncio
+async def test_convenience_helpers_use_internal_factory_initializer(monkeypatch):
+    class FakeFactory:
+        async def get_data_source(self, source_name):
+            return {"source": source_name}
+
+        async def get_data(self, domain, endpoint, params=None):
+            return {"domain": domain, "endpoint": endpoint, "params": params}
+
+    fake_factory = FakeFactory()
+    calls = []
+
+    async def fake_get_or_create_data_source_factory():
+        calls.append("internal")
+        return fake_factory
+
+    async def unexpected_public_getter():
+        raise AssertionError("service-internal helpers must not call the public compatibility getter")
+
+    monkeypatch.setattr(
+        data_source_factory_module, "_get_or_create_data_source_factory", fake_get_or_create_data_source_factory
+    )
+    monkeypatch.setattr(data_source_factory_module, "get_data_source_factory", unexpected_public_getter)
+
+    assert await data_source_factory_module.get_data_source("akshare") == {"source": "akshare"}
+    assert await data_source_factory_module.get_market_data("quotes", {"symbol": "000001"}) == {
+        "domain": "market",
+        "endpoint": "quotes",
+        "params": {"symbol": "000001"},
+    }
+    assert await data_source_factory_module.get_dashboard_data("summary") == {
+        "domain": "dashboard",
+        "endpoint": "summary",
+        "params": None,
+    }
+    assert await data_source_factory_module.get_technical_analysis_data("signals", {"limit": 3}) == {
+        "domain": "technical_analysis",
+        "endpoint": "signals",
+        "params": {"limit": 3},
+    }
+    assert calls == ["internal", "internal", "internal", "internal"]


### PR DESCRIPTION
## Summary
- implements G2.81 Phase 1 service-internal DataSourceFactory compatibility getter decoupling
- adds private _get_or_create_data_source_factory() and keeps public get_data_source_factory() as the compatibility wrapper
- updates lifecycle DI tests and steward-tree/report/task-card evidence

## Boundary
- public get_data_source_factory() remains
- package exports remain unchanged
- no route/API, OpenAPI exposure, frontend, runtime/PM2, OpenSpec, or issue-label changes

## Verification
- TDD RED: lifecycle tests failed as expected before _get_or_create_data_source_factory existed: 2 failed, 3 passed
- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short: 5 passed
- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short: 120 passed
- ruff check web/backend/app/services/data_source_factory/data_source_factory.py web/backend/tests/test_data_source_factory_lifecycle_di.py: passed
- black --check web/backend/app/services/data_source_factory/data_source_factory.py web/backend/tests/test_data_source_factory_lifecycle_di.py: passed
- OpenAPI smoke with root .env loaded: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0
- Reference scan: route/API direct calls=0, service helper public getter calls=0, package export mentions=4
- GitNexus staged detect_changes: HIGH, changed_files=6, affected_symbols=12, expected DataSourceFactory initialization blast radius
- Post-commit mainline scope gate: pass

## Notes
- Pre-commit mainline scope gate still reported the previous PR #233 drift, as expected before the new commit existed; post-commit gate passed for this PR scope.
