### PR TITLE
refactor(services): decouple advanced analysis getter fallback

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1389,9 +1389,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                dependency provider removal, private initializer addition,
 │   │                or issue-label change is made here
 │   ├── G2.87 AdvancedAnalysis compatibility getter Phase 1 authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#240` merged at
+│   │   │          `55861bb10d19dfafe9ff5e100f583069dcdbc2a9`
 │   │   ├── Evidence: `backend-advanced-analysis-compat-getter-phase1-authorization-2026-05-25.md`
-│   │   ├── Current HEAD: `a20c92eef786ee816d0a8c171641c292ba2455f8`
+│   │   ├── Current HEAD: `55861bb10d19dfafe9ff5e100f583069dcdbc2a9`
 │   │   ├── Result: authorizes only a future G2.88 Phase 1 implementation that
 │   │   │          may add a private async initializer, retarget
 │   │   │          `get_advanced_analysis_service_dependency()` fallback away
@@ -1403,9 +1404,28 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: authorization-only; no source, test, route/API, OpenAPI,
 │   │                frontend, runtime/PM2, OpenSpec, public getter deletion,
 │   │                dependency provider removal, or issue-label change is made
-│   └── Next gate: Human review / PR merge decision for G2.87 authorization; if
-│                  accepted, create G2.88 implementation branch before any
-│                  AdvancedAnalysis source edit
+│   ├── G2.88 AdvancedAnalysis compatibility getter Phase 1 implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-advanced-analysis-compat-getter-phase1-implementation-2026-05-25.md`
+│   │   ├── Current HEAD: `55861bb10d19dfafe9ff5e100f583069dcdbc2a9`
+│   │   ├── Result: adds private `_get_or_create_advanced_analysis_service()`,
+│   │   │          keeps public `get_advanced_analysis_service()` as a Phase 1
+│   │   │          compatibility wrapper, retargets
+│   │   │          `get_advanced_analysis_service_dependency()` fallback away
+│   │   │          from the public getter, and proves the fallback via TDD red /
+│   │   │          green lifecycle coverage; post-change scan shows route/API
+│   │   │          public getter hits=`0`, exact public getter production hits are
+│   │   │          definition-only, lifecycle tests `4 passed`, health route
+│   │   │          conflicts `120 passed`, and OpenAPI remains paths=`500` with
+│   │   │          duplicate operation IDs=`0`
+│   │   └── Boundary: source-capable but limited to the service module, focused
+│   │                lifecycle test, governance report, generated artifact,
+│   │                task card, and steward-tree update; no public getter
+│   │                deletion, route/API, OpenAPI exposure, frontend, PM2,
+│   │                OpenSpec, or issue-label change is made here
+│   └── Next gate: Human review / PR merge decision for G2.88 implementation; if
+│                  accepted, prepare a closeout / candidate-refresh packet before
+│                  any further AdvancedAnalysis getter retirement decision
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/advanced-analysis-compat-getter-phase1-implementation-2026-05-25.json
+++ b/.planning/codebase/generated/advanced-analysis-compat-getter-phase1-implementation-2026-05-25.json
@@ -1,0 +1,70 @@
+{
+  "workline": "G2.88 AdvancedAnalysis compatibility getter Phase 1 implementation",
+  "status": "ready_for_review",
+  "prepared_at": "2026-05-25T17:08:32+08:00",
+  "worktree": ".worktrees/g2-88-advanced-analysis-compat-getter-phase1-implementation",
+  "branch": "g2-88-advanced-analysis-compat-getter-phase1-implementation",
+  "base_head": "55861bb10d19dfafe9ff5e100f583069dcdbc2a9",
+  "parent_authorization_pr": {
+    "number": 240,
+    "state": "MERGED",
+    "merge_commit": "55861bb10d19dfafe9ff5e100f583069dcdbc2a9"
+  },
+  "allowed_source_scope": [
+    "web/backend/app/services/advanced_analysis_service.py",
+    "web/backend/tests/test_advanced_analysis_service_lifecycle_di.py"
+  ],
+  "implementation_summary": {
+    "private_initializer_added": "_get_or_create_advanced_analysis_service",
+    "public_compatibility_getter_kept": "get_advanced_analysis_service",
+    "dependency_provider_kept": "get_advanced_analysis_service_dependency",
+    "dependency_provider_fallback": "retargeted from public compatibility getter to private initializer",
+    "route_api_changes": false,
+    "openapi_exposure_changes": false,
+    "frontend_changes": false,
+    "openspec_changes": false,
+    "issue_label_changes": false
+  },
+  "tdd": {
+    "red_command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py::test_advanced_analysis_service_dependency_fallback_uses_private_initializer -q --no-cov --tb=short",
+    "red_result": "1 failed; provider fallback called patched public compatibility getter",
+    "green_command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q --no-cov --tb=short",
+    "green_result": "4 passed in 3.90s"
+  },
+  "gitnexus_pre_edit": {
+    "repo": "g2-88-advanced-analysis-compat-getter-phase1-implementation",
+    "get_advanced_analysis_service": {
+      "risk": "LOW",
+      "impacted_count": 1,
+      "direct_impacted_symbol": "get_advanced_analysis_service_dependency"
+    },
+    "get_advanced_analysis_service_dependency": {
+      "risk": "LOW",
+      "impacted_count": 0
+    }
+  },
+  "post_change_reference_scan": {
+    "public_getter_hits": 1,
+    "public_getter_hit_scope": "definition only",
+    "route_api_public_getter_hits": 0,
+    "private_initializer_hits": 3,
+    "dependency_provider_refs": 19
+  },
+  "verification": {
+    "focused_lifecycle_tests": "4 passed in 3.90s",
+    "health_route_conflicts": "120 passed in 76.56s",
+    "ruff_touched_backend_files": "passed",
+    "black_check_touched_backend_files": "passed",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "warnings": 0
+    }
+  },
+  "rollback": {
+    "strategy": "revert this PR as one unit",
+    "restores": "provider fallback direct call to public get_advanced_analysis_service and removes the private initializer plus focused test expectation"
+  }
+}

--- a/docs/reports/quality/backend-advanced-analysis-compat-getter-phase1-implementation-2026-05-25.md
+++ b/docs/reports/quality/backend-advanced-analysis-compat-getter-phase1-implementation-2026-05-25.md
@@ -1,0 +1,140 @@
+# Backend AdvancedAnalysis Compatibility Getter Phase 1 Implementation - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.88 AdvancedAnalysis compatibility getter Phase 1 implementation
+
+Status: ready for review
+
+## Scope
+
+This packet implements the G2.87 authorization accepted in PR `#240`.
+
+Allowed source/test files:
+
+- `web/backend/app/services/advanced_analysis_service.py`
+- `web/backend/tests/test_advanced_analysis_service_lifecycle_di.py`
+
+Governance evidence files:
+
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/advanced-analysis-compat-getter-phase1-implementation-2026-05-25.json`
+- `docs/reports/quality/backend-advanced-analysis-compat-getter-phase1-implementation-2026-05-25.md`
+- `governance/mainline/task-cards/pr-241.yaml`
+
+No route/API, OpenAPI exposure, frontend, PM2/runtime, OpenSpec, GitHub issue
+label, or public API contract change is made here.
+
+## Implementation Summary
+
+The implementation keeps the public compatibility getter and decouples the
+FastAPI dependency-provider fallback from it:
+
+- add `_get_or_create_advanced_analysis_service()`;
+- keep `get_advanced_analysis_service()` as a Phase 1 public compatibility
+  wrapper;
+- keep `get_advanced_analysis_service_dependency()`;
+- retarget `get_advanced_analysis_service_dependency()` fallback to the private
+  initializer;
+- update focused lifecycle coverage to prove the provider fallback no longer
+  calls the public compatibility getter.
+
+## TDD Evidence
+
+RED before implementation:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py::test_advanced_analysis_service_dependency_fallback_uses_private_initializer -q --no-cov --tb=short
+```
+
+Result:
+
+```text
+1 failed
+AssertionError: provider fallback must not call the public compatibility getter
+```
+
+GREEN after implementation:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q --no-cov --tb=short
+```
+
+Result:
+
+```text
+4 passed in 3.90s
+```
+
+## GitNexus Evidence
+
+GitNexus was refreshed for the G2.88 worktree before source edits:
+
+```text
+gitnexus analyze
+```
+
+Pre-edit impact checks:
+
+| Target | Risk | Impact |
+|---|---:|---|
+| `get_advanced_analysis_service` | LOW | 1 direct impacted symbol: `get_advanced_analysis_service_dependency` |
+| `get_advanced_analysis_service_dependency` | LOW | 0 impacted symbols |
+
+Pre-edit context confirmed that `get_advanced_analysis_service_dependency()`
+called `get_advanced_analysis_service()` directly before this change.
+
+## Reference Scan
+
+After implementation:
+
+| Metric | Value |
+|---|---:|
+| Exact public getter hits in scoped production/test scan | 1 |
+| Exact public getter production scope | definition only |
+| Route/API direct public getter hits | 0 |
+| Private initializer hits | 3 |
+| Dependency-provider refs | 19 |
+
+The single remaining exact public getter hit is the public compatibility getter
+definition itself. This PR does not delete, rename, or privatize that public
+getter.
+
+## Verification
+
+| Gate | Result |
+|---|---|
+| Focused lifecycle tests | `4 passed in 3.90s` |
+| `test_health_route_conflicts.py` | `120 passed in 76.56s` |
+| Ruff touched backend files | passed |
+| Black check touched backend files | passed |
+| OpenAPI smoke | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, warnings=`0` |
+
+OpenAPI smoke loaded the root `.env` and imported `app.main`.
+
+## Boundary
+
+This is Phase 1 service-internal decoupling only.
+
+The following remain out of scope:
+
+- deleting or renaming `get_advanced_analysis_service()`;
+- removing `get_advanced_analysis_service_dependency()`;
+- changing route paths, response models, response shapes, or OpenAPI exposure;
+- changing frontend clients or generated clients;
+- running PM2 stateful gates;
+- modifying OpenSpec changes/specs;
+- changing GitHub issue labels or readiness state.
+
+## Rollback
+
+Revert this PR as one unit. Rollback restores the provider fallback direct call
+to public `get_advanced_analysis_service()` and removes the private initializer
+plus the focused test expectation.
+
+## Next Gate
+
+If this packet is accepted, prepare a closeout / candidate-refresh governance
+packet before any further AdvancedAnalysis getter retirement decision.

--- a/governance/mainline/task-cards/pr-241.yaml
+++ b/governance/mainline/task-cards/pr-241.yaml
@@ -1,0 +1,137 @@
+version: "v0.2"
+
+task:
+  id: "pr-241"
+  title: "Implement AdvancedAnalysis compatibility getter phase 1"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-advanced-analysis-compat-getter-phase1-implementation"
+  objective: "implement G2.88 AdvancedAnalysisService Phase 1 service-internal decoupling"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-advanced-analysis-compat-getter-phase1"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-advanced-analysis-compat-getter-phase1-implementation"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow service lifecycle DI implementation authorized by PR #240; route paths, OpenAPI behavior, product surface, frontend, and runtime process state are unchanged"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/advanced-analysis-compat-getter-phase1-implementation-2026-05-25.json"
+    - "docs/reports/quality/backend-advanced-analysis-compat-getter-phase1-implementation-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-241.yaml"
+    - "web/backend/app/services/advanced_analysis_service.py"
+    - "web/backend/tests/test_advanced_analysis_service_lifecycle_di.py"
+  forbidden_paths:
+    - "web/backend/app/api/**"
+    - "web/backend/app/services/data_adapters/**"
+    - "web/backend/app/services/adapters/**"
+    - "web/backend/app/services/data_source_factory.py"
+    - "web/backend/app/services/tdx_service.py"
+    - "web/backend/app/services/stock_search_service/**"
+    - "web/backend/app/services/strategy_service.py"
+    - "web/backend/app/services/market_data_service*.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not delete, rename, or privatize get_advanced_analysis_service"
+  - "Do not remove get_advanced_analysis_service_dependency"
+  - "Do not edit route/API files or OpenAPI exposure"
+  - "Do not edit frontend or generated clients"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py::test_advanced_analysis_service_dependency_fallback_uses_private_initializer -q --no-cov --tb=short"
+      required: true
+    - id: "focused-lifecycle-pytest"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/advanced_analysis_service.py web/backend/tests/test_advanced_analysis_service_lifecycle_di.py"
+      required: true
+    - id: "black-check-touched"
+      command: "black --check web/backend/app/services/advanced_analysis_service.py web/backend/tests/test_advanced_analysis_service_lifecycle_di.py"
+      required: true
+    - id: "app-main-openapi-smoke"
+      command: >-
+        set -a && . /opt/claude/mystocks_spec/.env && set +a &&
+        PYTHONPATH=web/backend python -c "from collections import Counter; from app.main import app; schema=app.openapi(); ids=[operation.get('operationId') for methods in schema.get('paths', {}).values() for operation in methods.values() if isinstance(operation, dict) and operation.get('operationId')]; duplicates=[item for item,count in Counter(ids).items() if count > 1]; print(len(app.routes), len(schema.get('paths', {})), len(ids), len(duplicates))"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-advanced-analysis-compat-getter-phase1-implementation-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/advanced-analysis-compat-getter-phase1-implementation-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-241.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-241.yaml"
+      required: true
+    - id: "staged-gitnexus"
+      command: "gitnexus_detect_changes(scope=staged)"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If route/API files are edited in the same PR, the implementation exceeds the G2.87 authorization boundary"
+    - "If the public compatibility getter is removed in Phase 1, hidden callers could lose their compatibility bridge"
+  rollback_plan: "revert this PR; restore the dependency-provider fallback direct call to get_advanced_analysis_service and remove the private initializer plus focused test expectation as one unit"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "implement AdvancedAnalysisService Phase 1 service-internal decoupling after G2.87 authorization"
+    modified_scope: "advanced_analysis_service.py, focused lifecycle test, steward tree, implementation report, generated artifact, and this task card"
+    dependency_changes: "provider fallback now uses a private initializer; public compatibility getter remains as wrapper"
+    legacy_logic_impact: "public get_advanced_analysis_service remains available; route/API dependencies remain on get_advanced_analysis_service_dependency"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, health route conflicts, ruff, black check, OpenAPI smoke, mainline scope, staged GitNexus, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T17:08:32+08:00"
+    approval_note: "G2.87 authorization PR #240 was merged and the maintainer asked to continue into G2.88"
+    secondary_approved: false

--- a/web/backend/app/services/advanced_analysis_service.py
+++ b/web/backend/app/services/advanced_analysis_service.py
@@ -489,16 +489,20 @@ def install_advanced_analysis_service(
     return selected_service
 
 
-async def get_advanced_analysis_service() -> AdvancedAnalysisService:
-    """获取高级分析服务实例（依赖注入用）"""
+async def _get_or_create_advanced_analysis_service() -> AdvancedAnalysisService:
     await advanced_analysis_service.initialize()
     return advanced_analysis_service
+
+
+async def get_advanced_analysis_service() -> AdvancedAnalysisService:
+    """获取高级分析服务实例（依赖注入用）"""
+    return await _get_or_create_advanced_analysis_service()
 
 
 async def get_advanced_analysis_service_dependency(request: Request) -> AdvancedAnalysisService:
     """FastAPI dependency provider backed by app.state."""
     service = getattr(request.app.state, ADVANCED_ANALYSIS_SERVICE_STATE_KEY, None)
     if service is None:
-        service = await get_advanced_analysis_service()
+        service = await _get_or_create_advanced_analysis_service()
         setattr(request.app.state, ADVANCED_ANALYSIS_SERVICE_STATE_KEY, service)
     return service

--- a/web/backend/tests/test_advanced_analysis_service_lifecycle_di.py
+++ b/web/backend/tests/test_advanced_analysis_service_lifecycle_di.py
@@ -10,23 +10,31 @@ from app.services import advanced_analysis_service as advanced_analysis_service_
 
 
 @pytest.mark.asyncio
-async def test_advanced_analysis_service_dependency_installs_app_state_when_missing(monkeypatch):
-    fake_service = object()
+async def test_advanced_analysis_service_dependency_fallback_uses_private_initializer(monkeypatch):
+    class FakeAdvancedAnalysisService:
+        initialized = False
+
+        async def initialize(self):
+            self.initialized = True
+
+    fake_service = FakeAdvancedAnalysisService()
     fake_app = SimpleNamespace(state=SimpleNamespace())
     request = SimpleNamespace(app=fake_app)
 
-    async def fake_get_advanced_analysis_service():
-        return fake_service
+    async def fail_if_public_getter_called():
+        raise AssertionError("provider fallback must not call the public compatibility getter")
 
+    monkeypatch.setattr(advanced_analysis_service_module, "advanced_analysis_service", fake_service)
     monkeypatch.setattr(
         advanced_analysis_service_module,
         "get_advanced_analysis_service",
-        fake_get_advanced_analysis_service,
+        fail_if_public_getter_called,
     )
 
     result = await advanced_analysis_service_module.get_advanced_analysis_service_dependency(request)
 
     assert result is fake_service
+    assert fake_service.initialized is True
     assert getattr(fake_app.state, advanced_analysis_service_module.ADVANCED_ANALYSIS_SERVICE_STATE_KEY) is fake_service
 
 


### PR DESCRIPTION
## Summary

Implements G2.88 AdvancedAnalysisService Phase 1 service-internal decoupling after the accepted G2.87 authorization in PR #240.

- Adds private `_get_or_create_advanced_analysis_service()`.
- Keeps public `get_advanced_analysis_service()` as the Phase 1 compatibility wrapper.
- Retargets `get_advanced_analysis_service_dependency()` fallback away from the public getter.
- Updates focused lifecycle coverage so provider fallback fails if it calls the public compatibility getter.
- Updates the steward tree, implementation report, generated evidence artifact, and PR task card.

## Boundary

No route/API files, OpenAPI exposure, frontend, PM2/runtime, OpenSpec changes, issue labels, or public getter deletion are included.

## Evidence

- TDD red: `test_advanced_analysis_service_dependency_fallback_uses_private_initializer` failed before implementation because provider fallback called patched public getter.
- Focused lifecycle tests: `4 passed in 3.90s`.
- `test_health_route_conflicts.py`: `120 passed in 76.56s`.
- Ruff touched backend files: passed.
- Black check touched backend files: passed.
- OpenAPI smoke: routes `548`, paths `500`, operation IDs `536`, duplicate operation IDs `0`, warnings `0`.
- GitNexus pre-edit impact: LOW for both target functions.
- Staged GitNexus detect: LOW, affected processes `0`.
- Post-commit mainline gate: pass.
- Post-commit GitNexus analyze: up to date via `--with-gitignore` worktree workaround.

## Files

- `web/backend/app/services/advanced_analysis_service.py`
- `web/backend/tests/test_advanced_analysis_service_lifecycle_di.py`
- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
- `.planning/codebase/generated/advanced-analysis-compat-getter-phase1-implementation-2026-05-25.json`
- `docs/reports/quality/backend-advanced-analysis-compat-getter-phase1-implementation-2026-05-25.md`
- `governance/mainline/task-cards/pr-241.yaml`
