### PR TITLE
G2.84 retire DataSourceFactory compatibility getter

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1329,9 +1329,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                frontend, runtime/PM2, OpenSpec, or issue-label change is
 │   │                authorized
 │   ├── G2.83 DataSourceFactory compatibility getter final retirement authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#236` merged at
+│   │   │          `5de71a8847a45efd0628b184baff985a9dd3b180`
 │   │   ├── Evidence: `backend-data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.md`
-│   │   ├── Current HEAD: `075768a56ea78f11796387d25fe33eed04668c6f`
+│   │   ├── Current HEAD: `5de71a8847a45efd0628b184baff985a9dd3b180`
 │   │   ├── Result: precise scan shows production exact public getter hits are
 │   │   │          limited to the definition and package exports, route/API
 │   │   │          production consumers are `0`, package export lines are `2`,
@@ -1342,9 +1343,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: authorization-only; no source, test, public getter deletion,
 │   │                package export removal, route/API, OpenAPI, frontend,
 │   │                runtime/PM2, OpenSpec, or issue-label change is made here
-│   └── Next gate: Human review / PR merge decision for G2.83 authorization; if
-│                  accepted, create a G2.84 source implementation branch for
-│                  final public getter and package export retirement only
+│   ├── G2.84 DataSourceFactory compatibility getter final retirement implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-data-source-factory-compat-getter-final-retirement-implementation-2026-05-25.md`
+│   │   ├── Current HEAD: `5de71a8847a45efd0628b184baff985a9dd3b180`
+│   │   ├── Result: removes public `get_data_source_factory()` and its package
+│   │   │          export, keeps `get_data_source_factory_dependency` and
+│   │   │          `_get_or_create_data_source_factory`, moves production exact
+│   │   │          public getter hits to `0`, package export lines to `0`, patch
+│   │   │          points to `0`, keeps lifecycle tests at `5 passed`, stocks
+│   │   │          runtime fallback at `1 passed`, market API integration at
+│   │   │          `18 passed`, health route conflicts at `120 passed`, and
+│   │   │          OpenAPI paths=`500` with duplicate operation IDs=`0`
+│   │   └── Boundary: no route/API, OpenAPI, frontend, runtime/PM2, OpenSpec,
+│   │                issue-label, dependency provider removal, private initializer
+│   │                removal, or unrelated historical-route test-debt fix is made
+│   └── Next gate: Human review / PR merge decision for G2.84 implementation; if
+│                  accepted, create closeout/current-head refresh before any
+│                  further DataSourceFactory compatibility-surface cleanup
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1412,7 +1428,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-compat-getter-retirement-authorization-2026-05-25.md` | G | G2.80 authorization packet accepted in PR `#233` at `b922db6b`: authorizes only a future G2.81 Phase 1 service-internal decoupling step; public getter and package exports must remain, route/API direct calls stay `0`, lifecycle tests pass `4`, health route conflicts pass `120`, and OpenAPI paths remain `500` | G2.81 implementation branch may perform Phase 1 service-internal decoupling only |
 | `backend-data-source-factory-compat-getter-retirement-phase1-implementation-2026-05-25.md` | G | G2.81 implementation packet accepted in PR `#234` at `c176b9e`: adds private `_get_or_create_data_source_factory()`, keeps public `get_data_source_factory()` and package exports, removes service helper public getter calls, expands lifecycle tests to `5 passed`, keeps health route conflicts at `120 passed`, and keeps OpenAPI paths=`500` with duplicate operation IDs=`0` | Create closeout/current-head refresh before any public getter or package export retirement decision |
 | `backend-data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.md` | G | G2.82 closeout packet accepted in PR `#235` at `075768a`: records PR `#234` merge, reconfirms lifecycle tests `5 passed`, health route conflicts `120 passed`, OpenAPI routes=`548` paths=`500` duplicate operation IDs=`0`, route/API direct public getter calls=`0`, service helper public getter calls=`0`, and package export mentions=`4` | Separate source-capable authorization packet required before any public getter or package export retirement decision |
-| `backend-data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.md` | G | G2.83 authorization packet prepared at `075768a`: precise scan shows production public getter hits are definition plus package exports only, route/API production consumers=`0`, package export lines=`2`, lifecycle tests `5 passed`, stocks runtime fallback `1 passed`, GitNexus impact remains CRITICAL/stale-aware, and market/data regression public getter patch points have existing unrelated failures recorded | Human review / PR merge decision; if accepted, create G2.84 source implementation branch for final public getter and package export retirement only |
+| `backend-data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.md` | G | G2.83 authorization packet accepted in PR `#236` at `5de71a8`: precise scan shows production public getter hits are definition plus package exports only, route/API production consumers=`0`, package export lines=`2`, lifecycle tests `5 passed`, stocks runtime fallback `1 passed`, GitNexus impact remains CRITICAL/stale-aware, and market/data regression public getter patch points have existing unrelated failures recorded | G2.84 source implementation may remove the public getter and package exports only inside the authorized file scope |
+| `backend-data-source-factory-compat-getter-final-retirement-implementation-2026-05-25.md` | G | G2.84 implementation packet prepared at `5de71a8`: removes public `get_data_source_factory()` and package exports, keeps `get_data_source_factory_dependency` plus `_get_or_create_data_source_factory`, moves production public getter hits=`0`, package export lines=`0`, patch points=`0`, lifecycle tests `5 passed`, stocks runtime fallback `1 passed`, market API integration `18 passed`, health route conflicts `120 passed`, OpenAPI paths=`500`, duplicate operation IDs=`0`, and leaves known `test_data_api_regression.py` historical-route 404 failures unresolved | Human review / PR merge decision; if accepted, create closeout/current-head refresh before further DataSourceFactory compatibility-surface cleanup |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/data-source-factory-compat-getter-final-retirement-implementation-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-compat-getter-final-retirement-implementation-2026-05-25.json
@@ -1,0 +1,62 @@
+{
+  "artifact": "data-source-factory-compat-getter-final-retirement-implementation-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T13:45:00+08:00",
+  "branch": "g2-84-data-source-factory-compat-getter-final-retirement-implementation",
+  "baseline_head": "5de71a8847a45efd0628b184baff985a9dd3b180",
+  "authorization": {
+    "source": "backend-data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.md",
+    "merged_pr": 236,
+    "merged_head": "5de71a8847a45efd0628b184baff985a9dd3b180",
+    "allowed_stage": "G2.84 final public getter and package export retirement"
+  },
+  "implementation": {
+    "public_get_data_source_factory_removed": true,
+    "package_reexport_removed": true,
+    "package_all_entry_removed": true,
+    "get_data_source_factory_dependency_kept": true,
+    "_get_or_create_data_source_factory_kept": true,
+    "route_api_edits": false,
+    "openapi_exposure_edits": false
+  },
+  "tdd": {
+    "red": "1 failed, 4 passed; public getter still existed",
+    "green": "5 passed in lifecycle DI tests"
+  },
+  "verification": {
+    "lifecycle_tests": "5 passed in 1.97s",
+    "stocks_runtime_fallback": "1 passed in 14.48s",
+    "market_api_integration": "18 passed in 17.89s",
+    "data_api_regression": "3 failed; existing historical-route 404 failures remain",
+    "health_route_conflicts": "120 passed in 77.72s",
+    "ruff": "passed",
+    "black_check": "passed",
+    "openapi_smoke": {
+      "env_source": "/opt/claude/mystocks_spec/.env",
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0
+    },
+    "public_getter_scan": {
+      "exact_public_hits": 3,
+      "production_exact_public_hits": 0,
+      "package_export_lines": 0,
+      "public_getter_patch_points": 0,
+      "remaining_hits": "negative assertions in lifecycle DI test only"
+    }
+  },
+  "gitnexus": {
+    "pre_edit_get_data_source_factory_impact": "CRITICAL, 22 impacted symbols, 21 direct dependents, 12 affected processes",
+    "_get_or_create_data_source_factory": "not found after gitnexus analyze",
+    "get_data_source_factory_dependency": "not found after gitnexus analyze",
+    "staged_detect_changes": {
+      "changed_files": 10,
+      "changed_symbols": 0,
+      "affected_processes": 0,
+      "risk": "LOW"
+    },
+    "interpretation": "precise current-head text scan and tests are authoritative for this scoped retirement; GitNexus route/API callers remain stale-aware"
+  },
+  "next_gate": "Human review / PR merge decision for G2.84. If accepted, create closeout/current-head refresh before further DataSourceFactory compatibility cleanup."
+}

--- a/docs/reports/quality/backend-data-source-factory-compat-getter-final-retirement-implementation-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-compat-getter-final-retirement-implementation-2026-05-25.md
@@ -1,0 +1,153 @@
+# Backend DataSourceFactory Compatibility Getter Final Retirement Implementation - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.84 source implementation packet
+
+Status: ready for review
+
+Branch: `g2-84-data-source-factory-compat-getter-final-retirement-implementation`
+
+Baseline HEAD: `5de71a8847a45efd0628b184baff985a9dd3b180`
+
+Prepared at: `2026-05-25T13:45:00+08:00`
+
+## Purpose
+
+Implement the G2.83 authorization to retire the public
+`get_data_source_factory()` compatibility getter and its package export.
+
+This packet keeps `get_data_source_factory_dependency` and private
+`_get_or_create_data_source_factory()` intact. It does not edit route/API
+modules, OpenAPI exposure, frontend, runtime/PM2, OpenSpec, or issue labels.
+
+## Scope
+
+Changed source files:
+
+- `web/backend/app/services/data_source_factory/data_source_factory.py`;
+- `web/backend/app/services/data_source_factory/__init__.py`.
+
+Changed test files:
+
+- `web/backend/tests/test_data_source_factory_lifecycle_di.py`;
+- `web/backend/tests/test_market_api_integration.py`;
+- `web/backend/tests/test_data_stocks_runtime_fallback.py`;
+- `tests/backend/test_data_api_regression.py`.
+
+## Implementation Summary
+
+- Removed public `get_data_source_factory()` from
+  `data_source_factory.py`.
+- Removed the package re-export and `__all__` entry from
+  `web/backend/app/services/data_source_factory/__init__.py`.
+- Kept `_get_or_create_data_source_factory()`.
+- Kept `get_data_source_factory_dependency()`.
+- Retargeted test monkeypatches from package-level public getter patches to the
+  supported `get_data_source_factory_dependency` FastAPI override seam.
+- Replaced the old compatibility getter initialization test with a retirement
+  assertion proving the module and package no longer expose the public getter.
+
+## TDD Evidence
+
+RED:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short
+1 failed, 4 passed
+```
+
+Expected failure:
+
+- `test_package_no_longer_exports_public_compatibility_getter` failed because
+  `data_source_factory_module.get_data_source_factory` still existed.
+
+GREEN after implementation and formatting:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short
+5 passed in 1.97s
+```
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | 5 passed |
+| `pytest -o addopts= web/backend/tests/test_data_stocks_runtime_fallback.py -q --no-cov --tb=short` | 1 passed |
+| `pytest -o addopts= web/backend/tests/test_market_api_integration.py -q --no-cov --tb=short` | 18 passed |
+| `pytest -o addopts= tests/backend/test_data_api_regression.py -q --no-cov --tb=short` | 3 failed; existing historical-route 404 failures remain |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | 120 passed |
+| `ruff check` on all touched files | passed |
+| `black --check` on all touched files | passed |
+| OpenAPI smoke with root `.env` loaded | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+
+`test_data_api_regression.py` still fails because its in-file app includes the
+data router at a path that returns 404 for its historical expectations. This was
+recorded in G2.83 and is not fixed by this packet.
+
+## Public Getter Scan
+
+Current exact scan excluding `get_data_source_factory_dependency`:
+
+| Metric | Result |
+|---|---:|
+| Exact public getter hits | 3 |
+| Production exact public getter hits | 0 |
+| Package export lines | 0 |
+| Public getter patch points | 0 |
+
+Remaining exact hits are only negative assertions in
+`web/backend/tests/test_data_source_factory_lifecycle_di.py`.
+
+## GitNexus Evidence
+
+Pre-edit GitNexus impact for `get_data_source_factory`:
+
+| Metric | Result |
+|---|---|
+| Risk | CRITICAL |
+| Impacted count | 22 |
+| Direct dependents | 21 |
+| Processes affected | 12 |
+
+GitNexus still reports stale route/API and service helper callers. The precise
+current-head scan before implementation showed no live route/API production
+consumer; after implementation, production public getter hits are `0`.
+
+GitNexus did not find `_get_or_create_data_source_factory` or
+`get_data_source_factory_dependency`, even after `gitnexus analyze`. Those
+symbols were checked by current source scans and focused tests instead.
+
+Staged GitNexus `detect_changes(scope=staged)` was run before commit:
+
+| Metric | Result |
+|---|---|
+| Changed files | 10 |
+| Changed symbols | 0 |
+| Affected processes | 0 |
+| Risk | LOW |
+
+## Boundary Confirmation
+
+This packet did not:
+
+- remove `get_data_source_factory_dependency`;
+- remove `_get_or_create_data_source_factory`;
+- edit route modules under `web/backend/app/api/**`;
+- edit route paths, response models, response shapes, or OpenAPI exposure;
+- edit frontend files;
+- edit runtime or PM2 scripts;
+- edit OpenSpec changes;
+- change GitHub issue labels;
+- change `DATA_SOURCE_FACTORY_STATE_KEY`;
+- fix unrelated historical-route failures in `tests/backend/test_data_api_regression.py`.
+
+## Next Gate
+
+Human review / PR merge decision for G2.84.
+
+If accepted, create a closeout/current-head refresh before selecting any further
+DataSourceFactory compatibility-surface cleanup.

--- a/governance/mainline/task-cards/pr-237.yaml
+++ b/governance/mainline/task-cards/pr-237.yaml
@@ -1,0 +1,140 @@
+version: "v0.2"
+
+task:
+  id: "pr-237"
+  title: "Retire DataSourceFactory public compatibility getter"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-data-source-factory-compat-getter-final-retirement"
+  objective: "remove the public DataSourceFactory compatibility getter and package exports after phase 1 decoupling"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-compat-getter-final-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-data-source-factory-compat-getter-final-retirement"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Retires a backend service compatibility export after the steward tree authorization sequence; route/OpenAPI/function tree surfaces are unchanged"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-compat-getter-final-retirement-implementation-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-compat-getter-final-retirement-implementation-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-237.yaml"
+    - "web/backend/app/services/data_source_factory/data_source_factory.py"
+    - "web/backend/app/services/data_source_factory/__init__.py"
+    - "web/backend/tests/test_data_source_factory_lifecycle_di.py"
+    - "web/backend/tests/test_market_api_integration.py"
+    - "web/backend/tests/test_data_stocks_runtime_fallback.py"
+    - "tests/backend/test_data_api_regression.py"
+  forbidden_paths:
+    - "web/backend/app/api/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No route/API module edits"
+  - "No route path, response model, response shape, OpenAPI exposure, docs/API, generated client, frontend, PM2, runtime process, OpenSpec, or issue-label change"
+  - "No removal of get_data_source_factory_dependency"
+  - "No removal of _get_or_create_data_source_factory"
+  - "No unrelated historical-route test-debt fix"
+
+acceptance:
+  checks:
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short before implementation"
+      required: true
+    - id: "focused-green"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "stocks-runtime-fallback"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_stocks_runtime_fallback.py -q --no-cov --tb=short"
+      required: true
+    - id: "market-api-integration"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_api_integration.py -q --no-cov --tb=short"
+      required: true
+    - id: "data-api-regression-baseline"
+      command: "PYTHONPATH=web/backend pytest -o addopts= tests/backend/test_data_api_regression.py -q --no-cov --tb=short || true"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "style"
+      command: "ruff check <touched files> && black --check <touched files>"
+      required: true
+    - id: "openapi-smoke"
+      command: "PYTHONPATH=web/backend python -c \"from dotenv import load_dotenv; load_dotenv('/opt/claude/mystocks_spec/.env'); from app.main import app; app.openapi()\""
+      required: true
+    - id: "public-getter-scan"
+      command: "scan exact get_data_source_factory refs excluding get_data_source_factory_dependency"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-compat-getter-final-retirement-implementation-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-compat-getter-final-retirement-implementation-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-237.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-237.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "staged-gitnexus-scope"
+      command: "MCP gitnexus.detect_changes(scope=staged)"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If any production public getter consumer remains, deleting the compatibility API can break imports"
+    - "GitNexus still reports stale CRITICAL route/API callers and must be interpreted with current-head scans"
+    - "Historical data_api_regression failures remain and must not be misreported as fixed"
+  rollback_plan: "revert this path-limited PR to restore the public getter and package export; route/OpenAPI surfaces remain unchanged"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "retire the DataSourceFactory public compatibility getter and package exports"
+    modified_scope: "two service package files, four focused tests, implementation report, generated artifact, steward tree, and task card"
+    dependency_changes: "tests retarget package-level monkeypatches to get_data_source_factory_dependency overrides"
+    legacy_logic_impact: "public compatibility getter is removed; supported dependency provider and private initializer remain"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if any production public getter consumer or package export dependency is found"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T13:45:00+08:00"
+    approval_note: "human maintainer accepted continuing after G2.83; PR #236 authorizes this final retirement implementation only"
+    secondary_approved: false

--- a/tests/backend/test_data_api_regression.py
+++ b/tests/backend/test_data_api_regression.py
@@ -1,6 +1,6 @@
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import MagicMock, patch, AsyncMock
+from unittest.mock import MagicMock, AsyncMock
 from fastapi import FastAPI
 import sys
 import os
@@ -11,6 +11,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 # Import the router and dependencies
 from app.api.data import router
 from app.core.security import get_current_user
+from app.services.data_source_factory import get_data_source_factory_dependency
 
 app = FastAPI()
 app.include_router(router)
@@ -20,41 +21,43 @@ app.dependency_overrides[get_current_user] = lambda: MagicMock()
 
 client = TestClient(app)
 
+
 @pytest.fixture
 def mock_factory():
-    with patch("app.services.data_source_factory.get_data_source_factory") as mock:
-        factory_instance = AsyncMock()
-        mock.return_value = factory_instance
-        yield factory_instance
+    factory_instance = AsyncMock()
+
+    async def override_factory():
+        return factory_instance
+
+    app.dependency_overrides[get_data_source_factory_dependency] = override_factory
+    yield factory_instance
+    app.dependency_overrides.pop(get_data_source_factory_dependency, None)
+
 
 def test_get_stocks_basic(mock_factory):
     mock_factory.get_data.return_value = {
         "status": "success",
         "data": [{"symbol": "000001", "name": "Ping An"}],
-        "total": 1
+        "total": 1,
     }
-    
+
     response = client.get("/api/v1/data/stocks/basic")
     assert response.status_code == 200
     assert response.json()["success"] is True
     assert len(response.json()["data"]) == 1
 
+
 def test_get_market_overview(mock_factory):
-    mock_factory.get_data.return_value = {
-        "status": "success",
-        "data": {"index": "sh000001"}
-    }
-    
+    mock_factory.get_data.return_value = {"status": "success", "data": {"index": "sh000001"}}
+
     response = client.get("/api/v1/data/markets/overview")
     assert response.status_code == 200
     assert response.json()["success"] is True
 
+
 def test_get_kline(mock_factory):
-    mock_factory.get_data.return_value = {
-        "status": "success",
-        "data": [{"date": "2025-01-01", "close": 10.0}]
-    }
-    
+    mock_factory.get_data.return_value = {"status": "success", "data": [{"date": "2025-01-01", "close": 10.0}]}
+
     response = client.get("/api/v1/data/stocks/daily?symbol=000001")
     assert response.status_code == 200
     assert response.json()["success"] is True

--- a/web/backend/app/services/data_source_factory/__init__.py
+++ b/web/backend/app/services/data_source_factory/__init__.py
@@ -9,7 +9,6 @@ from .data_source_mode import RealDataSource  # noqa: F401
 from .data_source_mode import HybridDataSource  # noqa: F401
 from .data_source_mode import DynamicConfigManager  # noqa: F401
 from .data_source_factory import DataSourceFactory  # noqa: F401
-from .data_source_factory import get_data_source_factory  # noqa: F401
 from .data_source_factory import get_data_source_factory_dependency  # noqa: F401
 from .data_source_factory import get_data_source  # noqa: F401
 from .data_source_factory import get_market_data  # noqa: F401
@@ -28,7 +27,6 @@ __all__ = [
     "HybridDataSource",
     "DynamicConfigManager",
     "DataSourceFactory",
-    "get_data_source_factory",
     "get_data_source_factory_dependency",
     "get_data_source",
     "get_market_data",

--- a/web/backend/app/services/data_source_factory/data_source_factory.py
+++ b/web/backend/app/services/data_source_factory/data_source_factory.py
@@ -305,11 +305,6 @@ async def _get_or_create_data_source_factory() -> DataSourceFactory:
     return _global_factory
 
 
-async def get_data_source_factory() -> DataSourceFactory:
-    """获取全局数据源工厂实例"""
-    return await _get_or_create_data_source_factory()
-
-
 async def install_data_source_factory(app: Any, factory: Optional[DataSourceFactory] = None) -> DataSourceFactory:
     selected_factory = factory if factory is not None else await _get_or_create_data_source_factory()
     setattr(app.state, DATA_SOURCE_FACTORY_STATE_KEY, selected_factory)

--- a/web/backend/tests/test_data_source_factory_lifecycle_di.py
+++ b/web/backend/tests/test_data_source_factory_lifecycle_di.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+import app.services.data_source_factory as data_source_factory_package
 from app.services.data_source_factory import data_source_factory as data_source_factory_module
 
 
@@ -28,7 +29,7 @@ async def test_data_source_factory_dependency_returns_installed_factory(monkeypa
     async def unexpected_fallback():
         raise AssertionError("fallback getter should not run when app-state factory is installed")
 
-    monkeypatch.setattr(data_source_factory_module, "get_data_source_factory", unexpected_fallback)
+    monkeypatch.setattr(data_source_factory_module, "_get_or_create_data_source_factory", unexpected_fallback)
 
     result = await data_source_factory_module.get_data_source_factory_dependency(request)
 
@@ -58,22 +59,10 @@ async def test_data_source_factory_dependency_installs_fallback_factory(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_get_data_source_factory_compatibility_getter_still_initializes(monkeypatch):
-    class FakeDataSourceFactory:
-        def __init__(self):
-            self.initialized = False
-
-        async def initialize(self):
-            self.initialized = True
-
-    monkeypatch.setattr(data_source_factory_module, "DataSourceFactory", FakeDataSourceFactory)
-    monkeypatch.setattr(data_source_factory_module, "_global_factory", None)
-
-    result = await data_source_factory_module.get_data_source_factory()
-
-    assert isinstance(result, FakeDataSourceFactory)
-    assert result.initialized is True
-    assert data_source_factory_module._global_factory is result
+def test_package_no_longer_exports_public_compatibility_getter():
+    assert not hasattr(data_source_factory_module, "get_data_source_factory")
+    assert not hasattr(data_source_factory_package, "get_data_source_factory")
+    assert "get_data_source_factory" not in data_source_factory_package.__all__
 
 
 @pytest.mark.asyncio
@@ -92,13 +81,9 @@ async def test_convenience_helpers_use_internal_factory_initializer(monkeypatch)
         calls.append("internal")
         return fake_factory
 
-    async def unexpected_public_getter():
-        raise AssertionError("service-internal helpers must not call the public compatibility getter")
-
     monkeypatch.setattr(
         data_source_factory_module, "_get_or_create_data_source_factory", fake_get_or_create_data_source_factory
     )
-    monkeypatch.setattr(data_source_factory_module, "get_data_source_factory", unexpected_public_getter)
 
     assert await data_source_factory_module.get_data_source("akshare") == {"source": "akshare"}
     assert await data_source_factory_module.get_market_data("quotes", {"symbol": "000001"}) == {

--- a/web/backend/tests/test_data_stocks_runtime_fallback.py
+++ b/web/backend/tests/test_data_stocks_runtime_fallback.py
@@ -18,6 +18,7 @@ os.environ.setdefault("ADMIN_INITIAL_PASSWORD", "admin123")
 
 from app.core.security import User, get_current_user
 from app.main import app
+from app.services.data_source_factory import get_data_source_factory_dependency
 
 
 class _MissingDataSourceFactory:
@@ -40,8 +41,8 @@ def auth_client(monkeypatch: pytest.MonkeyPatch):
 
     monkeypatch.setenv("TESTING", "true")
     monkeypatch.setenv("DEVELOPMENT_MODE", "true")
-    monkeypatch.setattr("app.services.data_source_factory.get_data_source_factory", _get_data_source_factory)
     app.dependency_overrides[get_current_user] = lambda: user
+    app.dependency_overrides[get_data_source_factory_dependency] = _get_data_source_factory
 
     client = TestClient(app)
     yield client

--- a/web/backend/tests/test_market_api_integration.py
+++ b/web/backend/tests/test_market_api_integration.py
@@ -28,6 +28,7 @@ from unittest.mock import Mock
 # 导入应用
 from app.main import app
 from app.core.security import User, get_current_user
+from app.services.data_source_factory import get_data_source_factory_dependency
 from app.services.market_data_service import get_market_data_service_dependency
 
 
@@ -68,7 +69,7 @@ def mock_market_service():
 
 
 @pytest.fixture
-def client(mock_market_service, monkeypatch: pytest.MonkeyPatch):
+def client(mock_market_service):
     """提供测试客户端，使用dependency_overrides注入mock服务"""
 
     async def _get_data_source_factory():
@@ -82,7 +83,7 @@ def client(mock_market_service, monkeypatch: pytest.MonkeyPatch):
         role="admin",
         is_active=True,
     )
-    monkeypatch.setattr("app.services.data_source_factory.get_data_source_factory", _get_data_source_factory)
+    app.dependency_overrides[get_data_source_factory_dependency] = _get_data_source_factory
     yield TestClient(app)
     app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary

- Retires the public `get_data_source_factory` compatibility getter and package export after G2.81/G2.83 decoupling.
- Keeps `_get_or_create_data_source_factory()` and `get_data_source_factory_dependency()` as the internal/canonical DI path.
- Retargets the focused tests from package-level monkeypatches to FastAPI dependency overrides or the private initializer.
- Records the G2.84 implementation report, JSON evidence artifact, task card, and steward-tree ledger update.

## Verification

- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` -> 5 passed
- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_stocks_runtime_fallback.py -q --no-cov --tb=short` -> 1 passed
- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_api_integration.py -q --no-cov --tb=short` -> 18 passed
- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` -> 120 passed
- touched-file `ruff check` -> passed
- touched-file `black --check` -> passed
- OpenAPI smoke -> routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0
- Markdown governance gate -> passed
- JSON artifact parse -> passed
- `git diff --cached --check` -> passed
- GitNexus staged detect -> LOW, 10 changed files, 0 changed symbols, 0 affected processes
- Post-commit mainline scope gate -> passed
- `gitnexus analyze` -> already up to date

## Known Baseline

- `tests/backend/test_data_api_regression.py` remains at 3 existing historical-route 404 failures for `/api/v1/data/...`. G2.84 did not change or reopen that baseline debt.

## Boundary

No route/API production modules, OpenAPI definitions, frontend files, PM2/runtime state, OpenSpec issue state, or unrelated historical-route fixes are changed in this PR.
EOF 2>&1
