### PR TITLE
docs(governance): refresh service candidates after enhanced data service

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1607,9 +1607,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                `EnhancedDataService` deletion, or issue-label change is
 │   │                made here
 │   ├── G2.100 EnhancedDataService getter-retirement closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#253` merged at
+│   │   │          `d7be7e6e8bb0ad3bcf62b9420bc5da5d7941054e`
 │   │   ├── Evidence: `backend-enhanced-data-service-getter-retirement-closeout-2026-05-25.md`
-│   │   ├── Current HEAD: `e3bb781d8a92bc8e59a31a6d99d3d9a54f3d14b6`
+│   │   ├── Current HEAD: `d7be7e6e8bb0ad3bcf62b9420bc5da5d7941054e`
 │   │   ├── Result: records PR `#252` merge and closes the
 │   │   │          EnhancedDataService public compatibility getter lane;
 │   │   │          current-head scan shows `get_enhanced_data_service` app refs
@@ -1622,9 +1623,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                `EnhancedDataService` deletion, or issue-label change is
 │   │                made here
-│   └── Next gate: human review / PR merge decision for G2.100; if accepted,
-│                  refresh service lifecycle getter candidates before selecting
-│                  another implementation lane
+│   ├── G2.101 Service lifecycle candidate refresh after EnhancedDataService
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.md`
+│   │   ├── Current HEAD: `d7be7e6e8bb0ad3bcf62b9420bc5da5d7941054e`
+│   │   ├── Result: records PR `#253` merge, refreshes service getter
+│   │   │          candidates at current HEAD, scans `152` service files,
+│   │   │          `575` app files, `219` API files, and `1008` test files,
+│   │   │          finds `18` getter definitions and `4` candidate-like
+│   │   │          definitions, confirms `get_enhanced_data_service` is no
+│   │   │          longer a service getter definition, and selects
+│   │   │          `get_tradingview_service` as a future G2.102 authorization
+│   │   │          candidate only; GitNexus impact is LOW / `1`, with no
+│   │   │          affected processes
+│   │   └── Boundary: candidate-refresh only; no source, test, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter
+│   │                deletion, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.101; if accepted,
+│                  create G2.102 TradingView getter-retirement authorization
+│                  before any source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1710,7 +1727,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-candidate-refresh-after-wencai-2026-05-25.md` | G | G2.97 candidate refresh accepted in PR `#250` at `dfb1dce`: records PR `#249` merge, scans `152` service files / `575` app files / `219` API files / `1007` test files, finds `22` getter definitions and `5` candidate-like definitions, confirms `get_wencai_service` is no longer present as a service getter definition, selects `get_enhanced_data_service` as a future G2.98 authorization candidate only, and records GitNexus impact LOW / `3` with no affected processes | Superseded by G2.98 EnhancedDataService getter-retirement authorization |
 | `backend-enhanced-data-service-getter-retirement-authorization-2026-05-25.md` | G | G2.98 authorization accepted in PR `#251` at `8fb6db0`: authorizes only future G2.99 removal of `get_enhanced_data_service` after TDD red/green; current scan shows getter refs app=`1` file / route/API=`0` / focused tests=`0` / package exports=`0`, one module-local `__main__` smoke call, GitNexus impact LOW / `3`, and `EnhancedDataService` class usage remains active in system health route | Superseded by G2.99 EnhancedDataService getter-retirement implementation |
 | `backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md` | G | G2.99 implementation accepted in PR `#252` at `e3bb781`: removes only `get_enhanced_data_service` and `_enhanced_data_service`, preserves `EnhancedDataService`, updates the module-local `__main__` smoke call to direct construction, adds focused regression coverage, records TDD red `2 failed, 1 passed`, green `3 passed`, health route conflicts `120 passed`, ruff/black passed, and OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0` | Superseded by G2.100 closeout |
-| `backend-enhanced-data-service-getter-retirement-closeout-2026-05-25.md` | G | G2.100 closeout prepared at `e3bb781`: records PR `#252` merge, confirms `get_enhanced_data_service` app/API/package refs remain `0`, test refs are focused absence assertions only, `_enhanced_data_service` app/API refs are `0`, `EnhancedDataService` remains active with app refs=`8` and route/API refs=`4`, focused test `3 passed`, and health route conflicts `120 passed` | Human review / PR merge decision; if accepted, refresh service lifecycle getter candidates before selecting another implementation lane |
+| `backend-enhanced-data-service-getter-retirement-closeout-2026-05-25.md` | G | G2.100 closeout accepted in PR `#253` at `d7be7e6`: records PR `#252` merge, confirms `get_enhanced_data_service` app/API/package refs remain `0`, test refs are focused absence assertions only, `_enhanced_data_service` app/API refs are `0`, `EnhancedDataService` remains active with app refs=`8` and route/API refs=`4`, focused test `3 passed`, and health route conflicts `120 passed` | Superseded by G2.101 service lifecycle candidate refresh |
+| `backend-service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.md` | G | G2.101 candidate refresh prepared at `d7be7e6`: records PR `#253` merge, scans `152` service files / `575` app files / `219` API files / `1008` test files, finds `18` getter definitions and `4` candidate-like definitions, confirms `get_enhanced_data_service` is no longer present as a service getter definition, selects `get_tradingview_service` as a future G2.102 authorization candidate only, and records GitNexus impact LOW / `1` with no affected processes | Human review / PR merge decision; if accepted, create G2.102 TradingView getter-retirement authorization before any source edit |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.json
+++ b/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.json
@@ -1,0 +1,109 @@
+{
+  "artifact": "service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T21:09:40+08:00",
+  "branch": "g2-101-service-lifecycle-candidate-refresh-after-enhanced-data-service",
+  "current_head": "d7be7e6e8bb0ad3bcf62b9420bc5da5d7941054e",
+  "parent_pr": {
+    "number": 253,
+    "title": "docs(governance): close out enhanced data service getter retirement",
+    "merge_commit": "d7be7e6e8bb0ad3bcf62b9420bc5da5d7941054e",
+    "disposition": "accepted"
+  },
+  "scan_summary": {
+    "service_files": 152,
+    "app_files": 575,
+    "api_files": 219,
+    "test_files": 1008,
+    "getter_definitions": 18,
+    "candidate_like_definitions": 4,
+    "holds": 14
+  },
+  "candidate_rows": [
+    {
+      "symbol": "get_email_service",
+      "file": "web/backend/app/services/email_notification_service.py",
+      "line": 324,
+      "app_refs": 3,
+      "route_api_refs": 0,
+      "test_refs": 3,
+      "package_export_refs": 0,
+      "disposition": "hold_duplicate_logical_getter_name_prior_email_lane_requires_separate_decision"
+    },
+    {
+      "symbol": "get_announcement_service",
+      "file": "web/backend/app/services/announcement_service.py",
+      "line": 526,
+      "app_refs": 2,
+      "route_api_refs": 0,
+      "test_refs": 1,
+      "package_export_refs": 0,
+      "disposition": "hold_completed_announcement_di_lane_not_reopened_here"
+    },
+    {
+      "symbol": "get_email_service",
+      "file": "web/backend/app/services/email_service.py",
+      "line": 325,
+      "app_refs": 3,
+      "route_api_refs": 0,
+      "test_refs": 3,
+      "package_export_refs": 0,
+      "disposition": "hold_duplicate_logical_getter_name_prior_email_lane_requires_separate_decision"
+    },
+    {
+      "symbol": "get_tradingview_service",
+      "file": "web/backend/app/services/tradingview_widget_service.py",
+      "line": 322,
+      "app_refs": 2,
+      "route_api_refs": 0,
+      "test_refs": 2,
+      "package_export_refs": 0,
+      "disposition": "select_future_authorization_candidate_only"
+    }
+  ],
+  "selected_next_lane": {
+    "workline": "G2.102",
+    "candidate": "TradingViewWidgetService",
+    "symbol": "get_tradingview_service",
+    "decision": "prepare a future TradingView getter-retirement authorization packet only",
+    "source_edit_authorized_by_this_packet": false,
+    "service_deletion_authorized": false,
+    "future_authorization_required": true
+  },
+  "gitnexus": {
+    "analyze": {
+      "command": "gitnexus analyze --with-gitignore",
+      "result": "repository indexed successfully",
+      "nodes": 62761,
+      "edges": 145913,
+      "clusters": 3287,
+      "flows": 300
+    },
+    "impact": {
+      "target": "get_tradingview_service",
+      "direction": "upstream",
+      "risk": "LOW",
+      "impacted_count": 1,
+      "direct": 1,
+      "processes_affected": 0,
+      "affected_processes": []
+    },
+    "context": {
+      "incoming": "install_tradingview_service calls get_tradingview_service",
+      "outgoing": "none",
+      "processes": []
+    }
+  },
+  "boundary": {
+    "candidate_refresh_only": true,
+    "source_changes": false,
+    "test_changes": false,
+    "route_api_changes": false,
+    "openapi_exposure_changes": false,
+    "frontend_changes": false,
+    "pm2_execution": false,
+    "openspec_changes": false,
+    "github_issue_label_changes": false
+  },
+  "next_gate": "Human review / PR merge decision for G2.101; if accepted, create G2.102 TradingView getter-retirement authorization before any source edit."
+}

--- a/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.md
+++ b/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.md
@@ -1,0 +1,92 @@
+# Backend Service Lifecycle Candidate Refresh After EnhancedDataService - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.101 service lifecycle candidate refresh after EnhancedDataService
+Status: ready for review
+
+## Purpose
+
+Refresh service lifecycle getter candidates after the EnhancedDataService public
+compatibility getter lane was closed through PR `#253`.
+
+This packet is candidate-refresh only. It does not authorize source edits,
+getter deletion, route/API changes, OpenAPI exposure changes, PM2 execution,
+OpenSpec changes, frontend edits, or issue-label changes.
+
+## Input State
+
+G2.100 was accepted through PR `#253`, merged at
+`d7be7e6e8bb0ad3bcf62b9420bc5da5d7941054e`.
+
+Current HEAD for this packet:
+`d7be7e6e8bb0ad3bcf62b9420bc5da5d7941054e`.
+
+## Current-Head Scan Summary
+
+| Metric | Value |
+|---|---:|
+| Service files scanned | `152` |
+| Backend app files scanned | `575` |
+| API files scanned | `219` |
+| Test files scanned | `1008` |
+| Getter definitions | `18` |
+| Candidate-like definitions | `4` |
+| Holds | `14` |
+
+`get_enhanced_data_service` is no longer present as a service getter definition.
+
+## Candidate Rows
+
+| Symbol | File | Line | App refs | Route/API refs | Test refs | Package export refs | Disposition |
+|---|---|---:|---:|---:|---:|---:|---|
+| `get_email_service` | `web/backend/app/services/email_notification_service.py` | `324` | `3` | `0` | `3` | `0` | hold duplicate logical getter name; prior email lane requires separate decision |
+| `get_announcement_service` | `web/backend/app/services/announcement_service.py` | `526` | `2` | `0` | `1` | `0` | hold completed announcement DI lane; do not reopen here |
+| `get_email_service` | `web/backend/app/services/email_service.py` | `325` | `3` | `0` | `3` | `0` | hold duplicate logical getter name; prior email lane requires separate decision |
+| `get_tradingview_service` | `web/backend/app/services/tradingview_widget_service.py` | `322` | `2` | `0` | `2` | `0` | select future authorization candidate only |
+
+## Selected Next Lane
+
+Select `get_tradingview_service` as the next future authorization candidate.
+
+Rationale:
+
+- The getter has no route/API references.
+- It has no package export references.
+- GitNexus impact is LOW with impacted count `1` and affected processes `0`.
+- The only direct graph caller is `install_tradingview_service`, so the future
+  authorization packet can define a narrow implementation boundary around the
+  module-local fallback singleton without touching route registration.
+
+Boundary:
+
+- This selection does not authorize deleting `TradingViewWidgetService`.
+- This selection does not authorize changing TradingView routes, response
+  models, response shapes, OpenAPI exposure, frontend code, PM2 state, or issue
+  labels.
+- A future G2.102 packet must be authorization-only first and must distinguish
+  getter retirement from the active TradingView service class, install helper,
+  and dependency provider.
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| GitNexus index | Refreshed with `gitnexus analyze --with-gitignore`; graph contains `62,761` nodes, `145,913` edges, `3,287` clusters, and `300` flows |
+| Getter candidate scan | `152` service files, `575` app files, `219` API files, `1008` test files, `18` getter definitions, `4` candidate-like definitions, `14` holds |
+| Selected candidate impact | `get_tradingview_service`: LOW, impacted count `1`, affected processes `0` |
+| Selected candidate context | getter lazily initializes `_tradingview_service`; direct graph caller is `install_tradingview_service`; no process participation |
+
+## Boundary
+
+This packet makes no source, test, route/API, OpenAPI, PM2, frontend, OpenSpec,
+or issue-label changes.
+
+## Next Gate
+
+Human review / PR merge decision for this G2.101 governance packet.
+
+If accepted, create G2.102 as a TradingView getter-retirement authorization
+packet before any source edit.

--- a/governance/mainline/task-cards/pr-254.yaml
+++ b/governance/mainline/task-cards/pr-254.yaml
@@ -1,0 +1,107 @@
+version: "v0.2"
+
+task:
+  id: "pr-254"
+  title: "Refresh service lifecycle candidates after EnhancedDataService"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-service-lifecycle-candidate-refresh-after-enhanced-data-service"
+  objective: "record G2.100 merge evidence and select the next service getter authorization candidate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-candidate-refresh"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-candidate-refresh-after-enhanced-data-service"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate-refresh packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.json"
+    - "docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-254.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not delete get_tradingview_service in this packet"
+  - "Do not delete or migrate TradingViewWidgetService"
+  - "Do not change TradingView routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 253 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-254.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-254.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet is treated as source authorization, get_tradingview_service could be changed without the required G2.102 gate"
+    - "If TradingViewWidgetService class usage is confused with getter usage, active TradingView behavior could be over-scoped"
+  rollback_plan: "revert this governance-only PR and keep G2.100 as the latest accepted service lifecycle closeout evidence"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh service lifecycle candidates after EnhancedDataService getter retirement"
+    modified_scope: "steward tree, candidate-refresh report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; get_tradingview_service is only selected for a future authorization packet"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if parent PR evidence, candidate scan, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T21:09:40+08:00"
+    approval_note: "G2.100 closeout PR #253 was merged; this packet records a fresh candidate refresh and selects only a future G2.102 TradingView authorization candidate"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- accept G2.100 / PR #253 and refresh service lifecycle getter candidates
- confirm `get_enhanced_data_service` is no longer a service getter definition
- record 18 getter definitions, 4 candidate-like definitions, and 14 holds at current HEAD
- select `get_tradingview_service` only as a future G2.102 authorization candidate

## Evidence
- current HEAD: `d7be7e6e8bb0ad3bcf62b9420bc5da5d7941054e`
- scan: service files `152`, app files `575`, API files `219`, test files `1008`
- candidate rows: duplicate `get_email_service` held, `get_announcement_service` held as completed lane, `get_tradingview_service` selected for future authorization only
- GitNexus impact for `get_tradingview_service`: LOW, impacted count `1`, affected processes `0`
- direct graph caller: `install_tradingview_service`

## Verification
- `gitnexus analyze --with-gitignore`
- candidate scan script over `web/backend/app/services`, `web/backend/app`, `web/backend/app/api`, `web/backend/tests`, and `tests`
- `python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.md`
- `python -m json.tool .planning/codebase/generated/service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.json >/dev/null`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-254.yaml').read_text())"`
- `git diff --cached --check`
- GitNexus staged detect: low risk, changed files `4`, affected count `0`, affected processes `0`
- post-commit mainline scope: `pass=True`
- post-commit `gitnexus analyze --with-gitignore`: refreshed

## Boundary
- governance-only candidate refresh
- no backend source/test edits
- no route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label changes
- no `get_tradingview_service` or `TradingViewWidgetService` change authorized in this PR
