### PR TITLE
refactor(backend): retire wencai service getter

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1505,9 +1505,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter
 │   │                deletion, or issue-label change is made here
 │   ├── G2.94 Wencai getter-retirement authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#247` merged at
+│   │   │          `228a94d3ac0d77d421379ea37a4a328bd6975389`
 │   │   ├── Evidence: `backend-wencai-compat-getter-retirement-authorization-2026-05-25.md`
-│   │   ├── Current HEAD: `d8e1d14440d4db21a43b8dd50586f0deef383081`
+│   │   ├── Current HEAD: `228a94d3ac0d77d421379ea37a4a328bd6975389`
 │   │   ├── Result: authorizes only a future G2.95 implementation branch to
 │   │   │          remove `get_wencai_service` from
 │   │   │          `web/backend/app/services/wencai_service.py` after TDD
@@ -1518,9 +1519,28 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: authorization-only; no source, test, route/API, OpenAPI
 │   │                exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                `WencaiService` deletion, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.94; if accepted,
-│                  create G2.95 Wencai getter-retirement implementation branch
-│                  before any source edit
+│   ├── G2.95 Wencai getter-retirement implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-wencai-compat-getter-retirement-implementation-2026-05-25.md`
+│   │   ├── Current HEAD: `228a94d3ac0d77d421379ea37a4a328bd6975389`
+│   │   ├── Result: removes only `get_wencai_service` from
+│   │   │          `web/backend/app/services/wencai_service.py`, adds focused
+│   │   │          retirement regression coverage, and keeps `WencaiService`
+│   │   │          importable and active; TDD red confirmed `1 failed,
+│   │   │          1 passed`, green focused test `2 passed`, health route
+│   │   │          conflicts `120 passed`, ruff passed, black check passed,
+│   │   │          OpenAPI smoke routes=`548`, paths=`500`, duplicate
+│   │   │          operation IDs=`0`, and post-change app/API/package
+│   │   │          refs for `get_wencai_service` are `0`
+│   │   └── Boundary: source-capable but limited to `wencai_service.py`,
+│   │                `test_wencai_service_getter_retirement.py`, governance
+│   │                report, generated artifact, task card, and steward-tree
+│   │                update; no route/API, OpenAPI exposure, frontend, PM2,
+│   │                OpenSpec, `WencaiService` deletion, or issue-label change
+│   │                is made here
+│   └── Next gate: human review / PR merge decision for G2.95; if accepted,
+│                  create G2.96 Wencai getter-retirement closeout before
+│                  selecting another service lifecycle lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1600,7 +1620,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-advanced-analysis-compat-getter-final-retirement-implementation-2026-05-25.md` | G | G2.91 implementation accepted in PR `#244` at `1ebd0ae`: public `get_advanced_analysis_service()` removed, dependency provider and installer retained, focused lifecycle tests updated to `5 passed`, health route conflicts `120 passed`, and OpenAPI duplicate operation IDs=`0` | Superseded by G2.92 closeout |
 | `backend-advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.md` | G | G2.92 closeout accepted in PR `#245` at `0d98e77`: records PR `#244` merge, confirms the AdvancedAnalysis public getter lane is closed, route/API public mentions=`0`, package export mentions=`0`, private initializer hits=`2`, dependency-provider refs=`19`, lifecycle tests `5 passed`, health route conflicts `120 passed`, and OpenAPI duplicate operation IDs=`0` | Superseded by G2.93 service lifecycle candidate refresh |
 | `backend-service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.md` | G | G2.93 candidate refresh accepted in PR `#246` at `d8e1d14`: records PR `#245` merge, scans `152` service files / `575` app files / `219` API files, finds `23` getter definitions in this packet's scanner, selects `get_wencai_service` as a future G2.94 authorization candidate only, and records GitNexus impact LOW / `0` | Superseded by G2.94 Wencai getter-retirement authorization |
-| `backend-wencai-compat-getter-retirement-authorization-2026-05-25.md` | G | G2.94 authorization prepared at `d8e1d14`: authorizes only future G2.95 removal of `get_wencai_service` after TDD red/green; current scan shows app refs=`1`, route/API refs=`0`, test refs=`0`, package export refs=`0`; GitNexus impact LOW / `0`; `WencaiService` class usage remains active and outside deletion scope | Human review / PR merge decision; if accepted, create G2.95 implementation branch before any source edit |
+| `backend-wencai-compat-getter-retirement-authorization-2026-05-25.md` | G | G2.94 authorization accepted in PR `#247` at `228a94d`: authorizes only future G2.95 removal of `get_wencai_service` after TDD red/green; current scan shows app refs=`1`, route/API refs=`0`, test refs=`0`, package export refs=`0`; GitNexus impact LOW / `0`; `WencaiService` class usage remains active and outside deletion scope | Superseded by G2.95 implementation |
+| `backend-wencai-compat-getter-retirement-implementation-2026-05-25.md` | G | G2.95 implementation prepared at `228a94d`: removes only `get_wencai_service`, adds focused absence/import regression test, records TDD red `1 failed, 1 passed`, green `2 passed`, health route conflicts `120 passed`, ruff/black passed, OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0`, and post-change app/API/package getter refs=`0` | Human review / PR merge decision; if accepted, create G2.96 closeout before selecting another service lifecycle lane |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/wencai-compat-getter-retirement-implementation-2026-05-25.json
+++ b/.planning/codebase/generated/wencai-compat-getter-retirement-implementation-2026-05-25.json
@@ -1,0 +1,93 @@
+{
+  "artifact": "wencai-compat-getter-retirement-implementation-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T19:46:32+08:00",
+  "branch": "g2-95-wencai-getter-retirement-implementation",
+  "base_head": "228a94d3ac0d77d421379ea37a4a328bd6975389",
+  "parent_pr": {
+    "number": 247,
+    "state": "MERGED",
+    "merge_commit": "228a94d3ac0d77d421379ea37a4a328bd6975389",
+    "url": "https://github.com/chengjon/mystocks/pull/247"
+  },
+  "changes": {
+    "removed_symbols": [
+      {
+        "symbol": "get_wencai_service",
+        "file": "web/backend/app/services/wencai_service.py",
+        "previous_line": 419
+      }
+    ],
+    "retained_symbols": [
+      {
+        "symbol": "WencaiService",
+        "file": "web/backend/app/services/wencai_service.py"
+      }
+    ],
+    "added_tests": [
+      "web/backend/tests/test_wencai_service_getter_retirement.py"
+    ]
+  },
+  "tdd": {
+    "red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_wencai_service_getter_retirement.py -q --no-cov --tb=short",
+      "result": "1 failed, 1 passed",
+      "expected_failure": "test_public_wencai_service_getter_is_retired failed because get_wencai_service still existed"
+    },
+    "green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_wencai_service_getter_retirement.py -q --no-cov --tb=short",
+      "result": "2 passed"
+    }
+  },
+  "post_change_reference_scan": {
+    "get_wencai_service": {
+      "app_refs": 0,
+      "route_api_refs": 0,
+      "test_refs": 1,
+      "package_export_refs": 0
+    },
+    "WencaiService": {
+      "app_refs": 16,
+      "route_api_refs": 9,
+      "test_refs": 1
+    }
+  },
+  "verification": {
+    "gitnexus_pre_edit_impact": {
+      "target": "get_wencai_service",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct_callers": 0,
+      "affected_processes": 0,
+      "affected_modules": 0
+    },
+    "focused_pytest": "2 passed",
+    "health_route_conflicts": "120 passed in 73.74s",
+    "ruff_touched_paths": "All checks passed!",
+    "black_check_touched_paths": "2 files would be left unchanged",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0
+    },
+    "gitnexus_staged_detect": {
+      "risk_level": "low",
+      "changed_files": 6,
+      "affected_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "boundary": {
+    "wencai_service_class_deleted": false,
+    "wencai_routes_changed": false,
+    "wencai_tasks_changed": false,
+    "database_service_changed": false,
+    "route_api_changes": false,
+    "openapi_exposure_changes": false,
+    "pm2_execution": false,
+    "openspec_changes": false,
+    "github_issue_label_changes": false
+  },
+  "next_gate": "human review / PR merge decision for G2.95; if accepted, create G2.96 closeout before selecting another service lifecycle lane"
+}

--- a/docs/reports/quality/backend-wencai-compat-getter-retirement-implementation-2026-05-25.md
+++ b/docs/reports/quality/backend-wencai-compat-getter-retirement-implementation-2026-05-25.md
@@ -1,0 +1,80 @@
+# Backend Wencai Compatibility Getter Retirement Implementation - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.95 Wencai getter-retirement implementation
+Status: ready for review
+
+## Purpose
+
+Implement the G2.94 authorization by retiring only the unused public
+compatibility getter `get_wencai_service`.
+
+## Change Summary
+
+| Path | Change |
+|---|---|
+| `web/backend/app/services/wencai_service.py` | Removed only `get_wencai_service`; kept `WencaiService` intact |
+| `web/backend/tests/test_wencai_service_getter_retirement.py` | Added focused regression coverage for public getter absence and `WencaiService` class availability |
+| `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md` | Recorded G2.94 acceptance and G2.95 implementation state |
+| `.planning/codebase/generated/wencai-compat-getter-retirement-implementation-2026-05-25.json` | Added generated evidence snapshot |
+| `governance/mainline/task-cards/pr-248.yaml` | Added implementation task-card gate |
+
+## TDD Evidence
+
+| Step | Command | Result |
+|---|---|---|
+| Red | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_wencai_service_getter_retirement.py -q --no-cov --tb=short` | `1 failed, 1 passed`; failure was `hasattr(wencai_service_module, "get_wencai_service")` |
+| Green | Same focused command after source edit | `2 passed in 1.49s` |
+| Green rerun | Same focused command after verification batch | `2 passed in 1.63s` |
+
+## Post-Change Reference Scan
+
+| Signal | Value |
+|---|---:|
+| `get_wencai_service` app refs | `0` |
+| `get_wencai_service` route/API refs | `0` |
+| `get_wencai_service` test refs | `1` |
+| `get_wencai_service` package export refs | `0` |
+| `WencaiService` app refs | `16` |
+| `WencaiService` route/API refs | `9` |
+| `WencaiService` test refs | `1` |
+
+The remaining `get_wencai_service` test reference is the focused absence
+assertion.
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| Pre-edit GitNexus impact | `get_wencai_service`: LOW, impacted count `0`, direct callers `0`, affected processes `0`, affected modules `0` |
+| Focused pytest | `2 passed` |
+| Health route conflicts | `120 passed in 73.74s` |
+| Ruff touched paths | `All checks passed!` |
+| Black check touched paths | `2 files would be left unchanged` |
+| OpenAPI smoke | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+| GitNexus staged detect | LOW risk, changed files=`6`, affected count=`0`, affected processes=`0` |
+
+The OpenAPI smoke used non-sensitive local placeholder environment variables and
+did not run PM2 or authorize runtime promotion.
+
+## Boundary
+
+This implementation does not:
+
+- delete or rename `WencaiService`;
+- change `web/backend/app/api/wencai.py`;
+- change `web/backend/app/tasks/wencai_tasks.py`;
+- change `src/database/services/database_service.py`;
+- change routes, response models, response shapes, or OpenAPI exposure;
+- change frontend files, generated clients, PM2 state, OpenSpec files, or
+  GitHub issue labels.
+
+## Next Gate
+
+Human review / PR merge decision for this implementation packet.
+
+If accepted, create G2.96 as a closeout packet before selecting another service
+lifecycle lane.

--- a/governance/mainline/task-cards/pr-248.yaml
+++ b/governance/mainline/task-cards/pr-248.yaml
@@ -1,0 +1,123 @@
+version: "v0.2"
+
+task:
+  id: "pr-248"
+  title: "Retire Wencai compatibility getter"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-wencai-compat-getter-retirement-implementation"
+  objective: "remove the unused get_wencai_service compatibility getter while preserving WencaiService"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-wencai-compat-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-wencai-compat-getter-retirement-implementation"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "Narrow compatibility getter retirement; active route/service entrypoints and WencaiService class remain unchanged"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/services/wencai_service.py"
+    - "web/backend/tests/test_wencai_service_getter_retirement.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/wencai-compat-getter-retirement-implementation-2026-05-25.json"
+    - "docs/reports/quality/backend-wencai-compat-getter-retirement-implementation-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-248.yaml"
+  forbidden_paths:
+    - "web/backend/app/api/**"
+    - "web/backend/app/tasks/**"
+    - "src/database/services/database_service.py"
+    - "web/frontend/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not delete or rename WencaiService"
+  - "Do not change Wencai routes, tasks, or database service consumers"
+  - "Do not change routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_wencai_service_getter_retirement.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/wencai_service.py web/backend/tests/test_wencai_service_getter_retirement.py"
+      required: true
+    - id: "black-check-touched"
+      command: "black --check web/backend/app/services/wencai_service.py web/backend/tests/test_wencai_service_getter_retirement.py"
+      required: true
+    - id: "app-main-openapi-smoke"
+      command: "env PYTHONPATH=web/backend POSTGRESQL_HOST=localhost POSTGRESQL_USER=postgres POSTGRESQL_PASSWORD=postgres JWT_SECRET_KEY=test-secret-key-for-wencai-getter-retirement-smoke BACKEND_PORT=8020 BACKEND_BACKUP_PORT=8021 python -c 'from collections import Counter; from app.main import app; schema=app.openapi(); ops=[operation.get(\"operationId\") for path_item in schema.get(\"paths\", {}).values() for operation in path_item.values() if isinstance(operation, dict) and operation.get(\"operationId\")]; dups=[op for op, count in Counter(ops).items() if count > 1]; print(len(app.routes), len(schema.get(\"paths\", {})), len(ops), len(dups))'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-wencai-compat-getter-retirement-implementation-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/wencai-compat-getter-retirement-implementation-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-248.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-248.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If WencaiService class usage is confused with the retired getter, active Wencai functionality could be over-scoped"
+    - "If new consumers reintroduce get_wencai_service before merge, the branch must stop and refresh references"
+  rollback_plan: "revert this implementation PR to restore get_wencai_service and remove the focused absence test"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "retire unused get_wencai_service compatibility getter"
+    modified_scope: "wencai service module, focused regression test, steward tree, generated artifact, report, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "WencaiService class and route/task/database service consumers remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, health route conflicts, ruff/black, OpenAPI smoke, GitNexus staged detect, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T19:46:32+08:00"
+    approval_note: "G2.94 authorization PR #247 was merged; this branch implements only the approved get_wencai_service retirement"
+    secondary_approved: true

--- a/web/backend/app/services/wencai_service.py
+++ b/web/backend/app/services/wencai_service.py
@@ -413,17 +413,3 @@ class WencaiService:
         if hasattr(self, "adapter"):
             self.adapter.close()
         logger.info("WencaiService closed")
-
-
-# 工厂函数
-def get_wencai_service(db: Session = None) -> WencaiService:
-    """
-    获取WencaiService实例
-
-    Args:
-        db: 数据库会话
-
-    Returns:
-        WencaiService实例
-    """
-    return WencaiService(db=db)

--- a/web/backend/tests/test_wencai_service_getter_retirement.py
+++ b/web/backend/tests/test_wencai_service_getter_retirement.py
@@ -1,0 +1,9 @@
+from app.services import wencai_service as wencai_service_module
+
+
+def test_public_wencai_service_getter_is_retired():
+    assert not hasattr(wencai_service_module, "get_wencai_service")
+
+
+def test_wencai_service_class_remains_importable():
+    assert hasattr(wencai_service_module, "WencaiService")


### PR DESCRIPTION
## Summary\n- remove only the unused get_wencai_service compatibility getter\n- keep WencaiService and all route/task/database-service consumers intact\n- add focused regression coverage for getter absence and WencaiService availability\n- update steward tree, generated evidence, report, and task card\n\n## TDD\n- red: focused test failed as expected while getter existed (1 failed, 1 passed)\n- green: focused test passed after removal (2 passed)\n\n## Verification\n- focused pytest: 2 passed\n- health route conflicts: 120 passed\n- ruff touched paths: passed\n- black --check touched paths: passed\n- OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0\n- GitNexus pre-edit impact: LOW / impacted count 0\n- GitNexus staged detect: low risk / affected count 0\n- post-commit mainline scope gate: pass=True