### PR TITLE
refactor(services): retire tradingview getter

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1641,9 +1641,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter
 │   │                deletion, or issue-label change is made here
 │   ├── G2.102 TradingView getter-retirement authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#255` merged at
+│   │   │          `a0cfa4f35125bb0475b1d98c4225a4321c18de1c`
 │   │   ├── Evidence: `backend-tradingview-getter-retirement-authorization-2026-05-25.md`
-│   │   ├── Current HEAD: `c8eae46c738fff199100cf4e02015a9ade887eee`
+│   │   ├── Current HEAD: `a0cfa4f35125bb0475b1d98c4225a4321c18de1c`
 │   │   ├── Result: authorizes only a future G2.103 implementation branch to
 │   │   │          retire `get_tradingview_service` from
 │   │   │          `web/backend/app/services/tradingview_widget_service.py`
@@ -1656,9 +1657,27 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                `TradingViewWidgetService` deletion, or issue-label change
 │   │                is made here
-│   └── Next gate: human review / PR merge decision for G2.102; if accepted,
-│                  create G2.103 TradingView getter-retirement implementation
-│                  with TDD red/green before source edit
+│   ├── G2.103 TradingView getter-retirement implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-tradingview-getter-retirement-implementation-2026-05-26.md`
+│   │   ├── Base HEAD: `a0cfa4f35125bb0475b1d98c4225a4321c18de1c`
+│   │   ├── Result: removes only `get_tradingview_service` and the private
+│   │   │          `_tradingview_service` singleton state, changes
+│   │   │          `install_tradingview_service` fallback to direct
+│   │   │          `TradingViewWidgetService()` construction, and updates
+│   │   │          lifecycle DI coverage; TDD red was `1 failed, 7 passed`,
+│   │   │          green is `8 passed`, health route conflicts are
+│   │   │          `120 passed`, and schema-only OpenAPI smoke with
+│   │   │          non-sensitive placeholder env remains routes=`548`,
+│   │   │          paths=`500`, operation IDs=`536`, duplicate operation
+│   │   │          IDs=`0`
+│   │   └── Boundary: source-capable but getter-retirement-only; no route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                `TradingViewWidgetService` deletion, lifecycle helper
+│   │                deletion, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.103; if accepted,
+│                  create G2.104 closeout before selecting another service
+│                  lifecycle lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1746,7 +1765,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-enhanced-data-service-getter-retirement-implementation-2026-05-25.md` | G | G2.99 implementation accepted in PR `#252` at `e3bb781`: removes only `get_enhanced_data_service` and `_enhanced_data_service`, preserves `EnhancedDataService`, updates the module-local `__main__` smoke call to direct construction, adds focused regression coverage, records TDD red `2 failed, 1 passed`, green `3 passed`, health route conflicts `120 passed`, ruff/black passed, and OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0` | Superseded by G2.100 closeout |
 | `backend-enhanced-data-service-getter-retirement-closeout-2026-05-25.md` | G | G2.100 closeout accepted in PR `#253` at `d7be7e6`: records PR `#252` merge, confirms `get_enhanced_data_service` app/API/package refs remain `0`, test refs are focused absence assertions only, `_enhanced_data_service` app/API refs are `0`, `EnhancedDataService` remains active with app refs=`8` and route/API refs=`4`, focused test `3 passed`, and health route conflicts `120 passed` | Superseded by G2.101 service lifecycle candidate refresh |
 | `backend-service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.md` | G | G2.101 candidate refresh accepted in PR `#254` at `c8eae46`: records PR `#253` merge, scans `152` service files / `575` app files / `219` API files / `1008` test files, finds `18` getter definitions and `4` candidate-like definitions, confirms `get_enhanced_data_service` is no longer present as a service getter definition, selects `get_tradingview_service` as a future G2.102 authorization candidate only, and records GitNexus impact LOW / `1` with no affected processes | Superseded by G2.102 TradingView getter-retirement authorization |
-| `backend-tradingview-getter-retirement-authorization-2026-05-25.md` | G | G2.102 authorization prepared at `c8eae46`: authorizes only future G2.103 removal of `get_tradingview_service` after TDD red/green; current scan shows getter refs app=`2` / route/API=`0` / tests=`2` / package exports=`0`, direct caller `install_tradingview_service`, GitNexus impact LOW / `1`, and `TradingViewWidgetService` class plus dependency provider remain active and outside deletion scope | Human review / PR merge decision; if accepted, create G2.103 source-capable implementation with TDD red/green |
+| `backend-tradingview-getter-retirement-authorization-2026-05-25.md` | G | G2.102 authorization accepted in PR `#255` at `a0cfa4f`: authorizes only future G2.103 removal of `get_tradingview_service` after TDD red/green; current scan shows getter refs app=`2` / route/API=`0` / tests=`2` / package exports=`0`, direct caller `install_tradingview_service`, GitNexus impact LOW / `1`, and `TradingViewWidgetService` class plus dependency provider remain active and outside deletion scope | Superseded by G2.103 TradingView getter-retirement implementation |
+| `backend-tradingview-getter-retirement-implementation-2026-05-26.md` | G | G2.103 implementation prepared from base `a0cfa4f`: removes only `get_tradingview_service` and `_tradingview_service`, preserves `TradingViewWidgetService`, install/close helpers, and dependency provider, changes install fallback to direct `TradingViewWidgetService()` construction, records TDD red `1 failed, 7 passed`, green `8 passed`, health route conflicts `120 passed`, ruff/black passed, and OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0` | Human review / PR merge decision; if accepted, create G2.104 closeout before next candidate refresh |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/tradingview-getter-retirement-implementation-2026-05-26.json
+++ b/.planning/codebase/generated/tradingview-getter-retirement-implementation-2026-05-26.json
@@ -1,0 +1,113 @@
+{
+  "artifact": "tradingview-getter-retirement-implementation-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T00:08:36+08:00",
+  "branch": "g2-103-tradingview-getter-retirement-implementation",
+  "base_head": "a0cfa4f35125bb0475b1d98c4225a4321c18de1c",
+  "parent_pr": {
+    "number": 255,
+    "title": "docs(governance): authorize tradingview getter retirement",
+    "merge_commit": "a0cfa4f35125bb0475b1d98c4225a4321c18de1c",
+    "disposition": "accepted"
+  },
+  "changes": [
+    {
+      "path": "web/backend/app/services/tradingview_widget_service.py",
+      "change": "Removed only get_tradingview_service and private _tradingview_service singleton state; changed install_tradingview_service fallback to direct TradingViewWidgetService construction; preserved TradingViewWidgetService, install/close helpers, and dependency provider."
+    },
+    {
+      "path": "web/backend/tests/test_tradingview_service_lifecycle_di.py",
+      "change": "Updated lifecycle DI fallback coverage to prove default service construction without the public getter; added focused absence assertions for the retired getter/private singleton while preserving import/export checks."
+    },
+    {
+      "path": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      "change": "Recorded G2.102 acceptance and G2.103 implementation state."
+    },
+    {
+      "path": "docs/reports/quality/backend-tradingview-getter-retirement-implementation-2026-05-26.md",
+      "change": "Recorded implementation evidence."
+    },
+    {
+      "path": "governance/mainline/task-cards/pr-256.yaml",
+      "change": "Recorded implementation task-card gate."
+    }
+  ],
+  "tdd": {
+    "red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tradingview_service_lifecycle_di.py -q --no-cov --tb=short",
+      "result": "1 failed, 7 passed",
+      "expected_failure": "hasattr(tradingview_widget_service, \"get_tradingview_service\") was True"
+    },
+    "green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tradingview_service_lifecycle_di.py -q --no-cov --tb=short",
+      "result": "8 passed in 1.43s"
+    }
+  },
+  "post_change_reference_scan": {
+    "get_tradingview_service": {
+      "app_refs": 0,
+      "route_api_refs": 0,
+      "test_refs": 3,
+      "package_export_refs": 0,
+      "notes": "Remaining references are focused absence assertions only."
+    },
+    "_tradingview_service": {
+      "app_refs": 0,
+      "route_api_refs": 0,
+      "test_refs": 2,
+      "package_export_refs": 0,
+      "notes": "Remaining references are focused absence assertions only."
+    },
+    "TradingViewWidgetService": {
+      "app_refs": 13,
+      "route_api_refs": 7,
+      "test_refs": 1,
+      "notes": "Class remains defined in tradingview_widget_service.py and actively used by web/backend/app/api/tradingview.py."
+    },
+    "install_tradingview_service": {
+      "app_refs": 4,
+      "route_api_refs": 0,
+      "test_refs": 4,
+      "notes": "Lifecycle install helper remains active."
+    },
+    "get_tradingview_service_dependency": {
+      "app_refs": 8,
+      "route_api_refs": 7,
+      "test_refs": 3,
+      "notes": "FastAPI dependency provider remains active in TradingView routes."
+    }
+  },
+  "verification": {
+    "pre_edit_gitnexus_impact": {
+      "target": "get_tradingview_service",
+      "risk": "LOW",
+      "impacted_count": 1,
+      "direct": 1,
+      "affected_processes": 0
+    },
+    "focused_pytest": "8 passed in 1.08s",
+    "health_route_conflicts": "120 passed in 93.05s",
+    "ruff_touched_paths": "All checks passed!",
+    "black_check_touched_paths": "2 files would be left unchanged after formatting",
+    "openapi_smoke": {
+      "mode": "schema_only_with_non_sensitive_placeholder_env",
+      "routes": 548,
+      "paths": 500,
+      "operation_ids": 536,
+      "duplicate_operation_ids": 0
+    }
+  },
+  "boundary": {
+    "tradingview_service_class_deleted": false,
+    "install_helper_deleted": false,
+    "close_helper_deleted": false,
+    "dependency_provider_deleted": false,
+    "route_api_changes": false,
+    "openapi_exposure_changes": false,
+    "frontend_changes": false,
+    "pm2_execution": false,
+    "openspec_changes": false,
+    "github_issue_label_changes": false
+  },
+  "next_gate": "Human review / PR merge decision for G2.103; if accepted, create G2.104 closeout before selecting another service lifecycle lane."
+}

--- a/docs/reports/quality/backend-tradingview-getter-retirement-implementation-2026-05-26.md
+++ b/docs/reports/quality/backend-tradingview-getter-retirement-implementation-2026-05-26.md
@@ -1,0 +1,101 @@
+# Backend TradingView Getter Retirement Implementation - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.103 TradingView getter-retirement implementation
+Status: ready for review
+
+## Purpose
+
+Implement the G2.102 authorization by retiring only the unused public
+compatibility getter `get_tradingview_service`.
+
+This implementation preserves `TradingViewWidgetService`,
+`install_tradingview_service`, `close_tradingview_service`, and
+`get_tradingview_service_dependency`. It does not change TradingView routes,
+response models, OpenAPI exposure, frontend files, PM2 state, OpenSpec files, or
+GitHub issue labels.
+
+## Change Summary
+
+| Path | Change |
+|---|---|
+| `web/backend/app/services/tradingview_widget_service.py` | Removed only `get_tradingview_service` and private `_tradingview_service` singleton state; changed `install_tradingview_service` fallback to direct `TradingViewWidgetService()` construction |
+| `web/backend/tests/test_tradingview_service_lifecycle_di.py` | Updated lifecycle DI fallback coverage to prove default service construction without the public getter; added focused absence assertions for the retired getter/private singleton while preserving lifecycle helper checks |
+| `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md` | Recorded G2.102 acceptance and G2.103 implementation state |
+| `.planning/codebase/generated/tradingview-getter-retirement-implementation-2026-05-26.json` | Added generated implementation evidence |
+| `governance/mainline/task-cards/pr-256.yaml` | Added implementation task-card gate |
+
+## TDD Evidence
+
+| Step | Command | Result |
+|---|---|---|
+| Red | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tradingview_service_lifecycle_di.py -q --no-cov --tb=short` | `1 failed, 7 passed`; failure proved `get_tradingview_service` still existed |
+| Green | Same focused command after source edit and assertion refinement | `8 passed in 1.43s` |
+
+The assertion refinement narrowed the private-state check from the broad
+substring `_tradingview_service` to concrete singleton-state signals
+`_tradingview_service =` and `global _tradingview_service`, because helper names
+such as `install_tradingview_service` legitimately contain that substring.
+
+## Post-Change Reference Scan
+
+| Signal | Value |
+|---|---:|
+| `get_tradingview_service` app refs | `0` |
+| `get_tradingview_service` route/API refs | `0` |
+| `get_tradingview_service` test refs | `3` |
+| `get_tradingview_service` package export refs | `0` |
+| `_tradingview_service` app refs | `0` |
+| `_tradingview_service` route/API refs | `0` |
+| `_tradingview_service` test refs | `2` |
+| `TradingViewWidgetService` app refs | `13` |
+| `TradingViewWidgetService` route/API refs | `7` |
+| `TradingViewWidgetService` test refs | `1` |
+| `install_tradingview_service` app refs | `4` |
+| `install_tradingview_service` test refs | `4` |
+| `get_tradingview_service_dependency` app refs | `8` |
+| `get_tradingview_service_dependency` route/API refs | `7` |
+| `get_tradingview_service_dependency` test refs | `3` |
+
+Remaining `get_tradingview_service` and `_tradingview_service` references are
+focused absence assertions in
+`web/backend/tests/test_tradingview_service_lifecycle_di.py`.
+
+`TradingViewWidgetService` and `get_tradingview_service_dependency` remain
+active through `web/backend/app/api/tradingview.py`.
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| Pre-edit GitNexus impact | `get_tradingview_service`: LOW, impacted count `1`, direct `1`, affected processes `0` |
+| Focused pytest | `8 passed in 1.08s` |
+| Health route conflicts | `120 passed in 93.05s` |
+| Ruff touched paths | `All checks passed!` |
+| Black touched paths | final check passed; `2 files would be left unchanged` |
+| OpenAPI smoke | schema-only with non-sensitive placeholder env; routes=`548`, paths=`500`, operation IDs=`536`, duplicate operation IDs=`0` |
+
+The OpenAPI smoke used non-sensitive local placeholder environment variables for
+schema generation and did not run PM2 or authorize runtime promotion.
+
+## Boundary
+
+This implementation does not:
+
+- delete, rename, or migrate `TradingViewWidgetService`;
+- delete `install_tradingview_service`, `close_tradingview_service`, or
+  `get_tradingview_service_dependency`;
+- change `web/backend/app/api/tradingview.py`;
+- change routes, response models, response shapes, or OpenAPI exposure;
+- change frontend files, generated clients, PM2 state, OpenSpec files, or
+  GitHub issue labels.
+
+## Next Gate
+
+Human review / PR merge decision for this implementation packet.
+
+If accepted, create G2.104 as a closeout packet before selecting another service
+lifecycle lane.

--- a/governance/mainline/task-cards/pr-256.yaml
+++ b/governance/mainline/task-cards/pr-256.yaml
@@ -1,0 +1,121 @@
+version: "v0.2"
+
+task:
+  id: "pr-256"
+  title: "Retire TradingView compatibility getter"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-tradingview-getter-retirement-implementation"
+  objective: "remove the unused get_tradingview_service compatibility getter while preserving TradingViewWidgetService and lifecycle helpers"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-tradingview-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-tradingview-getter-retirement-implementation"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "Narrow compatibility getter retirement; active TradingView routes, service class, lifecycle helpers, and dependency provider remain unchanged"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/services/tradingview_widget_service.py"
+    - "web/backend/tests/test_tradingview_service_lifecycle_di.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/tradingview-getter-retirement-implementation-2026-05-26.json"
+    - "docs/reports/quality/backend-tradingview-getter-retirement-implementation-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-256.yaml"
+  forbidden_paths:
+    - "web/backend/app/api/**"
+    - "web/frontend/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not delete or rename TradingViewWidgetService"
+  - "Do not delete install_tradingview_service, close_tradingview_service, or get_tradingview_service_dependency"
+  - "Do not change TradingView routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tradingview_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/tradingview_widget_service.py web/backend/tests/test_tradingview_service_lifecycle_di.py"
+      required: true
+    - id: "black-check-touched"
+      command: "black --check web/backend/app/services/tradingview_widget_service.py web/backend/tests/test_tradingview_service_lifecycle_di.py"
+      required: true
+    - id: "app-main-openapi-smoke"
+      command: "env PYTHONPATH=web/backend POSTGRESQL_HOST=localhost POSTGRESQL_USER=postgres POSTGRESQL_PASSWORD=postgres JWT_SECRET_KEY=test-secret-key-for-tradingview-getter-smoke BACKEND_PORT=8020 BACKEND_BACKUP_PORT=8021 python -c 'from collections import Counter; from app.main import app; schema=app.openapi(); ops=[operation.get(\"operationId\") for path_item in schema.get(\"paths\", {}).values() for operation in path_item.values() if isinstance(operation, dict) and operation.get(\"operationId\")]; dups=[op for op, count in Counter(ops).items() if count > 1]; print(len(app.routes), len(schema.get(\"paths\", {})), len(ops), len(dups))'"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-tradingview-getter-retirement-implementation-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/tradingview-getter-retirement-implementation-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-256.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-256.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If TradingViewWidgetService or lifecycle helpers are confused with the retired getter, active TradingView behavior could be over-scoped"
+    - "If new consumers reintroduce get_tradingview_service before merge, the branch must stop and refresh references"
+  rollback_plan: "revert this implementation PR to restore get_tradingview_service and _tradingview_service, and restore the previous compatibility fallback test"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "retire unused get_tradingview_service compatibility getter"
+    modified_scope: "tradingview_widget_service.py, focused lifecycle DI test, steward tree, implementation report, generated artifact, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; TradingViewWidgetService, lifecycle helpers, dependency provider, and routes remain active"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this implementation PR if focused pytest, health-route conflicts, ruff, black, OpenAPI smoke, governance validation, mainline scope, or staged GitNexus checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T00:08:36+08:00"
+    approval_note: "G2.102 authorization PR #255 was merged; this implementation removes only get_tradingview_service and preserves TradingViewWidgetService plus lifecycle helpers"
+    secondary_approved: false

--- a/web/backend/app/services/tradingview_widget_service.py
+++ b/web/backend/app/services/tradingview_widget_service.py
@@ -316,15 +316,6 @@ class TradingViewWidgetService:
 
 # 创建全局实例
 TRADINGVIEW_SERVICE_STATE_KEY = "tradingview_service"
-_tradingview_service = None
-
-
-def get_tradingview_service() -> TradingViewWidgetService:
-    """获取 TradingView 服务兼容单例"""
-    global _tradingview_service
-    if _tradingview_service is None:
-        _tradingview_service = TradingViewWidgetService()
-    return _tradingview_service
 
 
 def install_tradingview_service(
@@ -332,7 +323,7 @@ def install_tradingview_service(
     service: Optional[TradingViewWidgetService] = None,
 ) -> TradingViewWidgetService:
     """Install the TradingView service instance on FastAPI app.state."""
-    selected_service = service if service is not None else get_tradingview_service()
+    selected_service = service if service is not None else TradingViewWidgetService()
     setattr(app.state, TRADINGVIEW_SERVICE_STATE_KEY, selected_service)
     return selected_service
 

--- a/web/backend/tests/test_tradingview_service_lifecycle_di.py
+++ b/web/backend/tests/test_tradingview_service_lifecycle_di.py
@@ -55,17 +55,17 @@ def test_tradingview_dependency_can_be_overridden():
     assert response.json() == {"marker": "override"}
 
 
-def test_tradingview_dependency_falls_back_to_compatibility_getter(monkeypatch):
+def test_tradingview_dependency_falls_back_to_default_service_factory(monkeypatch):
     app = _build_probe_app()
     fallback = DummyTradingViewService("fallback")
     calls = 0
 
-    def get_fallback():
+    def build_default_service():
         nonlocal calls
         calls += 1
         return fallback
 
-    monkeypatch.setattr(tradingview_widget_service, "get_tradingview_service", get_fallback)
+    monkeypatch.setattr(tradingview_widget_service, "TradingViewWidgetService", build_default_service)
 
     client = TestClient(app)
     first_response = client.get("/probe")
@@ -77,6 +77,15 @@ def test_tradingview_dependency_falls_back_to_compatibility_getter(monkeypatch):
     assert second_response.json() == {"marker": "fallback"}
     assert calls == 1
     assert getattr(app.state, TRADINGVIEW_SERVICE_STATE_KEY) is fallback
+
+
+def test_public_tradingview_service_getter_is_retired():
+    content = Path(tradingview_widget_service.__file__).read_text(encoding="utf-8")
+
+    assert not hasattr(tradingview_widget_service, "get_tradingview_service")
+    assert "_tradingview_service =" not in content
+    assert "global _tradingview_service" not in content
+    assert "get_tradingview_service()" not in content
 
 
 def test_close_installed_tradingview_service_calls_optional_close():
@@ -130,16 +139,12 @@ def test_app_factory_lifespan_calls_service_lifecycle_outside_exception_handlers
     }
 
     call_names = {
-        call.func.id
-        for call in ast.walk(lifespan)
-        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+        call.func.id for call in ast.walk(lifespan) if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
     }
     assert required_calls <= call_names
 
     for handler in (node for node in ast.walk(lifespan) if isinstance(node, ast.ExceptHandler)):
         handler_call_names = {
-            call.func.id
-            for call in ast.walk(handler)
-            if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+            call.func.id for call in ast.walk(handler) if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
         }
         assert required_calls.isdisjoint(handler_call_names)


### PR DESCRIPTION
## Summary
- Retire the legacy get_tradingview_service compatibility getter and private _tradingview_service singleton state.
- Keep TradingViewWidgetService, install_tradingview_service, close_tradingview_service, and get_tradingview_service_dependency active.
- Update lifecycle DI tests, G2.103 evidence report, generated artifact, task card, and steward tree.

## Verification
- TDD red: 1 failed, 7 passed before implementation.
- Focused pytest: 8 passed in 1.08s.
- Health route conflicts: 120 passed in 93.05s.
- Ruff touched paths: All checks passed.
- Black check touched paths: 2 files would be left unchanged.
- OpenAPI smoke: routes=548, paths=500, operation_ids=536, duplicate_operation_ids=0 using schema-only placeholder env.
- Markdown governance: checked_files=2, errors=0.
- JSON/YAML parse checks passed.
- GitNexus staged detect_changes: low risk, affected_count=0.
- Mainline scope gate: pass=True.