### PR TITLE
docs(governance): close out advanced analysis getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1455,9 +1455,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                exposure, frontend, PM2, OpenSpec, public getter deletion,
 │   │                or issue-label change is made here
 │   ├── G2.91 AdvancedAnalysis public compatibility getter final-retirement implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#244` merged at
+│   │   │          `1ebd0aeaf3f21fbaefd570955ca89b571207c18a`
 │   │   ├── Evidence: `backend-advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.md`
-│   │   ├── Current HEAD: `db5ebd408f0d89c012e8c3e0ea23361e7836a53f`
+│   │   ├── Current HEAD: `1ebd0aeaf3f21fbaefd570955ca89b571207c18a`
 │   │   ├── Result: removes public `get_advanced_analysis_service()`, keeps
 │   │   │          `_get_or_create_advanced_analysis_service()` and
 │   │   │          `get_advanced_analysis_service_dependency()`, updates focused
@@ -1471,8 +1472,23 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                task card, and steward-tree update; no route/API, OpenAPI
 │   │                exposure, frontend, PM2, OpenSpec, or issue-label change is
 │   │                made here
-│   └── Next gate: Human review / PR merge decision for G2.91 implementation; if
-│                  accepted, prepare final closeout / next-candidate refresh
+│   ├── G2.92 AdvancedAnalysis public compatibility getter final-retirement closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.md`
+│   │   ├── Current HEAD: `1ebd0aeaf3f21fbaefd570955ca89b571207c18a`
+│   │   ├── Result: records PR `#244` merge and closes the AdvancedAnalysis
+│   │   │          public compatibility getter lane; current-head evidence shows
+│   │   │          exact public getter symbol mentions are test assertion only,
+│   │   │          route/API public mentions=`0`, package export mentions=`0`,
+│   │   │          private initializer hits=`2`, dependency-provider refs=`19`,
+│   │   │          lifecycle tests `5 passed`, health route conflicts
+│   │   │          `120 passed`, and OpenAPI remains paths=`500` with duplicate
+│   │   │          operation IDs=`0`
+│   │   └── Boundary: closeout-only; no source, test, route/API, OpenAPI
+│   │                exposure, frontend, PM2, OpenSpec, getter deletion, or
+│   │                issue-label change is made here
+│   └── Next gate: run a fresh service lifecycle candidate refresh before
+│                  selecting another getter-retirement lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.json
+++ b/.planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.json
@@ -1,0 +1,46 @@
+{
+  "workline": "G2.92 AdvancedAnalysis public compatibility getter final-retirement closeout",
+  "status": "ready_for_review",
+  "prepared_at": "2026-05-25T18:15:12+08:00",
+  "worktree": ".worktrees/g2-92-advanced-analysis-compat-getter-final-retirement-closeout",
+  "branch": "g2-92-advanced-analysis-compat-getter-final-retirement-closeout",
+  "current_head": "1ebd0aeaf3f21fbaefd570955ca89b571207c18a",
+  "parent_implementation_pr": {
+    "number": 244,
+    "state": "MERGED",
+    "merge_commit": "1ebd0aeaf3f21fbaefd570955ca89b571207c18a",
+    "merged_at": "2026-05-25T10:10:32Z"
+  },
+  "reference_matrix": {
+    "exact_public_symbol_mentions": 1,
+    "remaining_public_symbol_scope": "focused absence assertion string only",
+    "route_public_mentions": 0,
+    "package_export_mentions": 0,
+    "private_initializer_hits": 2,
+    "dependency_provider_refs": 19
+  },
+  "verification": {
+    "focused_lifecycle_tests": "5 passed in 4.79s",
+    "health_route_conflicts": "120 passed in 77.16s",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0,
+      "warnings": 0
+    }
+  },
+  "decision": {
+    "advanced_analysis_public_getter_lane": "closed_pending_review",
+    "next_gate": "fresh service lifecycle candidate refresh",
+    "source_changes_in_this_packet": false
+  },
+  "boundaries": [
+    "No source or test edits",
+    "No route/API edits",
+    "No OpenAPI exposure change",
+    "No frontend or generated client edits",
+    "No OpenSpec changes",
+    "No GitHub issue label changes"
+  ]
+}

--- a/docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.md
+++ b/docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.md
@@ -1,0 +1,90 @@
+# Backend AdvancedAnalysis Compatibility Getter Final Retirement Closeout - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.92 AdvancedAnalysis public compatibility getter final-retirement
+closeout
+
+Status: ready for review
+
+## Purpose
+
+Record the accepted G2.91 implementation and close the AdvancedAnalysis public
+compatibility getter lane.
+
+This packet is closeout-only. It does not edit source, tests, routes, OpenAPI
+exposure, frontend clients, OpenSpec changes, PM2/runtime state, or GitHub issue
+labels.
+
+## Current Head
+
+| Field | Value |
+|---|---|
+| Worktree | `.worktrees/g2-92-advanced-analysis-compat-getter-final-retirement-closeout` |
+| Branch | `g2-92-advanced-analysis-compat-getter-final-retirement-closeout` |
+| Current HEAD | `1ebd0aeaf3f21fbaefd570955ca89b571207c18a` |
+| Parent PR | `#244` |
+| Parent PR state | `MERGED` |
+| Parent merge commit | `1ebd0aeaf3f21fbaefd570955ca89b571207c18a` |
+
+## Reference Matrix
+
+Current-head scan:
+
+| Metric | Value |
+|---|---:|
+| Exact public symbol mentions | 1 |
+| Remaining public symbol scope | focused absence assertion string only |
+| Route/API public mentions | 0 |
+| Package export mentions | 0 |
+| Private initializer hits | 2 |
+| Dependency-provider refs | 19 |
+
+Interpretation:
+
+- G2.91 retired the public `get_advanced_analysis_service()` compatibility
+  getter.
+- Route/API continues to use `get_advanced_analysis_service_dependency()`.
+- The lane should not proceed directly into another service without a fresh
+  service lifecycle candidate refresh.
+
+## Verification
+
+| Gate | Result |
+|---|---|
+| Focused lifecycle tests | `5 passed in 4.79s` |
+| `test_health_route_conflicts.py` | `120 passed in 77.16s` |
+| OpenAPI smoke | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`, warnings=`0` |
+
+OpenAPI smoke loaded the root `.env` and imported `app.main`.
+
+## Decision
+
+AdvancedAnalysis public compatibility getter final retirement is ready to close
+once this packet is accepted.
+
+Next gate:
+
+`Fresh service lifecycle candidate refresh`
+
+Do not directly start another getter-retirement source branch from stale
+candidate data.
+
+## Boundary
+
+Out of scope here:
+
+- source or test edits;
+- route/API edits;
+- OpenAPI exposure changes;
+- frontend or generated client edits;
+- PM2/runtime execution;
+- OpenSpec changes/spec updates;
+- GitHub issue label changes.
+
+## Rollback
+
+Revert this governance-only packet. Reverting it does not revert PR `#244`; it
+only restores the steward tree to the G2.91 implementation review state.

--- a/governance/mainline/task-cards/pr-245.yaml
+++ b/governance/mainline/task-cards/pr-245.yaml
@@ -1,0 +1,112 @@
+version: "v0.2"
+
+task:
+  id: "pr-245"
+  title: "Close out AdvancedAnalysis getter final retirement"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-advanced-analysis-compat-getter-final-retirement-closeout"
+  objective: "record G2.91 merge evidence and close the AdvancedAnalysis public getter retirement lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-advanced-analysis-compat-getter-final-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-advanced-analysis-compat-getter-final-retirement-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.json"
+    - "docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-245.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not change routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not select another service getter implementation lane from stale candidate data"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 244 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "focused-lifecycle-pytest"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_advanced_analysis_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-245.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-245.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet is treated as source authorization, another service getter lane could start from stale data"
+    - "If parent PR evidence is stale, the steward tree could falsely close the AdvancedAnalysis lane"
+  rollback_plan: "revert this governance-only closeout PR and keep G2.91 as the latest accepted implementation evidence"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out AdvancedAnalysis public compatibility getter final retirement"
+    modified_scope: "steward tree, closeout report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source retirement already landed in PR #244"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this closeout PR if parent PR evidence, reference matrix, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T18:15:12+08:00"
+    approval_note: "G2.91 implementation PR #244 was merged; this packet records closeout and requires a fresh candidate refresh before the next getter lane"
+    secondary_approved: false


### PR DESCRIPTION
## Summary

Closes out the AdvancedAnalysis public compatibility getter final-retirement lane after PR #244 was merged.

- Marks G2.91 accepted in the steward tree.
- Records current HEAD `1ebd0aeaf3f21fbaefd570955ca89b571207c18a`.
- Confirms remaining public getter text is the focused absence assertion only.
- Confirms route/API public mentions `0`, package export mentions `0`, private initializer hits `2`, dependency-provider refs `19`.
- Sets the next gate to a fresh service lifecycle candidate refresh before selecting another getter-retirement lane.

## Boundary

Governance-only closeout. No backend source/test edits, route/API edits, OpenAPI exposure changes, frontend changes, OpenSpec changes, PM2/runtime changes, issue label changes, or new implementation authorization.

## Evidence

- Parent PR #244: MERGED, merge commit `1ebd0aeaf3f21fbaefd570955ca89b571207c18a`.
- Focused lifecycle tests: `5 passed in 4.79s`.
- `test_health_route_conflicts.py`: `120 passed in 77.16s`.
- OpenAPI smoke: routes `548`, paths `500`, operation IDs `536`, duplicate operation IDs `0`, warnings `0`.
- Markdown governance: errors `0`.
- JSON/YAML parse: passed.
- Post-commit mainline gate: pass.

## Files

- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
- `.planning/codebase/generated/advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.json`
- `docs/reports/quality/backend-advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.md`
- `governance/mainline/task-cards/pr-245.yaml`
