### PR TITLE
docs(governance): authorize factory getter final retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1315,9 +1315,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                edit, OpenAPI exposure change, frontend change, runtime/PM2
 │   │                change, OpenSpec change, or issue-label change is authorized
 │   ├── G2.82 DataSourceFactory compatibility getter retirement Phase 1 closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#235` merged at
+│   │   │          `075768a56ea78f11796387d25fe33eed04668c6f`
 │   │   ├── Evidence: `backend-data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.md`
-│   │   ├── Current HEAD: `c176b9e71dd0fe4fb9df65c1f2c82631a45cfc3d`
+│   │   ├── Current HEAD: `075768a56ea78f11796387d25fe33eed04668c6f`
 │   │   ├── Result: records PR `#234` merge, confirms lifecycle tests
 │   │   │          pass `5`, health route conflicts pass `120`, OpenAPI remains
 │   │   │          routes=`548`, paths=`500`, duplicate operation IDs=`0`,
@@ -1327,10 +1328,23 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                deletion, package export removal, route/API, OpenAPI,
 │   │                frontend, runtime/PM2, OpenSpec, or issue-label change is
 │   │                authorized
-│   └── Next gate: Human review / PR merge decision for G2.82 closeout; if
-│                  accepted, create a separate source-capable authorization
-│                  packet before any public getter or package export retirement
-│                  decision
+│   ├── G2.83 DataSourceFactory compatibility getter final retirement authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.md`
+│   │   ├── Current HEAD: `075768a56ea78f11796387d25fe33eed04668c6f`
+│   │   ├── Result: precise scan shows production exact public getter hits are
+│   │   │          limited to the definition and package exports, route/API
+│   │   │          production consumers are `0`, package export lines are `2`,
+│   │   │          lifecycle tests pass `5`, stocks runtime fallback passes `1`,
+│   │   │          and remaining public getter patch points are test-only; future
+│   │   │          G2.84 may remove the public getter and package exports only
+│   │   │          under the listed source/test scope
+│   │   └── Boundary: authorization-only; no source, test, public getter deletion,
+│   │                package export removal, route/API, OpenAPI, frontend,
+│   │                runtime/PM2, OpenSpec, or issue-label change is made here
+│   └── Next gate: Human review / PR merge decision for G2.83 authorization; if
+│                  accepted, create a G2.84 source implementation branch for
+│                  final public getter and package export retirement only
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1397,7 +1411,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-compat-getter-retained-shim-decision-2026-05-25.md` | G | G2.79 decision packet prepared at `b3aefed2`: route/API direct `get_data_source_factory()` calls are `0`, but the compatibility getter remains package-exported, lifecycle-tested, and used by service-internal helper fallback paths; decision is retain shim for now | Human review / PR merge decision; if accepted, create a separate source-capable retirement authorization packet before any compatibility API removal |
 | `backend-data-source-factory-compat-getter-retirement-authorization-2026-05-25.md` | G | G2.80 authorization packet accepted in PR `#233` at `b922db6b`: authorizes only a future G2.81 Phase 1 service-internal decoupling step; public getter and package exports must remain, route/API direct calls stay `0`, lifecycle tests pass `4`, health route conflicts pass `120`, and OpenAPI paths remain `500` | G2.81 implementation branch may perform Phase 1 service-internal decoupling only |
 | `backend-data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.md` | G | G2.81 implementation packet accepted in PR `#234` at `c176b9e`: adds private `_get_or_create_data_source_factory()`, keeps public `get_data_source_factory()` and package exports, removes service helper public getter calls, expands lifecycle tests to `5 passed`, keeps health route conflicts at `120 passed`, and keeps OpenAPI paths=`500` with duplicate operation IDs=`0` | Create closeout/current-head refresh before any public getter or package export retirement decision |
-| `backend-data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.md` | G | G2.82 closeout packet prepared at `c176b9e`: records PR `#234` merge, reconfirms lifecycle tests `5 passed`, health route conflicts `120 passed`, OpenAPI routes=`548` paths=`500` duplicate operation IDs=`0`, route/API direct public getter calls=`0`, service helper public getter calls=`0`, and package export mentions=`4` | Human review / PR merge decision; if accepted, require a separate source-capable authorization packet before any public getter or package export retirement decision |
+| `backend-data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.md` | G | G2.82 closeout packet accepted in PR `#235` at `075768a`: records PR `#234` merge, reconfirms lifecycle tests `5 passed`, health route conflicts `120 passed`, OpenAPI routes=`548` paths=`500` duplicate operation IDs=`0`, route/API direct public getter calls=`0`, service helper public getter calls=`0`, and package export mentions=`4` | Separate source-capable authorization packet required before any public getter or package export retirement decision |
+| `backend-data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.md` | G | G2.83 authorization packet prepared at `075768a`: precise scan shows production public getter hits are definition plus package exports only, route/API production consumers=`0`, package export lines=`2`, lifecycle tests `5 passed`, stocks runtime fallback `1 passed`, GitNexus impact remains CRITICAL/stale-aware, and market/data regression public getter patch points have existing unrelated failures recorded | Human review / PR merge decision; if accepted, create G2.84 source implementation branch for final public getter and package export retirement only |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.json
@@ -1,0 +1,71 @@
+{
+  "artifact": "data-source-factory-compat-getter-final-retirement-authorization-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T13:21:46+08:00",
+  "branch": "g2-83-data-source-factory-compat-getter-final-retirement-authorization",
+  "current_head": "075768a56ea78f11796387d25fe33eed04668c6f",
+  "current_state": {
+    "exact_public_getter_hits": 9,
+    "production_exact_public_getter_hits": 3,
+    "exact_public_getter_imports": 1,
+    "exact_public_getter_calls": 2,
+    "exact_public_getter_definitions": 1,
+    "package_export_lines": 2,
+    "production_hits_are_definition_and_package_exports_only": true,
+    "route_api_production_consumers": 0
+  },
+  "remaining_test_consumers": [
+    "web/backend/tests/test_data_source_factory_lifecycle_di.py",
+    "web/backend/tests/test_market_api_integration.py",
+    "web/backend/tests/test_data_stocks_runtime_fallback.py",
+    "tests/backend/test_data_api_regression.py"
+  ],
+  "verification": {
+    "lifecycle_tests": "5 passed",
+    "stocks_runtime_fallback": "1 passed",
+    "market_api_integration": "3 failed, 15 passed; existing DB-dependent localhost:5438 failures",
+    "data_api_regression": "3 failed; existing historical-route 404 failures"
+  },
+  "gitnexus": {
+    "get_data_source_factory_impact": {
+      "risk": "CRITICAL",
+      "impacted_count": 22,
+      "direct_dependents": 21,
+      "processes_affected": 12,
+      "process_families": [
+        "Get_sources_health",
+        "Get_system_status_overview"
+      ]
+    },
+    "interpretation": "Treat GitNexus route/API callers as stale-index/high-risk warning because precise current-head scan shows no live route/API production consumer remains."
+  },
+  "authorization": {
+    "future_stage": "G2.84 final public getter and package export retirement",
+    "authorized": true,
+    "source_edits_in_this_packet": false,
+    "allowed_future_files": [
+      "web/backend/app/services/data_source_factory/data_source_factory.py",
+      "web/backend/app/services/data_source_factory/__init__.py",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py",
+      "web/backend/tests/test_market_api_integration.py",
+      "web/backend/tests/test_data_stocks_runtime_fallback.py",
+      "tests/backend/test_data_api_regression.py"
+    ],
+    "forbidden_future_scope": [
+      "web/backend/app/api/**",
+      "route paths",
+      "response models",
+      "response shapes",
+      "OpenAPI exposure",
+      "frontend files",
+      "runtime or PM2 scripts",
+      "OpenSpec changes",
+      "GitHub issue labels",
+      "DATA_SOURCE_FACTORY_STATE_KEY",
+      "get_data_source_factory_dependency removal",
+      "_get_or_create_data_source_factory removal",
+      "unrelated DB-dependent or historical-route test fixes"
+    ]
+  },
+  "next_gate": "Human review / PR merge decision for G2.83 authorization. If accepted, create G2.84 source implementation branch."
+}

--- a/docs/reports/quality/backend-data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.md
@@ -1,0 +1,185 @@
+# Backend DataSourceFactory Compatibility Getter Final Retirement Authorization - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.83 source-capable authorization packet
+
+Status: ready for review
+
+Branch: `g2-83-data-source-factory-compat-getter-final-retirement-authorization`
+
+Current HEAD: `075768a56ea78f11796387d25fe33eed04668c6f`
+
+Prepared at: `2026-05-25T13:21:46+08:00`
+
+## Purpose
+
+Authorize a future G2.84 implementation to retire the public
+`get_data_source_factory()` compatibility getter and its package export, if the
+implementation stays inside the file and gate boundaries below.
+
+This packet does not edit backend source or tests. It records the evidence and
+scope required before any final retirement implementation can start.
+
+## Current State
+
+G2.81 removed service-internal helper dependency on the public getter. G2.82
+closed out that implementation at current HEAD.
+
+Current precise scan excluding `get_data_source_factory_dependency` shows:
+
+| Metric | Count |
+|---|---:|
+| Exact public getter hits | 9 |
+| Production exact public getter hits | 3 |
+| Exact public getter imports | 1 |
+| Exact public getter calls | 2 |
+| Exact public getter definitions | 1 |
+| Package export lines | 2 |
+
+The 3 production hits are only:
+
+| File | Line | Role |
+|---|---:|---|
+| `web/backend/app/services/data_source_factory/data_source_factory.py` | 308 | public getter definition |
+| `web/backend/app/services/data_source_factory/__init__.py` | 12 | package re-export |
+| `web/backend/app/services/data_source_factory/__init__.py` | 31 | package `__all__` entry |
+
+No route/API production consumer remains.
+
+## Remaining Test Consumers
+
+The public getter still appears in test monkeypatch or compatibility coverage:
+
+| File | Line | Role |
+|---|---:|---|
+| `web/backend/tests/test_data_source_factory_lifecycle_di.py` | 31 | monkeypatch public getter to prove dependency fallback bypasses it |
+| `web/backend/tests/test_data_source_factory_lifecycle_di.py` | 72 | compatibility getter still initializes |
+| `web/backend/tests/test_data_source_factory_lifecycle_di.py` | 101 | monkeypatch public getter to prove service helpers bypass it |
+| `web/backend/tests/test_market_api_integration.py` | 85 | monkeypatch package public getter |
+| `web/backend/tests/test_data_stocks_runtime_fallback.py` | 43 | monkeypatch package public getter |
+| `tests/backend/test_data_api_regression.py` | 25 | patch package public getter |
+
+Future G2.84 must migrate or remove these test assumptions as part of the
+retirement implementation.
+
+## Current Verification
+
+| Check | Result |
+|---|---|
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | 5 passed |
+| `pytest -o addopts= web/backend/tests/test_data_stocks_runtime_fallback.py -q --no-cov --tb=short` | 1 passed |
+| `pytest -o addopts= web/backend/tests/test_market_api_integration.py -q --no-cov --tb=short` | 3 failed, 15 passed; failures are existing DB-dependent market overview failures against localhost:5438 |
+| `pytest -o addopts= tests/backend/test_data_api_regression.py -q --no-cov --tb=short` | 3 failed; existing route expectation failures return 404 |
+
+The failing tests are not introduced by this authorization packet. They are
+recorded because they contain public getter patch points that a future G2.84
+implementation may need to edit. Future G2.84 must not claim those files become
+fully green unless it separately fixes their pre-existing failures inside an
+approved scope.
+
+## GitNexus Evidence
+
+GitNexus impact for `get_data_source_factory` at current source state:
+
+| Metric | Result |
+|---|---|
+| Risk | CRITICAL |
+| Impacted count | 22 |
+| Direct dependents | 21 |
+| Processes affected | 12 |
+| Process families | `Get_sources_health`, `Get_system_status_overview` |
+
+GitNexus context still lists route/API callers and service helper callers that
+the precise current-head text scan shows have been migrated. Treat this as a
+stale-index/high-risk warning, not as proof of live route/API consumers.
+
+G2.84 must still run fresh GitNexus impact/context before source edits and
+staged `detect_changes(scope=staged)` before commit.
+
+## Authorization Decision
+
+Authorize a future G2.84 final retirement implementation only under the scope
+below.
+
+Allowed future source and test files:
+
+- `web/backend/app/services/data_source_factory/data_source_factory.py`;
+- `web/backend/app/services/data_source_factory/__init__.py`;
+- `web/backend/tests/test_data_source_factory_lifecycle_di.py`;
+- `web/backend/tests/test_market_api_integration.py`;
+- `web/backend/tests/test_data_stocks_runtime_fallback.py`;
+- `tests/backend/test_data_api_regression.py`.
+
+Allowed future intent:
+
+1. Remove the public `get_data_source_factory()` compatibility getter.
+2. Remove its package re-export and `__all__` entry.
+3. Update or remove tests that assert the old public getter exists.
+4. Retarget package-level test monkeypatches to supported dependency seams.
+5. Keep `get_data_source_factory_dependency` and private
+   `_get_or_create_data_source_factory()` intact.
+
+## Required Future G2.84 Gates
+
+1. Read `architecture/STANDARDS.md`.
+2. Run GitNexus impact/context for `get_data_source_factory`,
+   `_get_or_create_data_source_factory`, and
+   `get_data_source_factory_dependency`.
+3. TDD RED: add or update a focused test proving the package no longer exports
+   public `get_data_source_factory`.
+4. Implement only the authorized retirement.
+5. Run:
+   - lifecycle DI tests;
+   - stocks runtime fallback test;
+   - health route conflicts test;
+   - ruff and black on touched files;
+   - OpenAPI smoke with root `.env` loaded.
+6. For `test_market_api_integration.py` and
+   `tests/backend/test_data_api_regression.py`, record whether existing
+   unrelated failures remain unchanged. Do not convert their current baseline
+   failures into new G2.84 success claims.
+7. Text scan must show:
+   - production public getter hits `0`;
+   - package export lines `0`;
+   - route/API direct calls `0`;
+   - no `get_data_source_factory` public getter patch points remain.
+8. Run staged GitNexus `detect_changes(scope=staged)`.
+
+## Forbidden Future G2.84 Scope
+
+G2.84 must not:
+
+- edit route modules under `web/backend/app/api/**`;
+- edit route paths, response models, response shapes, or OpenAPI exposure;
+- edit frontend files;
+- edit runtime or PM2 scripts;
+- edit OpenSpec changes;
+- change GitHub issue labels;
+- change `DATA_SOURCE_FACTORY_STATE_KEY`;
+- remove `get_data_source_factory_dependency`;
+- remove `_get_or_create_data_source_factory`;
+- fix unrelated DB-dependent or historical-route test failures without a
+  separate approved scope.
+
+## Stop Conditions
+
+Stop before implementation or commit if:
+
+- any live production consumer outside the allowed source files is found;
+- deleting the public getter requires route/API, OpenAPI, frontend, runtime, or
+  OpenSpec changes;
+- the future implementation needs to fix unrelated market integration or
+  historical-route regression failures;
+- GitNexus reports a new HIGH/CRITICAL impact outside the known stale-index
+  route-handler set and DataSourceFactory initialization paths.
+
+## Next Gate
+
+Human review / PR merge decision for this G2.83 authorization.
+
+If accepted, create a separate G2.84 source implementation branch for final
+public getter and package export retirement. Do not implement G2.84 in this
+authorization packet.

--- a/governance/mainline/task-cards/pr-236.yaml
+++ b/governance/mainline/task-cards/pr-236.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-236"
+  title: "Authorize DataSourceFactory compatibility getter final retirement"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-compat-getter-final-retirement-authorization"
+  objective: "authorize a future source implementation to remove the public DataSourceFactory compatibility getter and package exports after phase 1 decoupling"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-compat-getter-final-retirement-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-compat-getter-final-retirement-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only authorization packet that records future source scope and does not change runtime behavior"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-236.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source or test edits in this authorization packet"
+  - "No public get_data_source_factory() deletion in this authorization packet"
+  - "No package export removal in this authorization packet"
+  - "No route path, response model, response shape, OpenAPI exposure, docs/API, generated client, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+
+acceptance:
+  checks:
+    - id: "precise-consumer-scan"
+      command: "scan exact public get_data_source_factory refs excluding get_data_source_factory_dependency"
+      required: true
+    - id: "gitnexus-impact"
+      command: "MCP gitnexus.impact(target=get_data_source_factory, direction=upstream, includeTests=true)"
+      required: true
+    - id: "focused-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "stocks-runtime-fallback-test"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_stocks_runtime_fallback.py -q --no-cov --tb=short"
+      required: true
+    - id: "known-test-consumer-baseline"
+      command: "record current market_api_integration and data_api_regression failures without treating them as G2.84 success criteria"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-236.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-236.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If future implementation deletes the public getter while live production consumers remain, runtime imports can break"
+    - "If future implementation treats existing unrelated test failures as fixed, the verification record becomes misleading"
+    - "GitNexus still reports stale CRITICAL route/API callers and must not be ignored without precise current-head scans"
+  rollback_plan: "revert this authorization PR; G2.82 remains the accepted state with public getter and package exports retained"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize future final retirement of the DataSourceFactory compatibility getter"
+    modified_scope: "authorization report, generated artifact, steward tree, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none in this packet; future G2.84 may remove the public getter only under this packet's scope"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this authorization PR if the future source scope or evidence is incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T13:21:46+08:00"
+    approval_note: "human maintainer accepted continuing after G2.82; this packet authorizes a future implementation branch only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records G2.82 / PR #235 as accepted in the steward tree
- authorizes a future G2.84 source implementation to retire public get_data_source_factory() and package exports under a narrow scope
- does not edit backend source or tests in this packet

## Evidence
- precise scan excluding get_data_source_factory_dependency: production public getter hits are only definition plus package exports
- route/API production consumers: 0
- package export lines: 2
- lifecycle DI tests: 5 passed
- stocks runtime fallback: 1 passed
- GitNexus impact for get_data_source_factory: CRITICAL, treated as stale-aware because precise current-head scan contradicts route/API caller entries
- known test consumer baselines recorded: market_api_integration has existing DB-dependent failures; data_api_regression has existing historical-route 404 failures
- post-commit mainline scope gate: pass

## Future Boundary
Future G2.84 may touch only:
- web/backend/app/services/data_source_factory/data_source_factory.py
- web/backend/app/services/data_source_factory/__init__.py
- web/backend/tests/test_data_source_factory_lifecycle_di.py
- web/backend/tests/test_market_api_integration.py
- web/backend/tests/test_data_stocks_runtime_fallback.py
- tests/backend/test_data_api_regression.py

Forbidden for G2.84:
- route/API modules, OpenAPI exposure, frontend, runtime/PM2, OpenSpec, issue labels
- get_data_source_factory_dependency removal
- _get_or_create_data_source_factory removal
- unrelated test-debt fixes
