### PR TITLE
G2.86 select next service lifecycle DI lane

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1360,9 +1360,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                issue-label, dependency provider removal, private initializer
 │   │                removal, or unrelated historical-route test-debt fix is made
 │   ├── G2.85 DataSourceFactory compatibility getter final retirement closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#238` merged at
+│   │   │          `ed033a45552a22b6ce4027a04029ea0764d191cf`
 │   │   ├── Evidence: `backend-data-source-factory-compat-getter-final-retirement-closeout-2026-05-25.md`
-│   │   ├── Current HEAD: `f31720ec3a891607eec3ce29b27ad1bc80be0a43`
+│   │   ├── Current HEAD: `ed033a45552a22b6ce4027a04029ea0764d191cf`
 │   │   ├── Result: confirms PR `#237` merged, production exact public getter
 │   │   │          hits remain `0`, package export lines remain `0`, route/API
 │   │   │          public getter hits remain `0`, lifecycle tests pass `5`,
@@ -1371,10 +1372,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: closeout-only; no source, test, route/API, OpenAPI,
 │   │                frontend, runtime/PM2, OpenSpec, dependency provider,
 │   │                private initializer, or issue-label change is made here
-│   └── Next gate: Human review / PR merge decision for G2.85 closeout; if
-│                  accepted, DataSourceFactory public compatibility getter
-│                  retirement is closed and the next service lifecycle lane can
-│                  be selected by a separate authorization packet
+│   ├── G2.86 Service lifecycle next-lane decision after DataSourceFactory
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-service-lifecycle-di-next-lane-after-data-source-factory-2026-05-25.md`
+│   │   ├── Current HEAD: `ed033a45552a22b6ce4027a04029ea0764d191cf`
+│   │   ├── Result: selects `AdvancedAnalysisService` compatibility getter
+│   │   │          Phase 1 service-internal decoupling as the next authorization
+│   │   │          candidate only; current-head exact production getter hits are
+│   │   │          definition plus provider fallback only, route/API direct hits
+│   │   │          are `0`, GitNexus impact is LOW / `0`, lifecycle tests pass
+│   │   │          `4`, health route conflicts pass `120`, and OpenAPI remains
+│   │   │          paths=`500` with duplicate operation IDs=`0`
+│   │   └── Boundary: decision-only; no source, test, route/API, OpenAPI,
+│   │                frontend, runtime/PM2, OpenSpec, public getter deletion,
+│   │                dependency provider removal, private initializer addition,
+│   │                or issue-label change is made here
+│   └── Next gate: Human review / PR merge decision for G2.86 decision packet; if
+│                  accepted, create G2.87 source-capable authorization for
+│                  `AdvancedAnalysisService` Phase 1 service-internal decoupling
+│                  before any source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1444,6 +1460,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-compat-getter-retirement-phase1-closeout-2026-05-25.md` | G | G2.82 closeout packet accepted in PR `#235` at `075768a`: records PR `#234` merge, reconfirms lifecycle tests `5 passed`, health route conflicts `120 passed`, OpenAPI routes=`548` paths=`500` duplicate operation IDs=`0`, route/API direct public getter calls=`0`, service helper public getter calls=`0`, and package export mentions=`4` | Separate source-capable authorization packet required before any public getter or package export retirement decision |
 | `backend-data-source-factory-compat-getter-final-retirement-authorization-2026-05-25.md` | G | G2.83 authorization packet accepted in PR `#236` at `5de71a8`: precise scan shows production public getter hits are definition plus package exports only, route/API production consumers=`0`, package export lines=`2`, lifecycle tests `5 passed`, stocks runtime fallback `1 passed`, GitNexus impact remains CRITICAL/stale-aware, and market/data regression public getter patch points have existing unrelated failures recorded | G2.84 source implementation may remove the public getter and package exports only inside the authorized file scope |
 | `backend-data-source-factory-compat-getter-final-retirement-implementation-2026-05-25.md` | G | G2.84 implementation packet prepared at `5de71a8`: removes public `get_data_source_factory()` and package exports, keeps `get_data_source_factory_dependency` plus `_get_or_create_data_source_factory`, moves production public getter hits=`0`, package export lines=`0`, patch points=`0`, lifecycle tests `5 passed`, stocks runtime fallback `1 passed`, market API integration `18 passed`, health route conflicts `120 passed`, OpenAPI paths=`500`, duplicate operation IDs=`0`, and leaves known `test_data_api_regression.py` historical-route 404 failures unresolved | Human review / PR merge decision; if accepted, create closeout/current-head refresh before further DataSourceFactory compatibility-surface cleanup |
+| `backend-data-source-factory-compat-getter-final-retirement-closeout-2026-05-25.md` | G | G2.85 closeout accepted in PR `#238` at `ed033a4`: records PR `#237` merge, confirms production exact public getter hits=`0`, package export lines=`0`, route/API public getter hits=`0`, lifecycle tests `5 passed`, health route conflicts `120 passed`, touched-path ruff passed, and OpenAPI paths=`500` with duplicate operation IDs=`0` | DataSourceFactory public compatibility getter retirement lane closed; next service lifecycle lane must start from a separate authorization packet |
+| `backend-service-lifecycle-di-next-lane-after-data-source-factory-2026-05-25.md` | G | G2.86 next-lane decision prepared at `ed033a4`: selects `AdvancedAnalysisService` compatibility getter Phase 1 service-internal decoupling as the next authorization candidate only; exact production getter hits are definition plus provider fallback only, route/API direct hits=`0`, GitNexus impact LOW / `0`, lifecycle tests `4 passed`, health route conflicts `120 passed`, OpenAPI paths=`500`, duplicate operation IDs=`0`; broad `get_data_service` and `get_strategy_service` seams remain CRITICAL holds, and StockSearch compatibility cleanup remains blocked by prior retain decision plus stale-aware GitNexus route-process noise | Human review / PR merge decision; if accepted, create G2.87 source-capable authorization before any AdvancedAnalysis source edit |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/service-lifecycle-di-next-lane-after-data-source-factory-2026-05-25.json
+++ b/.planning/codebase/generated/service-lifecycle-di-next-lane-after-data-source-factory-2026-05-25.json
@@ -1,0 +1,81 @@
+{
+  "artifact": "service-lifecycle-di-next-lane-after-data-source-factory",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T16:18:43+08:00",
+  "branch": "g2-86-service-lifecycle-next-lane-decision",
+  "current_head": "ed033a45552a22b6ce4027a04029ea0764d191cf",
+  "input_state": {
+    "pr_238": {
+      "state": "MERGED",
+      "merge_commit": "ed033a45552a22b6ce4027a04029ea0764d191cf"
+    },
+    "issue_79": {
+      "state": "OPEN",
+      "labels": ["needs-triage"]
+    },
+    "issue_92": {
+      "state": "OPEN",
+      "labels": ["enhancement", "ready-for-human", "ready-for-downstream"]
+    }
+  },
+  "selected_next_lane": {
+    "candidate": "AdvancedAnalysisService",
+    "symbol": "get_advanced_analysis_service",
+    "decision": "prepare G2.87 source-capable authorization for Phase 1 service-internal decoupling only",
+    "future_source_authorization_required": true,
+    "public_getter_deletion_authorized": false
+  },
+  "candidate_scan": {
+    "get_advanced_analysis_service": {
+      "python_hits": 4,
+      "production_hits": 2,
+      "route_api_hits": 0,
+      "test_hits": 2,
+      "provider_refs": 19,
+      "route_provider_refs": 15,
+      "gitnexus_risk": "LOW",
+      "gitnexus_impacted_count": 0,
+      "disposition": "selected_next_authorization_candidate"
+    },
+    "get_stock_search_service": {
+      "production_exact_hits": 4,
+      "route_api_direct_hits": 0,
+      "package_export_lines": 2,
+      "gitnexus_risk": "CRITICAL",
+      "gitnexus_impacted_count": 6,
+      "disposition": "hold; prior matrix keeps compatibility surface active"
+    },
+    "get_data_service": {
+      "production_hits": 6,
+      "route_api_hits": 5,
+      "gitnexus_risk": "CRITICAL",
+      "gitnexus_impacted_count": 4,
+      "disposition": "broad data seam hold"
+    },
+    "get_strategy_service": {
+      "production_hits": 11,
+      "route_api_hits": 4,
+      "gitnexus_risk": "CRITICAL",
+      "gitnexus_impacted_count": 11,
+      "disposition": "broad strategy seam hold"
+    }
+  },
+  "verification": {
+    "advanced_analysis_lifecycle_tests": "4 passed in 4.20s",
+    "health_route_conflicts": "120 passed in 78.00s",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "root_env_loaded": true
+    },
+    "gitnexus_staged_detect_changes": {
+      "changed_files": 4,
+      "changed_symbols": 0,
+      "affected_processes": 0,
+      "risk": "LOW"
+    }
+  },
+  "next_gate": "human review / PR merge decision for G2.86; if accepted create G2.87 authorization packet before source edits"
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-next-lane-after-data-source-factory-2026-05-25.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-next-lane-after-data-source-factory-2026-05-25.md
@@ -1,0 +1,112 @@
+# Backend Service Lifecycle DI Next-Lane After DataSourceFactory - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.86 service lifecycle DI next-lane decision
+
+Status: ready for review
+
+Branch: `g2-86-service-lifecycle-next-lane-decision`
+
+Current HEAD: `ed033a45552a22b6ce4027a04029ea0764d191cf`
+
+Prepared at: `2026-05-25T16:18:43+08:00`
+
+## Purpose
+
+Select the next service lifecycle DI lane after the DataSourceFactory public
+compatibility getter retirement was closed by PR `#238`.
+
+This packet is decision-only. It does not authorize backend source edits, test
+edits, route/API edits, OpenAPI changes, frontend changes, runtime/PM2 work,
+OpenSpec changes, issue-label changes, public getter deletion, dependency
+provider removal, or private initializer creation.
+
+## Input State
+
+| Item | Current state |
+|---|---|
+| PR `#238` | `MERGED` at `ed033a45552a22b6ce4027a04029ea0764d191cf` |
+| Issue `#79` | `OPEN`, `needs-triage` |
+| Issue `#92` | `OPEN`, `enhancement`, `ready-for-human`, `ready-for-downstream` |
+| DataSourceFactory public compatibility getter | Retired and closed |
+| OpenAPI smoke | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+
+## Current-Head Candidate Scan
+
+The scan below is a current-head planning signal. It is not a deletion backlog.
+
+| Candidate | Current-head evidence | GitNexus spot check | Disposition |
+|---|---|---|---|
+| `get_advanced_analysis_service` / `AdvancedAnalysisService` | Python hits=`4`; production hits=`2`; route/API direct hits=`0`; test hits=`2`; provider refs=`19`; route provider refs=`15`; lifecycle tests `4 passed` | LOW / impacted count `0` | Select as the next authorization candidate for Phase 1 service-internal decoupling only |
+| `get_stock_search_service` / `StockSearchService` | Production exact hits=`4`; route/API direct hits=`0`; package export lines=`2`; prior G2.23 matrix says keep as active compatibility surface | CRITICAL / impacted count `6`, stale-aware route-process noise from route provider sites | Do not reopen cleanup here; requires a fresh dedicated compatibility decision before any deletion |
+| `get_data_service` / `DataService` | Production hits=`6`; route/API hits=`5` in indicator and strategy surfaces | CRITICAL / impacted count `4`; modules: Indicators, Strategy | Broad data seam; hold for separate design, not ordinary cleanup |
+| `get_strategy_service` / `StrategyService` | Production hits=`11`; route/API hits=`4`; adapter/task consumers remain | CRITICAL / impacted count `11`; modules: Data_adapters, Strategy_management, Adapters, Tasks | Broad strategy seam; hold for separate design, not ordinary cleanup |
+| `get_market_data_service_v2` / `MarketDataServiceV2` | Dashboard helper route/provider fallback still has route/API hits=`2` | Not rerun in this packet | Hold; dashboard helper consumer surface remains distinct |
+| `get_tdx_service` / `TdxService` | Dashboard helper provider fallback still has route/API hits=`2` | Not rerun in this packet | Hold; dashboard helper consumer surface remains distinct |
+
+## Selected Next Lane
+
+Select `AdvancedAnalysisService` compatibility getter Phase 1 service-internal
+decoupling as the next authorization candidate.
+
+The future G2.87 authorization packet may define a source-capable implementation
+lane with this intended shape:
+
+- add a private async initializer such as
+  `_get_or_create_advanced_analysis_service()`;
+- retarget `get_advanced_analysis_service_dependency()` so its fallback no
+  longer calls the public compatibility getter;
+- keep public `get_advanced_analysis_service()` in Phase 1;
+- keep `get_advanced_analysis_service_dependency()`,
+  `install_advanced_analysis_service()`, and
+  `ADVANCED_ANALYSIS_SERVICE_STATE_KEY`;
+- update focused lifecycle tests only;
+- run GitNexus impact before source edits;
+- run focused lifecycle, health route, ruff/black, OpenAPI, staged GitNexus,
+  and mainline gates before commit.
+
+Any public getter deletion, rename, package-surface removal, route/API edit, or
+OpenAPI exposure change must remain locked until a later closeout plus separate
+final-retirement authorization.
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| `test_advanced_analysis_service_lifecycle_di.py` | 4 passed in 4.20s |
+| `test_health_route_conflicts.py` | 120 passed in 78.00s |
+| OpenAPI smoke with root `.env` loaded | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+| `get_advanced_analysis_service` current-head scan | production hits=`2`, route/API hits=`0`, tests=`2` |
+| GitNexus `get_advanced_analysis_service` impact | LOW, impacted count=`0` |
+| GitNexus `get_data_service` impact | CRITICAL, impacted count=`4` |
+| GitNexus `get_strategy_service` impact | CRITICAL, impacted count=`11` |
+| GitNexus `get_stock_search_service` impact | CRITICAL, impacted count=`6`; treated as stale-aware against current text scan |
+| GitNexus `detect_changes(scope=staged)` | LOW, changed files=`4`, changed symbols=`0`, affected processes=`0` |
+
+## Boundary Confirmation
+
+This G2.86 packet does not authorize:
+
+- backend source edits;
+- test edits;
+- route/API edits;
+- route path, response model, response shape, or OpenAPI exposure changes;
+- frontend edits;
+- runtime or PM2 changes;
+- OpenSpec changes;
+- GitHub issue-label changes;
+- public `get_advanced_analysis_service()` deletion;
+- `get_advanced_analysis_service_dependency()` removal;
+- `install_advanced_analysis_service()` removal;
+- any broad `DataService` or `StrategyService` migration.
+
+## Next Gate
+
+Human review / PR merge decision for this G2.86 decision packet.
+
+If accepted, create a separate G2.87 source-capable authorization packet for
+`AdvancedAnalysisService` Phase 1 service-internal decoupling before any source
+edit.

--- a/governance/mainline/task-cards/pr-239.yaml
+++ b/governance/mainline/task-cards/pr-239.yaml
@@ -1,0 +1,111 @@
+version: "v0.2"
+task:
+  id: "pr-239"
+  title: "Select next service lifecycle DI lane after DataSourceFactory"
+  owner: "main"
+  created_at: "2026-05-25"
+mainline:
+  id: "L1-service-lifecycle-di-next-lane-after-data-source-factory"
+  objective: "choose the next service lifecycle DI authorization candidate after DataSourceFactory compatibility getter retirement"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-next-lane"
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+openspec:
+  change_id: "not-required-service-lifecycle-next-lane-after-data-source-factory"
+  approval_status: "not_required"
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision-only next-lane packet; no runtime entrypoint, route, service symbol, or public API surface is changed"
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-di-next-lane-after-data-source-factory-2026-05-25.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-next-lane-after-data-source-factory-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-239.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not change routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify an OpenSpec change"
+  - "Do not move GitHub issue labels"
+  - "Do not delete, rename, or privatize any compatibility getter"
+  - "Do not authorize broad DataService or StrategyService implementation work"
+acceptance:
+  checks:
+    - id: "current-head-input"
+      command: "gh pr view 238 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "advanced-analysis-lifecycle-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "openapi-smoke"
+      command: "PYTHONPATH=web/backend python -c \"from dotenv import load_dotenv; load_dotenv('/opt/claude/mystocks_spec/.env'); from app.main import app; app.openapi()\""
+      required: true
+    - id: "candidate-scan"
+      command: "scan AdvancedAnalysisService, StockSearchService, DataService, and StrategyService current-head getter surfaces"
+      required: true
+    - id: "gitnexus-spot-checks"
+      command: "run GitNexus impact for get_advanced_analysis_service, get_data_service, get_strategy_service, and get_stock_search_service"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-next-lane-after-data-source-factory-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-di-next-lane-after-data-source-factory-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-239.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-239.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+risk_and_rollback:
+  risks:
+    - "If this decision is treated as implementation authorization, later work could bypass required source gates"
+    - "If broad DataService or StrategyService seams are mixed into the next source lane, scope and risk will exceed the intended low-risk candidate"
+  rollback_plan: "revert this governance-only decision PR and keep G2.85 as the latest closed service lifecycle lane until fresh candidate evidence is prepared"
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "select the next service lifecycle DI authorization candidate after DataSourceFactory closure"
+    modified_scope: "steward tree, decision report, generated artifact, and task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; recommends future AdvancedAnalysisService Phase 1 decoupling only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if the selected candidate is rejected"
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T16:18:43+08:00"
+    approval_note: "human maintainer asked to continue after G2.85; this packet is decision-only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- Records PR #238 / DataSourceFactory compatibility getter retirement closeout as accepted.
- Refreshes current-head service lifecycle DI candidate evidence after DataSourceFactory closure.
- Selects `AdvancedAnalysisService` compatibility getter Phase 1 service-internal decoupling as the next authorization candidate only.
- Updates the steward tree, decision report, JSON artifact, and mainline task card.

## Decision

The next step is not source implementation. If this PR is accepted, create a separate G2.87 source-capable authorization packet for `AdvancedAnalysisService` Phase 1 service-internal decoupling before any source edit.

The intended future scope is limited to adding a private async initializer, retargeting provider fallback away from the public getter, preserving the public getter in Phase 1, and updating focused lifecycle tests. Public getter deletion remains locked for a later closeout plus separate final-retirement authorization.

## Evidence

- Current HEAD: `ed033a45552a22b6ce4027a04029ea0764d191cf`
- PR #238 state: `MERGED`
- `get_advanced_analysis_service`: production hits=2, route/API hits=0, test hits=2
- `get_advanced_analysis_service_dependency`: 19 refs, including 15 route provider refs
- GitNexus `get_advanced_analysis_service`: LOW, impacted count=0
- GitNexus `get_data_service`: CRITICAL, impacted count=4, held as broad data seam
- GitNexus `get_strategy_service`: CRITICAL, impacted count=11, held as broad strategy seam
- GitNexus `get_stock_search_service`: CRITICAL/stale-aware, impacted count=6; prior matrix keeps compatibility surface active

## Verification

- `test_advanced_analysis_service_lifecycle_di.py` -> 4 passed
- `test_health_route_conflicts.py` -> 120 passed
- OpenAPI smoke with root `.env` loaded -> routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0
- Markdown governance gate -> 0 errors
- JSON parse -> passed
- YAML parse -> passed
- GitNexus staged detect -> LOW, 4 changed files, 0 changed symbols, 0 affected processes
- Post-commit mainline scope gate -> passed
- `git diff --cached --check` -> passed

## Boundary

Governance-only. No backend source, tests, route/API modules, OpenAPI exposure, frontend code, runtime/PM2 state, OpenSpec state, GitHub issue labels, public getter deletion, dependency provider removal, or broad DataService/StrategyService migration is changed or authorized here.
EOF 2>&1
