### PR TITLE
docs(governance): close out wencai getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1520,9 +1520,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                `WencaiService` deletion, or issue-label change is made here
 │   ├── G2.95 Wencai getter-retirement implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#248` merged at
+│   │   │          `689d619c715ec521a3f5c1d967b0fc8eeb798293`
 │   │   ├── Evidence: `backend-wencai-compat-getter-retirement-implementation-2026-05-25.md`
-│   │   ├── Current HEAD: `228a94d3ac0d77d421379ea37a4a328bd6975389`
+│   │   ├── Current HEAD: `689d619c715ec521a3f5c1d967b0fc8eeb798293`
 │   │   ├── Result: removes only `get_wencai_service` from
 │   │   │          `web/backend/app/services/wencai_service.py`, adds focused
 │   │   │          retirement regression coverage, and keeps `WencaiService`
@@ -1538,9 +1539,22 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                update; no route/API, OpenAPI exposure, frontend, PM2,
 │   │                OpenSpec, `WencaiService` deletion, or issue-label change
 │   │                is made here
-│   └── Next gate: human review / PR merge decision for G2.95; if accepted,
-│                  create G2.96 Wencai getter-retirement closeout before
-│                  selecting another service lifecycle lane
+│   ├── G2.96 Wencai getter-retirement closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-wencai-compat-getter-retirement-closeout-2026-05-25.md`
+│   │   ├── Current HEAD: `689d619c715ec521a3f5c1d967b0fc8eeb798293`
+│   │   ├── Result: records PR `#248` merge and closes the Wencai public
+│   │   │          compatibility getter lane; current-head scan shows
+│   │   │          `get_wencai_service` refs app=`0`, route/API=`0`,
+│   │   │          tests=`1` absence assertion, package exports=`0`,
+│   │   │          `WencaiService` remains active with app refs=`16` and
+│   │   │          route/API refs=`9`, focused test `2 passed`, and health
+│   │   │          route conflicts `120 passed`
+│   │   └── Boundary: closeout-only; no source, test, route/API, OpenAPI
+│   │                exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                `WencaiService` deletion, or issue-label change is made here
+│   └── Next gate: run a fresh service lifecycle candidate refresh before
+│                  selecting another getter-retirement lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1621,7 +1635,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-advanced-analysis-compat-getter-final-retirement-closeout-2026-05-25.md` | G | G2.92 closeout accepted in PR `#245` at `0d98e77`: records PR `#244` merge, confirms the AdvancedAnalysis public getter lane is closed, route/API public mentions=`0`, package export mentions=`0`, private initializer hits=`2`, dependency-provider refs=`19`, lifecycle tests `5 passed`, health route conflicts `120 passed`, and OpenAPI duplicate operation IDs=`0` | Superseded by G2.93 service lifecycle candidate refresh |
 | `backend-service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.md` | G | G2.93 candidate refresh accepted in PR `#246` at `d8e1d14`: records PR `#245` merge, scans `152` service files / `575` app files / `219` API files, finds `23` getter definitions in this packet's scanner, selects `get_wencai_service` as a future G2.94 authorization candidate only, and records GitNexus impact LOW / `0` | Superseded by G2.94 Wencai getter-retirement authorization |
 | `backend-wencai-compat-getter-retirement-authorization-2026-05-25.md` | G | G2.94 authorization accepted in PR `#247` at `228a94d`: authorizes only future G2.95 removal of `get_wencai_service` after TDD red/green; current scan shows app refs=`1`, route/API refs=`0`, test refs=`0`, package export refs=`0`; GitNexus impact LOW / `0`; `WencaiService` class usage remains active and outside deletion scope | Superseded by G2.95 implementation |
-| `backend-wencai-compat-getter-retirement-implementation-2026-05-25.md` | G | G2.95 implementation prepared at `228a94d`: removes only `get_wencai_service`, adds focused absence/import regression test, records TDD red `1 failed, 1 passed`, green `2 passed`, health route conflicts `120 passed`, ruff/black passed, OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0`, and post-change app/API/package getter refs=`0` | Human review / PR merge decision; if accepted, create G2.96 closeout before selecting another service lifecycle lane |
+| `backend-wencai-compat-getter-retirement-implementation-2026-05-25.md` | G | G2.95 implementation accepted in PR `#248` at `689d619`: removes only `get_wencai_service`, adds focused absence/import regression test, records TDD red `1 failed, 1 passed`, green `2 passed`, health route conflicts `120 passed`, ruff/black passed, OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0`, and post-change app/API/package getter refs=`0` | Superseded by G2.96 closeout |
+| `backend-wencai-compat-getter-retirement-closeout-2026-05-25.md` | G | G2.96 closeout prepared at `689d619`: records PR `#248` merge, confirms `get_wencai_service` app/API/package refs remain `0`, test refs are the focused absence assertion only, `WencaiService` remains active with app refs=`16` and route/API refs=`9`, focused test `2 passed`, and health route conflicts `120 passed` | Human review / PR merge decision; if accepted, run a fresh service lifecycle candidate refresh before selecting another getter-retirement lane |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/wencai-compat-getter-retirement-closeout-2026-05-25.json
+++ b/.planning/codebase/generated/wencai-compat-getter-retirement-closeout-2026-05-25.json
@@ -1,0 +1,53 @@
+{
+  "artifact": "wencai-compat-getter-retirement-closeout-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T20:00:00+08:00",
+  "branch": "g2-96-wencai-getter-retirement-closeout",
+  "current_head": "689d619c715ec521a3f5c1d967b0fc8eeb798293",
+  "parent_pr": {
+    "number": 248,
+    "state": "MERGED",
+    "merge_commit": "689d619c715ec521a3f5c1d967b0fc8eeb798293",
+    "merged_at": "2026-05-25T11:54:51Z",
+    "url": "https://github.com/chengjon/mystocks/pull/248"
+  },
+  "current_reference_scan": {
+    "get_wencai_service": {
+      "app_refs": 0,
+      "route_api_refs": 0,
+      "test_refs": 1,
+      "package_export_refs": 0,
+      "remaining_test_reference": "focused absence assertion only"
+    },
+    "WencaiService": {
+      "app_refs": 16,
+      "route_api_refs": 9,
+      "test_refs": 1
+    }
+  },
+  "verification": {
+    "focused_wencai_retirement_test": "2 passed in 1.55s",
+    "health_route_conflicts": "120 passed in 71.43s",
+    "parent_pr_checks": {
+      "mainline_governance_gate": "pass",
+      "check_compliance": "pass",
+      "weekly_full_scan": "skipped"
+    }
+  },
+  "closed_scope": [
+    "get_wencai_service public compatibility getter retirement",
+    "focused absence/import regression coverage",
+    "G2.95 steward-tree implementation evidence"
+  ],
+  "boundary": {
+    "closeout_only": true,
+    "backend_source_edits": false,
+    "backend_test_edits": false,
+    "route_api_changes": false,
+    "openapi_exposure_changes": false,
+    "pm2_execution": false,
+    "openspec_changes": false,
+    "github_issue_label_changes": false
+  },
+  "next_gate": "fresh service lifecycle candidate refresh before selecting another getter-retirement lane"
+}

--- a/docs/reports/quality/backend-wencai-compat-getter-retirement-closeout-2026-05-25.md
+++ b/docs/reports/quality/backend-wencai-compat-getter-retirement-closeout-2026-05-25.md
@@ -1,0 +1,81 @@
+# Backend Wencai Compatibility Getter Retirement Closeout - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.96 Wencai getter-retirement closeout
+Status: ready for review
+
+## Purpose
+
+Close out the Wencai public compatibility getter retirement lane after PR `#248`
+merged.
+
+This packet is closeout-only. It does not edit source, tests, routes, OpenAPI
+exposure, PM2 state, OpenSpec content, frontend files, or issue labels.
+
+## Parent Merge
+
+| Field | Value |
+|---|---|
+| Parent PR | `#248` |
+| Parent state | `MERGED` |
+| Merge commit | `689d619c715ec521a3f5c1d967b0fc8eeb798293` |
+| Merged at | `2026-05-25T11:54:51Z` |
+| PR URL | `https://github.com/chengjon/mystocks/pull/248` |
+
+## Current-Head Reference Scan
+
+| Signal | Value |
+|---|---:|
+| `get_wencai_service` app refs | `0` |
+| `get_wencai_service` route/API refs | `0` |
+| `get_wencai_service` test refs | `1` |
+| `get_wencai_service` package export refs | `0` |
+| `WencaiService` app refs | `16` |
+| `WencaiService` route/API refs | `9` |
+| `WencaiService` test refs | `1` |
+
+The remaining `get_wencai_service` test reference is the focused absence
+assertion in `test_wencai_service_getter_retirement.py`.
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| Focused Wencai retirement test | `2 passed in 1.55s` |
+| Health route conflicts | `120 passed in 71.43s` |
+| Parent PR checks | PR `#248`: Mainline Governance Gate pass, check-compliance pass, weekly-full-scan skipped |
+
+## Closed Scope
+
+Closed:
+
+- `get_wencai_service` public compatibility getter retirement.
+- Focused absence/import regression coverage.
+- Steward-tree implementation evidence for G2.95.
+
+Still out of scope:
+
+- deleting or renaming `WencaiService`;
+- changing Wencai routes, tasks, or database service consumers;
+- changing route/OpenAPI exposure;
+- changing frontend, PM2, OpenSpec, or issue labels.
+
+## Boundary
+
+Out of scope here:
+
+- source or test edits;
+- route/API edits;
+- OpenAPI exposure changes;
+- frontend or generated client edits;
+- PM2/runtime execution;
+- OpenSpec changes/spec updates;
+- GitHub issue label changes.
+
+## Next Gate
+
+Run a fresh service lifecycle candidate refresh before selecting another
+getter-retirement lane.

--- a/governance/mainline/task-cards/pr-249.yaml
+++ b/governance/mainline/task-cards/pr-249.yaml
@@ -1,0 +1,113 @@
+version: "v0.2"
+
+task:
+  id: "pr-249"
+  title: "Close out Wencai getter retirement"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-wencai-compat-getter-retirement-closeout"
+  objective: "record G2.95 merge evidence and close the Wencai public getter retirement lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-wencai-compat-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-wencai-compat-getter-retirement-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/wencai-compat-getter-retirement-closeout-2026-05-25.json"
+    - "docs/reports/quality/backend-wencai-compat-getter-retirement-closeout-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-249.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not select another service getter implementation lane from stale candidate data"
+  - "Do not delete or migrate WencaiService"
+  - "Do not change routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 248 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "focused-pytest"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_wencai_service_getter_retirement.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-wencai-compat-getter-retirement-closeout-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/wencai-compat-getter-retirement-closeout-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-249.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-249.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet is treated as new source authorization, another getter lane could start from stale data"
+    - "If parent PR evidence is stale, the steward tree could falsely close the Wencai lane"
+  rollback_plan: "revert this governance-only closeout PR and keep G2.95 as the latest accepted implementation evidence"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out Wencai public compatibility getter retirement"
+    modified_scope: "steward tree, closeout report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source retirement already landed in PR #248"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this closeout PR if parent PR evidence, reference matrix, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T20:00:00+08:00"
+    approval_note: "G2.95 implementation PR #248 was merged; this packet records closeout and requires a fresh candidate refresh before the next getter lane"
+    secondary_approved: false


### PR DESCRIPTION
## Summary\n- mark G2.95 / PR #248 accepted in the steward tree\n- close the Wencai public compatibility getter retirement lane\n- record current-head reference scan and focused verification\n- require a fresh service lifecycle candidate refresh before selecting another getter lane\n\n## Evidence\n- PR #248: MERGED at 689d619c715ec521a3f5c1d967b0fc8eeb798293\n- get_wencai_service refs: app=0, route/API=0, tests=1 absence assertion, package exports=0\n- WencaiService remains active: app refs=16, route/API refs=9\n- focused Wencai test: 2 passed\n- health route conflicts: 120 passed\n\n## Boundary\n- closeout-only\n- no source/test/route/OpenAPI/PM2/OpenSpec/frontend/issue-label changes