### PR TITLE
docs(governance): authorize advanced analysis getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1425,9 +1425,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                deletion, route/API, OpenAPI exposure, frontend, PM2,
 │   │                OpenSpec, or issue-label change is made here
 │   ├── G2.89 AdvancedAnalysis compatibility getter Phase 1 closeout / candidate refresh
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#242` merged at
+│   │   │          `7b6d81aaad7af8279cbb7304903a88987682e579`
 │   │   ├── Evidence: `backend-advanced-analysis-compat-getter-phase1-closeout-2026-05-25.md`
-│   │   ├── Current HEAD: `33c3d34dc00caa8b347e90d66084c1d001559186`
+│   │   ├── Current HEAD: `7b6d81aaad7af8279cbb7304903a88987682e579`
 │   │   ├── Result: records PR `#241` merge, confirms exact public getter
 │   │   │          production hits are definition-only, route/API public getter
 │   │   │          hits=`0`, package export hits=`0`, private initializer hits=`3`,
@@ -1437,10 +1438,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: closeout / candidate-refresh only; no source, test,
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                public getter deletion, or issue-label change is made here
-│   └── Next gate: Human review / PR merge decision for G2.89 closeout; if
-│                  accepted, prepare a separate G2.90 final-retirement
-│                  authorization packet before any `get_advanced_analysis_service`
-│                  deletion or test update
+│   ├── G2.90 AdvancedAnalysis public compatibility getter final-retirement authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-advanced-analysis-compat-getter-final-retirement-authorization-2026-05-25.md`
+│   │   ├── Current HEAD: `7b6d81aaad7af8279cbb7304903a88987682e579`
+│   │   ├── Result: authorizes only a future G2.91 source branch to remove
+│   │   │          public `get_advanced_analysis_service()` after TDD red/green;
+│   │   │          current-head evidence shows GitNexus impact LOW / `0`,
+│   │   │          exact public getter production hits are definition-only,
+│   │   │          route/API public getter hits=`0`, package export hits=`0`,
+│   │   │          lifecycle tests `4 passed`, health route conflicts
+│   │   │          `120 passed`, and OpenAPI remains paths=`500` with duplicate
+│   │   │          operation IDs=`0`
+│   │   └── Boundary: authorization-only; no source, test, route/API, OpenAPI
+│   │                exposure, frontend, PM2, OpenSpec, public getter deletion,
+│   │                or issue-label change is made here
+│   └── Next gate: Human review / PR merge decision for G2.90 authorization; if
+│                  accepted, create G2.91 implementation branch before any
+│                  `get_advanced_analysis_service()` deletion or test update
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-authorization-2026-05-25.json
+++ b/.planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-authorization-2026-05-25.json
@@ -1,0 +1,74 @@
+{
+  "workline": "G2.90 AdvancedAnalysis public compatibility getter final-retirement authorization",
+  "status": "ready_for_review",
+  "prepared_at": "2026-05-25T17:47:35+08:00",
+  "worktree": ".worktrees/g2-90-advanced-analysis-compat-getter-final-retirement-authorization",
+  "branch": "g2-90-advanced-analysis-compat-getter-final-retirement-authorization",
+  "current_head": "7b6d81aaad7af8279cbb7304903a88987682e579",
+  "parent_closeout_pr": {
+    "number": 242,
+    "state": "MERGED",
+    "merge_commit": "7b6d81aaad7af8279cbb7304903a88987682e579",
+    "merged_at": "2026-05-25T09:41:31Z"
+  },
+  "authorization": {
+    "future_branch": "G2.91 AdvancedAnalysis public compatibility getter final-retirement implementation",
+    "source_edit_authorized_in_this_packet": false,
+    "future_allowed_files": [
+      "web/backend/app/services/advanced_analysis_service.py",
+      "web/backend/tests/test_advanced_analysis_service_lifecycle_di.py"
+    ],
+    "future_allowed_actions": [
+      "delete public get_advanced_analysis_service()",
+      "update focused lifecycle tests to remove public getter monkeypatch references",
+      "prove dependency provider still uses _get_or_create_advanced_analysis_service()"
+    ],
+    "future_forbidden_actions": [
+      "route/API edits",
+      "OpenAPI exposure changes",
+      "frontend or generated client edits",
+      "OpenSpec changes",
+      "PM2/runtime state changes",
+      "GitHub issue label changes"
+    ]
+  },
+  "current_head_evidence": {
+    "gitnexus_impact": {
+      "target": "get_advanced_analysis_service",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "processes_affected": 0
+    },
+    "reference_matrix": {
+      "public_getter_hits": 1,
+      "public_getter_scope": "definition only",
+      "route_api_public_getter_hits": 0,
+      "service_public_getter_hits": 1,
+      "test_public_mentions": 5,
+      "private_initializer_hits": 3,
+      "dependency_provider_refs": 19,
+      "package_export_hits": 0
+    },
+    "verification": {
+      "focused_lifecycle_tests": "4 passed in 4.27s",
+      "health_route_conflicts": "120 passed in 71.72s",
+      "openapi_smoke": {
+        "routes": 548,
+        "paths": 500,
+        "operation_ids": 536,
+        "duplicate_operation_ids": 0,
+        "warnings": 0
+      }
+    }
+  },
+  "future_g2_91_required_gates": [
+    "Run GitNexus impact/context before source edits",
+    "Add a failing focused test proving public getter removal or absence",
+    "Run focused lifecycle tests",
+    "Run test_health_route_conflicts.py",
+    "Run ruff and black check on touched backend files",
+    "Run OpenAPI smoke",
+    "Run staged GitNexus detect_changes",
+    "Run post-commit mainline gate"
+  ]
+}

--- a/docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-authorization-2026-05-25.md
+++ b/docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-authorization-2026-05-25.md
@@ -1,0 +1,129 @@
+# Backend AdvancedAnalysis Compatibility Getter Final Retirement Authorization - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.90 AdvancedAnalysis public compatibility getter final-retirement
+authorization
+
+Status: ready for review
+
+## Purpose
+
+Authorize a future G2.91 source implementation branch to remove the remaining
+public `get_advanced_analysis_service()` compatibility getter, if this packet is
+accepted.
+
+This packet does not implement the deletion. It records current-head evidence,
+allowed future files, required tests, and rollback boundaries.
+
+## Current Head
+
+| Field | Value |
+|---|---|
+| Worktree | `.worktrees/g2-90-advanced-analysis-compat-getter-final-retirement-authorization` |
+| Branch | `g2-90-advanced-analysis-compat-getter-final-retirement-authorization` |
+| Current HEAD | `7b6d81aaad7af8279cbb7304903a88987682e579` |
+| Parent PR | `#242` |
+| Parent PR state | `MERGED` |
+| Parent merge commit | `7b6d81aaad7af8279cbb7304903a88987682e579` |
+
+## Current Evidence
+
+GitNexus was refreshed for this worktree with:
+
+```text
+gitnexus analyze --with-gitignore
+```
+
+Pre-authorization GitNexus result:
+
+| Target | Risk | Impact |
+|---|---:|---:|
+| `get_advanced_analysis_service` | LOW | 0 impacted symbols / 0 affected processes |
+
+Current-head reference matrix:
+
+| Metric | Value |
+|---|---:|
+| Exact public getter hits | 1 |
+| Public getter production scope | definition only |
+| Route/API direct public getter hits | 0 |
+| Service public getter hits | 1 |
+| Test public mentions | 5 |
+| Private initializer hits | 3 |
+| Dependency-provider refs | 19 |
+| Package export hits | 0 |
+
+## Verification
+
+| Gate | Result |
+|---|---|
+| Focused lifecycle tests | `4 passed in 4.27s` |
+| `test_health_route_conflicts.py` | `120 passed in 71.72s` |
+| OpenAPI smoke | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, warnings=`0` |
+
+OpenAPI smoke loaded the root `.env` and imported `app.main`.
+
+## Authorized Future G2.91 Scope
+
+Only a future G2.91 implementation branch may edit:
+
+- `web/backend/app/services/advanced_analysis_service.py`;
+- `web/backend/tests/test_advanced_analysis_service_lifecycle_di.py`;
+- the G2.91 implementation report, generated artifact, task card, and steward
+  tree entry.
+
+The future implementation may:
+
+- delete public `get_advanced_analysis_service()`;
+- update focused lifecycle tests so they no longer monkeypatch that public
+  getter;
+- keep `_get_or_create_advanced_analysis_service()`;
+- keep `get_advanced_analysis_service_dependency()`;
+- keep `install_advanced_analysis_service()`;
+- keep `ADVANCED_ANALYSIS_SERVICE_STATE_KEY`;
+- prove dependency-provider fallback still uses
+  `_get_or_create_advanced_analysis_service()`.
+
+## Required Future G2.91 Gates
+
+Before source edits:
+
+1. Run GitNexus impact/context for `get_advanced_analysis_service()`.
+2. Add or update a focused lifecycle test that fails before implementation.
+3. Reconfirm route/API public getter hits remain `0`.
+
+Before a G2.91 commit:
+
+1. Run focused lifecycle tests.
+2. Run `test_health_route_conflicts.py`.
+3. Run ruff and black check on touched backend files.
+4. Run OpenAPI smoke.
+5. Run staged GitNexus `detect_changes`.
+6. Run post-commit mainline gate.
+
+## Hard Boundaries
+
+This packet and the future G2.91 implementation do not authorize:
+
+- route/API edits;
+- route path, response model, response shape, or OpenAPI exposure changes;
+- frontend or generated client edits;
+- PM2/runtime state changes;
+- OpenSpec changes/spec updates;
+- GitHub issue label changes;
+- deleting `_get_or_create_advanced_analysis_service()`;
+- removing `get_advanced_analysis_service_dependency()`;
+- removing `install_advanced_analysis_service()`.
+
+If future G2.91 finds any route/API or package-export consumer of
+`get_advanced_analysis_service()`, stop and return to review instead of deleting
+the public getter.
+
+## Rollback
+
+If accepted but later rejected during implementation review, revert only the
+future implementation branch. This authorization packet can remain as a
+historical decision record, or be reverted as governance-only documentation.

--- a/governance/mainline/task-cards/pr-243.yaml
+++ b/governance/mainline/task-cards/pr-243.yaml
@@ -1,0 +1,112 @@
+version: "v0.2"
+
+task:
+  id: "pr-243"
+  title: "Authorize AdvancedAnalysis getter final retirement"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-advanced-analysis-compat-getter-final-retirement-authorization"
+  objective: "authorize a future G2.91 source branch to retire the remaining AdvancedAnalysis public compatibility getter"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-advanced-analysis-compat-getter-final-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-advanced-analysis-compat-getter-final-retirement-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-authorization-2026-05-25.json"
+    - "docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-authorization-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-243.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests in this authorization PR"
+  - "Do not delete, rename, or privatize get_advanced_analysis_service in this PR"
+  - "Do not change routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 242 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "focused-lifecycle-pytest"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-authorization-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-authorization-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-243.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-243.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet is treated as implementation, public getter deletion could bypass G2.91 TDD and staged GitNexus gates"
+    - "If hidden consumers appear before G2.91, final retirement must stop and return to review"
+  rollback_plan: "revert this governance-only authorization PR and keep G2.89 as the latest accepted closeout"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize future AdvancedAnalysis public compatibility getter final retirement"
+    modified_scope: "steward tree, authorization report, generated artifact, and this task card only"
+    dependency_changes: "none in this PR; future G2.91 may remove the public wrapper after TDD"
+    legacy_logic_impact: "none; public compatibility getter remains present in this PR"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this authorization PR if the G2.91 scope boundary or current-head evidence is rejected"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T17:47:35+08:00"
+    approval_note: "G2.89 closeout PR #242 was merged; this packet is authorization-only for a future G2.91 source branch"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

Authorizes a future G2.91 implementation branch to retire the remaining public `get_advanced_analysis_service()` compatibility getter.

- Marks G2.89 accepted in the steward tree.
- Records current HEAD `7b6d81aaad7af8279cbb7304903a88987682e579`.
- Confirms GitNexus impact for `get_advanced_analysis_service` is LOW / 0 impacted symbols.
- Confirms public getter hits are definition-only, route/API public getter hits `0`, package export hits `0`.
- Defines future G2.91 allowed files and hard boundaries.

## Boundary

Authorization-only. No backend source/test edits, route/API edits, OpenAPI exposure changes, frontend changes, OpenSpec changes, PM2/runtime changes, issue label changes, or public getter deletion.

## Evidence

- Parent PR #242: MERGED, merge commit `7b6d81aaad7af8279cbb7304903a88987682e579`.
- GitNexus impact: LOW, impacted symbols `0`, affected processes `0`.
- Focused lifecycle tests: `4 passed in 4.27s`.
- `test_health_route_conflicts.py`: `120 passed in 71.72s`.
- OpenAPI smoke: routes `548`, paths `500`, operation IDs `536`, duplicate operation IDs `0`, warnings `0`.
- Markdown governance: errors `0`.
- JSON/YAML parse: passed.
- Post-commit mainline gate: pass.

## Future G2.91 Scope

Only after this authorization is accepted, a separate implementation branch may edit:

- `web/backend/app/services/advanced_analysis_service.py`
- `web/backend/tests/test_advanced_analysis_service_lifecycle_di.py`
- G2.91 report / artifact / task card / steward tree

It may delete `get_advanced_analysis_service()` and update focused tests, but must not touch route/API, OpenAPI exposure, frontend, PM2/runtime, OpenSpec, or issue labels.
