### PR TITLE
G2.85 close out DataSourceFactory getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1344,9 +1344,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                package export removal, route/API, OpenAPI, frontend,
 │   │                runtime/PM2, OpenSpec, or issue-label change is made here
 │   ├── G2.84 DataSourceFactory compatibility getter final retirement implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#237` merged at
+│   │   │          `f31720ec3a891607eec3ce29b27ad1bc80be0a43`
 │   │   ├── Evidence: `backend-data-source-factory-compat-getter-final-retirement-implementation-2026-05-25.md`
-│   │   ├── Current HEAD: `5de71a8847a45efd0628b184baff985a9dd3b180`
+│   │   ├── Current HEAD: `f31720ec3a891607eec3ce29b27ad1bc80be0a43`
 │   │   ├── Result: removes public `get_data_source_factory()` and its package
 │   │   │          export, keeps `get_data_source_factory_dependency` and
 │   │   │          `_get_or_create_data_source_factory`, moves production exact
@@ -1358,9 +1359,22 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: no route/API, OpenAPI, frontend, runtime/PM2, OpenSpec,
 │   │                issue-label, dependency provider removal, private initializer
 │   │                removal, or unrelated historical-route test-debt fix is made
-│   └── Next gate: Human review / PR merge decision for G2.84 implementation; if
-│                  accepted, create closeout/current-head refresh before any
-│                  further DataSourceFactory compatibility-surface cleanup
+│   ├── G2.85 DataSourceFactory compatibility getter final retirement closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-data-source-factory-compat-getter-final-retirement-closeout-2026-05-25.md`
+│   │   ├── Current HEAD: `f31720ec3a891607eec3ce29b27ad1bc80be0a43`
+│   │   ├── Result: confirms PR `#237` merged, production exact public getter
+│   │   │          hits remain `0`, package export lines remain `0`, route/API
+│   │   │          public getter hits remain `0`, lifecycle tests pass `5`,
+│   │   │          health route conflicts pass `120`, touched-path ruff passes,
+│   │   │          and OpenAPI remains paths=`500` with duplicate operation IDs=`0`
+│   │   └── Boundary: closeout-only; no source, test, route/API, OpenAPI,
+│   │                frontend, runtime/PM2, OpenSpec, dependency provider,
+│   │                private initializer, or issue-label change is made here
+│   └── Next gate: Human review / PR merge decision for G2.85 closeout; if
+│                  accepted, DataSourceFactory public compatibility getter
+│                  retirement is closed and the next service lifecycle lane can
+│                  be selected by a separate authorization packet
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/data-source-factory-compat-getter-final-retirement-closeout-2026-05-25.json
+++ b/.planning/codebase/generated/data-source-factory-compat-getter-final-retirement-closeout-2026-05-25.json
@@ -1,0 +1,50 @@
+{
+  "artifact": "data-source-factory-compat-getter-final-retirement-closeout",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T15:41:45+08:00",
+  "branch": "g2-85-data-source-factory-compat-getter-final-retirement-closeout",
+  "current_head": "f31720ec3a891607eec3ce29b27ad1bc80be0a43",
+  "merged_pr": {
+    "number": 237,
+    "url": "https://github.com/chengjon/mystocks/pull/237",
+    "state": "MERGED",
+    "merged_at": "2026-05-25T05:55:18Z",
+    "merge_commit": "f31720ec3a891607eec3ce29b27ad1bc80be0a43",
+    "implementation_commit": "cf3085e54"
+  },
+  "current_head_scan": {
+    "exact_public_symbol_hits": 3,
+    "production_exact_public_symbol_hits": 0,
+    "package_export_lines": 0,
+    "route_api_public_symbol_hits": 0,
+    "get_data_source_factory_dependency_token_count": 51,
+    "private_initializer_token_count": 13,
+    "remaining_public_symbol_hits": [
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py:63",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py:64",
+      "web/backend/tests/test_data_source_factory_lifecycle_di.py:65"
+    ]
+  },
+  "verification": {
+    "lifecycle_tests": "5 passed in 2.07s",
+    "health_route_conflicts": "120 passed in 83.93s",
+    "ruff_touched_paths": "passed",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "root_env_loaded": true
+    },
+    "gitnexus_staged_detect_changes": {
+      "changed_files": 4,
+      "changed_symbols": 0,
+      "affected_processes": 0,
+      "risk": "LOW"
+    }
+  },
+  "known_baseline": {
+    "tests/backend/test_data_api_regression.py": "existing historical-route 404 debt remains out of scope"
+  },
+  "next_gate": "human review / PR merge decision for G2.85 closeout"
+}

--- a/docs/reports/quality/backend-data-source-factory-compat-getter-final-retirement-closeout-2026-05-25.md
+++ b/docs/reports/quality/backend-data-source-factory-compat-getter-final-retirement-closeout-2026-05-25.md
@@ -1,0 +1,105 @@
+# Backend DataSourceFactory Compatibility Getter Final Retirement Closeout - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.85 closeout/current-head refresh
+
+Status: ready for review
+
+Branch: `g2-85-data-source-factory-compat-getter-final-retirement-closeout`
+
+Current HEAD: `f31720ec3a891607eec3ce29b27ad1bc80be0a43`
+
+Prepared at: `2026-05-25T15:41:45+08:00`
+
+## Purpose
+
+Close out the merged G2.84 implementation and update the steward tree so the
+DataSourceFactory public compatibility getter retirement is recorded as accepted
+against current HEAD.
+
+This packet is governance-only. It does not edit backend source, tests, routes,
+OpenAPI exposure, frontend code, runtime/PM2 scripts, OpenSpec changes,
+dependency providers, private initializers, or GitHub issue labels.
+
+## Merge Evidence
+
+| Item | Value |
+|---|---|
+| G2.84 PR | `#237` |
+| PR URL | `https://github.com/chengjon/mystocks/pull/237` |
+| PR state | `MERGED` |
+| Merge timestamp | `2026-05-25T05:55:18Z` |
+| Merge commit | `f31720ec3a891607eec3ce29b27ad1bc80be0a43` |
+| Implementation commit | `cf3085e54` |
+| Base branch | `wip/root-dirty-20260403` |
+
+## Current-Head Evidence
+
+| Check | Result |
+|---|---|
+| `pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` | 5 passed in 2.07s |
+| `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | 120 passed in 83.93s |
+| touched-path `ruff check` | passed |
+| OpenAPI smoke with root `.env` loaded | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+| GitNexus `detect_changes(scope=staged)` | LOW, changed files=`4`, changed symbols=`0`, affected processes=`0` |
+
+Current-head reference scan:
+
+| Metric | Result |
+|---|---:|
+| Exact public `get_data_source_factory` symbol hits | 3 |
+| Production exact public symbol hits | 0 |
+| Package export lines | 0 |
+| Route/API public symbol hits | 0 |
+| `get_data_source_factory_dependency` token count | 51 |
+| `_get_or_create_data_source_factory` token count | 13 |
+
+The remaining exact public symbol hits are negative assertions in
+`web/backend/tests/test_data_source_factory_lifecycle_di.py`.
+
+## Steward Decision
+
+G2.84 is accepted as the final public compatibility getter retirement.
+
+The current state is:
+
+- public `get_data_source_factory()` no longer exists in the service module;
+- the package no longer exports `get_data_source_factory`;
+- production exact public getter hits are `0`;
+- route/API public getter hits are `0`;
+- `get_data_source_factory_dependency()` remains the canonical FastAPI DI
+  provider;
+- `_get_or_create_data_source_factory()` remains the service-internal
+  initializer.
+
+## Known Baseline
+
+`tests/backend/test_data_api_regression.py` still contains existing
+historical-route 404 debt for `/api/v1/data/...`. G2.84 did not change that
+baseline, and this G2.85 closeout does not reopen it.
+
+## Boundary Confirmation
+
+This closeout does not authorize:
+
+- route/API edits;
+- route path, response model, response shape, or OpenAPI exposure changes;
+- frontend edits;
+- runtime or PM2 changes;
+- OpenSpec changes;
+- GitHub issue-label changes;
+- removing `get_data_source_factory_dependency()`;
+- removing `_get_or_create_data_source_factory()`;
+- unrelated historical-route test-debt fixes.
+
+## Next Gate
+
+Human review / PR merge decision for this G2.85 closeout.
+
+After this closeout is accepted, the DataSourceFactory public compatibility
+getter retirement lane is closed. Any next service lifecycle lane must start
+from a separate authorization packet with fresh current-head evidence and a
+clear source/test boundary.

--- a/governance/mainline/task-cards/pr-238.yaml
+++ b/governance/mainline/task-cards/pr-238.yaml
@@ -1,0 +1,108 @@
+version: "v0.2"
+task:
+  id: "pr-238"
+  title: "Close out DataSourceFactory compatibility getter final retirement"
+  owner: "main"
+  created_at: "2026-05-25"
+mainline:
+  id: "L1-data-source-factory-compat-getter-final-retirement-closeout"
+  objective: "record PR #237 as accepted and close the DataSourceFactory public compatibility getter retirement lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-data-source-factory-compat-getter-final-retirement"
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+openspec:
+  change_id: "not-required-data-source-factory-compat-getter-final-retirement-closeout"
+  approval_status: "not_required"
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only closeout records PR #237 acceptance; no runtime entrypoint, route, service symbol, or public API surface is changed"
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/data-source-factory-compat-getter-final-retirement-closeout-2026-05-25.json"
+    - "docs/reports/quality/backend-data-source-factory-compat-getter-final-retirement-closeout-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-238.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not change route paths, response models, response shapes, or OpenAPI exposure"
+  - "Do not remove get_data_source_factory_dependency"
+  - "Do not remove _get_or_create_data_source_factory"
+  - "Do not fix unrelated historical-route data API regression debt"
+  - "Do not change frontend, runtime, PM2, OpenSpec, or GitHub issue state"
+acceptance:
+  checks:
+    - id: "pr-237-merged"
+      command: "gh pr view 237 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "current-head-provider-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "current-head-health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "current-head-openapi-smoke"
+      command: "PYTHONPATH=web/backend python -c \"from dotenv import load_dotenv; load_dotenv('/opt/claude/mystocks_spec/.env'); from app.main import app; app.openapi()\""
+      required: true
+    - id: "reference-scan"
+      command: "scan production public getter hits, route/API public getter hits, package export lines, dependency provider refs, and private initializer refs"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-data-source-factory-compat-getter-final-retirement-closeout-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/data-source-factory-compat-getter-final-retirement-closeout-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-238.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-238.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+risk_and_rollback:
+  risks:
+    - "If this closeout is treated as new implementation authorization, later work could bypass the required separate source-capable packet"
+    - "If current-head evidence is stale, the steward tree could incorrectly close the compatibility getter lane"
+  rollback_plan: "revert this governance-only closeout PR and keep G2.84 recorded as accepted but awaiting closeout until fresh evidence is prepared"
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out DataSourceFactory public compatibility getter final retirement after PR #237 merge"
+    modified_scope: "steward tree, closeout report, generated artifact, and task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; accepted implementation already removed the public compatibility getter and package export"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only closeout PR if current-head evidence is found stale"
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T15:41:45+08:00"
+    approval_note: "human maintainer asked to continue after G2.84 merge; this closeout is governance-only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- Records PR #237 as accepted and merged at `f31720ec3a891607eec3ce29b27ad1bc80be0a43`.
- Refreshes current-head evidence for the DataSourceFactory public compatibility getter retirement.
- Updates the steward tree, closeout report, JSON artifact, and mainline task card only.

## Current-Head Evidence

- PR #237 state: `MERGED`
- Current HEAD: `f31720ec3a891607eec3ce29b27ad1bc80be0a43`
- Exact public symbol hits: 3, all negative assertions in lifecycle test
- Production exact public symbol hits: 0
- Package export lines: 0
- Route/API public getter hits: 0
- `get_data_source_factory_dependency` token count: 51
- `_get_or_create_data_source_factory` token count: 13

## Verification

- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_source_factory_lifecycle_di.py -q --no-cov --tb=short` -> 5 passed
- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` -> 120 passed
- touched-path `ruff check` -> passed
- OpenAPI smoke with root `.env` loaded -> routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0
- Markdown governance gate -> 0 errors
- JSON parse -> passed
- YAML parse -> passed
- GitNexus staged detect -> LOW, 4 changed files, 0 changed symbols, 0 affected processes
- Post-commit mainline scope gate -> passed
- `git diff --cached --check` -> passed

## Boundary

This is governance-only. It does not edit backend source, tests, route/API modules, OpenAPI exposure, frontend code, runtime/PM2 state, OpenSpec state, dependency providers, private initializers, or GitHub issue labels.
EOF 2>&1
