### PR TITLE
docs(governance): refresh service candidates after wencai

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1540,9 +1540,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenSpec, `WencaiService` deletion, or issue-label change
 │   │                is made here
 │   ├── G2.96 Wencai getter-retirement closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#249` merged at
+│   │   │          `c0aa9731503f3f8d8c9017ed787745ddaf6a5aab`
 │   │   ├── Evidence: `backend-wencai-compat-getter-retirement-closeout-2026-05-25.md`
-│   │   ├── Current HEAD: `689d619c715ec521a3f5c1d967b0fc8eeb798293`
+│   │   ├── Current HEAD: `c0aa9731503f3f8d8c9017ed787745ddaf6a5aab`
 │   │   ├── Result: records PR `#248` merge and closes the Wencai public
 │   │   │          compatibility getter lane; current-head scan shows
 │   │   │          `get_wencai_service` refs app=`0`, route/API=`0`,
@@ -1553,8 +1554,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: closeout-only; no source, test, route/API, OpenAPI
 │   │                exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                `WencaiService` deletion, or issue-label change is made here
-│   └── Next gate: run a fresh service lifecycle candidate refresh before
-│                  selecting another getter-retirement lane
+│   ├── G2.97 Service lifecycle candidate refresh after Wencai
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-wencai-2026-05-25.md`
+│   │   ├── Current HEAD: `c0aa9731503f3f8d8c9017ed787745ddaf6a5aab`
+│   │   ├── Result: records PR `#249` merge, refreshes service getter
+│   │   │          candidates at current HEAD, scans `152` service files,
+│   │   │          `575` app files, `219` API files, and `1007` test files,
+│   │   │          finds `22` getter definitions and `5` candidate-like
+│   │   │          definitions, confirms `get_wencai_service` is no longer a
+│   │   │          service getter definition, and selects
+│   │   │          `get_enhanced_data_service` as a future G2.98 authorization
+│   │   │          candidate only; GitNexus impact is LOW / `3`, with no
+│   │   │          affected processes
+│   │   └── Boundary: candidate-refresh only; no source, test, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter
+│   │                deletion, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.97; if accepted,
+│                  create G2.98 EnhancedDataService getter-retirement
+│                  authorization packet before any source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1636,7 +1654,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-candidate-refresh-after-advanced-analysis-2026-05-25.md` | G | G2.93 candidate refresh accepted in PR `#246` at `d8e1d14`: records PR `#245` merge, scans `152` service files / `575` app files / `219` API files, finds `23` getter definitions in this packet's scanner, selects `get_wencai_service` as a future G2.94 authorization candidate only, and records GitNexus impact LOW / `0` | Superseded by G2.94 Wencai getter-retirement authorization |
 | `backend-wencai-compat-getter-retirement-authorization-2026-05-25.md` | G | G2.94 authorization accepted in PR `#247` at `228a94d`: authorizes only future G2.95 removal of `get_wencai_service` after TDD red/green; current scan shows app refs=`1`, route/API refs=`0`, test refs=`0`, package export refs=`0`; GitNexus impact LOW / `0`; `WencaiService` class usage remains active and outside deletion scope | Superseded by G2.95 implementation |
 | `backend-wencai-compat-getter-retirement-implementation-2026-05-25.md` | G | G2.95 implementation accepted in PR `#248` at `689d619`: removes only `get_wencai_service`, adds focused absence/import regression test, records TDD red `1 failed, 1 passed`, green `2 passed`, health route conflicts `120 passed`, ruff/black passed, OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0`, and post-change app/API/package getter refs=`0` | Superseded by G2.96 closeout |
-| `backend-wencai-compat-getter-retirement-closeout-2026-05-25.md` | G | G2.96 closeout prepared at `689d619`: records PR `#248` merge, confirms `get_wencai_service` app/API/package refs remain `0`, test refs are the focused absence assertion only, `WencaiService` remains active with app refs=`16` and route/API refs=`9`, focused test `2 passed`, and health route conflicts `120 passed` | Human review / PR merge decision; if accepted, run a fresh service lifecycle candidate refresh before selecting another getter-retirement lane |
+| `backend-wencai-compat-getter-retirement-closeout-2026-05-25.md` | G | G2.96 closeout accepted in PR `#249` at `c0aa973`: records PR `#248` merge, confirms `get_wencai_service` app/API/package refs remain `0`, test refs are the focused absence assertion only, `WencaiService` remains active with app refs=`16` and route/API refs=`9`, focused test `2 passed`, and health route conflicts `120 passed` | Superseded by G2.97 service lifecycle candidate refresh |
+| `backend-service-lifecycle-candidate-refresh-after-wencai-2026-05-25.md` | G | G2.97 candidate refresh prepared at `c0aa973`: records PR `#249` merge, scans `152` service files / `575` app files / `219` API files / `1007` test files, finds `22` getter definitions and `5` candidate-like definitions, confirms `get_wencai_service` is no longer present as a service getter definition, selects `get_enhanced_data_service` as a future G2.98 authorization candidate only, and records GitNexus impact LOW / `3` with no affected processes | Human review / PR merge decision; if accepted, create G2.98 EnhancedDataService getter-retirement authorization before any source edit |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-wencai-2026-05-25.json
+++ b/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-wencai-2026-05-25.json
@@ -1,0 +1,108 @@
+{
+  "artifact": "service-lifecycle-candidate-refresh-after-wencai-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T20:06:36+08:00",
+  "branch": "g2-97-service-lifecycle-candidate-refresh-after-wencai",
+  "current_head": "c0aa9731503f3f8d8c9017ed787745ddaf6a5aab",
+  "parent_pr": {
+    "number": 249,
+    "state": "MERGED",
+    "merge_commit": "c0aa9731503f3f8d8c9017ed787745ddaf6a5aab",
+    "url": "https://github.com/chengjon/mystocks/pull/249"
+  },
+  "scan_summary": {
+    "service_files": 152,
+    "app_files": 575,
+    "api_files": 219,
+    "test_files": 1007,
+    "getter_definitions": 22,
+    "candidate_like_definitions": 5,
+    "hold_definitions": 17,
+    "wencai_getter_definition_present": false
+  },
+  "candidate_rows": [
+    {
+      "symbol": "get_enhanced_data_service",
+      "file": "web/backend/app/services/data_service_enhanced.py",
+      "line": 580,
+      "app_refs": 2,
+      "route_api_refs": 0,
+      "test_refs": 0,
+      "package_export_refs": 0,
+      "disposition": "select_future_authorization_candidate_only"
+    },
+    {
+      "symbol": "get_announcement_service",
+      "file": "web/backend/app/services/announcement_service.py",
+      "line": 526,
+      "app_refs": 2,
+      "route_api_refs": 0,
+      "test_refs": 1,
+      "package_export_refs": 0,
+      "disposition": "hold_completed_announcement_di_lane_not_reopened_here"
+    },
+    {
+      "symbol": "get_tradingview_service",
+      "file": "web/backend/app/services/tradingview_widget_service.py",
+      "line": 322,
+      "app_refs": 2,
+      "route_api_refs": 0,
+      "test_refs": 2,
+      "package_export_refs": 0,
+      "disposition": "hold_for_dedicated_tradingview_follow_up_if_needed"
+    },
+    {
+      "symbol": "get_email_service",
+      "file": "web/backend/app/services/email_notification_service.py",
+      "line": 324,
+      "app_refs": 3,
+      "route_api_refs": 0,
+      "test_refs": 3,
+      "package_export_refs": 0,
+      "disposition": "hold_duplicate_logical_getter_name_prior_email_lane_requires_separate_decision"
+    },
+    {
+      "symbol": "get_email_service",
+      "file": "web/backend/app/services/email_service.py",
+      "line": 325,
+      "app_refs": 3,
+      "route_api_refs": 0,
+      "test_refs": 3,
+      "package_export_refs": 0,
+      "disposition": "hold_duplicate_logical_getter_name_prior_email_lane_requires_separate_decision"
+    }
+  ],
+  "selected_next_lane": {
+    "workline": "G2.98",
+    "candidate": "EnhancedDataService",
+    "symbol": "get_enhanced_data_service",
+    "decision": "prepare a future EnhancedDataService getter-retirement authorization packet only",
+    "source_edit_authorized_by_this_packet": false,
+    "service_deletion_authorized": false,
+    "future_authorization_required": true
+  },
+  "gitnexus": {
+    "index_refresh": "gitnexus analyze --with-gitignore completed before packet creation",
+    "nodes": 62762,
+    "edges": 145902,
+    "clusters": 3299,
+    "flows": 300,
+    "selected_symbol_impact": {
+      "target": "get_enhanced_data_service",
+      "risk": "LOW",
+      "impacted_count": 3,
+      "affected_processes": 0
+    }
+  },
+  "boundary": {
+    "governance_only": true,
+    "backend_source_edits": false,
+    "backend_test_edits": false,
+    "route_api_changes": false,
+    "openapi_exposure_changes": false,
+    "pm2_execution": false,
+    "openspec_changes": false,
+    "github_issue_label_changes": false
+  },
+  "next_gate": "human review / PR merge decision for G2.97; if accepted, create G2.98 EnhancedDataService getter-retirement authorization packet before source edits"
+}

--- a/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-wencai-2026-05-25.md
+++ b/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-wencai-2026-05-25.md
@@ -1,0 +1,101 @@
+# Backend Service Lifecycle Candidate Refresh After Wencai - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.97 service lifecycle candidate refresh after Wencai
+Status: ready for review
+
+## Purpose
+
+Refresh the service lifecycle getter-retirement candidate list after the Wencai
+public compatibility getter lane closed in PR `#249`.
+
+This packet is governance-only. It records current evidence, updates the
+steward tree, and selects a future authorization candidate. It does not
+authorize backend source edits, tests edits, route/API changes, OpenAPI exposure
+changes, PM2 execution, OpenSpec changes, GitHub issue label movement, or getter
+deletion.
+
+## Input State
+
+| Field | Value |
+|---|---|
+| Worktree | `.worktrees/g2-97-service-lifecycle-candidate-refresh-after-wencai` |
+| Branch | `g2-97-service-lifecycle-candidate-refresh-after-wencai` |
+| Current HEAD | `c0aa9731503f3f8d8c9017ed787745ddaf6a5aab` |
+| HEAD subject | `docs(governance): close out wencai getter retirement (#249)` |
+| Parent PR | `#249`, `MERGED`, merge commit `c0aa9731503f3f8d8c9017ed787745ddaf6a5aab` |
+| GitNexus refresh | `gitnexus analyze --with-gitignore` completed before this packet |
+
+## Current-Head Scan Summary
+
+| Metric | Value |
+|---|---:|
+| Service files scanned | `152` |
+| App files scanned | `575` |
+| API files scanned | `219` |
+| Test files scanned | `1007` |
+| Getter definitions found | `22` |
+| Candidate-like definitions | `5` |
+| Hold definitions | `17` |
+
+`get_wencai_service` is no longer present as a service getter definition.
+
+## Candidate Rows
+
+| Candidate | File | App refs | Route/API refs | Test refs | Package export refs | Disposition |
+|---|---|---:|---:|---:|---:|---|
+| `get_enhanced_data_service` | `web/backend/app/services/data_service_enhanced.py:580` | `2` | `0` | `0` | `0` | Select as future G2.98 authorization candidate only |
+| `get_announcement_service` | `web/backend/app/services/announcement_service.py:526` | `2` | `0` | `1` | `0` | Hold; announcement route DI lane is already closed |
+| `get_tradingview_service` | `web/backend/app/services/tradingview_widget_service.py:322` | `2` | `0` | `2` | `0` | Hold for dedicated TradingView follow-up if needed |
+| `get_email_service` | `web/backend/app/services/email_notification_service.py:324` | `3` | `0` | `3` | `0` | Hold; duplicate logical getter name and prior email DI lane require a separate decision |
+| `get_email_service` | `web/backend/app/services/email_service.py:325` | `3` | `0` | `3` | `0` | Hold; duplicate logical getter name and prior email DI lane require a separate decision |
+
+## Selected Next Lane
+
+Select `get_enhanced_data_service` as the next future authorization candidate.
+
+Rationale:
+
+- The getter has no route/API references.
+- It has no focused test references.
+- It has no package export references.
+- GitNexus impact is LOW with impacted count `3` and affected processes `0`.
+
+Boundary:
+
+- This selection does not authorize deleting `EnhancedDataService`.
+- `EnhancedDataService` remains active through direct class usage in
+  `web/backend/app/api/v1/system/health.py`.
+- A future G2.98 packet must be authorization-only first and must distinguish
+  getter retirement from the active enhanced-data service class.
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| GitNexus index | Refreshed with `gitnexus analyze --with-gitignore`; graph contains `62,762` nodes, `145,902` edges, `3,299` clusters, and `300` flows |
+| Getter candidate scan | `152` service files, `575` app files, `219` API files, `1007` test files, `22` getter definitions, `5` candidate-like definitions, `17` holds |
+| Selected candidate impact | `get_enhanced_data_service`: LOW, impacted count `3`, affected processes `0` |
+| Selected candidate context | getter body initializes `_enhanced_data_service` lazily; incoming graph refs are internal to `data_service_enhanced.py` only |
+
+## Boundary
+
+Out of scope here:
+
+- source or test edits;
+- route/API edits;
+- OpenAPI exposure changes;
+- frontend or generated client edits;
+- PM2/runtime execution;
+- OpenSpec changes/spec updates;
+- GitHub issue label changes.
+
+## Next Gate
+
+Human review / PR merge decision for this G2.97 governance packet.
+
+If accepted, create G2.98 as an EnhancedDataService getter-retirement
+authorization packet before any source edit.

--- a/governance/mainline/task-cards/pr-250.yaml
+++ b/governance/mainline/task-cards/pr-250.yaml
@@ -1,0 +1,107 @@
+version: "v0.2"
+
+task:
+  id: "pr-250"
+  title: "Refresh service lifecycle candidates after Wencai"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-service-lifecycle-candidate-refresh-after-wencai"
+  objective: "record G2.96 merge evidence and select the next service getter authorization candidate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-candidate-refresh"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-candidate-refresh-after-wencai"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate-refresh packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-candidate-refresh-after-wencai-2026-05-25.json"
+    - "docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-wencai-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-250.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not delete get_enhanced_data_service in this packet"
+  - "Do not delete or migrate EnhancedDataService"
+  - "Do not change routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 249 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-wencai-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-candidate-refresh-after-wencai-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-250.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-250.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet is treated as source authorization, get_enhanced_data_service could be deleted without the required G2.98 gate"
+    - "If EnhancedDataService class usage is confused with getter usage, an active health-route service class could be over-scoped"
+  rollback_plan: "revert this governance-only PR and keep G2.96 as the latest accepted service lifecycle closeout evidence"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh service lifecycle candidates after Wencai getter retirement"
+    modified_scope: "steward tree, candidate-refresh report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; get_enhanced_data_service is only selected for a future authorization packet"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if parent PR evidence, candidate scan, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T20:06:36+08:00"
+    approval_note: "G2.96 closeout PR #249 was merged; this packet records a fresh candidate refresh and selects only a future G2.98 EnhancedDataService authorization candidate"
+    secondary_approved: false


### PR DESCRIPTION
## Summary\n- mark G2.96 / PR #249 accepted in the steward tree\n- refresh service lifecycle getter candidates after Wencai getter retirement\n- confirm get_wencai_service is no longer a service getter definition\n- select get_enhanced_data_service only as a future G2.98 authorization candidate\n\n## Evidence\n- service files=152, app files=575, API files=219, test files=1007\n- getter definitions=22, candidate-like definitions=5, holds=17\n- GitNexus impact get_enhanced_data_service: LOW / impacted count 3 / affected processes 0\n\n## Boundary\n- governance-only packet\n- no backend source or test edits\n- no route/API, OpenAPI, PM2, OpenSpec, frontend, or issue-label changes\n- no get_enhanced_data_service or EnhancedDataService deletion authorized