### PR TITLE
docs(governance): close out tradingview getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1658,7 +1658,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                `TradingViewWidgetService` deletion, or issue-label change
 │   │                is made here
 │   ├── G2.103 TradingView getter-retirement implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#256` merged at
+│   │   │          `81cd6191c178f8a443e8f3b303e47c2583fc4402`
 │   │   ├── Evidence: `backend-tradingview-getter-retirement-implementation-2026-05-26.md`
 │   │   ├── Base HEAD: `a0cfa4f35125bb0475b1d98c4225a4321c18de1c`
 │   │   ├── Result: removes only `get_tradingview_service` and the private
@@ -1675,9 +1676,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                `TradingViewWidgetService` deletion, lifecycle helper
 │   │                deletion, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.103; if accepted,
-│                  create G2.104 closeout before selecting another service
-│                  lifecycle lane
+│   ├── G2.104 TradingView getter-retirement closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-tradingview-getter-retirement-closeout-2026-05-26.md`
+│   │   ├── Current HEAD: `81cd6191c178f8a443e8f3b303e47c2583fc4402`
+│   │   ├── Result: records PR `#256` merge and closes the
+│   │   │          TradingView public compatibility getter lane; current-head
+│   │   │          scan shows `get_tradingview_service` app refs=`0`,
+│   │   │          route/API refs=`0`, test refs=`3`, package export refs=`0`,
+│   │   │          and `_tradingview_service` app refs=`0`, route/API refs=`0`,
+│   │   │          test refs=`2`, package export refs=`0`; focused lifecycle
+│   │   │          tests are `8 passed` and health route conflicts are
+│   │   │          `120 passed`
+│   │   └── Boundary: closeout-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, service class
+│   │                deletion, lifecycle helper deletion, or issue-label change
+│   │                is made here
+│   └── Next gate: human review / PR merge decision for G2.104; if accepted,
+│                  create the next service lifecycle candidate refresh before
+│                  selecting another implementation lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1766,7 +1783,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-enhanced-data-service-getter-retirement-closeout-2026-05-25.md` | G | G2.100 closeout accepted in PR `#253` at `d7be7e6`: records PR `#252` merge, confirms `get_enhanced_data_service` app/API/package refs remain `0`, test refs are focused absence assertions only, `_enhanced_data_service` app/API refs are `0`, `EnhancedDataService` remains active with app refs=`8` and route/API refs=`4`, focused test `3 passed`, and health route conflicts `120 passed` | Superseded by G2.101 service lifecycle candidate refresh |
 | `backend-service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.md` | G | G2.101 candidate refresh accepted in PR `#254` at `c8eae46`: records PR `#253` merge, scans `152` service files / `575` app files / `219` API files / `1008` test files, finds `18` getter definitions and `4` candidate-like definitions, confirms `get_enhanced_data_service` is no longer present as a service getter definition, selects `get_tradingview_service` as a future G2.102 authorization candidate only, and records GitNexus impact LOW / `1` with no affected processes | Superseded by G2.102 TradingView getter-retirement authorization |
 | `backend-tradingview-getter-retirement-authorization-2026-05-25.md` | G | G2.102 authorization accepted in PR `#255` at `a0cfa4f`: authorizes only future G2.103 removal of `get_tradingview_service` after TDD red/green; current scan shows getter refs app=`2` / route/API=`0` / tests=`2` / package exports=`0`, direct caller `install_tradingview_service`, GitNexus impact LOW / `1`, and `TradingViewWidgetService` class plus dependency provider remain active and outside deletion scope | Superseded by G2.103 TradingView getter-retirement implementation |
-| `backend-tradingview-getter-retirement-implementation-2026-05-26.md` | G | G2.103 implementation prepared from base `a0cfa4f`: removes only `get_tradingview_service` and `_tradingview_service`, preserves `TradingViewWidgetService`, install/close helpers, and dependency provider, changes install fallback to direct `TradingViewWidgetService()` construction, records TDD red `1 failed, 7 passed`, green `8 passed`, health route conflicts `120 passed`, ruff/black passed, and OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0` | Human review / PR merge decision; if accepted, create G2.104 closeout before next candidate refresh |
+| `backend-tradingview-getter-retirement-implementation-2026-05-26.md` | G | G2.103 implementation accepted in PR `#256` at `81cd619`: removed only `get_tradingview_service` and `_tradingview_service`, preserved `TradingViewWidgetService`, install/close helpers, and dependency provider, changed install fallback to direct `TradingViewWidgetService()` construction, recorded TDD red `1 failed, 7 passed`, green `8 passed`, health route conflicts `120 passed`, ruff/black passed, and schema-only OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0` | Superseded by G2.104 TradingView getter-retirement closeout |
+| `backend-tradingview-getter-retirement-closeout-2026-05-26.md` | G | G2.104 closeout prepared at `81cd619`: records PR `#256` merge, confirms `get_tradingview_service` app refs=`0`, route/API refs=`0`, tests=`3`, package exports=`0`, confirms `_tradingview_service` app refs=`0`, route/API refs=`0`, tests=`2`, package exports=`0`, and preserves `TradingViewWidgetService`, install/close helpers, and dependency provider as active surfaces | Human review / PR merge decision; if accepted, create the next service lifecycle candidate refresh before another implementation lane |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/tradingview-getter-retirement-closeout-2026-05-26.json
+++ b/.planning/codebase/generated/tradingview-getter-retirement-closeout-2026-05-26.json
@@ -1,0 +1,103 @@
+{
+  "artifact": "tradingview-getter-retirement-closeout-2026-05-26",
+  "status": "ready_for_review",
+  "branch": "g2-104-tradingview-getter-retirement-closeout",
+  "created_at": "2026-05-26T00:33:00+08:00",
+  "current_head": "81cd6191c178f8a443e8f3b303e47c2583fc4402",
+  "parent_implementation_pr": {
+    "number": 256,
+    "state": "MERGED",
+    "url": "https://github.com/chengjon/mystocks/pull/256",
+    "base_ref": "wip/root-dirty-20260403",
+    "head_ref": "g2-103-tradingview-getter-retirement-implementation",
+    "merged_at": "2026-05-25T16:26:07Z",
+    "merge_commit": "81cd6191c178f8a443e8f3b303e47c2583fc4402",
+    "implementation_commit": "cbfeec1ef3f40499c5d12be7bbc4f44e655027db"
+  },
+  "current_head_reference_scan": {
+    "get_tradingview_service": {
+      "app_refs": 0,
+      "route_api_refs": 0,
+      "test_refs": 3,
+      "service_package_export_refs": 0,
+      "remaining_files": [
+        "web/backend/tests/test_tradingview_service_lifecycle_di.py"
+      ]
+    },
+    "_tradingview_service": {
+      "app_refs": 0,
+      "route_api_refs": 0,
+      "test_refs": 2,
+      "service_package_export_refs": 0,
+      "remaining_files": [
+        "web/backend/tests/test_tradingview_service_lifecycle_di.py"
+      ]
+    },
+    "TradingViewWidgetService": {
+      "app_refs": 13,
+      "route_api_refs": 7,
+      "test_refs": 1,
+      "service_package_export_refs": 0,
+      "app_files": [
+        "web/backend/app/services/tradingview_widget_service.py",
+        "web/backend/app/api/tradingview.py"
+      ],
+      "route_api_files": [
+        "web/backend/app/api/tradingview.py"
+      ]
+    },
+    "install_tradingview_service": {
+      "app_refs": 4,
+      "route_api_refs": 0,
+      "test_refs": 4,
+      "service_package_export_refs": 0,
+      "app_files": [
+        "web/backend/app/app_factory.py",
+        "web/backend/app/services/tradingview_widget_service.py"
+      ]
+    },
+    "close_tradingview_service": {
+      "app_refs": 3,
+      "route_api_refs": 0,
+      "test_refs": 3,
+      "service_package_export_refs": 0,
+      "app_files": [
+        "web/backend/app/app_factory.py",
+        "web/backend/app/services/tradingview_widget_service.py"
+      ]
+    },
+    "get_tradingview_service_dependency": {
+      "app_refs": 8,
+      "route_api_refs": 7,
+      "test_refs": 3,
+      "service_package_export_refs": 0,
+      "app_files": [
+        "web/backend/app/services/tradingview_widget_service.py",
+        "web/backend/app/api/tradingview.py"
+      ],
+      "route_api_files": [
+        "web/backend/app/api/tradingview.py"
+      ]
+    }
+  },
+  "verification": {
+    "parent_pr_state": "MERGED",
+    "focused_pytest": "8 passed in 0.87s",
+    "health_route_conflicts": "120 passed in 72.53s"
+  },
+  "boundary": {
+    "backend_source_changes": false,
+    "backend_test_changes": false,
+    "route_api_changes": false,
+    "openapi_exposure_changes": false,
+    "frontend_changes": false,
+    "pm2_execution": false,
+    "openspec_changes": false,
+    "github_issue_label_changes": false,
+    "service_class_deleted": false,
+    "install_helper_deleted": false,
+    "close_helper_deleted": false,
+    "dependency_provider_deleted": false
+  },
+  "next_gate": "Human review and PR merge decision for G2.104; if accepted, create the next service lifecycle candidate refresh before another implementation lane."
+}

--- a/docs/reports/quality/backend-tradingview-getter-retirement-closeout-2026-05-26.md
+++ b/docs/reports/quality/backend-tradingview-getter-retirement-closeout-2026-05-26.md
@@ -1,0 +1,82 @@
+# Backend TradingView Getter Retirement Closeout - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+## Purpose
+
+This closeout records the accepted G2.103 implementation result after PR `#256`
+merged. It closes the TradingView public compatibility getter lane before any
+new service lifecycle candidate is selected.
+
+This is a closeout-only governance packet. It does not edit backend source,
+tests, routes, OpenAPI exposure, frontend files, PM2 state, OpenSpec files, or
+GitHub issue labels.
+
+## Merge Evidence
+
+| Field | Value |
+|---|---|
+| Parent implementation PR | `#256` |
+| State | `MERGED` |
+| URL | `https://github.com/chengjon/mystocks/pull/256` |
+| Base ref | `wip/root-dirty-20260403` |
+| Head ref | `g2-103-tradingview-getter-retirement-implementation` |
+| Merged at | `2026-05-25T16:26:07Z` |
+| Merge commit | `81cd6191c178f8a443e8f3b303e47c2583fc4402` |
+| Implementation commit | `cbfeec1ef3f40499c5d12be7bbc4f44e655027db` |
+
+## Current-Head Reference Scan
+
+Current HEAD: `81cd6191c178f8a443e8f3b303e47c2583fc4402`.
+
+| Signal | App refs | Route/API refs | Test refs | Service package export refs |
+|---|---:|---:|---:|---:|
+| `get_tradingview_service` | `0` | `0` | `3` | `0` |
+| `_tradingview_service` | `0` | `0` | `2` | `0` |
+| `TradingViewWidgetService` | `13` | `7` | `1` | `0` |
+| `install_tradingview_service` | `4` | `0` | `4` | `0` |
+| `close_tradingview_service` | `3` | `0` | `3` | `0` |
+| `get_tradingview_service_dependency` | `8` | `7` | `3` | `0` |
+
+Remaining `get_tradingview_service` and `_tradingview_service` references are
+focused absence assertions in
+`web/backend/tests/test_tradingview_service_lifecycle_di.py`.
+
+Active TradingView service surfaces remain through:
+
+- `web/backend/app/services/tradingview_widget_service.py`;
+- `web/backend/app/api/tradingview.py`;
+- `web/backend/app/app_factory.py`.
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| Parent PR state | `#256` is `MERGED` |
+| Focused TradingView lifecycle tests | `8 passed in 0.87s` |
+| Health route conflicts | `120 passed in 72.53s` |
+| Current-head reference scan | `get_tradingview_service` app refs=`0`, route/API refs=`0`; `_tradingview_service` app refs=`0`, route/API refs=`0` |
+
+## Boundary
+
+This closeout does not:
+
+- edit backend source or tests;
+- reintroduce or delete `get_tradingview_service`;
+- reintroduce `_tradingview_service`;
+- delete, rename, or migrate `TradingViewWidgetService`;
+- delete `install_tradingview_service`, `close_tradingview_service`, or
+  `get_tradingview_service_dependency`;
+- change routes, response models, response shapes, or OpenAPI exposure;
+- change frontend files, generated clients, PM2 state, OpenSpec files, or
+  GitHub issue labels.
+
+## Next Gate
+
+Human review / PR merge decision for this G2.104 closeout. If accepted, create
+the next service lifecycle candidate refresh before selecting another
+implementation lane.

--- a/governance/mainline/task-cards/pr-257.yaml
+++ b/governance/mainline/task-cards/pr-257.yaml
@@ -1,0 +1,115 @@
+version: "v0.2"
+
+task:
+  id: "pr-257"
+  title: "Close out TradingView getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-tradingview-getter-retirement-closeout"
+  objective: "record PR #256 merge evidence and close the TradingView getter-retirement lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-tradingview-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-tradingview-getter-retirement-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/tradingview-getter-retirement-closeout-2026-05-26.json"
+    - "docs/reports/quality/backend-tradingview-getter-retirement-closeout-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-257.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not reintroduce or delete get_tradingview_service"
+  - "Do not reintroduce _tradingview_service"
+  - "Do not delete or migrate TradingViewWidgetService"
+  - "Do not delete install_tradingview_service, close_tradingview_service, or get_tradingview_service_dependency"
+  - "Do not change routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 256 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "focused-pytest"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tradingview_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-tradingview-getter-retirement-closeout-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/tradingview-getter-retirement-closeout-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-257.yaml').read_text())\""
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-257.yaml"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is mistaken for source authorization, future work could skip the required candidate-refresh gate"
+    - "If test-only absence references are mistaken for live app refs, the TradingView getter lane could be reopened unnecessarily"
+  rollback_plan: "revert this governance-only PR and keep G2.103 implementation evidence as the latest accepted state"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out TradingView getter retirement after PR #256 merge"
+    modified_scope: "steward tree, closeout report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; closeout-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if parent PR evidence, focused pytest, health-route conflicts, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T00:33:00+08:00"
+    approval_note: "G2.103 implementation PR #256 was merged; this packet closes out the TradingView getter-retirement lane and requires a candidate refresh before another implementation lane"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Close out G2.103 after PR #256 merged at 81cd6191c178f8a443e8f3b303e47c2583fc4402.
- Record current-head TradingView getter absence evidence and preserve active service/lifecycle surfaces.
- Update steward tree, generated closeout artifact, closeout report, and PR #257 task card only.

## Verification
- Parent PR #256: MERGED.
- Current-head scan: get_tradingview_service app refs=0, route/API refs=0; _tradingview_service app refs=0, route/API refs=0.
- Focused pytest: 8 passed in 0.87s.
- Health route conflicts: 120 passed in 72.53s.
- Markdown governance: checked_files=2, errors=0.
- JSON/YAML parse checks passed.
- GitNexus staged detect_changes: low risk, changed_count=0, affected_count=0.
- Post-commit mainline scope gate: pass=True.

## Boundary
Closeout-only. No backend source/test edits, route/API changes, OpenAPI exposure changes, frontend changes, PM2 execution, OpenSpec changes, or issue label changes.