### PR TITLE
docs(governance): close out advanced analysis getter phase1

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1405,9 +1405,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                frontend, runtime/PM2, OpenSpec, public getter deletion,
 │   │                dependency provider removal, or issue-label change is made
 │   ├── G2.88 AdvancedAnalysis compatibility getter Phase 1 implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#241` merged at
+│   │   │          `33c3d34dc00caa8b347e90d66084c1d001559186`
 │   │   ├── Evidence: `backend-advanced-analysis-compat-getter-phase1-implementation-2026-05-25.md`
-│   │   ├── Current HEAD: `55861bb10d19dfafe9ff5e100f583069dcdbc2a9`
+│   │   ├── Current HEAD: `33c3d34dc00caa8b347e90d66084c1d001559186`
 │   │   ├── Result: adds private `_get_or_create_advanced_analysis_service()`,
 │   │   │          keeps public `get_advanced_analysis_service()` as a Phase 1
 │   │   │          compatibility wrapper, retargets
@@ -1423,9 +1424,23 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                task card, and steward-tree update; no public getter
 │   │                deletion, route/API, OpenAPI exposure, frontend, PM2,
 │   │                OpenSpec, or issue-label change is made here
-│   └── Next gate: Human review / PR merge decision for G2.88 implementation; if
-│                  accepted, prepare a closeout / candidate-refresh packet before
-│                  any further AdvancedAnalysis getter retirement decision
+│   ├── G2.89 AdvancedAnalysis compatibility getter Phase 1 closeout / candidate refresh
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-advanced-analysis-compat-getter-phase1-closeout-2026-05-25.md`
+│   │   ├── Current HEAD: `33c3d34dc00caa8b347e90d66084c1d001559186`
+│   │   ├── Result: records PR `#241` merge, confirms exact public getter
+│   │   │          production hits are definition-only, route/API public getter
+│   │   │          hits=`0`, package export hits=`0`, private initializer hits=`3`,
+│   │   │          dependency-provider refs=`19`, lifecycle tests `4 passed`,
+│   │   │          health route conflicts `120 passed`, and OpenAPI remains
+│   │   │          paths=`500` with duplicate operation IDs=`0`
+│   │   └── Boundary: closeout / candidate-refresh only; no source, test,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                public getter deletion, or issue-label change is made here
+│   └── Next gate: Human review / PR merge decision for G2.89 closeout; if
+│                  accepted, prepare a separate G2.90 final-retirement
+│                  authorization packet before any `get_advanced_analysis_service`
+│                  deletion or test update
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/advanced-analysis-compat-getter-phase1-closeout-2026-05-25.json
+++ b/.planning/codebase/generated/advanced-analysis-compat-getter-phase1-closeout-2026-05-25.json
@@ -1,0 +1,50 @@
+{
+  "workline": "G2.89 AdvancedAnalysis compatibility getter Phase 1 closeout / candidate refresh",
+  "status": "ready_for_review",
+  "prepared_at": "2026-05-25T17:34:02+08:00",
+  "worktree": ".worktrees/g2-89-advanced-analysis-compat-getter-phase1-closeout",
+  "branch": "g2-89-advanced-analysis-compat-getter-phase1-closeout",
+  "current_head": "33c3d34dc00caa8b347e90d66084c1d001559186",
+  "parent_implementation_pr": {
+    "number": 241,
+    "state": "MERGED",
+    "merge_commit": "33c3d34dc00caa8b347e90d66084c1d001559186",
+    "merged_at": "2026-05-25T09:28:29Z"
+  },
+  "reference_matrix": {
+    "public_getter_hits": 1,
+    "public_getter_scope": "definition only",
+    "route_api_public_getter_hits": 0,
+    "service_public_getter_hits": 1,
+    "test_public_mentions": 5,
+    "private_initializer_hits": 3,
+    "dependency_provider_refs": 19,
+    "package_export_hits": 0
+  },
+  "verification": {
+    "focused_lifecycle_tests": "4 passed in 3.60s",
+    "health_route_conflicts": "120 passed in 67.35s",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "warnings": 0
+    }
+  },
+  "decision": {
+    "phase1_state": "closed_pending_review",
+    "next_candidate": "G2.90 AdvancedAnalysis public compatibility getter final-retirement authorization",
+    "authorization_required_before_source_edit": true,
+    "source_changes_in_this_packet": false
+  },
+  "boundaries": [
+    "No source or test edits",
+    "No route/API edits",
+    "No OpenAPI exposure change",
+    "No frontend or generated client edits",
+    "No OpenSpec changes",
+    "No GitHub issue label changes",
+    "No public getter deletion in this packet"
+  ]
+}

--- a/docs/reports/quality/backend-advanced-analysis-compat-getter-phase1-closeout-2026-05-25.md
+++ b/docs/reports/quality/backend-advanced-analysis-compat-getter-phase1-closeout-2026-05-25.md
@@ -1,0 +1,93 @@
+# Backend AdvancedAnalysis Compatibility Getter Phase 1 Closeout - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.89 AdvancedAnalysis compatibility getter Phase 1 closeout /
+candidate refresh
+
+Status: ready for review
+
+## Purpose
+
+Record the accepted G2.88 implementation, refresh the current-head getter
+reference matrix, and decide the next governance gate.
+
+This packet is closeout / candidate-refresh only. It does not edit source, tests,
+routes, OpenAPI exposure, frontend clients, OpenSpec changes, PM2/runtime state,
+or GitHub issue labels.
+
+## Current Head
+
+| Field | Value |
+|---|---|
+| Worktree | `.worktrees/g2-89-advanced-analysis-compat-getter-phase1-closeout` |
+| Branch | `g2-89-advanced-analysis-compat-getter-phase1-closeout` |
+| Current HEAD | `33c3d34dc00caa8b347e90d66084c1d001559186` |
+| Parent PR | `#241` |
+| Parent PR state | `MERGED` |
+| Parent merge commit | `33c3d34dc00caa8b347e90d66084c1d001559186` |
+
+## Reference Matrix
+
+Current-head scan:
+
+| Metric | Value |
+|---|---:|
+| Exact public getter hits | 1 |
+| Public getter production scope | definition only |
+| Route/API direct public getter hits | 0 |
+| Service public getter hits | 1 |
+| Test public mentions | 5 |
+| Private initializer hits | 3 |
+| Dependency-provider refs | 19 |
+| Package export hits | 0 |
+
+Interpretation:
+
+- G2.88 closed the provider fallback dependency on the public compatibility
+  getter.
+- The public getter remains as a Phase 1 compatibility surface.
+- The next possible source lane is not implementation. It is a separate
+  final-retirement authorization packet that must explicitly decide whether to
+  remove the public getter and update focused tests.
+
+## Verification
+
+| Gate | Result |
+|---|---|
+| Focused lifecycle tests | `4 passed in 3.60s` |
+| `test_health_route_conflicts.py` | `120 passed in 67.35s` |
+| OpenAPI smoke | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, warnings=`0` |
+
+OpenAPI smoke loaded the root `.env` and imported `app.main`.
+
+## Decision
+
+G2.88 Phase 1 is ready to close once this closeout packet is accepted.
+
+Next candidate:
+
+`G2.90 AdvancedAnalysis public compatibility getter final-retirement authorization`
+
+The G2.90 candidate must remain authorization-only until accepted. It must not
+delete `get_advanced_analysis_service()` in the same packet.
+
+## Boundary
+
+Out of scope here:
+
+- source or test edits;
+- route/API edits;
+- OpenAPI exposure changes;
+- frontend or generated client edits;
+- PM2/runtime execution;
+- OpenSpec changes/spec updates;
+- GitHub issue label changes;
+- deleting, renaming, or privatizing `get_advanced_analysis_service()`.
+
+## Rollback
+
+Revert this governance-only packet. Reverting it does not revert PR `#241`; it
+only restores the steward tree to the G2.88 implementation review state.

--- a/governance/mainline/task-cards/pr-242.yaml
+++ b/governance/mainline/task-cards/pr-242.yaml
@@ -1,0 +1,112 @@
+version: "v0.2"
+
+task:
+  id: "pr-242"
+  title: "Close out AdvancedAnalysis getter phase 1"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-advanced-analysis-compat-getter-phase1-closeout"
+  objective: "record G2.88 merge evidence and select the next AdvancedAnalysis getter governance gate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-advanced-analysis-compat-getter-phase1"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-advanced-analysis-compat-getter-phase1-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/advanced-analysis-compat-getter-phase1-closeout-2026-05-25.json"
+    - "docs/reports/quality/backend-advanced-analysis-compat-getter-phase1-closeout-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-242.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not delete, rename, or privatize get_advanced_analysis_service"
+  - "Do not change routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 241 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "focused-lifecycle-pytest"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-advanced-analysis-compat-getter-phase1-closeout-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/advanced-analysis-compat-getter-phase1-closeout-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-242.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-242.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet is treated as source authorization, future deletion could bypass the required G2.90 gate"
+    - "If current-head scan data is stale, the final-retirement candidate could be over-authorized"
+  rollback_plan: "revert this governance-only closeout PR and keep G2.88 as the latest accepted implementation evidence"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out G2.88 AdvancedAnalysisService Phase 1 getter decoupling"
+    modified_scope: "steward tree, closeout report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; public compatibility getter remains present"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this closeout PR if parent PR evidence, reference matrix, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T17:34:02+08:00"
+    approval_note: "G2.88 implementation PR #241 was merged; this packet records closeout and the next authorization candidate only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

Closes out G2.88 after PR #241 was merged and refreshes the AdvancedAnalysisService getter reference matrix.

- Marks G2.88 accepted in the steward tree.
- Records current HEAD `33c3d34dc00caa8b347e90d66084c1d001559186`.
- Confirms public `get_advanced_analysis_service()` production hits are definition-only.
- Confirms route/API public getter hits `0`, package export hits `0`, private initializer hits `3`, dependency-provider refs `19`.
- Selects the next candidate as a separate G2.90 final-retirement authorization packet.

## Boundary

Governance-only closeout. No backend source/test edits, route/API edits, OpenAPI exposure changes, frontend changes, OpenSpec changes, PM2/runtime changes, issue label changes, or public getter deletion.

## Evidence

- Parent PR #241: MERGED, merge commit `33c3d34dc00caa8b347e90d66084c1d001559186`.
- Focused lifecycle tests: `4 passed in 3.60s`.
- `test_health_route_conflicts.py`: `120 passed in 67.35s`.
- OpenAPI smoke: routes `548`, paths `500`, operation IDs `536`, duplicate operation IDs `0`, warnings `0`.
- Markdown governance: errors `0`.
- JSON/YAML parse: passed.
- Post-commit mainline gate: pass.

## Files

- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
- `.planning/codebase/generated/advanced-analysis-compat-getter-phase1-closeout-2026-05-25.json`
- `docs/reports/quality/backend-advanced-analysis-compat-getter-phase1-closeout-2026-05-25.md`
- `governance/mainline/task-cards/pr-242.yaml`
