### PR TITLE
docs(governance): authorize wencai getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1489,9 +1489,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                exposure, frontend, PM2, OpenSpec, getter deletion, or
 │   │                issue-label change is made here
 │   ├── G2.93 Service lifecycle candidate refresh after AdvancedAnalysis
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#246` merged at
+│   │   │          `d8e1d14440d4db21a43b8dd50586f0deef383081`
 │   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.md`
-│   │   ├── Current HEAD: `0d98e77257372ba9a92dfda40b2c42343b89e92f`
+│   │   ├── Current HEAD: `d8e1d14440d4db21a43b8dd50586f0deef383081`
 │   │   ├── Result: records PR `#245` merge, refreshes service getter
 │   │   │          candidates at current HEAD, scans `152` service files,
 │   │   │          `575` app files, and `219` API files, finds `23` getter
@@ -1503,9 +1504,23 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: candidate-refresh only; no source, test, route/API,
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter
 │   │                deletion, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.93; if accepted,
-│                  create G2.94 Wencai getter-retirement authorization
-│                  packet before any source edit
+│   ├── G2.94 Wencai getter-retirement authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-wencai-compat-getter-retirement-authorization-2026-05-25.md`
+│   │   ├── Current HEAD: `d8e1d14440d4db21a43b8dd50586f0deef383081`
+│   │   ├── Result: authorizes only a future G2.95 implementation branch to
+│   │   │          remove `get_wencai_service` from
+│   │   │          `web/backend/app/services/wencai_service.py` after TDD
+│   │   │          red/green; current evidence shows `get_wencai_service`
+│   │   │          refs app=`1`, route/API=`0`, tests=`0`, package exports=`0`,
+│   │   │          GitNexus impact LOW / `0`, while `WencaiService` remains
+│   │   │          active through direct class usage and is not a deletion target
+│   │   └── Boundary: authorization-only; no source, test, route/API, OpenAPI
+│   │                exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                `WencaiService` deletion, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.94; if accepted,
+│                  create G2.95 Wencai getter-retirement implementation branch
+│                  before any source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1584,7 +1599,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-advanced-analysis-compat-getter-final-retirement-authorization-2026-05-25.md` | G | G2.90 authorization accepted in PR `#243` at `db5ebd4`: authorizes only future G2.91 removal of public `get_advanced_analysis_service()` after TDD red/green, with private initializer, dependency provider, installer, app.state key, route/API, OpenAPI, frontend, PM2, and issue labels locked outside scope | Superseded by G2.91 implementation |
 | `backend-advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.md` | G | G2.91 implementation accepted in PR `#244` at `1ebd0ae`: public `get_advanced_analysis_service()` removed, dependency provider and installer retained, focused lifecycle tests updated to `5 passed`, health route conflicts `120 passed`, and OpenAPI duplicate operation IDs=`0` | Superseded by G2.92 closeout |
 | `backend-advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.md` | G | G2.92 closeout accepted in PR `#245` at `0d98e77`: records PR `#244` merge, confirms the AdvancedAnalysis public getter lane is closed, route/API public mentions=`0`, package export mentions=`0`, private initializer hits=`2`, dependency-provider refs=`19`, lifecycle tests `5 passed`, health route conflicts `120 passed`, and OpenAPI duplicate operation IDs=`0` | Superseded by G2.93 service lifecycle candidate refresh |
-| `backend-service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.md` | G | G2.93 candidate refresh prepared at `0d98e77`: records PR `#245` merge, scans `152` service files / `575` app files / `219` API files, finds `23` getter definitions in this packet's scanner, selects `get_wencai_service` as a future G2.94 authorization candidate only, and records GitNexus impact LOW / `0` | Human review / PR merge decision; if accepted, create G2.94 Wencai getter-retirement authorization before any source edit |
+| `backend-service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.md` | G | G2.93 candidate refresh accepted in PR `#246` at `d8e1d14`: records PR `#245` merge, scans `152` service files / `575` app files / `219` API files, finds `23` getter definitions in this packet's scanner, selects `get_wencai_service` as a future G2.94 authorization candidate only, and records GitNexus impact LOW / `0` | Superseded by G2.94 Wencai getter-retirement authorization |
+| `backend-wencai-compat-getter-retirement-authorization-2026-05-25.md` | G | G2.94 authorization prepared at `d8e1d14`: authorizes only future G2.95 removal of `get_wencai_service` after TDD red/green; current scan shows app refs=`1`, route/API refs=`0`, test refs=`0`, package export refs=`0`; GitNexus impact LOW / `0`; `WencaiService` class usage remains active and outside deletion scope | Human review / PR merge decision; if accepted, create G2.95 implementation branch before any source edit |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/wencai-compat-getter-retirement-authorization-2026-05-25.json
+++ b/.planning/codebase/generated/wencai-compat-getter-retirement-authorization-2026-05-25.json
@@ -1,0 +1,93 @@
+{
+  "artifact": "wencai-compat-getter-retirement-authorization-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T19:36:00+08:00",
+  "branch": "g2-94-wencai-getter-retirement-authorization",
+  "current_head": "d8e1d14440d4db21a43b8dd50586f0deef383081",
+  "parent_pr": {
+    "number": 246,
+    "state": "MERGED",
+    "merge_commit": "d8e1d14440d4db21a43b8dd50586f0deef383081",
+    "url": "https://github.com/chengjon/mystocks/pull/246"
+  },
+  "target": {
+    "symbol": "get_wencai_service",
+    "file": "web/backend/app/services/wencai_service.py",
+    "line": 419,
+    "current_body_summary": "returns WencaiService(db=db)",
+    "future_action_authorized_if_accepted": "remove public compatibility getter only"
+  },
+  "current_reference_scan": {
+    "app_files": 575,
+    "api_files": 219,
+    "test_files": 1006,
+    "get_wencai_service": {
+      "app_refs": 1,
+      "route_api_refs": 0,
+      "test_refs": 0,
+      "package_export_refs": 0
+    },
+    "WencaiService": {
+      "app_refs": 20,
+      "route_api_refs": 9,
+      "test_refs": 0
+    }
+  },
+  "gitnexus": {
+    "index_refresh": "gitnexus analyze --with-gitignore completed in G2.94 worktree",
+    "nodes": 62750,
+    "edges": 145902,
+    "clusters": 3294,
+    "flows": 300,
+    "impact": {
+      "target": "get_wencai_service",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct_callers": 0,
+      "affected_processes": 0,
+      "affected_modules": 0
+    },
+    "context": {
+      "incoming": 0,
+      "outgoing": 0,
+      "processes": 0
+    }
+  },
+  "future_g2_95_authorized_scope_if_accepted": {
+    "source_paths": [
+      "web/backend/app/services/wencai_service.py"
+    ],
+    "test_paths": [
+      "web/backend/tests/test_wencai_service_getter_retirement.py"
+    ],
+    "governance_paths": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/wencai-compat-getter-retirement-implementation-2026-05-25.json",
+      "docs/reports/quality/backend-wencai-compat-getter-retirement-implementation-2026-05-25.md",
+      "governance/mainline/task-cards/pr-248.yaml"
+    ],
+    "allowed_action": "remove get_wencai_service only after TDD red/green",
+    "forbidden_actions": [
+      "delete WencaiService",
+      "change wencai routes",
+      "change wencai tasks",
+      "change database_service WencaiService usage",
+      "change OpenAPI exposure",
+      "change frontend files",
+      "change PM2 state",
+      "change OpenSpec files",
+      "change GitHub issue labels"
+    ]
+  },
+  "boundary": {
+    "authorization_only": true,
+    "backend_source_edits": false,
+    "backend_test_edits": false,
+    "route_api_changes": false,
+    "openapi_exposure_changes": false,
+    "pm2_execution": false,
+    "openspec_changes": false,
+    "github_issue_label_changes": false
+  },
+  "next_gate": "human review / PR merge decision for G2.94; if accepted, create G2.95 Wencai getter-retirement implementation branch before source edits"
+}

--- a/docs/reports/quality/backend-wencai-compat-getter-retirement-authorization-2026-05-25.md
+++ b/docs/reports/quality/backend-wencai-compat-getter-retirement-authorization-2026-05-25.md
@@ -1,0 +1,95 @@
+# Backend Wencai Compatibility Getter Retirement Authorization - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.94 Wencai getter-retirement authorization
+Status: ready for review
+
+## Purpose
+
+Authorize the exact scope for a future G2.95 implementation branch to remove the
+unused public compatibility getter `get_wencai_service`.
+
+This packet is authorization-only. It does not change backend source, tests,
+routes, OpenAPI exposure, PM2 state, OpenSpec content, frontend files, or issue
+labels.
+
+## Input State
+
+| Field | Value |
+|---|---|
+| Worktree | `.worktrees/g2-94-wencai-getter-retirement-authorization` |
+| Branch | `g2-94-wencai-getter-retirement-authorization` |
+| Current HEAD | `d8e1d14440d4db21a43b8dd50586f0deef383081` |
+| HEAD subject | `docs(governance): refresh service lifecycle candidates (#246)` |
+| Parent PR | `#246`, `MERGED`, merge commit `d8e1d14440d4db21a43b8dd50586f0deef383081` |
+| Parent evidence | `backend-service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.md` |
+| GitNexus refresh | `gitnexus analyze --with-gitignore` completed in this worktree |
+
+## Current Evidence
+
+| Signal | Value |
+|---|---:|
+| `get_wencai_service` definition line | `web/backend/app/services/wencai_service.py:419` |
+| `get_wencai_service` app refs | `1` |
+| `get_wencai_service` route/API refs | `0` |
+| `get_wencai_service` test refs | `0` |
+| `get_wencai_service` package export refs | `0` |
+| `WencaiService` app refs | `20` |
+| `WencaiService` route/API refs | `9` |
+| `WencaiService` test refs | `0` |
+| GitNexus impact | LOW / impacted count `0` |
+
+GitNexus context for `get_wencai_service` reports no incoming references, no
+outgoing references, and no participating processes. The function body only
+returns `WencaiService(db=db)`.
+
+## Authorized Future Scope
+
+If this G2.94 packet is reviewed and accepted, G2.95 may be created as a
+source-capable implementation branch with this maximum scope:
+
+| Path | Future allowed action |
+|---|---|
+| `web/backend/app/services/wencai_service.py` | Remove only `get_wencai_service`; keep `WencaiService` and existing direct class usage intact |
+| `web/backend/tests/test_wencai_service_getter_retirement.py` | Add a focused static/import regression test proving the public getter is absent while `WencaiService` remains importable |
+| `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md` | Record implementation status after the branch runs |
+| `.planning/codebase/generated/wencai-compat-getter-retirement-implementation-2026-05-25.json` | Record generated implementation evidence |
+| `docs/reports/quality/backend-wencai-compat-getter-retirement-implementation-2026-05-25.md` | Record implementation evidence |
+| `governance/mainline/task-cards/pr-248.yaml` | Record implementation task-card gate |
+
+## Required Future G2.95 Verification
+
+G2.95 must not rely on this packet's checks alone. It must rerun:
+
+- GitNexus impact for `get_wencai_service` before source edits.
+- TDD red/green:
+  - red: focused test fails while `get_wencai_service` is still present;
+  - green: focused test passes after removing the public getter.
+- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_wencai_service_getter_retirement.py -q --no-cov --tb=short`.
+- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short`.
+- `ruff check` on touched backend source/test paths.
+- `git diff --cached --check`.
+- staged GitNexus change detection before commit.
+- post-commit mainline scope gate.
+
+## Boundary
+
+Out of scope here and in the authorized future G2.95 scope:
+
+- deleting or renaming `WencaiService`;
+- changing `web/backend/app/api/wencai.py`;
+- changing `web/backend/app/tasks/wencai_tasks.py`;
+- changing `src/database/services/database_service.py`;
+- changing routes, response models, response shapes, or OpenAPI exposure;
+- changing frontend files, generated clients, PM2 state, OpenSpec files, or
+  GitHub issue labels.
+
+## Next Gate
+
+Human review / PR merge decision for this authorization packet.
+
+If accepted, create G2.95 as the Wencai getter-retirement implementation branch
+before any source edit.

--- a/governance/mainline/task-cards/pr-247.yaml
+++ b/governance/mainline/task-cards/pr-247.yaml
@@ -1,0 +1,107 @@
+version: "v0.2"
+
+task:
+  id: "pr-247"
+  title: "Authorize Wencai getter retirement"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-wencai-compat-getter-retirement-authorization"
+  objective: "authorize exact future scope for retiring get_wencai_service"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-wencai-compat-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-wencai-compat-getter-retirement-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/wencai-compat-getter-retirement-authorization-2026-05-25.json"
+    - "docs/reports/quality/backend-wencai-compat-getter-retirement-authorization-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-247.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not delete get_wencai_service in this packet"
+  - "Do not delete or migrate WencaiService"
+  - "Do not change routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 246 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-wencai-compat-getter-retirement-authorization-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/wencai-compat-getter-retirement-authorization-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-247.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-247.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this authorization is misread as implementation permission, source could be edited without the required G2.95 TDD branch"
+    - "If WencaiService class usage is confused with get_wencai_service usage, an active service class could be over-scoped"
+  rollback_plan: "revert this governance-only authorization PR and keep G2.93 as the latest accepted candidate-refresh evidence"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize exact future retirement scope for get_wencai_service"
+    modified_scope: "steward tree, authorization report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source retirement is only authorized for a future branch"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this authorization PR if parent PR evidence, Wencai reference scan, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T19:36:00+08:00"
+    approval_note: "G2.93 candidate refresh PR #246 was merged; this packet authorizes only a future G2.95 Wencai getter-retirement implementation scope"
+    secondary_approved: false


### PR DESCRIPTION
## Summary\n- mark G2.93 / PR #246 accepted in the steward tree\n- authorize only future G2.95 removal of get_wencai_service\n- keep WencaiService, routes, tasks, database service usage, OpenAPI, PM2, OpenSpec, frontend, and issue labels out of scope\n\n## Evidence\n- get_wencai_service refs: app=1, route/API=0, tests=0, package exports=0\n- WencaiService remains active: app refs=20, route/API refs=9\n- GitNexus impact get_wencai_service: LOW / impacted count 0\n\n## Verification\n- markdown governance gate: 2 checked, 0 errors\n- JSON/YAML parse: passed\n- git diff --cached --check: passed\n- post-commit mainline scope gate: pass=True