### PR TITLE
docs(governance): authorize enhanced data service getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1555,9 +1555,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                `WencaiService` deletion, or issue-label change is made here
 │   ├── G2.97 Service lifecycle candidate refresh after Wencai
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#250` merged at
+│   │   │          `dfb1dce27c0501b7eb855e478e68b82db4959d9d`
 │   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-wencai-2026-05-25.md`
-│   │   ├── Current HEAD: `c0aa9731503f3f8d8c9017ed787745ddaf6a5aab`
+│   │   ├── Current HEAD: `dfb1dce27c0501b7eb855e478e68b82db4959d9d`
 │   │   ├── Result: records PR `#249` merge, refreshes service getter
 │   │   │          candidates at current HEAD, scans `152` service files,
 │   │   │          `575` app files, `219` API files, and `1007` test files,
@@ -1570,9 +1571,26 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: candidate-refresh only; no source, test, route/API,
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter
 │   │                deletion, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.97; if accepted,
-│                  create G2.98 EnhancedDataService getter-retirement
-│                  authorization packet before any source edit
+│   ├── G2.98 EnhancedDataService getter-retirement authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-enhanced-data-service-getter-retirement-authorization-2026-05-25.md`
+│   │   ├── Current HEAD: `dfb1dce27c0501b7eb855e478e68b82db4959d9d`
+│   │   ├── Result: authorizes only a future G2.99 implementation branch to
+│   │   │          retire `get_enhanced_data_service` from
+│   │   │          `web/backend/app/services/data_service_enhanced.py` after
+│   │   │          TDD red/green; current evidence shows getter refs app=`1`
+│   │   │          file, route/API=`0`, focused tests=`0`, package exports=`0`,
+│   │   │          with one module-local `__main__` smoke call, while
+│   │   │          `EnhancedDataService` remains active through direct class
+│   │   │          usage in `web/backend/app/api/v1/system/health.py`;
+│   │   │          GitNexus impact is LOW / `3`, with no affected processes
+│   │   └── Boundary: authorization-only; no source, test, route/API, OpenAPI
+│   │                exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                `EnhancedDataService` deletion, or issue-label change is
+│   │                made here
+│   └── Next gate: human review / PR merge decision for G2.98; if accepted,
+│                  create G2.99 EnhancedDataService getter-retirement
+│                  implementation with TDD red/green before source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1655,7 +1673,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-wencai-compat-getter-retirement-authorization-2026-05-25.md` | G | G2.94 authorization accepted in PR `#247` at `228a94d`: authorizes only future G2.95 removal of `get_wencai_service` after TDD red/green; current scan shows app refs=`1`, route/API refs=`0`, test refs=`0`, package export refs=`0`; GitNexus impact LOW / `0`; `WencaiService` class usage remains active and outside deletion scope | Superseded by G2.95 implementation |
 | `backend-wencai-compat-getter-retirement-implementation-2026-05-25.md` | G | G2.95 implementation accepted in PR `#248` at `689d619`: removes only `get_wencai_service`, adds focused absence/import regression test, records TDD red `1 failed, 1 passed`, green `2 passed`, health route conflicts `120 passed`, ruff/black passed, OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0`, and post-change app/API/package getter refs=`0` | Superseded by G2.96 closeout |
 | `backend-wencai-compat-getter-retirement-closeout-2026-05-25.md` | G | G2.96 closeout accepted in PR `#249` at `c0aa973`: records PR `#248` merge, confirms `get_wencai_service` app/API/package refs remain `0`, test refs are the focused absence assertion only, `WencaiService` remains active with app refs=`16` and route/API refs=`9`, focused test `2 passed`, and health route conflicts `120 passed` | Superseded by G2.97 service lifecycle candidate refresh |
-| `backend-service-lifecycle-candidate-refresh-after-wencai-2026-05-25.md` | G | G2.97 candidate refresh prepared at `c0aa973`: records PR `#249` merge, scans `152` service files / `575` app files / `219` API files / `1007` test files, finds `22` getter definitions and `5` candidate-like definitions, confirms `get_wencai_service` is no longer present as a service getter definition, selects `get_enhanced_data_service` as a future G2.98 authorization candidate only, and records GitNexus impact LOW / `3` with no affected processes | Human review / PR merge decision; if accepted, create G2.98 EnhancedDataService getter-retirement authorization before any source edit |
+| `backend-service-lifecycle-candidate-refresh-after-wencai-2026-05-25.md` | G | G2.97 candidate refresh accepted in PR `#250` at `dfb1dce`: records PR `#249` merge, scans `152` service files / `575` app files / `219` API files / `1007` test files, finds `22` getter definitions and `5` candidate-like definitions, confirms `get_wencai_service` is no longer present as a service getter definition, selects `get_enhanced_data_service` as a future G2.98 authorization candidate only, and records GitNexus impact LOW / `3` with no affected processes | Superseded by G2.98 EnhancedDataService getter-retirement authorization |
+| `backend-enhanced-data-service-getter-retirement-authorization-2026-05-25.md` | G | G2.98 authorization prepared at `dfb1dce`: authorizes only future G2.99 removal of `get_enhanced_data_service` after TDD red/green; current scan shows getter refs app=`1` file / route/API=`0` / focused tests=`0` / package exports=`0`, one module-local `__main__` smoke call, GitNexus impact LOW / `3`, and `EnhancedDataService` class usage remains active in system health route | Human review / PR merge decision; if accepted, create G2.99 source-capable implementation with TDD red/green |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/enhanced-data-service-getter-retirement-authorization-2026-05-25.json
+++ b/.planning/codebase/generated/enhanced-data-service-getter-retirement-authorization-2026-05-25.json
@@ -1,0 +1,125 @@
+{
+  "artifact": "enhanced-data-service-getter-retirement-authorization-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T20:20:06+08:00",
+  "branch": "g2-98-enhanced-data-service-getter-authorization",
+  "current_head": "dfb1dce27c0501b7eb855e478e68b82db4959d9d",
+  "parent_pr": {
+    "number": 250,
+    "title": "docs(governance): refresh service candidates after wencai",
+    "merge_commit": "dfb1dce27c0501b7eb855e478e68b82db4959d9d",
+    "disposition": "accepted"
+  },
+  "workline": {
+    "id": "G2.98",
+    "name": "EnhancedDataService getter-retirement authorization",
+    "next_authorized_workline": "G2.99",
+    "source_edit_authorized_by_this_packet": false
+  },
+  "target": {
+    "getter_symbol": "get_enhanced_data_service",
+    "service_class": "EnhancedDataService",
+    "service_file": "web/backend/app/services/data_service_enhanced.py",
+    "getter_lines": "580-585",
+    "module_local_smoke_call_line": 592,
+    "active_class_usage_file": "web/backend/app/api/v1/system/health.py"
+  },
+  "current_head_reference_scan": {
+    "get_enhanced_data_service": {
+      "files": 1,
+      "total_refs": 2,
+      "route_api_refs": 0,
+      "focused_test_refs": 0,
+      "package_export_refs": 0,
+      "notes": [
+        "Refs are limited to the getter definition and a module-local __main__ smoke call in web/backend/app/services/data_service_enhanced.py."
+      ]
+    },
+    "EnhancedDataService": {
+      "files": 2,
+      "total_refs": 9,
+      "active_direct_class_usage": [
+        "web/backend/app/api/v1/system/health.py"
+      ],
+      "deletion_authorized": false
+    },
+    "_enhanced_data_service": {
+      "files": 1,
+      "total_refs": 5,
+      "notes": [
+        "Private module singleton state is tied to the public getter and may be removed only by the future G2.99 implementation if TDD red/green proves the retirement boundary."
+      ]
+    }
+  },
+  "gitnexus": {
+    "analyze": {
+      "command": "gitnexus analyze --with-gitignore",
+      "result": "repository indexed successfully",
+      "nodes": 62748,
+      "edges": 145908,
+      "clusters": 3283,
+      "flows": 300
+    },
+    "impact": {
+      "target": "get_enhanced_data_service",
+      "direction": "upstream",
+      "risk": "LOW",
+      "impacted_count": 3,
+      "direct": 1,
+      "processes_affected": 0,
+      "affected_processes": []
+    },
+    "context": {
+      "incoming": "module-local file reference only",
+      "outgoing": "none",
+      "processes": []
+    }
+  },
+  "authorized_future_scope": {
+    "if_this_packet_is_accepted": {
+      "may_create": "G2.99 EnhancedDataService getter-retirement implementation",
+      "allowed_paths": [
+        "web/backend/app/services/data_service_enhanced.py",
+        "web/backend/tests/test_enhanced_data_service_getter_retirement.py",
+        ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+        ".planning/codebase/generated/enhanced-data-service-getter-retirement-implementation-2026-05-25.json",
+        "docs/reports/quality/backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md",
+        "governance/mainline/task-cards/pr-252.yaml"
+      ],
+      "allowed_actions": [
+        "Remove only get_enhanced_data_service from web/backend/app/services/data_service_enhanced.py.",
+        "Remove the private _enhanced_data_service singleton state only if it becomes unused after getter retirement.",
+        "Replace the module-local __main__ smoke call with direct EnhancedDataService construction or remove only that obsolete smoke dependency.",
+        "Add focused static/import regression coverage proving the getter is absent while EnhancedDataService remains importable."
+      ]
+    }
+  },
+  "forbidden_scope": [
+    "Do not delete EnhancedDataService.",
+    "Do not change web/backend/app/api/v1/system/health.py in this authorization packet.",
+    "Do not change routes, response models, response shapes, or OpenAPI exposure.",
+    "Do not change frontend, PM2, OpenSpec changes/specs, GitHub issue labels, or readiness state.",
+    "Do not broaden future G2.99 beyond the getter-retirement seam without a separate authorization packet."
+  ],
+  "required_future_g2_99_verification": [
+    "Read architecture/STANDARDS.md before source edits.",
+    "Run GitNexus impact/context for get_enhanced_data_service before editing.",
+    "Add the focused regression test first and verify red state.",
+    "Apply the minimal source edit.",
+    "Verify green focused test.",
+    "Run ruff and black --check on touched backend files.",
+    "Run the route/OpenAPI smoke if the import path changes or if app.main import could be affected.",
+    "Stage only the authorized paths and run gitnexus detect_changes with scope=staged before commit.",
+    "Run the mainline scope gate and markdown governance gate for updated governance artifacts."
+  ],
+  "boundary": {
+    "this_packet_changes_source": false,
+    "this_packet_changes_tests": false,
+    "this_packet_changes_routes": false,
+    "this_packet_changes_openapi": false,
+    "this_packet_changes_pm2": false,
+    "this_packet_changes_openspec": false,
+    "this_packet_changes_issue_labels": false
+  },
+  "next_gate": "Human review / PR merge decision for G2.98; if accepted, create G2.99 source-capable implementation with TDD red/green."
+}

--- a/docs/reports/quality/backend-enhanced-data-service-getter-retirement-authorization-2026-05-25.md
+++ b/docs/reports/quality/backend-enhanced-data-service-getter-retirement-authorization-2026-05-25.md
@@ -1,0 +1,118 @@
+# Backend EnhancedDataService Getter Retirement Authorization - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.98 EnhancedDataService getter-retirement authorization
+Status: ready for review
+
+## Purpose
+
+Authorize only a future, source-capable G2.99 branch to retire the public
+compatibility getter `get_enhanced_data_service` from
+`web/backend/app/services/data_service_enhanced.py`.
+
+This packet does not modify source code, tests, routes, OpenAPI exposure, PM2
+state, OpenSpec changes, frontend assets, or GitHub issue labels. It exists to
+separate the getter-retirement decision from implementation.
+
+## Input State
+
+G2.97 was accepted through PR `#250`, merged at
+`dfb1dce27c0501b7eb855e478e68b82db4959d9d`.
+
+G2.97 selected `get_enhanced_data_service` only as a future authorization
+candidate because:
+
+- route/API references are `0`;
+- focused test references are `0`;
+- package export references are `0`;
+- GitNexus impact is LOW with impacted count `3` and affected processes `0`.
+
+## Current Evidence
+
+Current HEAD for this packet:
+`dfb1dce27c0501b7eb855e478e68b82db4959d9d`.
+
+| Check | Result |
+|---|---|
+| GitNexus index | `gitnexus analyze --with-gitignore`; `62,748` nodes, `145,908` edges, `3,283` clusters, `300` flows |
+| GitNexus impact | `get_enhanced_data_service`: LOW, impacted count `3`, direct `1`, affected processes `0` |
+| GitNexus context | getter has module-local incoming reference only; no outgoing refs; no process participation |
+| `get_enhanced_data_service` scan | `1` app file, `2` refs total: definition at line `580` and module-local `__main__` smoke call at line `592` |
+| Route/API refs | `0` |
+| Focused test refs | `0` |
+| Package export refs | `0` |
+| `EnhancedDataService` scan | `2` files, `9` refs total; class remains active through `web/backend/app/api/v1/system/health.py` |
+| `_enhanced_data_service` scan | `1` file, `5` refs total; private state is tied to the public getter |
+
+The active runtime path must not be confused with the compatibility getter:
+
+- `web/backend/app/api/v1/system/health.py` imports `EnhancedDataService`
+  directly.
+- `web/backend/app/api/v1/system/health.py` constructs
+  `EnhancedDataService(auto_fetch=False, use_cache=False)` through its own
+  `_get_data_service()` helper.
+- No route/API path imports or calls `get_enhanced_data_service`.
+
+## Authorized Future Scope
+
+If this G2.98 packet is reviewed and accepted, G2.99 may be created as a
+source-capable implementation branch with this maximum scope:
+
+| Path | Future allowed action |
+|---|---|
+| `web/backend/app/services/data_service_enhanced.py` | Remove only `get_enhanced_data_service`; remove `_enhanced_data_service` only if it becomes unused; replace the module-local `__main__` smoke call with direct `EnhancedDataService` construction or remove only that obsolete smoke dependency |
+| `web/backend/tests/test_enhanced_data_service_getter_retirement.py` | Add a focused static/import regression test proving the public getter is absent while `EnhancedDataService` remains importable |
+| `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md` | Record implementation status after the branch runs |
+| `.planning/codebase/generated/enhanced-data-service-getter-retirement-implementation-2026-05-25.json` | Record generated implementation evidence |
+| `docs/reports/quality/backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md` | Record implementation evidence |
+| `governance/mainline/task-cards/pr-252.yaml` | Record implementation task-card gate if PR numbering remains sequential |
+
+Future G2.99 must remain a getter-retirement branch. It must not delete
+`EnhancedDataService`, migrate the system health route, alter response models,
+change OpenAPI exposure, edit frontend code, touch PM2 state, or change issue
+labels.
+
+## Required Future G2.99 Verification
+
+Before any source edit:
+
+1. Read `architecture/STANDARDS.md`.
+2. Run GitNexus impact/context for `get_enhanced_data_service`.
+3. Add the focused regression test first and verify red state.
+
+After the minimal source edit:
+
+1. Verify the focused test is green.
+2. Run `ruff check` and `black --check` on touched backend files.
+3. Run the route/OpenAPI smoke if the import path changes or if `app.main`
+   import could be affected.
+4. Stage only authorized paths and run GitNexus `detect_changes` with
+   `scope=staged`.
+5. Run the mainline scope gate and markdown governance gate for updated
+   governance artifacts.
+
+## Boundary
+
+This packet makes no source or test changes and does not authorize any immediate
+implementation.
+
+Explicitly out of scope:
+
+- deleting `EnhancedDataService`;
+- editing `web/backend/app/api/v1/system/health.py` in this authorization
+  packet;
+- changing routes, response models, response shapes, or OpenAPI exposure;
+- changing frontend, PM2, OpenSpec changes/specs, GitHub issue labels, or
+  readiness state;
+- broadening future G2.99 beyond the getter-retirement seam without a separate
+  authorization packet.
+
+## Next Gate
+
+Human review / PR merge decision for this G2.98 authorization packet.
+
+If accepted, create G2.99 as a source-capable implementation branch and apply
+TDD red/green before retiring `get_enhanced_data_service`.

--- a/governance/mainline/task-cards/pr-251.yaml
+++ b/governance/mainline/task-cards/pr-251.yaml
@@ -1,0 +1,108 @@
+version: "v0.2"
+
+task:
+  id: "pr-251"
+  title: "Authorize EnhancedDataService getter retirement"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-enhanced-data-service-getter-retirement-authorization"
+  objective: "authorize only a future EnhancedDataService getter-retirement implementation branch"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-enhanced-data-service-getter-retirement-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/enhanced-data-service-getter-retirement-authorization-2026-05-25.json"
+    - "docs/reports/quality/backend-enhanced-data-service-getter-retirement-authorization-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-251.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not delete get_enhanced_data_service in this packet"
+  - "Do not delete or migrate EnhancedDataService"
+  - "Do not edit web/backend/app/api/v1/system/health.py"
+  - "Do not change routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 250 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-enhanced-data-service-getter-retirement-authorization-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/enhanced-data-service-getter-retirement-authorization-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-251.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-251.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet is treated as implementation authority, get_enhanced_data_service could be deleted without the required G2.99 TDD gate"
+    - "If EnhancedDataService class usage is confused with getter usage, an active system-health service class could be over-scoped"
+  rollback_plan: "revert this governance-only PR and keep G2.97 as the latest accepted service lifecycle candidate-refresh evidence"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize only a future EnhancedDataService getter-retirement implementation branch"
+    modified_scope: "steward tree, authorization report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; get_enhanced_data_service is not deleted in this packet and EnhancedDataService remains active"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if parent PR evidence, authorization boundary, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T20:20:06+08:00"
+    approval_note: "G2.97 candidate refresh PR #250 was merged; this packet authorizes only a future G2.99 EnhancedDataService getter-retirement implementation branch"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- accept G2.97 / PR #250 and add the G2.98 authorization packet for `get_enhanced_data_service`
- distinguish getter retirement from the active `EnhancedDataService` class used by system health
- authorize only a future G2.99 TDD implementation branch; this PR does not delete or edit backend source

## Evidence
- current HEAD: `dfb1dce27c0501b7eb855e478e68b82db4959d9d`
- `get_enhanced_data_service`: app file refs `1`, total refs `2`, route/API refs `0`, focused test refs `0`, package export refs `0`
- `EnhancedDataService`: active class usage remains in `web/backend/app/api/v1/system/health.py`
- GitNexus impact: LOW, impacted count `3`, affected processes `0`

## Verification
- `gitnexus analyze --with-gitignore`
- `python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-enhanced-data-service-getter-retirement-authorization-2026-05-25.md`
- `python -m json.tool .planning/codebase/generated/enhanced-data-service-getter-retirement-authorization-2026-05-25.json >/dev/null`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-251.yaml').read_text())"`
- `git diff --cached --check`
- `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-251.yaml` after commit: pass=True
- GitNexus staged detect: low risk, changed files `4`, affected count `0`, affected processes `0`

## Boundary
- governance-only
- no backend source/test changes
- no route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label changes
- no `get_enhanced_data_service` deletion in this PR
- no `EnhancedDataService` deletion or migration authorized
