### PR TITLE
refactor(services): retire enhanced data service getter

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1572,9 +1572,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter
 │   │                deletion, or issue-label change is made here
 │   ├── G2.98 EnhancedDataService getter-retirement authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#251` merged at
+│   │   │          `8fb6db0e13018d83eef7e0deca02106104c06160`
 │   │   ├── Evidence: `backend-enhanced-data-service-getter-retirement-authorization-2026-05-25.md`
-│   │   ├── Current HEAD: `dfb1dce27c0501b7eb855e478e68b82db4959d9d`
+│   │   ├── Current HEAD: `8fb6db0e13018d83eef7e0deca02106104c06160`
 │   │   ├── Result: authorizes only a future G2.99 implementation branch to
 │   │   │          retire `get_enhanced_data_service` from
 │   │   │          `web/backend/app/services/data_service_enhanced.py` after
@@ -1588,9 +1589,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                `EnhancedDataService` deletion, or issue-label change is
 │   │                made here
-│   └── Next gate: human review / PR merge decision for G2.98; if accepted,
-│                  create G2.99 EnhancedDataService getter-retirement
-│                  implementation with TDD red/green before source edit
+│   ├── G2.99 EnhancedDataService getter-retirement implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md`
+│   │   ├── Base HEAD: `8fb6db0e13018d83eef7e0deca02106104c06160`
+│   │   ├── Result: removes only `get_enhanced_data_service` and its private
+│   │   │          `_enhanced_data_service` singleton state, updates the
+│   │   │          module-local `__main__` smoke call to construct
+│   │   │          `EnhancedDataService()` directly, and adds focused regression
+│   │   │          coverage; TDD red was `2 failed, 1 passed`, green is
+│   │   │          `3 passed`, health route conflicts are `120 passed`, and
+│   │   │          OpenAPI smoke remains routes=`548`, paths=`500`,
+│   │   │          operation IDs=`536`, duplicate operation IDs=`0`
+│   │   └── Boundary: source-capable but getter-retirement-only; no route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                `EnhancedDataService` deletion, or issue-label change is
+│   │                made here
+│   └── Next gate: human review / PR merge decision for G2.99; if accepted,
+│                  create G2.100 closeout before selecting another service
+│                  lifecycle lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1674,7 +1691,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-wencai-compat-getter-retirement-implementation-2026-05-25.md` | G | G2.95 implementation accepted in PR `#248` at `689d619`: removes only `get_wencai_service`, adds focused absence/import regression test, records TDD red `1 failed, 1 passed`, green `2 passed`, health route conflicts `120 passed`, ruff/black passed, OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0`, and post-change app/API/package getter refs=`0` | Superseded by G2.96 closeout |
 | `backend-wencai-compat-getter-retirement-closeout-2026-05-25.md` | G | G2.96 closeout accepted in PR `#249` at `c0aa973`: records PR `#248` merge, confirms `get_wencai_service` app/API/package refs remain `0`, test refs are the focused absence assertion only, `WencaiService` remains active with app refs=`16` and route/API refs=`9`, focused test `2 passed`, and health route conflicts `120 passed` | Superseded by G2.97 service lifecycle candidate refresh |
 | `backend-service-lifecycle-candidate-refresh-after-wencai-2026-05-25.md` | G | G2.97 candidate refresh accepted in PR `#250` at `dfb1dce`: records PR `#249` merge, scans `152` service files / `575` app files / `219` API files / `1007` test files, finds `22` getter definitions and `5` candidate-like definitions, confirms `get_wencai_service` is no longer present as a service getter definition, selects `get_enhanced_data_service` as a future G2.98 authorization candidate only, and records GitNexus impact LOW / `3` with no affected processes | Superseded by G2.98 EnhancedDataService getter-retirement authorization |
-| `backend-enhanced-data-service-getter-retirement-authorization-2026-05-25.md` | G | G2.98 authorization prepared at `dfb1dce`: authorizes only future G2.99 removal of `get_enhanced_data_service` after TDD red/green; current scan shows getter refs app=`1` file / route/API=`0` / focused tests=`0` / package exports=`0`, one module-local `__main__` smoke call, GitNexus impact LOW / `3`, and `EnhancedDataService` class usage remains active in system health route | Human review / PR merge decision; if accepted, create G2.99 source-capable implementation with TDD red/green |
+| `backend-enhanced-data-service-getter-retirement-authorization-2026-05-25.md` | G | G2.98 authorization accepted in PR `#251` at `8fb6db0`: authorizes only future G2.99 removal of `get_enhanced_data_service` after TDD red/green; current scan shows getter refs app=`1` file / route/API=`0` / focused tests=`0` / package exports=`0`, one module-local `__main__` smoke call, GitNexus impact LOW / `3`, and `EnhancedDataService` class usage remains active in system health route | Superseded by G2.99 EnhancedDataService getter-retirement implementation |
+| `backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md` | G | G2.99 implementation prepared from base `8fb6db0`: removes only `get_enhanced_data_service` and `_enhanced_data_service`, preserves `EnhancedDataService`, updates the module-local `__main__` smoke call to direct construction, adds focused regression coverage, records TDD red `2 failed, 1 passed`, green `3 passed`, health route conflicts `120 passed`, ruff/black passed, and OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0` | Human review / PR merge decision; if accepted, create G2.100 closeout before next candidate refresh |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/enhanced-data-service-getter-retirement-implementation-2026-05-25.json
+++ b/.planning/codebase/generated/enhanced-data-service-getter-retirement-implementation-2026-05-25.json
@@ -1,0 +1,108 @@
+{
+  "artifact": "enhanced-data-service-getter-retirement-implementation-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T20:41:10+08:00",
+  "branch": "g2-99-enhanced-data-service-getter-retirement-implementation",
+  "base_head": "8fb6db0e13018d83eef7e0deca02106104c06160",
+  "parent_pr": {
+    "number": 251,
+    "title": "docs(governance): authorize enhanced data service getter retirement",
+    "merge_commit": "8fb6db0e13018d83eef7e0deca02106104c06160",
+    "disposition": "accepted"
+  },
+  "changes": [
+    {
+      "path": "web/backend/app/services/data_service_enhanced.py",
+      "change": "Removed only get_enhanced_data_service and the private _enhanced_data_service singleton state; preserved EnhancedDataService and changed the module-local __main__ smoke call to direct EnhancedDataService construction."
+    },
+    {
+      "path": "web/backend/tests/test_enhanced_data_service_getter_retirement.py",
+      "change": "Added focused regression coverage for getter absence, class availability, and removal of the private singleton state from the service source."
+    },
+    {
+      "path": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      "change": "Recorded G2.98 acceptance and G2.99 implementation state."
+    },
+    {
+      "path": "docs/reports/quality/backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md",
+      "change": "Recorded implementation evidence."
+    },
+    {
+      "path": "governance/mainline/task-cards/pr-252.yaml",
+      "change": "Recorded implementation task-card gate."
+    }
+  ],
+  "tdd": {
+    "red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_enhanced_data_service_getter_retirement.py -q --no-cov --tb=short",
+      "result": "2 failed, 1 passed",
+      "expected_failures": [
+        "hasattr(enhanced_data_service_module, \"get_enhanced_data_service\") was True",
+        "_enhanced_data_service remained in web/backend/app/services/data_service_enhanced.py"
+      ]
+    },
+    "green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_enhanced_data_service_getter_retirement.py -q --no-cov --tb=short",
+      "result": "3 passed in 1.82s"
+    }
+  },
+  "post_change_reference_scan": {
+    "get_enhanced_data_service": {
+      "app_refs": 0,
+      "route_api_refs": 0,
+      "test_refs": 2,
+      "package_export_refs": 0,
+      "notes": "Remaining refs are the focused absence assertions only."
+    },
+    "_enhanced_data_service": {
+      "app_refs": 0,
+      "route_api_refs": 0,
+      "test_refs": 1,
+      "package_export_refs": 0,
+      "notes": "Remaining ref is the focused absence assertion only."
+    },
+    "EnhancedDataService": {
+      "app_refs": 8,
+      "route_api_refs": 4,
+      "test_refs": 1,
+      "notes": "Class remains defined in data_service_enhanced.py and actively used by web/backend/app/api/v1/system/health.py."
+    }
+  },
+  "verification": {
+    "pre_edit_gitnexus_impact": {
+      "target": "get_enhanced_data_service",
+      "risk": "LOW",
+      "impacted_count": 3,
+      "direct": 1,
+      "affected_processes": 0
+    },
+    "focused_pytest": "3 passed",
+    "health_route_conflicts": "120 passed in 72.40s",
+    "ruff_touched_paths": "All checks passed!",
+    "black_check_touched_paths": "2 files would be left unchanged",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0
+    },
+    "gitnexus_staged_detect": {
+      "risk_level": "low",
+      "changed_files": 6,
+      "affected_count": 0,
+      "affected_processes": 0,
+      "note": "GitNexus marked multiple data_service_enhanced.py symbols as modified due to structured diff around the retired tail getter; no affected processes were detected."
+    }
+  },
+  "boundary": {
+    "enhanced_data_service_class_deleted": false,
+    "system_health_route_changed": false,
+    "route_api_changes": false,
+    "openapi_exposure_changes": false,
+    "frontend_changes": false,
+    "pm2_execution": false,
+    "openspec_changes": false,
+    "github_issue_label_changes": false
+  },
+  "next_gate": "Human review / PR merge decision for G2.99; if accepted, create G2.100 closeout before selecting another service lifecycle lane."
+}

--- a/docs/reports/quality/backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md
+++ b/docs/reports/quality/backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md
@@ -1,0 +1,92 @@
+# Backend EnhancedDataService Getter Retirement Implementation - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.99 EnhancedDataService getter-retirement implementation
+Status: ready for review
+
+## Purpose
+
+Implement the G2.98 authorization by retiring only the unused public
+compatibility getter `get_enhanced_data_service`.
+
+This implementation preserves `EnhancedDataService` and does not change system
+health routes, response models, OpenAPI exposure, frontend files, PM2 state,
+OpenSpec files, or GitHub issue labels.
+
+## Change Summary
+
+| Path | Change |
+|---|---|
+| `web/backend/app/services/data_service_enhanced.py` | Removed only `get_enhanced_data_service` and its private `_enhanced_data_service` singleton state; kept `EnhancedDataService` intact; changed the module-local `__main__` smoke call to construct `EnhancedDataService()` directly |
+| `web/backend/tests/test_enhanced_data_service_getter_retirement.py` | Added focused regression coverage for public getter absence, class importability, and private singleton-state removal |
+| `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md` | Recorded G2.98 acceptance and G2.99 implementation state |
+| `.planning/codebase/generated/enhanced-data-service-getter-retirement-implementation-2026-05-25.json` | Added generated implementation evidence |
+| `governance/mainline/task-cards/pr-252.yaml` | Added implementation task-card gate |
+
+## TDD Evidence
+
+| Step | Command | Result |
+|---|---|---|
+| Red | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_enhanced_data_service_getter_retirement.py -q --no-cov --tb=short` | `2 failed, 1 passed`; failures proved `get_enhanced_data_service` and `_enhanced_data_service` still existed |
+| Green | Same focused command after source edit | `3 passed in 1.82s` |
+
+## Post-Change Reference Scan
+
+| Signal | Value |
+|---|---:|
+| `get_enhanced_data_service` app refs | `0` |
+| `get_enhanced_data_service` route/API refs | `0` |
+| `get_enhanced_data_service` test refs | `2` |
+| `get_enhanced_data_service` package export refs | `0` |
+| `_enhanced_data_service` app refs | `0` |
+| `_enhanced_data_service` route/API refs | `0` |
+| `_enhanced_data_service` test refs | `1` |
+| `EnhancedDataService` app refs | `8` |
+| `EnhancedDataService` route/API refs | `4` |
+| `EnhancedDataService` test refs | `1` |
+
+Remaining `get_enhanced_data_service` and `_enhanced_data_service` references
+are focused absence assertions in
+`web/backend/tests/test_enhanced_data_service_getter_retirement.py`.
+
+`EnhancedDataService` remains active through direct class usage in
+`web/backend/app/api/v1/system/health.py`.
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| Pre-edit GitNexus impact | `get_enhanced_data_service`: LOW, impacted count `3`, direct `1`, affected processes `0` |
+| Focused pytest | `3 passed` |
+| Health route conflicts | `120 passed in 72.40s` |
+| Ruff touched paths | `All checks passed!` |
+| Black check touched paths | `2 files would be left unchanged` |
+| OpenAPI smoke | routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+| GitNexus staged detect | LOW risk, changed files=`6`, affected count=`0`, affected processes=`0` |
+
+The OpenAPI smoke used non-sensitive local placeholder environment variables and
+did not run PM2 or authorize runtime promotion.
+
+GitNexus marked multiple `data_service_enhanced.py` symbols as modified due to
+the structured diff around the retired tail getter. No affected execution flows
+were detected.
+
+## Boundary
+
+This implementation does not:
+
+- delete, rename, or migrate `EnhancedDataService`;
+- change `web/backend/app/api/v1/system/health.py`;
+- change routes, response models, response shapes, or OpenAPI exposure;
+- change frontend files, generated clients, PM2 state, OpenSpec files, or
+  GitHub issue labels.
+
+## Next Gate
+
+Human review / PR merge decision for this implementation packet.
+
+If accepted, create G2.100 as a closeout packet before selecting another service
+lifecycle lane.

--- a/governance/mainline/task-cards/pr-252.yaml
+++ b/governance/mainline/task-cards/pr-252.yaml
@@ -1,0 +1,121 @@
+version: "v0.2"
+
+task:
+  id: "pr-252"
+  title: "Retire EnhancedDataService compatibility getter"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-enhanced-data-service-getter-retirement-implementation"
+  objective: "remove the unused get_enhanced_data_service compatibility getter while preserving EnhancedDataService"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-enhanced-data-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-enhanced-data-service-getter-retirement-implementation"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "Narrow compatibility getter retirement; active system health route and EnhancedDataService class remain unchanged"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/services/data_service_enhanced.py"
+    - "web/backend/tests/test_enhanced_data_service_getter_retirement.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/enhanced-data-service-getter-retirement-implementation-2026-05-25.json"
+    - "docs/reports/quality/backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-252.yaml"
+  forbidden_paths:
+    - "web/backend/app/api/**"
+    - "web/frontend/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not delete or rename EnhancedDataService"
+  - "Do not change system health routes or route registration"
+  - "Do not change routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_enhanced_data_service_getter_retirement.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/data_service_enhanced.py web/backend/tests/test_enhanced_data_service_getter_retirement.py"
+      required: true
+    - id: "black-check-touched"
+      command: "black --check web/backend/app/services/data_service_enhanced.py web/backend/tests/test_enhanced_data_service_getter_retirement.py"
+      required: true
+    - id: "app-main-openapi-smoke"
+      command: "env PYTHONPATH=web/backend POSTGRESQL_HOST=localhost POSTGRESQL_USER=postgres POSTGRESQL_PASSWORD=postgres JWT_SECRET_KEY=test-secret-key-for-enhanced-data-service-getter-smoke BACKEND_PORT=8020 BACKEND_BACKUP_PORT=8021 python -c 'from collections import Counter; from app.main import app; schema=app.openapi(); ops=[operation.get(\"operationId\") for path_item in schema.get(\"paths\", {}).values() for operation in path_item.values() if isinstance(operation, dict) and operation.get(\"operationId\")]; dups=[op for op, count in Counter(ops).items() if count > 1]; print(len(app.routes), len(schema.get(\"paths\", {})), len(ops), len(dups))'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/enhanced-data-service-getter-retirement-implementation-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-252.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-252.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If EnhancedDataService class usage is confused with the retired getter, the active system health route could be over-scoped"
+    - "If new consumers reintroduce get_enhanced_data_service before merge, the branch must stop and refresh references"
+  rollback_plan: "revert this implementation PR to restore get_enhanced_data_service and _enhanced_data_service, and remove the focused absence test"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "retire unused get_enhanced_data_service compatibility getter"
+    modified_scope: "data_service_enhanced.py, focused regression test, steward tree, implementation report, generated artifact, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; EnhancedDataService remains active and system health route is unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this implementation PR if focused pytest, health-route conflicts, ruff, black, OpenAPI smoke, governance validation, mainline scope, or staged GitNexus checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T20:41:10+08:00"
+    approval_note: "G2.98 authorization PR #251 was merged; this implementation removes only get_enhanced_data_service and preserves EnhancedDataService"
+    secondary_approved: false

--- a/web/backend/app/services/data_service_enhanced.py
+++ b/web/backend/app/services/data_service_enhanced.py
@@ -573,23 +573,11 @@ class EnhancedDataService:
             return None
 
 
-# Enhanced singleton
-_enhanced_data_service = None
-
-
-def get_enhanced_data_service() -> EnhancedDataService:
-    """获取增强数据服务单例"""
-    global _enhanced_data_service
-    if _enhanced_data_service is None:
-        _enhanced_data_service = EnhancedDataService()
-    return _enhanced_data_service
-
-
 if __name__ == "__main__":
     logger.info("Testing Enhanced Data Service...")
 
     # Test enhanced data service
-    service = get_enhanced_data_service()
+    service = EnhancedDataService()
 
     # Test health check
     health = service.get_service_health()

--- a/web/backend/tests/test_enhanced_data_service_getter_retirement.py
+++ b/web/backend/tests/test_enhanced_data_service_getter_retirement.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+from app.services import data_service_enhanced as enhanced_data_service_module
+
+
+def test_public_enhanced_data_service_getter_is_retired():
+    assert not hasattr(enhanced_data_service_module, "get_enhanced_data_service")
+
+
+def test_enhanced_data_service_class_remains_importable():
+    assert hasattr(enhanced_data_service_module, "EnhancedDataService")
+
+
+def test_enhanced_data_service_singleton_state_is_retired():
+    source = Path(enhanced_data_service_module.__file__).read_text()
+
+    assert "_enhanced_data_service" not in source
+    assert "get_enhanced_data_service()" not in source


### PR DESCRIPTION
## Summary
- remove only `get_enhanced_data_service` and `_enhanced_data_service` from `data_service_enhanced.py`
- preserve `EnhancedDataService` and leave system health route behavior unchanged
- add focused regression coverage proving getter/state absence and class importability
- update the steward tree, implementation evidence JSON/report, and PR #252 task-card

## TDD
- red: `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_enhanced_data_service_getter_retirement.py -q --no-cov --tb=short` -> `2 failed, 1 passed`
- green: same command -> `3 passed in 1.82s`

## Verification
- pre-edit GitNexus impact: `get_enhanced_data_service` LOW, impacted count `3`, affected processes `0`
- `ruff check web/backend/app/services/data_service_enhanced.py web/backend/tests/test_enhanced_data_service_getter_retirement.py`: passed
- `black --check web/backend/app/services/data_service_enhanced.py web/backend/tests/test_enhanced_data_service_getter_retirement.py`: passed
- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short`: `120 passed`
- OpenAPI smoke: routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0`
- Markdown governance: checked files `2`, errors `0`
- JSON/YAML parse: passed
- `git diff --cached --check`: passed
- post-commit mainline scope: `pass=True`
- GitNexus staged detect: low risk, changed files `6`, affected count `0`, affected processes `0`
- post-commit `gitnexus analyze --with-gitignore`: refreshed

## Boundary
- does not delete, rename, or migrate `EnhancedDataService`
- does not edit `web/backend/app/api/v1/system/health.py`
- no route/API, OpenAPI exposure, response model, PM2, frontend, OpenSpec, or issue-label changes
