### PR TITLE
docs(governance): close out enhanced data service getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1590,9 +1590,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                `EnhancedDataService` deletion, or issue-label change is
 │   │                made here
 │   ├── G2.99 EnhancedDataService getter-retirement implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#252` merged at
+│   │   │          `e3bb781d8a92bc8e59a31a6d99d3d9a54f3d14b6`
 │   │   ├── Evidence: `backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md`
-│   │   ├── Base HEAD: `8fb6db0e13018d83eef7e0deca02106104c06160`
+│   │   ├── Current HEAD: `e3bb781d8a92bc8e59a31a6d99d3d9a54f3d14b6`
 │   │   ├── Result: removes only `get_enhanced_data_service` and its private
 │   │   │          `_enhanced_data_service` singleton state, updates the
 │   │   │          module-local `__main__` smoke call to construct
@@ -1605,9 +1606,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                `EnhancedDataService` deletion, or issue-label change is
 │   │                made here
-│   └── Next gate: human review / PR merge decision for G2.99; if accepted,
-│                  create G2.100 closeout before selecting another service
-│                  lifecycle lane
+│   ├── G2.100 EnhancedDataService getter-retirement closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-enhanced-data-service-getter-retirement-closeout-2026-05-25.md`
+│   │   ├── Current HEAD: `e3bb781d8a92bc8e59a31a6d99d3d9a54f3d14b6`
+│   │   ├── Result: records PR `#252` merge and closes the
+│   │   │          EnhancedDataService public compatibility getter lane;
+│   │   │          current-head scan shows `get_enhanced_data_service` app refs
+│   │   │          `0`, route/API refs `0`, tests `2` absence assertions,
+│   │   │          package exports `0`, `_enhanced_data_service` app refs `0`,
+│   │   │          and `EnhancedDataService` remains active with app refs `8`
+│   │   │          and route/API refs `4`; focused test `3 passed`, health
+│   │   │          route conflicts `120 passed`
+│   │   └── Boundary: closeout-only; no source, test, route/API, OpenAPI
+│   │                exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                `EnhancedDataService` deletion, or issue-label change is
+│   │                made here
+│   └── Next gate: human review / PR merge decision for G2.100; if accepted,
+│                  refresh service lifecycle getter candidates before selecting
+│                  another implementation lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1692,7 +1709,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-wencai-compat-getter-retirement-closeout-2026-05-25.md` | G | G2.96 closeout accepted in PR `#249` at `c0aa973`: records PR `#248` merge, confirms `get_wencai_service` app/API/package refs remain `0`, test refs are the focused absence assertion only, `WencaiService` remains active with app refs=`16` and route/API refs=`9`, focused test `2 passed`, and health route conflicts `120 passed` | Superseded by G2.97 service lifecycle candidate refresh |
 | `backend-service-lifecycle-candidate-refresh-after-wencai-2026-05-25.md` | G | G2.97 candidate refresh accepted in PR `#250` at `dfb1dce`: records PR `#249` merge, scans `152` service files / `575` app files / `219` API files / `1007` test files, finds `22` getter definitions and `5` candidate-like definitions, confirms `get_wencai_service` is no longer present as a service getter definition, selects `get_enhanced_data_service` as a future G2.98 authorization candidate only, and records GitNexus impact LOW / `3` with no affected processes | Superseded by G2.98 EnhancedDataService getter-retirement authorization |
 | `backend-enhanced-data-service-getter-retirement-authorization-2026-05-25.md` | G | G2.98 authorization accepted in PR `#251` at `8fb6db0`: authorizes only future G2.99 removal of `get_enhanced_data_service` after TDD red/green; current scan shows getter refs app=`1` file / route/API=`0` / focused tests=`0` / package exports=`0`, one module-local `__main__` smoke call, GitNexus impact LOW / `3`, and `EnhancedDataService` class usage remains active in system health route | Superseded by G2.99 EnhancedDataService getter-retirement implementation |
-| `backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md` | G | G2.99 implementation prepared from base `8fb6db0`: removes only `get_enhanced_data_service` and `_enhanced_data_service`, preserves `EnhancedDataService`, updates the module-local `__main__` smoke call to direct construction, adds focused regression coverage, records TDD red `2 failed, 1 passed`, green `3 passed`, health route conflicts `120 passed`, ruff/black passed, and OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0` | Human review / PR merge decision; if accepted, create G2.100 closeout before next candidate refresh |
+| `backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md` | G | G2.99 implementation accepted in PR `#252` at `e3bb781`: removes only `get_enhanced_data_service` and `_enhanced_data_service`, preserves `EnhancedDataService`, updates the module-local `__main__` smoke call to direct construction, adds focused regression coverage, records TDD red `2 failed, 1 passed`, green `3 passed`, health route conflicts `120 passed`, ruff/black passed, and OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0` | Superseded by G2.100 closeout |
+| `backend-enhanced-data-service-getter-retirement-closeout-2026-05-25.md` | G | G2.100 closeout prepared at `e3bb781`: records PR `#252` merge, confirms `get_enhanced_data_service` app/API/package refs remain `0`, test refs are focused absence assertions only, `_enhanced_data_service` app/API refs are `0`, `EnhancedDataService` remains active with app refs=`8` and route/API refs=`4`, focused test `3 passed`, and health route conflicts `120 passed` | Human review / PR merge decision; if accepted, refresh service lifecycle getter candidates before selecting another implementation lane |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/enhanced-data-service-getter-retirement-closeout-2026-05-25.json
+++ b/.planning/codebase/generated/enhanced-data-service-getter-retirement-closeout-2026-05-25.json
@@ -1,0 +1,57 @@
+{
+  "artifact": "enhanced-data-service-getter-retirement-closeout-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T20:56:14+08:00",
+  "branch": "g2-100-enhanced-data-service-getter-retirement-closeout",
+  "current_head": "e3bb781d8a92bc8e59a31a6d99d3d9a54f3d14b6",
+  "parent_pr": {
+    "number": 252,
+    "title": "refactor(services): retire enhanced data service getter",
+    "merge_commit": "e3bb781d8a92bc8e59a31a6d99d3d9a54f3d14b6",
+    "state": "MERGED",
+    "merged_at": "2026-05-25T12:52:13Z"
+  },
+  "post_merge_reference_scan": {
+    "get_enhanced_data_service": {
+      "app_refs": 0,
+      "route_api_refs": 0,
+      "test_refs": 2,
+      "package_export_refs": 0,
+      "notes": "Remaining references are focused absence assertions only."
+    },
+    "_enhanced_data_service": {
+      "app_refs": 0,
+      "route_api_refs": 0,
+      "test_refs": 1,
+      "package_export_refs": 0,
+      "notes": "Remaining reference is the focused absence assertion only."
+    },
+    "EnhancedDataService": {
+      "app_refs": 8,
+      "route_api_refs": 4,
+      "test_refs": 1,
+      "active_usage": [
+        "web/backend/app/services/data_service_enhanced.py",
+        "web/backend/app/api/v1/system/health.py"
+      ],
+      "deletion_authorized": false
+    }
+  },
+  "verification": {
+    "focused_pytest": "3 passed in 1.82s",
+    "health_route_conflicts": "120 passed in 75.34s",
+    "parent_pr_state": "MERGED"
+  },
+  "boundary": {
+    "closeout_only": true,
+    "source_changes": false,
+    "test_changes": false,
+    "route_api_changes": false,
+    "openapi_exposure_changes": false,
+    "frontend_changes": false,
+    "pm2_execution": false,
+    "openspec_changes": false,
+    "github_issue_label_changes": false
+  },
+  "next_gate": "Human review / PR merge decision for G2.100; if accepted, refresh service lifecycle getter candidates before selecting another implementation lane."
+}

--- a/docs/reports/quality/backend-enhanced-data-service-getter-retirement-closeout-2026-05-25.md
+++ b/docs/reports/quality/backend-enhanced-data-service-getter-retirement-closeout-2026-05-25.md
@@ -1,0 +1,78 @@
+# Backend EnhancedDataService Getter Retirement Closeout - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.100 EnhancedDataService getter-retirement closeout
+Status: ready for review
+
+## Purpose
+
+Close out the G2.99 EnhancedDataService getter-retirement implementation after
+PR `#252` was merged.
+
+This closeout is governance-only. It records merge state, current-head
+references, verification evidence, and the next service lifecycle gate.
+
+## Merge Evidence
+
+| Field | Value |
+|---|---|
+| Parent PR | `#252` |
+| Parent PR state | `MERGED` |
+| Parent PR URL | `https://github.com/chengjon/mystocks/pull/252` |
+| Merge commit | `e3bb781d8a92bc8e59a31a6d99d3d9a54f3d14b6` |
+| Merged at | `2026-05-25T12:52:13Z` |
+| Current HEAD | `e3bb781d8a92bc8e59a31a6d99d3d9a54f3d14b6` |
+
+## Current-Head Reference Scan
+
+| Signal | Value |
+|---|---:|
+| `get_enhanced_data_service` app refs | `0` |
+| `get_enhanced_data_service` route/API refs | `0` |
+| `get_enhanced_data_service` test refs | `2` |
+| `get_enhanced_data_service` package export refs | `0` |
+| `_enhanced_data_service` app refs | `0` |
+| `_enhanced_data_service` route/API refs | `0` |
+| `_enhanced_data_service` test refs | `1` |
+| `_enhanced_data_service` package export refs | `0` |
+| `EnhancedDataService` app refs | `8` |
+| `EnhancedDataService` route/API refs | `4` |
+| `EnhancedDataService` test refs | `1` |
+
+Remaining `get_enhanced_data_service` and `_enhanced_data_service` references
+are focused absence assertions in
+`web/backend/tests/test_enhanced_data_service_getter_retirement.py`.
+
+`EnhancedDataService` remains active through:
+
+- `web/backend/app/services/data_service_enhanced.py`;
+- `web/backend/app/api/v1/system/health.py`.
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| Parent PR state | `MERGED` |
+| Focused pytest | `3 passed in 1.82s` |
+| Health route conflicts | `120 passed in 75.34s` |
+
+## Boundary
+
+This closeout does not:
+
+- edit backend source or tests;
+- delete `get_enhanced_data_service`;
+- delete, rename, or migrate `EnhancedDataService`;
+- change routes, response models, response shapes, or OpenAPI exposure;
+- change frontend files, generated clients, PM2 state, OpenSpec files, or
+  GitHub issue labels.
+
+## Next Gate
+
+Human review / PR merge decision for this closeout packet.
+
+If accepted, refresh service lifecycle getter candidates before selecting the
+next implementation lane.

--- a/governance/mainline/task-cards/pr-253.yaml
+++ b/governance/mainline/task-cards/pr-253.yaml
@@ -1,0 +1,113 @@
+version: "v0.2"
+
+task:
+  id: "pr-253"
+  title: "Close out EnhancedDataService getter retirement"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-enhanced-data-service-getter-retirement-closeout"
+  objective: "record PR #252 merge evidence and close the EnhancedDataService getter-retirement lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-enhanced-data-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-enhanced-data-service-getter-retirement-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/enhanced-data-service-getter-retirement-closeout-2026-05-25.json"
+    - "docs/reports/quality/backend-enhanced-data-service-getter-retirement-closeout-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-253.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not delete or reintroduce get_enhanced_data_service"
+  - "Do not delete or migrate EnhancedDataService"
+  - "Do not change routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 252 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "focused-pytest"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_enhanced_data_service_getter_retirement.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-enhanced-data-service-getter-retirement-closeout-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/enhanced-data-service-getter-retirement-closeout-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-253.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-253.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is mistaken for source authorization, future work could skip the required candidate-refresh gate"
+    - "If test-only absence references are mistaken for live app refs, the lane could be reopened unnecessarily"
+  rollback_plan: "revert this governance-only PR and keep G2.99 implementation evidence as the latest accepted state"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out EnhancedDataService getter retirement after PR #252 merge"
+    modified_scope: "steward tree, closeout report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; closeout-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if parent PR evidence, focused pytest, health-route conflicts, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T20:56:14+08:00"
+    approval_note: "G2.99 implementation PR #252 was merged; this packet closes out the EnhancedDataService getter-retirement lane and requires a candidate refresh before another implementation lane"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record PR #252 merge evidence for the EnhancedDataService getter-retirement implementation
- confirm `get_enhanced_data_service` and `_enhanced_data_service` have no live app/API/package refs after merge
- keep `EnhancedDataService` active and explicitly outside deletion scope
- set the next gate to a fresh service lifecycle candidate refresh before another implementation lane

## Evidence
- parent PR #252: MERGED at `e3bb781d8a92bc8e59a31a6d99d3d9a54f3d14b6`
- focused pytest: `3 passed in 1.82s`
- health route conflicts: `120 passed in 75.34s`
- current-head scan: getter app/API/package refs `0`; remaining getter/private-state refs are focused absence assertions only
- `EnhancedDataService` remains active with app refs `8` and route/API refs `4`

## Verification
- `gh pr view 252 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url`
- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_enhanced_data_service_getter_retirement.py -q --no-cov --tb=short`
- `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short`
- `python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-enhanced-data-service-getter-retirement-closeout-2026-05-25.md`
- `python -m json.tool .planning/codebase/generated/enhanced-data-service-getter-retirement-closeout-2026-05-25.json >/dev/null`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-253.yaml').read_text())"`
- `git diff --cached --check`
- GitNexus staged detect: low risk, changed files `4`, affected count `0`, affected processes `0`
- post-commit mainline scope: `pass=True`
- post-commit `gitnexus analyze --with-gitignore`: refreshed

## Boundary
- closeout-only
- no backend source/test changes
- no route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label changes
- no getter deletion or `EnhancedDataService` deletion in this PR
