### PR TITLE
docs(governance): close out factory getter phase one

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1299,9 +1299,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                edits, OpenAPI exposure changes, frontend changes,
 │   │                runtime/PM2 changes, OpenSpec changes, or issue-label changes
 │   ├── G2.81 DataSourceFactory compatibility getter retirement Phase 1 implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#234` merged at
+│   │   │          `c176b9e71dd0fe4fb9df65c1f2c82631a45cfc3d`
 │   │   ├── Evidence: `backend-data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.md`
-│   │   ├── Current HEAD: `b922db6b672f1084dcefb9ecba953b780ac8dbe3`
+│   │   ├── Current HEAD: `c176b9e71dd0fe4fb9df65c1f2c82631a45cfc3d`
 │   │   ├── Result: introduces private `_get_or_create_data_source_factory()`,
 │   │   │          keeps public `get_data_source_factory()` as a compatibility
 │   │   │          wrapper, decouples service-internal helper fallback calls from
@@ -1313,9 +1314,23 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: no public getter deletion, package export removal, route/API
 │   │                edit, OpenAPI exposure change, frontend change, runtime/PM2
 │   │                change, OpenSpec change, or issue-label change is authorized
-│   └── Next gate: Human review / PR merge decision for G2.81 implementation; if
-│                  accepted, create a separate closeout/current-head refresh
-│                  before any public getter or package export retirement decision
+│   ├── G2.82 DataSourceFactory compatibility getter retirement Phase 1 closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.md`
+│   │   ├── Current HEAD: `c176b9e71dd0fe4fb9df65c1f2c82631a45cfc3d`
+│   │   ├── Result: records PR `#234` merge, confirms lifecycle tests
+│   │   │          pass `5`, health route conflicts pass `120`, OpenAPI remains
+│   │   │          routes=`548`, paths=`500`, duplicate operation IDs=`0`,
+│   │   │          route/API direct public getter calls stay `0`, service helper
+│   │   │          public getter calls stay `0`, and package export mentions stay `4`
+│   │   └── Boundary: governance-only closeout; no source, test, public getter
+│   │                deletion, package export removal, route/API, OpenAPI,
+│   │                frontend, runtime/PM2, OpenSpec, or issue-label change is
+│   │                authorized
+│   └── Next gate: Human review / PR merge decision for G2.82 closeout; if
+│                  accepted, create a separate source-capable authorization
+│                  packet before any public getter or package export retirement
+│                  decision
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1381,7 +1396,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-futures-route-migration-closeout-2026-05-25.md` | G | G2.78 closeout packet prepared at `e7a2a436`: PR `#230` merge recorded, health tests remain `120 passed`, provider tests remain `4 passed`, total route/API direct factory refs remain `0`, OpenAPI paths remain `500`, and compatibility getter remains unchanged | Human review / PR merge decision; if accepted, prepare a separate compatibility getter retirement / retained-shim decision packet |
 | `backend-data-source-factory-compat-getter-retained-shim-decision-2026-05-25.md` | G | G2.79 decision packet prepared at `b3aefed2`: route/API direct `get_data_source_factory()` calls are `0`, but the compatibility getter remains package-exported, lifecycle-tested, and used by service-internal helper fallback paths; decision is retain shim for now | Human review / PR merge decision; if accepted, create a separate source-capable retirement authorization packet before any compatibility API removal |
 | `backend-data-source-factory-compat-getter-retirement-authorization-2026-05-25.md` | G | G2.80 authorization packet accepted in PR `#233` at `b922db6b`: authorizes only a future G2.81 Phase 1 service-internal decoupling step; public getter and package exports must remain, route/API direct calls stay `0`, lifecycle tests pass `4`, health route conflicts pass `120`, and OpenAPI paths remain `500` | G2.81 implementation branch may perform Phase 1 service-internal decoupling only |
-| `backend-data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.md` | G | G2.81 implementation packet prepared at `b922db6b`: adds private `_get_or_create_data_source_factory()`, keeps public `get_data_source_factory()` and package exports, removes service helper public getter calls, expands lifecycle tests to `5 passed`, keeps health route conflicts at `120 passed`, and keeps OpenAPI paths=`500` with duplicate operation IDs=`0` | Human review / PR merge decision; if accepted, create closeout/current-head refresh before any public getter or package export retirement decision |
+| `backend-data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.md` | G | G2.81 implementation packet accepted in PR `#234` at `c176b9e`: adds private `_get_or_create_data_source_factory()`, keeps public `get_data_source_factory()` and package exports, removes service helper public getter calls, expands lifecycle tests to `5 passed`, keeps health route conflicts at `120 passed`, and keeps OpenAPI paths=`500` with duplicate operation IDs=`0` | Create closeout/current-head refresh before any public getter or package export retirement decision |
+| `backend-data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.md` | G | G2.82 closeout packet prepared at `c176b9e`: records PR `#234` merge, reconfirms lifecycle tests `5 passed`, health route conflicts `120 passed`, OpenAPI routes=`548` paths=`500` duplicate operation IDs=`0`, route/API direct public getter calls=`0`, service helper public getter calls=`0`, and package export mentions=`4` | Human review / PR merge decision; if accepted, require a separate source-capable authorization packet before any public getter or package export retirement decision |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.json
@@ -1,0 +1,43 @@
+{
+  "artifact": "data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T13:10:00+08:00",
+  "branch": "g2-82-data-source-factory-compat-getter-phase1-closeout",
+  "current_head": "c176b9e71dd0fe4fb9df65c1f2c82631a45cfc3d",
+  "merge_evidence": {
+    "g2_81_pr": 234,
+    "pr_state": "MERGED",
+    "merged_at": "2026-05-25T05:06:06Z",
+    "merge_commit": "c176b9e71dd0fe4fb9df65c1f2c82631a45cfc3d",
+    "implementation_commit": "3e2888c4ff89788d512d2dbde64f1e605ae66225",
+    "base_branch": "wip/root-dirty-20260403"
+  },
+  "current_head_evidence": {
+    "lifecycle_tests": "5 passed in 1.77s",
+    "health_route_conflicts": "120 passed in 69.72s",
+    "openapi_smoke": {
+      "env_source": "/opt/claude/mystocks_spec/.env",
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0
+    },
+    "reference_scan": {
+      "route_api_direct_get_data_source_factory_calls": 0,
+      "service_module_exact_refs": 1,
+      "service_helper_public_getter_calls": 0,
+      "package_export_mentions": 4,
+      "service_private_initializer_refs": 7
+    }
+  },
+  "accepted_state": {
+    "g2_81_phase_1_service_internal_decoupling": true,
+    "private_initializer_exists": "_get_or_create_data_source_factory",
+    "public_getter_kept": true,
+    "public_getter_role": "compatibility wrapper",
+    "package_exports_kept": true,
+    "public_getter_deletion_authorized": false,
+    "package_export_removal_authorized": false
+  },
+  "next_gate": "Human review / PR merge decision for G2.82 closeout. Further public getter or package export retirement requires a separate authorization packet."
+}

--- a/docs/reports/quality/backend-data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.md
@@ -1,0 +1,90 @@
+# Backend DataSourceFactory Compatibility Getter Retirement Phase 1 Closeout - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.82 closeout/current-head refresh
+
+Status: ready for review
+
+Branch: `g2-82-data-source-factory-compat-getter-phase1-closeout`
+
+Current HEAD: `c176b9e71dd0fe4fb9df65c1f2c82631a45cfc3d`
+
+Prepared at: `2026-05-25T13:10:00+08:00`
+
+## Purpose
+
+Close out the merged G2.81 implementation and update the steward tree so the
+G2.81 function is recorded as accepted against current HEAD.
+
+This packet is governance-only. It does not edit backend source, tests, routes,
+OpenAPI exposure, frontend code, runtime/PM2 scripts, OpenSpec changes, package
+exports, or GitHub issue labels.
+
+## Merge Evidence
+
+| Item | Value |
+|---|---|
+| G2.81 PR | `#234` |
+| PR state | `MERGED` |
+| Merge timestamp | `2026-05-25T05:06:06Z` |
+| Merge commit | `c176b9e71dd0fe4fb9df65c1f2c82631a45cfc3d` |
+| Implementation commit | `3e2888c4ff89788d512d2dbde64f1e605ae66225` |
+| Base branch | `wip/root-dirty-20260403` |
+
+## Current-Head Evidence
+
+| Check | Result |
+|---|---|
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | 5 passed in 1.77s |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | 120 passed in 69.72s |
+| OpenAPI smoke with root `.env` loaded | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+
+Current-head reference scan:
+
+| Metric | Result |
+|---|---:|
+| Route/API direct `get_data_source_factory()` calls | 0 |
+| Service-module exact refs | 1 |
+| Service helper public getter calls | 0 |
+| Package export mentions | 4 |
+| Service private initializer refs | 7 |
+
+The single service-module exact ref is the public compatibility getter
+definition itself. Package exports remain intentionally present.
+
+## Steward Decision
+
+G2.81 is accepted as Phase 1 service-internal decoupling.
+
+The current state is:
+
+- private `_get_or_create_data_source_factory()` exists;
+- public `get_data_source_factory()` remains a compatibility wrapper;
+- service-internal helper fallback calls no longer depend on the public getter;
+- route/API direct public getter calls remain `0`;
+- package exports remain unchanged.
+
+## Boundary Confirmation
+
+This closeout does not authorize:
+
+- public `get_data_source_factory()` deletion;
+- package export removal from
+  `web/backend/app/services/data_source_factory/__init__.py`;
+- route/API edits;
+- route path, response model, response shape, or OpenAPI exposure changes;
+- frontend edits;
+- runtime or PM2 changes;
+- OpenSpec changes;
+- GitHub issue-label changes.
+
+## Next Gate
+
+Human review / PR merge decision for this G2.82 closeout.
+
+After this closeout is accepted, any further public getter or package export
+retirement still requires a separate source-capable authorization packet with
+fresh current-head reference scans and GitNexus impact analysis.

--- a/governance/mainline/task-cards/pr-235.yaml
+++ b/governance/mainline/task-cards/pr-235.yaml
@@ -1,0 +1,114 @@
+version: "v0.2"
+
+task:
+  id: "pr-235"
+  title: "Close out DataSourceFactory compatibility getter phase 1 decoupling"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-compat-getter-phase1-closeout"
+  objective: "record the merged G2.81 phase 1 decoupling as accepted and refresh current-head evidence"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-compat-getter-phase1-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-compat-getter-phase1-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only closeout that records current-head evidence and does not change runtime behavior"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-235.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source or test edits"
+  - "No public get_data_source_factory() deletion"
+  - "No package export removal from web/backend/app/services/data_source_factory/__init__.py"
+  - "No route path, response model, response shape, OpenAPI exposure, docs/API, generated client, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+
+acceptance:
+  checks:
+    - id: "current-head-provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "current-head-health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "current-head-openapi-smoke"
+      command: "PYTHONPATH=web/backend python -c \"from dotenv import load_dotenv; load_dotenv('/opt/claude/mystocks_spec/.env'); from app.main import app; app.openapi()\""
+      required: true
+    - id: "reference-scan"
+      command: "scan route/API direct calls, service helper public getter calls, package export mentions, and private initializer refs"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-235.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-235.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is treated as deletion authorization, later work could bypass the required source-capable decision packet"
+    - "If current-head evidence is stale, steward tree sequencing could mislead the next retained-shim decision"
+  rollback_plan: "revert this governance-only closeout PR and keep G2.81 recorded as pending review until fresh evidence is prepared"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out merged G2.81 phase 1 service-internal decoupling"
+    modified_scope: "closeout report, generated artifact, steward tree, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; public compatibility getter and package exports remain intact"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this closeout PR if current-head evidence or steward-tree state is incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T13:10:00+08:00"
+    approval_note: "human maintainer accepted continuing after PR #234 merge; this packet records closeout evidence only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records PR #234 / G2.81 as accepted in the steward tree
- adds current-head closeout evidence for the DataSourceFactory compatibility getter Phase 1 decoupling
- keeps this packet governance-only and explicitly does not authorize public getter deletion or package export removal

## Verification
- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short: 5 passed
- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short: 120 passed
- OpenAPI smoke with root .env loaded: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0
- Reference scan: route/API direct calls=0, service helper public getter calls=0, package export mentions=4
- Markdown governance: errors=0
- JSON/YAML parse: passed
- Post-commit mainline scope gate: pass

## Boundary
- no backend source or test edits
- no route/API, OpenAPI exposure, frontend, runtime/PM2, OpenSpec, or issue-label changes
- no public get_data_source_factory() deletion
- no package export removal
