### PR TITLE
refactor(services): retire advanced analysis getter

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1439,9 +1439,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                public getter deletion, or issue-label change is made here
 │   ├── G2.90 AdvancedAnalysis public compatibility getter final-retirement authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#243` merged at
+│   │   │          `db5ebd408f0d89c012e8c3e0ea23361e7836a53f`
 │   │   ├── Evidence: `backend-advanced-analysis-compat-getter-final-retirement-authorization-2026-05-25.md`
-│   │   ├── Current HEAD: `7b6d81aaad7af8279cbb7304903a88987682e579`
+│   │   ├── Current HEAD: `db5ebd408f0d89c012e8c3e0ea23361e7836a53f`
 │   │   ├── Result: authorizes only a future G2.91 source branch to remove
 │   │   │          public `get_advanced_analysis_service()` after TDD red/green;
 │   │   │          current-head evidence shows GitNexus impact LOW / `0`,
@@ -1453,9 +1454,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: authorization-only; no source, test, route/API, OpenAPI
 │   │                exposure, frontend, PM2, OpenSpec, public getter deletion,
 │   │                or issue-label change is made here
-│   └── Next gate: Human review / PR merge decision for G2.90 authorization; if
-│                  accepted, create G2.91 implementation branch before any
-│                  `get_advanced_analysis_service()` deletion or test update
+│   ├── G2.91 AdvancedAnalysis public compatibility getter final-retirement implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.md`
+│   │   ├── Current HEAD: `db5ebd408f0d89c012e8c3e0ea23361e7836a53f`
+│   │   ├── Result: removes public `get_advanced_analysis_service()`, keeps
+│   │   │          `_get_or_create_advanced_analysis_service()` and
+│   │   │          `get_advanced_analysis_service_dependency()`, updates focused
+│   │   │          lifecycle tests via TDD red/green, leaves route/API public
+│   │   │          getter hits=`0`, package export hits=`0`, exact public getter
+│   │   │          call hits=`0`, lifecycle tests `5 passed`, health route
+│   │   │          conflicts `120 passed`, and OpenAPI remains paths=`500` with
+│   │   │          duplicate operation IDs=`0`
+│   │   └── Boundary: source-capable but limited to the service module, focused
+│   │                lifecycle test, governance report, generated artifact,
+│   │                task card, and steward-tree update; no route/API, OpenAPI
+│   │                exposure, frontend, PM2, OpenSpec, or issue-label change is
+│   │                made here
+│   └── Next gate: Human review / PR merge decision for G2.91 implementation; if
+│                  accepted, prepare final closeout / next-candidate refresh
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.json
+++ b/.planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.json
@@ -1,0 +1,64 @@
+{
+  "workline": "G2.91 AdvancedAnalysis public compatibility getter final-retirement implementation",
+  "status": "ready_for_review",
+  "prepared_at": "2026-05-25T18:03:29+08:00",
+  "worktree": ".worktrees/g2-91-advanced-analysis-compat-getter-final-retirement-implementation",
+  "branch": "g2-91-advanced-analysis-compat-getter-final-retirement-implementation",
+  "base_head": "db5ebd408f0d89c012e8c3e0ea23361e7836a53f",
+  "parent_authorization_pr": {
+    "number": 243,
+    "state": "MERGED",
+    "merge_commit": "db5ebd408f0d89c012e8c3e0ea23361e7836a53f"
+  },
+  "implementation_summary": {
+    "public_getter_removed": "get_advanced_analysis_service",
+    "private_initializer_kept": "_get_or_create_advanced_analysis_service",
+    "dependency_provider_kept": "get_advanced_analysis_service_dependency",
+    "installer_kept": "install_advanced_analysis_service",
+    "state_key_kept": "ADVANCED_ANALYSIS_SERVICE_STATE_KEY",
+    "route_api_changes": false,
+    "openapi_exposure_changes": false,
+    "frontend_changes": false,
+    "openspec_changes": false,
+    "issue_label_changes": false
+  },
+  "tdd": {
+    "red_command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py::test_public_advanced_analysis_service_getter_is_retired -q --no-cov --tb=short",
+    "red_result": "1 failed; public compatibility getter still existed",
+    "green_command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q --no-cov --tb=short",
+    "green_result": "5 passed in 3.78s"
+  },
+  "gitnexus_pre_edit": {
+    "repo": "g2-91-advanced-analysis-compat-getter-final-retirement-implementation",
+    "get_advanced_analysis_service": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "processes_affected": 0
+    }
+  },
+  "post_change_reference_scan": {
+    "exact_public_getter_call_hits": 0,
+    "route_api_public_getter_call_hits": 0,
+    "package_export_hits": 0,
+    "private_initializer_hits": 2,
+    "dependency_provider_refs": 19,
+    "remaining_public_getter_mentions": "test assertion string only"
+  },
+  "verification": {
+    "focused_lifecycle_tests": "5 passed in 3.78s",
+    "health_route_conflicts": "120 passed in 76.54s",
+    "ruff_touched_backend_files": "passed",
+    "black_check_touched_backend_files": "passed",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "warnings": 0
+    }
+  },
+  "rollback": {
+    "strategy": "revert this PR as one unit",
+    "restores": "public get_advanced_analysis_service compatibility wrapper and prior focused tests"
+  }
+}

--- a/docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.md
+++ b/docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.md
@@ -1,0 +1,141 @@
+# Backend AdvancedAnalysis Compatibility Getter Final Retirement Implementation - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.91 AdvancedAnalysis public compatibility getter final-retirement
+implementation
+
+Status: ready for review
+
+## Scope
+
+This packet implements the G2.90 authorization accepted in PR `#243`.
+
+Allowed source/test files:
+
+- `web/backend/app/services/advanced_analysis_service.py`
+- `web/backend/tests/test_advanced_analysis_service_lifecycle_di.py`
+
+Governance evidence files:
+
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.json`
+- `docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.md`
+- `governance/mainline/task-cards/pr-244.yaml`
+
+No route/API, OpenAPI exposure, frontend, PM2/runtime, OpenSpec, GitHub issue
+label, or public API contract change is made here.
+
+## Implementation Summary
+
+The implementation retires the final public AdvancedAnalysis compatibility
+getter:
+
+- delete public `get_advanced_analysis_service()`;
+- keep `_get_or_create_advanced_analysis_service()`;
+- keep `get_advanced_analysis_service_dependency()`;
+- keep `install_advanced_analysis_service()`;
+- keep `ADVANCED_ANALYSIS_SERVICE_STATE_KEY`;
+- update focused lifecycle tests so they no longer monkeypatch the removed public
+  getter.
+
+## TDD Evidence
+
+RED before implementation:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py::test_public_advanced_analysis_service_getter_is_retired -q --no-cov --tb=short
+```
+
+Result:
+
+```text
+1 failed
+AssertionError: assert not True
+```
+
+GREEN after implementation:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q --no-cov --tb=short
+```
+
+Result:
+
+```text
+5 passed in 3.78s
+```
+
+## GitNexus Evidence
+
+GitNexus was refreshed for the G2.91 worktree before source edits:
+
+```text
+gitnexus analyze --with-gitignore
+```
+
+Pre-edit impact checks:
+
+| Target | Risk | Impact |
+|---|---:|---:|
+| `get_advanced_analysis_service` | LOW | 0 impacted symbols / 0 affected processes |
+
+Pre-edit context showed `get_advanced_analysis_service()` as a public wrapper
+that only called `_get_or_create_advanced_analysis_service()`.
+
+## Reference Scan
+
+After implementation:
+
+| Metric | Value |
+|---|---:|
+| Exact public getter call hits | 0 |
+| Route/API direct public getter call hits | 0 |
+| Package export hits | 0 |
+| Private initializer hits | 2 |
+| Dependency-provider refs | 19 |
+
+The only remaining public getter text is the focused test assertion string that
+proves `get_advanced_analysis_service` is absent.
+
+## Verification
+
+| Gate | Result |
+|---|---|
+| Focused lifecycle tests | `5 passed in 3.78s` |
+| `test_health_route_conflicts.py` | `120 passed in 76.54s` |
+| Ruff touched backend files | passed |
+| Black check touched backend files | passed |
+| OpenAPI smoke | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, warnings=`0` |
+
+OpenAPI smoke loaded the root `.env` and imported `app.main`.
+
+## Boundary
+
+This is final-retirement implementation for the AdvancedAnalysis public
+compatibility getter only.
+
+The following remain out of scope:
+
+- route/API edits;
+- route path, response model, response shape, or OpenAPI exposure changes;
+- frontend or generated client edits;
+- PM2/runtime execution;
+- OpenSpec changes/spec updates;
+- GitHub issue label changes;
+- deleting `_get_or_create_advanced_analysis_service()`;
+- removing `get_advanced_analysis_service_dependency()`;
+- removing `install_advanced_analysis_service()`.
+
+## Rollback
+
+Revert this PR as one unit. Rollback restores the public
+`get_advanced_analysis_service()` wrapper and prior focused lifecycle test
+expectations.
+
+## Next Gate
+
+If this packet is accepted, prepare a closeout / next-candidate refresh before
+starting any other service getter retirement lane.

--- a/governance/mainline/task-cards/pr-244.yaml
+++ b/governance/mainline/task-cards/pr-244.yaml
@@ -1,0 +1,131 @@
+version: "v0.2"
+
+task:
+  id: "pr-244"
+  title: "Retire AdvancedAnalysis public compatibility getter"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-advanced-analysis-compat-getter-final-retirement-implementation"
+  objective: "implement G2.91 AdvancedAnalysis public compatibility getter final retirement"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-advanced-analysis-compat-getter-final-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-advanced-analysis-compat-getter-final-retirement-implementation"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow service lifecycle DI cleanup authorized by PR #243; route paths, OpenAPI behavior, product surface, frontend, and runtime process state are unchanged"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.json"
+    - "docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-244.yaml"
+    - "web/backend/app/services/advanced_analysis_service.py"
+    - "web/backend/tests/test_advanced_analysis_service_lifecycle_di.py"
+  forbidden_paths:
+    - "web/backend/app/api/**"
+    - "web/backend/app/services/data_adapters/**"
+    - "web/backend/app/services/adapters/**"
+    - "web/backend/app/services/data_source_factory.py"
+    - "web/backend/app/services/tdx_service.py"
+    - "web/backend/app/services/stock_search_service/**"
+    - "web/backend/app/services/strategy_service.py"
+    - "web/backend/app/services/market_data_service*.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit route/API files or OpenAPI exposure"
+  - "Do not edit frontend or generated clients"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not remove _get_or_create_advanced_analysis_service, get_advanced_analysis_service_dependency, install_advanced_analysis_service, or ADVANCED_ANALYSIS_SERVICE_STATE_KEY"
+
+acceptance:
+  checks:
+    - id: "tdd-red-evidence"
+      command: "Recorded in docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.md"
+      required: true
+    - id: "focused-lifecycle-pytest"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/advanced_analysis_service.py web/backend/tests/test_advanced_analysis_service_lifecycle_di.py"
+      required: true
+    - id: "black-check-touched"
+      command: "black --check web/backend/app/services/advanced_analysis_service.py web/backend/tests/test_advanced_analysis_service_lifecycle_di.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-244.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-244.yaml"
+      required: true
+    - id: "staged-gitnexus"
+      command: "gitnexus_detect_changes(scope=staged)"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If route/API files are edited in the same PR, the implementation exceeds the G2.90 authorization boundary"
+    - "If dependency provider or private initializer is removed, AdvancedAnalysis routes may lose their service path"
+  rollback_plan: "revert this PR; restore public get_advanced_analysis_service wrapper and prior focused lifecycle tests as one unit"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "retire the final AdvancedAnalysis public compatibility getter after G2.90 authorization"
+    modified_scope: "advanced_analysis_service.py, focused lifecycle test, steward tree, implementation report, generated artifact, and this task card"
+    dependency_changes: "public wrapper removed; dependency provider continues to use the private initializer"
+    legacy_logic_impact: "route/API dependencies remain on get_advanced_analysis_service_dependency; no route/OpenAPI exposure changes"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, health route conflicts, ruff, black check, OpenAPI smoke, mainline scope, staged GitNexus, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T18:03:29+08:00"
+    approval_note: "G2.90 authorization PR #243 was merged; this implementation stays inside its source/test boundary"
+    secondary_approved: false

--- a/web/backend/app/services/advanced_analysis_service.py
+++ b/web/backend/app/services/advanced_analysis_service.py
@@ -494,11 +494,6 @@ async def _get_or_create_advanced_analysis_service() -> AdvancedAnalysisService:
     return advanced_analysis_service
 
 
-async def get_advanced_analysis_service() -> AdvancedAnalysisService:
-    """获取高级分析服务实例（依赖注入用）"""
-    return await _get_or_create_advanced_analysis_service()
-
-
 async def get_advanced_analysis_service_dependency(request: Request) -> AdvancedAnalysisService:
     """FastAPI dependency provider backed by app.state."""
     service = getattr(request.app.state, ADVANCED_ANALYSIS_SERVICE_STATE_KEY, None)

--- a/web/backend/tests/test_advanced_analysis_service_lifecycle_di.py
+++ b/web/backend/tests/test_advanced_analysis_service_lifecycle_di.py
@@ -9,6 +9,10 @@ from app.api import advanced_analysis_api as advanced_analysis_routes
 from app.services import advanced_analysis_service as advanced_analysis_service_module
 
 
+def test_public_advanced_analysis_service_getter_is_retired():
+    assert not hasattr(advanced_analysis_service_module, "get_advanced_analysis_service")
+
+
 @pytest.mark.asyncio
 async def test_advanced_analysis_service_dependency_fallback_uses_private_initializer(monkeypatch):
     class FakeAdvancedAnalysisService:
@@ -21,15 +25,7 @@ async def test_advanced_analysis_service_dependency_fallback_uses_private_initia
     fake_app = SimpleNamespace(state=SimpleNamespace())
     request = SimpleNamespace(app=fake_app)
 
-    async def fail_if_public_getter_called():
-        raise AssertionError("provider fallback must not call the public compatibility getter")
-
     monkeypatch.setattr(advanced_analysis_service_module, "advanced_analysis_service", fake_service)
-    monkeypatch.setattr(
-        advanced_analysis_service_module,
-        "get_advanced_analysis_service",
-        fail_if_public_getter_called,
-    )
 
     result = await advanced_analysis_service_module.get_advanced_analysis_service_dependency(request)
 
@@ -50,7 +46,7 @@ async def test_advanced_analysis_service_dependency_prefers_installed_app_state(
 
     monkeypatch.setattr(
         advanced_analysis_service_module,
-        "get_advanced_analysis_service",
+        "_get_or_create_advanced_analysis_service",
         fail_if_fallback_called,
     )
 


### PR DESCRIPTION
## Summary

Implements G2.91 after the accepted G2.90 authorization in PR #243.

- Deletes public `get_advanced_analysis_service()`.
- Keeps `_get_or_create_advanced_analysis_service()` and `get_advanced_analysis_service_dependency()`.
- Keeps `install_advanced_analysis_service()` and `ADVANCED_ANALYSIS_SERVICE_STATE_KEY`.
- Updates focused lifecycle tests so they no longer monkeypatch the removed public getter.
- Updates the steward tree, implementation report, generated artifact, and PR task card.

## Boundary

No route/API files, OpenAPI exposure, frontend, PM2/runtime, OpenSpec changes, or issue labels are changed.

## Evidence

- TDD red: `test_public_advanced_analysis_service_getter_is_retired` failed before implementation because the public getter still existed.
- Focused lifecycle tests: `5 passed in 3.78s`.
- `test_health_route_conflicts.py`: `120 passed in 76.54s`.
- Ruff touched backend files: passed.
- Black check touched backend files: passed.
- OpenAPI smoke: routes `548`, paths `500`, operation IDs `536`, duplicate operation IDs `0`, warnings `0`.
- Pre-edit GitNexus impact: LOW, impacted symbols `0`, affected processes `0`.
- Staged GitNexus detect: LOW, affected processes `0`.
- Post-commit mainline gate: pass.
- Post-commit GitNexus analyze: indexed successfully.

## Post-change Scan

- Exact public getter call hits: `0`.
- Route/API public getter call hits: `0`.
- Package export hits: `0`.
- Private initializer hits: `2`.
- Dependency provider refs: `19`.
- Remaining public getter text is only the focused absence assertion string.

## Files

- `web/backend/app/services/advanced_analysis_service.py`
- `web/backend/tests/test_advanced_analysis_service_lifecycle_di.py`
- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
- `.planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.json`
- `docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.md`
- `governance/mainline/task-cards/pr-244.yaml`
