### PR TITLE
docs(governance): refresh service lifecycle candidates

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1473,9 +1473,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                exposure, frontend, PM2, OpenSpec, or issue-label change is
 │   │                made here
 │   ├── G2.92 AdvancedAnalysis public compatibility getter final-retirement closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#245` merged at
+│   │   │          `0d98e77257372ba9a92dfda40b2c42343b89e92f`
 │   │   ├── Evidence: `backend-advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.md`
-│   │   ├── Current HEAD: `1ebd0aeaf3f21fbaefd570955ca89b571207c18a`
+│   │   ├── Current HEAD: `0d98e77257372ba9a92dfda40b2c42343b89e92f`
 │   │   ├── Result: records PR `#244` merge and closes the AdvancedAnalysis
 │   │   │          public compatibility getter lane; current-head evidence shows
 │   │   │          exact public getter symbol mentions are test assertion only,
@@ -1487,8 +1488,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: closeout-only; no source, test, route/API, OpenAPI
 │   │                exposure, frontend, PM2, OpenSpec, getter deletion, or
 │   │                issue-label change is made here
-│   └── Next gate: run a fresh service lifecycle candidate refresh before
-│                  selecting another getter-retirement lane
+│   ├── G2.93 Service lifecycle candidate refresh after AdvancedAnalysis
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.md`
+│   │   ├── Current HEAD: `0d98e77257372ba9a92dfda40b2c42343b89e92f`
+│   │   ├── Result: records PR `#245` merge, refreshes service getter
+│   │   │          candidates at current HEAD, scans `152` service files,
+│   │   │          `575` app files, and `219` API files, finds `23` getter
+│   │   │          definitions under this packet's scanner, and selects
+│   │   │          `get_wencai_service` as the next future authorization
+│   │   │          candidate only; its current references are definition-only
+│   │   │          in app code with route/API hits=`0`, test hits=`0`,
+│   │   │          package export hits=`0`, and GitNexus impact LOW / `0`
+│   │   └── Boundary: candidate-refresh only; no source, test, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter
+│   │                deletion, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.93; if accepted,
+│                  create G2.94 Wencai getter-retirement authorization
+│                  packet before any source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1561,6 +1578,13 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-data-source-factory-compat-getter-final-retirement-closeout-2026-05-25.md` | G | G2.85 closeout accepted in PR `#238` at `ed033a4`: records PR `#237` merge, confirms production exact public getter hits=`0`, package export lines=`0`, route/API public getter hits=`0`, lifecycle tests `5 passed`, health route conflicts `120 passed`, touched-path ruff passed, and OpenAPI paths=`500` with duplicate operation IDs=`0` | DataSourceFactory public compatibility getter retirement lane closed; next service lifecycle lane must start from a separate authorization packet |
 | `backend-service-lifecycle-di-next-lane-after-data-source-factory-2026-05-25.md` | G | G2.86 next-lane decision prepared at `ed033a4`: selects `AdvancedAnalysisService` compatibility getter Phase 1 service-internal decoupling as the next authorization candidate only; exact production getter hits are definition plus provider fallback only, route/API direct hits=`0`, GitNexus impact LOW / `0`, lifecycle tests `4 passed`, health route conflicts `120 passed`, OpenAPI paths=`500`, duplicate operation IDs=`0`; broad `get_data_service` and `get_strategy_service` seams remain CRITICAL holds, and StockSearch compatibility cleanup remains blocked by prior retain decision plus stale-aware GitNexus route-process noise | Human review / PR merge decision; if accepted, create G2.87 source-capable authorization before any AdvancedAnalysis source edit |
 | `backend-advanced-analysis-compat-getter-phase1-authorization-2026-05-25.md` | G | G2.87 authorization packet prepared at `a20c92e`: authorizes only a future G2.88 Phase 1 service-internal decoupling for `AdvancedAnalysisService`; allowed future source scope is `advanced_analysis_service.py` plus focused lifecycle tests, public `get_advanced_analysis_service()` must remain, dependency provider and installer must remain, route/API direct getter hits remain `0`, GitNexus impact LOW / `0`, lifecycle tests `4 passed`, health route conflicts `120 passed`, and OpenAPI paths=`500`, duplicate operation IDs=`0` | Human review / PR merge decision; if accepted, create G2.88 implementation branch before any AdvancedAnalysis source edit |
+
+| `backend-advanced-analysis-compat-getter-phase1-implementation-2026-05-25.md` | G | G2.88 implementation accepted in PR `#241` at `33c3d34`: private `_get_or_create_advanced_analysis_service()` added, dependency fallback retargeted away from the public getter, public getter retained, lifecycle tests `4 passed`, health route conflicts `120 passed`, and OpenAPI duplicate operation IDs=`0` | Superseded by G2.89 closeout / candidate refresh |
+| `backend-advanced-analysis-compat-getter-phase1-closeout-2026-05-25.md` | G | G2.89 closeout accepted in PR `#242` at `7b6d81a`: records PR `#241` merge, confirms route/API public getter hits=`0`, package export hits=`0`, private initializer hits=`3`, dependency-provider refs=`19`, lifecycle tests `4 passed`, health route conflicts `120 passed`, and OpenAPI duplicate operation IDs=`0` | Superseded by G2.90 final-retirement authorization |
+| `backend-advanced-analysis-compat-getter-final-retirement-authorization-2026-05-25.md` | G | G2.90 authorization accepted in PR `#243` at `db5ebd4`: authorizes only future G2.91 removal of public `get_advanced_analysis_service()` after TDD red/green, with private initializer, dependency provider, installer, app.state key, route/API, OpenAPI, frontend, PM2, and issue labels locked outside scope | Superseded by G2.91 implementation |
+| `backend-advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.md` | G | G2.91 implementation accepted in PR `#244` at `1ebd0ae`: public `get_advanced_analysis_service()` removed, dependency provider and installer retained, focused lifecycle tests updated to `5 passed`, health route conflicts `120 passed`, and OpenAPI duplicate operation IDs=`0` | Superseded by G2.92 closeout |
+| `backend-advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.md` | G | G2.92 closeout accepted in PR `#245` at `0d98e77`: records PR `#244` merge, confirms the AdvancedAnalysis public getter lane is closed, route/API public mentions=`0`, package export mentions=`0`, private initializer hits=`2`, dependency-provider refs=`19`, lifecycle tests `5 passed`, health route conflicts `120 passed`, and OpenAPI duplicate operation IDs=`0` | Superseded by G2.93 service lifecycle candidate refresh |
+| `backend-service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.md` | G | G2.93 candidate refresh prepared at `0d98e77`: records PR `#245` merge, scans `152` service files / `575` app files / `219` API files, finds `23` getter definitions in this packet's scanner, selects `get_wencai_service` as a future G2.94 authorization candidate only, and records GitNexus impact LOW / `0` | Human review / PR merge decision; if accepted, create G2.94 Wencai getter-retirement authorization before any source edit |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.json
+++ b/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.json
@@ -1,0 +1,115 @@
+{
+  "artifact": "service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T19:15:45+08:00",
+  "branch": "g2-93-service-lifecycle-candidate-refresh-after-advanced-analysis",
+  "current_head": "0d98e77257372ba9a92dfda40b2c42343b89e92f",
+  "parent_pr": {
+    "number": 245,
+    "state": "MERGED",
+    "merge_commit": "0d98e77257372ba9a92dfda40b2c42343b89e92f",
+    "url": "https://github.com/chengjon/mystocks/pull/245"
+  },
+  "scan_summary": {
+    "service_files": 152,
+    "app_files": 575,
+    "api_files": 219,
+    "getter_definitions": 23,
+    "candidate_like_definitions": 6,
+    "hold_definitions": 17,
+    "scanner_note": "This packet includes service package exporter definitions in the getter-definition count; earlier narrower summaries may count fewer definitions."
+  },
+  "candidate_rows": [
+    {
+      "symbol": "get_wencai_service",
+      "file": "web/backend/app/services/wencai_service.py",
+      "line": 419,
+      "app_refs": 1,
+      "route_api_refs": 0,
+      "test_refs": 0,
+      "package_export_refs": 0,
+      "disposition": "select_future_authorization_candidate_only"
+    },
+    {
+      "symbol": "get_enhanced_data_service",
+      "file": "web/backend/app/services/data_service_enhanced.py",
+      "line": 580,
+      "app_refs": 2,
+      "route_api_refs": 0,
+      "test_refs": 0,
+      "package_export_refs": 0,
+      "disposition": "hold_for_separate_enhanced_data_ownership_review"
+    },
+    {
+      "symbol": "get_announcement_service",
+      "file": "web/backend/app/services/announcement_service.py",
+      "line": 526,
+      "app_refs": 2,
+      "route_api_refs": 0,
+      "test_refs": 1,
+      "package_export_refs": 0,
+      "disposition": "hold_completed_announcement_di_lane_not_reopened_here"
+    },
+    {
+      "symbol": "get_tradingview_service",
+      "file": "web/backend/app/services/tradingview_widget_service.py",
+      "line": 322,
+      "app_refs": 2,
+      "route_api_refs": 0,
+      "test_refs": 2,
+      "package_export_refs": 0,
+      "disposition": "hold_for_dedicated_tradingview_follow_up_if_needed"
+    },
+    {
+      "symbol": "get_email_service",
+      "file": "web/backend/app/services/email_notification_service.py",
+      "line": 324,
+      "app_refs": 3,
+      "route_api_refs": 0,
+      "test_refs": 3,
+      "package_export_refs": 0,
+      "disposition": "hold_duplicate_logical_getter_name_prior_email_lane_requires_separate_decision"
+    },
+    {
+      "symbol": "get_email_service",
+      "file": "web/backend/app/services/email_service.py",
+      "line": 325,
+      "app_refs": 3,
+      "route_api_refs": 0,
+      "test_refs": 3,
+      "package_export_refs": 0,
+      "disposition": "hold_duplicate_logical_getter_name_prior_email_lane_requires_separate_decision"
+    }
+  ],
+  "selected_next_lane": {
+    "workline": "G2.94",
+    "candidate": "WencaiService",
+    "symbol": "get_wencai_service",
+    "decision": "prepare a future Wencai getter-retirement authorization packet only",
+    "source_edit_authorized_by_this_packet": false,
+    "service_deletion_authorized": false,
+    "future_authorization_required": true
+  },
+  "gitnexus": {
+    "index_refresh": "gitnexus analyze --with-gitignore completed before packet creation",
+    "selected_symbol_impact": {
+      "target": "get_wencai_service",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct_callers": 0,
+      "affected_processes": 0,
+      "affected_modules": 0
+    }
+  },
+  "boundary": {
+    "governance_only": true,
+    "backend_source_edits": false,
+    "backend_test_edits": false,
+    "route_api_changes": false,
+    "openapi_exposure_changes": false,
+    "pm2_execution": false,
+    "openspec_changes": false,
+    "github_issue_label_changes": false
+  },
+  "next_gate": "human review / PR merge decision for G2.93; if accepted, create G2.94 Wencai getter-retirement authorization packet before source edits"
+}

--- a/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.md
+++ b/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.md
@@ -1,0 +1,116 @@
+# Backend Service Lifecycle Candidate Refresh After AdvancedAnalysis - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.93 service lifecycle candidate refresh after AdvancedAnalysis
+Status: ready for review
+
+## Purpose
+
+Refresh the service lifecycle getter-retirement candidate list after the
+AdvancedAnalysis public compatibility getter lane closed in PR `#245`.
+
+This packet is governance-only. It records current evidence, updates the
+steward tree, and selects a future authorization candidate. It does not
+authorize backend source edits, tests edits, route/API changes, OpenAPI exposure
+changes, PM2 execution, OpenSpec changes, GitHub issue label movement, or getter
+deletion.
+
+## Input State
+
+| Field | Value |
+|---|---|
+| Worktree | `.worktrees/g2-93-service-lifecycle-candidate-refresh-after-advanced-analysis` |
+| Branch | `g2-93-service-lifecycle-candidate-refresh-after-advanced-analysis` |
+| Current HEAD | `0d98e77257372ba9a92dfda40b2c42343b89e92f` |
+| HEAD subject | `docs(governance): close out advanced analysis getter retirement (#245)` |
+| Parent PR | `#245`, `MERGED`, merge commit `0d98e77257372ba9a92dfda40b2c42343b89e92f` |
+| Parent PR URL | `https://github.com/chengjon/mystocks/pull/245` |
+| GitNexus refresh | `gitnexus analyze --with-gitignore` completed before this packet |
+
+## Current-Head Scan Summary
+
+| Metric | Value | Notes |
+|---|---:|---|
+| Service files scanned | `152` | `web/backend/app/services/**/*.py` |
+| App files scanned | `575` | `web/backend/app/**/*.py` |
+| API files scanned | `219` | `web/backend/app/api/**/*.py` |
+| Getter definitions found | `23` | This packet includes service package exporter definitions in the scan. Earlier narrower summaries counted fewer definitions. |
+| Candidate-like definitions | `6` | Route/API hits=`0`, package export hits=`0`, and low app-reference count. |
+| Hold definitions | `17` | Exported package seams, active route consumers, or broad service seams. |
+
+## Candidate Rows
+
+| Candidate | File | App refs | Route/API refs | Test refs | Package export refs | Disposition |
+|---|---|---:|---:|---:|---:|---|
+| `get_wencai_service` | `web/backend/app/services/wencai_service.py:419` | `1` | `0` | `0` | `0` | Select as future G2.94 authorization candidate only |
+| `get_enhanced_data_service` | `web/backend/app/services/data_service_enhanced.py:580` | `2` | `0` | `0` | `0` | Hold; enhanced data seam needs its own ownership review before selection |
+| `get_announcement_service` | `web/backend/app/services/announcement_service.py:526` | `2` | `0` | `1` | `0` | Hold; announcement route DI lane is already closed, so avoid reopening from a generic refresh |
+| `get_tradingview_service` | `web/backend/app/services/tradingview_widget_service.py:322` | `2` | `0` | `2` | `0` | Hold; keep behind a dedicated TradingView follow-up if needed |
+| `get_email_service` | `web/backend/app/services/email_notification_service.py:324` | `3` | `0` | `3` | `0` | Hold; duplicate logical getter name and prior email DI lane require a separate decision |
+| `get_email_service` | `web/backend/app/services/email_service.py:325` | `3` | `0` | `3` | `0` | Hold; duplicate logical getter name and prior email DI lane require a separate decision |
+
+## Selected Next Lane
+
+Select `get_wencai_service` as the next future authorization candidate.
+
+Rationale:
+
+- Its app-code references are definition-only in the service module.
+- It has `0` route/API references.
+- It has `0` focused test references.
+- It has `0` `web/backend/app/services/__init__.py` package export references.
+- GitNexus upstream impact for `get_wencai_service` is LOW with impacted count
+  `0`, direct callers `0`, affected processes `0`, and affected modules `0`.
+
+Boundary:
+
+- This selection does not authorize deleting `WencaiService`.
+- `WencaiService` remains active through direct class usage in
+  `web/backend/app/api/wencai.py`, `web/backend/app/tasks/wencai_tasks.py`, and
+  `src/database/services/database_service.py`.
+- A future G2.94 packet must be authorization-only first. Any later source-capable
+  branch must rerun GitNexus impact, prove TDD red/green, and define exact source
+  and test scope before modifying `web/backend/app/services/wencai_service.py`.
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| Parent PR state | `#245` is `MERGED`, merge commit `0d98e77257372ba9a92dfda40b2c42343b89e92f` |
+| GitNexus index | Refreshed with `gitnexus analyze --with-gitignore`; graph contains `62,748` nodes, `145,892` edges, `3,295` clusters, and `300` flows |
+| Getter candidate scan | `152` service files, `575` app files, `219` API files, `23` getter definitions, `6` candidate-like definitions, `17` holds |
+| Selected candidate impact | `get_wencai_service`: LOW, impacted count `0`, direct callers `0`, affected processes `0`, affected modules `0` |
+
+## Non-Goals
+
+- Do not edit backend source or tests.
+- Do not delete `get_wencai_service` in this packet.
+- Do not delete or migrate `WencaiService`.
+- Do not change routes, response models, response shapes, or OpenAPI exposure.
+- Do not create or modify OpenSpec changes/specs.
+- Do not change GitHub issue labels or readiness state.
+- Do not reopen completed email, announcement, DataSourceFactory, StockSearch, or
+  AdvancedAnalysis getter lanes from this packet.
+
+## Boundary
+
+Out of scope here:
+
+- source or test edits;
+- route/API edits;
+- OpenAPI exposure changes;
+- frontend or generated client edits;
+- PM2/runtime execution;
+- OpenSpec changes/spec updates;
+- GitHub issue label changes.
+
+## Next Gate
+
+Human review / PR merge decision for this G2.93 governance packet.
+
+If accepted, create G2.94 as a Wencai getter-retirement authorization packet
+before any source edit. G2.94 should remain authorization-only unless it is
+explicitly superseded by a separately approved implementation branch.

--- a/governance/mainline/task-cards/pr-246.yaml
+++ b/governance/mainline/task-cards/pr-246.yaml
@@ -1,0 +1,107 @@
+version: "v0.2"
+
+task:
+  id: "pr-246"
+  title: "Refresh service lifecycle candidates after AdvancedAnalysis"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-service-lifecycle-candidate-refresh-after-advanced-analysis"
+  objective: "record G2.92 merge evidence and select the next service getter authorization candidate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-candidate-refresh"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-candidate-refresh-after-advanced-analysis"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate-refresh packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.json"
+    - "docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-246.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not delete get_wencai_service in this packet"
+  - "Do not delete or migrate WencaiService"
+  - "Do not change routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 245 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-246.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-246.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet is treated as source authorization, get_wencai_service could be deleted without the required G2.94 gate"
+    - "If current-head scan data is stale, the next getter-retirement lane could be selected from an outdated surface"
+  rollback_plan: "revert this governance-only PR and keep G2.92 as the latest accepted service lifecycle closeout evidence"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh service lifecycle candidates after AdvancedAnalysis getter retirement"
+    modified_scope: "steward tree, candidate-refresh report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; get_wencai_service is only selected for a future authorization packet"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if parent PR evidence, candidate scan, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T19:15:45+08:00"
+    approval_note: "G2.92 closeout PR #245 was merged; this packet records a fresh candidate refresh and selects only a future G2.94 Wencai authorization candidate"
+    secondary_approved: false


### PR DESCRIPTION
## Summary\n- mark G2.92 / PR #245 accepted in the steward tree\n- refresh service lifecycle getter candidates after AdvancedAnalysis public getter retirement\n- select get_wencai_service only as a future G2.94 authorization candidate\n\n## Boundary\n- governance-only packet\n- no backend source or test edits\n- no route/API, OpenAPI, PM2, OpenSpec, frontend, or issue-label changes\n\n## Verification\n- markdown governance gate: 2 checked, 0 errors\n- JSON/YAML parse: passed\n- git diff --cached --check: passed\n- post-commit mainline scope gate: pass=True\n- GitNexus impact get_wencai_service: LOW / impacted count 0