### PR TITLE
docs(governance): authorize tradingview getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1624,9 +1624,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                `EnhancedDataService` deletion, or issue-label change is
 │   │                made here
 │   ├── G2.101 Service lifecycle candidate refresh after EnhancedDataService
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#254` merged at
+│   │   │          `c8eae46c738fff199100cf4e02015a9ade887eee`
 │   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.md`
-│   │   ├── Current HEAD: `d7be7e6e8bb0ad3bcf62b9420bc5da5d7941054e`
+│   │   ├── Current HEAD: `c8eae46c738fff199100cf4e02015a9ade887eee`
 │   │   ├── Result: records PR `#253` merge, refreshes service getter
 │   │   │          candidates at current HEAD, scans `152` service files,
 │   │   │          `575` app files, `219` API files, and `1008` test files,
@@ -1639,9 +1640,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: candidate-refresh only; no source, test, route/API,
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter
 │   │                deletion, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.101; if accepted,
-│                  create G2.102 TradingView getter-retirement authorization
-│                  before any source edit
+│   ├── G2.102 TradingView getter-retirement authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-tradingview-getter-retirement-authorization-2026-05-25.md`
+│   │   ├── Current HEAD: `c8eae46c738fff199100cf4e02015a9ade887eee`
+│   │   ├── Result: authorizes only a future G2.103 implementation branch to
+│   │   │          retire `get_tradingview_service` from
+│   │   │          `web/backend/app/services/tradingview_widget_service.py`
+│   │   │          after TDD red/green; current evidence shows getter refs
+│   │   │          app=`2`, route/API=`0`, tests=`2`, package exports=`0`,
+│   │   │          with `install_tradingview_service` as the only direct graph
+│   │   │          caller; GitNexus impact is LOW / `1`, with no affected
+│   │   │          processes
+│   │   └── Boundary: authorization-only; no source, test, route/API, OpenAPI
+│   │                exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                `TradingViewWidgetService` deletion, or issue-label change
+│   │                is made here
+│   └── Next gate: human review / PR merge decision for G2.102; if accepted,
+│                  create G2.103 TradingView getter-retirement implementation
+│                  with TDD red/green before source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1728,7 +1745,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-enhanced-data-service-getter-retirement-authorization-2026-05-25.md` | G | G2.98 authorization accepted in PR `#251` at `8fb6db0`: authorizes only future G2.99 removal of `get_enhanced_data_service` after TDD red/green; current scan shows getter refs app=`1` file / route/API=`0` / focused tests=`0` / package exports=`0`, one module-local `__main__` smoke call, GitNexus impact LOW / `3`, and `EnhancedDataService` class usage remains active in system health route | Superseded by G2.99 EnhancedDataService getter-retirement implementation |
 | `backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md` | G | G2.99 implementation accepted in PR `#252` at `e3bb781`: removes only `get_enhanced_data_service` and `_enhanced_data_service`, preserves `EnhancedDataService`, updates the module-local `__main__` smoke call to direct construction, adds focused regression coverage, records TDD red `2 failed, 1 passed`, green `3 passed`, health route conflicts `120 passed`, ruff/black passed, and OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0` | Superseded by G2.100 closeout |
 | `backend-enhanced-data-service-getter-retirement-closeout-2026-05-25.md` | G | G2.100 closeout accepted in PR `#253` at `d7be7e6`: records PR `#252` merge, confirms `get_enhanced_data_service` app/API/package refs remain `0`, test refs are focused absence assertions only, `_enhanced_data_service` app/API refs are `0`, `EnhancedDataService` remains active with app refs=`8` and route/API refs=`4`, focused test `3 passed`, and health route conflicts `120 passed` | Superseded by G2.101 service lifecycle candidate refresh |
-| `backend-service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.md` | G | G2.101 candidate refresh prepared at `d7be7e6`: records PR `#253` merge, scans `152` service files / `575` app files / `219` API files / `1008` test files, finds `18` getter definitions and `4` candidate-like definitions, confirms `get_enhanced_data_service` is no longer present as a service getter definition, selects `get_tradingview_service` as a future G2.102 authorization candidate only, and records GitNexus impact LOW / `1` with no affected processes | Human review / PR merge decision; if accepted, create G2.102 TradingView getter-retirement authorization before any source edit |
+| `backend-service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.md` | G | G2.101 candidate refresh accepted in PR `#254` at `c8eae46`: records PR `#253` merge, scans `152` service files / `575` app files / `219` API files / `1008` test files, finds `18` getter definitions and `4` candidate-like definitions, confirms `get_enhanced_data_service` is no longer present as a service getter definition, selects `get_tradingview_service` as a future G2.102 authorization candidate only, and records GitNexus impact LOW / `1` with no affected processes | Superseded by G2.102 TradingView getter-retirement authorization |
+| `backend-tradingview-getter-retirement-authorization-2026-05-25.md` | G | G2.102 authorization prepared at `c8eae46`: authorizes only future G2.103 removal of `get_tradingview_service` after TDD red/green; current scan shows getter refs app=`2` / route/API=`0` / tests=`2` / package exports=`0`, direct caller `install_tradingview_service`, GitNexus impact LOW / `1`, and `TradingViewWidgetService` class plus dependency provider remain active and outside deletion scope | Human review / PR merge decision; if accepted, create G2.103 source-capable implementation with TDD red/green |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/tradingview-getter-retirement-authorization-2026-05-25.json
+++ b/.planning/codebase/generated/tradingview-getter-retirement-authorization-2026-05-25.json
@@ -1,0 +1,118 @@
+{
+  "artifact": "tradingview-getter-retirement-authorization-2026-05-25",
+  "status": "ready_for_review",
+  "created_at": "2026-05-25T21:23:23+08:00",
+  "branch": "g2-102-tradingview-getter-retirement-authorization",
+  "current_head": "c8eae46c738fff199100cf4e02015a9ade887eee",
+  "parent_pr": {
+    "number": 254,
+    "title": "docs(governance): refresh service candidates after enhanced data service",
+    "merge_commit": "c8eae46c738fff199100cf4e02015a9ade887eee",
+    "disposition": "accepted"
+  },
+  "target": {
+    "getter_symbol": "get_tradingview_service",
+    "service_class": "TradingViewWidgetService",
+    "service_file": "web/backend/app/services/tradingview_widget_service.py",
+    "getter_lines": "322-327",
+    "direct_caller": "install_tradingview_service",
+    "dependency_provider": "get_tradingview_service_dependency"
+  },
+  "current_head_reference_scan": {
+    "get_tradingview_service": {
+      "app_refs": 2,
+      "route_api_refs": 0,
+      "test_refs": 2,
+      "package_export_refs": 0,
+      "notes": [
+        "App refs are the getter definition plus install_tradingview_service fallback call.",
+        "Test refs are in web/backend/tests/test_tradingview_service_lifecycle_di.py."
+      ]
+    },
+    "_tradingview_service": {
+      "app_refs": 5,
+      "route_api_refs": 0,
+      "test_refs": 0,
+      "package_export_refs": 0
+    },
+    "TradingViewWidgetService": {
+      "app_refs": 14,
+      "route_api_refs": 7,
+      "test_refs": 0,
+      "deletion_authorized": false
+    },
+    "install_tradingview_service": {
+      "app_refs": 4,
+      "route_api_refs": 0,
+      "test_refs": 4,
+      "deletion_authorized": false
+    },
+    "get_tradingview_service_dependency": {
+      "app_refs": 8,
+      "route_api_refs": 7,
+      "test_refs": 3,
+      "deletion_authorized": false
+    }
+  },
+  "gitnexus": {
+    "analyze": {
+      "command": "gitnexus analyze --with-gitignore",
+      "result": "repository indexed successfully",
+      "nodes": 62770,
+      "edges": 145915,
+      "clusters": 3294,
+      "flows": 300
+    },
+    "impact": {
+      "target": "get_tradingview_service",
+      "direction": "upstream",
+      "risk": "LOW",
+      "impacted_count": 1,
+      "direct": 1,
+      "processes_affected": 0,
+      "affected_processes": []
+    },
+    "context": {
+      "incoming": "install_tradingview_service calls get_tradingview_service",
+      "outgoing": "none",
+      "processes": []
+    }
+  },
+  "authorized_future_scope": {
+    "if_this_packet_is_accepted": {
+      "may_create": "G2.103 TradingView getter-retirement implementation",
+      "allowed_paths": [
+        "web/backend/app/services/tradingview_widget_service.py",
+        "web/backend/tests/test_tradingview_service_lifecycle_di.py",
+        ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+        ".planning/codebase/generated/tradingview-getter-retirement-implementation-2026-05-25.json",
+        "docs/reports/quality/backend-tradingview-getter-retirement-implementation-2026-05-25.md",
+        "governance/mainline/task-cards/pr-256.yaml"
+      ],
+      "allowed_actions": [
+        "Remove only get_tradingview_service from web/backend/app/services/tradingview_widget_service.py.",
+        "Remove the private _tradingview_service singleton state only if it becomes unused after getter retirement.",
+        "Change install_tradingview_service fallback from the retired getter to direct TradingViewWidgetService construction or an equivalent module-local factory that does not preserve a public compatibility getter.",
+        "Update the existing lifecycle DI test so it proves app.state fallback installation still works without the public getter.",
+        "Add or update focused absence assertions proving the public getter and private singleton state are retired while TradingViewWidgetService, install_tradingview_service, close_tradingview_service, and get_tradingview_service_dependency remain importable."
+      ]
+    }
+  },
+  "forbidden_scope": [
+    "Do not delete TradingViewWidgetService.",
+    "Do not delete install_tradingview_service, close_tradingview_service, or get_tradingview_service_dependency.",
+    "Do not edit TradingView route modules in this authorization packet.",
+    "Do not change routes, response models, response shapes, or OpenAPI exposure.",
+    "Do not change frontend, PM2, OpenSpec changes/specs, GitHub issue labels, or readiness state."
+  ],
+  "boundary": {
+    "this_packet_changes_source": false,
+    "this_packet_changes_tests": false,
+    "this_packet_changes_routes": false,
+    "this_packet_changes_openapi": false,
+    "this_packet_changes_pm2": false,
+    "this_packet_changes_openspec": false,
+    "this_packet_changes_issue_labels": false
+  },
+  "next_gate": "Human review / PR merge decision for G2.102; if accepted, create G2.103 source-capable implementation with TDD red/green."
+}

--- a/docs/reports/quality/backend-tradingview-getter-retirement-authorization-2026-05-25.md
+++ b/docs/reports/quality/backend-tradingview-getter-retirement-authorization-2026-05-25.md
@@ -1,0 +1,118 @@
+# Backend TradingView Getter Retirement Authorization - 2026-05-25
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.102 TradingView getter-retirement authorization
+Status: ready for review
+
+## Purpose
+
+Authorize only a future, source-capable G2.103 branch to retire the public
+compatibility getter `get_tradingview_service` from
+`web/backend/app/services/tradingview_widget_service.py`.
+
+This packet does not modify source code, tests, routes, OpenAPI exposure, PM2
+state, OpenSpec changes, frontend assets, or GitHub issue labels. It exists to
+separate the getter-retirement decision from implementation.
+
+## Input State
+
+G2.101 was accepted through PR `#254`, merged at
+`c8eae46c738fff199100cf4e02015a9ade887eee`.
+
+G2.101 selected `get_tradingview_service` only as a future authorization
+candidate because:
+
+- route/API references are `0`;
+- package export references are `0`;
+- GitNexus impact is LOW with impacted count `1` and affected processes `0`;
+- the only direct graph caller is `install_tradingview_service`.
+
+## Current Evidence
+
+Current HEAD for this packet:
+`c8eae46c738fff199100cf4e02015a9ade887eee`.
+
+| Check | Result |
+|---|---|
+| GitNexus index | `gitnexus analyze --with-gitignore`; `62,770` nodes, `145,915` edges, `3,294` clusters, `300` flows |
+| GitNexus impact | `get_tradingview_service`: LOW, impacted count `1`, direct `1`, affected processes `0` |
+| GitNexus context | direct caller is `install_tradingview_service`; no outgoing refs; no process participation |
+| `get_tradingview_service` scan | app refs `2`, route/API refs `0`, test refs `2`, package export refs `0` |
+| `_tradingview_service` scan | app refs `5`, route/API refs `0`, test refs `0`, package export refs `0` |
+| `TradingViewWidgetService` scan | app refs `14`, route/API refs `7`, test refs `0` |
+| `install_tradingview_service` scan | app refs `4`, route/API refs `0`, test refs `4` |
+| `get_tradingview_service_dependency` scan | app refs `8`, route/API refs `7`, test refs `3` |
+
+The future implementation must distinguish the compatibility getter from the
+active TradingView service and lifecycle helpers:
+
+- `TradingViewWidgetService` remains active in
+  `web/backend/app/services/tradingview_widget_service.py` and
+  `web/backend/app/api/tradingview.py`.
+- `install_tradingview_service` remains active from `app_factory.py` and tests.
+- `get_tradingview_service_dependency` remains active in TradingView routes.
+
+## Authorized Future Scope
+
+If this G2.102 packet is reviewed and accepted, G2.103 may be created as a
+source-capable implementation branch with this maximum scope:
+
+| Path | Future allowed action |
+|---|---|
+| `web/backend/app/services/tradingview_widget_service.py` | Remove only `get_tradingview_service`; remove `_tradingview_service` only if it becomes unused; change `install_tradingview_service` fallback from the retired getter to direct `TradingViewWidgetService` construction or an equivalent module-local factory that does not preserve a public compatibility getter |
+| `web/backend/tests/test_tradingview_service_lifecycle_di.py` | Update the existing fallback test so it proves app-state fallback installation still works without the public getter; add or update focused absence assertions for the retired getter/private singleton while keeping class/install/dependency imports intact |
+| `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md` | Record implementation status after the branch runs |
+| `.planning/codebase/generated/tradingview-getter-retirement-implementation-2026-05-25.json` | Record generated implementation evidence |
+| `docs/reports/quality/backend-tradingview-getter-retirement-implementation-2026-05-25.md` | Record implementation evidence |
+| `governance/mainline/task-cards/pr-256.yaml` | Record implementation task-card gate if PR numbering remains sequential |
+
+Future G2.103 must remain a getter-retirement branch. It must not delete
+`TradingViewWidgetService`, remove lifecycle helpers, migrate TradingView
+routes, alter response models, change OpenAPI exposure, edit frontend code,
+touch PM2 state, or change issue labels.
+
+## Required Future G2.103 Verification
+
+Before any source edit:
+
+1. Read `architecture/STANDARDS.md`.
+2. Run GitNexus impact/context for `get_tradingview_service`.
+3. Add or update the focused regression test first and verify red state.
+
+After the minimal source edit:
+
+1. Verify the focused TradingView lifecycle DI tests are green.
+2. Run `ruff check` and `black --check` on touched backend files.
+3. Run TradingView route/API focused tests if the implementation touches route
+   imports or dependency wiring.
+4. Run the route/OpenAPI smoke if `app.main` import or route exposure could be
+   affected.
+5. Stage only authorized paths and run GitNexus `detect_changes` with
+   `scope=staged`.
+6. Run the mainline scope gate and markdown governance gate for updated
+   governance artifacts.
+
+## Boundary
+
+This packet makes no source or test changes and does not authorize any immediate
+implementation.
+
+Explicitly out of scope:
+
+- deleting `TradingViewWidgetService`;
+- deleting `install_tradingview_service`, `close_tradingview_service`, or
+  `get_tradingview_service_dependency`;
+- editing TradingView route modules in this authorization packet;
+- changing routes, response models, response shapes, or OpenAPI exposure;
+- changing frontend, PM2, OpenSpec changes/specs, GitHub issue labels, or
+  readiness state.
+
+## Next Gate
+
+Human review / PR merge decision for this G2.102 authorization packet.
+
+If accepted, create G2.103 as a source-capable implementation branch and apply
+TDD red/green before retiring `get_tradingview_service`.

--- a/governance/mainline/task-cards/pr-255.yaml
+++ b/governance/mainline/task-cards/pr-255.yaml
@@ -1,0 +1,107 @@
+version: "v0.2"
+
+task:
+  id: "pr-255"
+  title: "Authorize TradingView getter retirement"
+  owner: "main"
+  created_at: "2026-05-25"
+
+mainline:
+  id: "L1-tradingview-getter-retirement-authorization"
+  objective: "authorize only a future TradingView getter-retirement implementation branch"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-tradingview-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-tradingview-getter-retirement-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/tradingview-getter-retirement-authorization-2026-05-25.json"
+    - "docs/reports/quality/backend-tradingview-getter-retirement-authorization-2026-05-25.md"
+    - "governance/mainline/task-cards/pr-255.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not delete get_tradingview_service in this packet"
+  - "Do not delete or migrate TradingViewWidgetService"
+  - "Do not change TradingView routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 254 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-tradingview-getter-retirement-authorization-2026-05-25.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/tradingview-getter-retirement-authorization-2026-05-25.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-255.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-255.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet is treated as implementation authority, get_tradingview_service could be changed without the required G2.103 TDD gate"
+    - "If TradingViewWidgetService or lifecycle helpers are confused with getter usage, active TradingView behavior could be over-scoped"
+  rollback_plan: "revert this governance-only PR and keep G2.101 as the latest accepted service lifecycle candidate-refresh evidence"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize only a future TradingView getter-retirement implementation branch"
+    modified_scope: "steward tree, authorization report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; get_tradingview_service is not deleted in this packet and TradingViewWidgetService remains active"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if parent PR evidence, authorization boundary, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-25T21:23:23+08:00"
+    approval_note: "G2.101 candidate refresh PR #254 was merged; this packet authorizes only a future G2.103 TradingView getter-retirement implementation branch"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- accept G2.101 / PR #254 and add the G2.102 TradingView getter-retirement authorization packet
- distinguish `get_tradingview_service` from the active `TradingViewWidgetService`, install helper, close helper, and FastAPI dependency provider
- authorize only a future G2.103 TDD implementation branch; this PR does not delete or edit backend source

## Evidence
- current HEAD: `c8eae46c738fff199100cf4e02015a9ade887eee`
- `get_tradingview_service`: app refs `2`, route/API refs `0`, test refs `2`, package export refs `0`
- direct graph caller: `install_tradingview_service`
- `TradingViewWidgetService` remains active with app refs `14` and route/API refs `7`
- `get_tradingview_service_dependency` remains active with route/API refs `7`
- GitNexus impact: LOW, impacted count `1`, affected processes `0`

## Verification
- `gitnexus analyze --with-gitignore`
- current-head reference scan for getter/private state/service class/install helper/dependency provider
- `python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-tradingview-getter-retirement-authorization-2026-05-25.md`
- `python -m json.tool .planning/codebase/generated/tradingview-getter-retirement-authorization-2026-05-25.json >/dev/null`
- `python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-255.yaml').read_text())"`
- `git diff --cached --check`
- GitNexus staged detect: low risk, changed files `4`, affected count `0`, affected processes `0`
- post-commit mainline scope: `pass=True`
- post-commit `gitnexus analyze --with-gitignore`: refreshed

## Boundary
- authorization-only
- no backend source/test edits
- no route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label changes
- no `get_tradingview_service` deletion in this PR
- no `TradingViewWidgetService`, install helper, close helper, or dependency-provider deletion authorized
