### PR TITLE
docs(governance): refresh candidates after tradingview

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1677,7 +1677,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                `TradingViewWidgetService` deletion, lifecycle helper
 │   │                deletion, or issue-label change is made here
 │   ├── G2.104 TradingView getter-retirement closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#257` merged at
+│   │   │          `750fa311eb716ff54c577748e5658329736632b4`
 │   │   ├── Evidence: `backend-tradingview-getter-retirement-closeout-2026-05-26.md`
 │   │   ├── Current HEAD: `81cd6191c178f8a443e8f3b303e47c2583fc4402`
 │   │   ├── Result: records PR `#256` merge and closes the
@@ -1692,9 +1693,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, service class
 │   │                deletion, lifecycle helper deletion, or issue-label change
 │   │                is made here
-│   └── Next gate: human review / PR merge decision for G2.104; if accepted,
-│                  create the next service lifecycle candidate refresh before
-│                  selecting another implementation lane
+│   ├── G2.105 Service lifecycle candidate refresh after TradingView
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.md`
+│   │   ├── Current HEAD: `750fa311eb716ff54c577748e5658329736632b4`
+│   │   ├── Result: scan covers service files=`152`, backend app files=`575`,
+│   │   │          API files=`219`, test files=`1008`, getter definitions=`17`,
+│   │   │          candidate-like definitions=`3`, holds=`14`; the remaining
+│   │   │          candidate-like rows are `get_announcement_service` as an
+│   │   │          already-completed hold and two duplicate logical
+│   │   │          `get_email_service` rows, so no direct source implementation
+│   │   │          lane is selected here
+│   │   └── Boundary: candidate-refresh-only; no backend source/test edit,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                getter deletion, service migration, or issue-label change
+│   │                is made here
+│   └── Next gate: human review / PR merge decision for G2.105; if accepted,
+│                  create a G2.106 email duplicate getter ownership decision
+│                  packet before any email getter source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1784,7 +1800,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-candidate-refresh-after-enhanced-data-service-2026-05-25.md` | G | G2.101 candidate refresh accepted in PR `#254` at `c8eae46`: records PR `#253` merge, scans `152` service files / `575` app files / `219` API files / `1008` test files, finds `18` getter definitions and `4` candidate-like definitions, confirms `get_enhanced_data_service` is no longer present as a service getter definition, selects `get_tradingview_service` as a future G2.102 authorization candidate only, and records GitNexus impact LOW / `1` with no affected processes | Superseded by G2.102 TradingView getter-retirement authorization |
 | `backend-tradingview-getter-retirement-authorization-2026-05-25.md` | G | G2.102 authorization accepted in PR `#255` at `a0cfa4f`: authorizes only future G2.103 removal of `get_tradingview_service` after TDD red/green; current scan shows getter refs app=`2` / route/API=`0` / tests=`2` / package exports=`0`, direct caller `install_tradingview_service`, GitNexus impact LOW / `1`, and `TradingViewWidgetService` class plus dependency provider remain active and outside deletion scope | Superseded by G2.103 TradingView getter-retirement implementation |
 | `backend-tradingview-getter-retirement-implementation-2026-05-26.md` | G | G2.103 implementation accepted in PR `#256` at `81cd619`: removed only `get_tradingview_service` and `_tradingview_service`, preserved `TradingViewWidgetService`, install/close helpers, and dependency provider, changed install fallback to direct `TradingViewWidgetService()` construction, recorded TDD red `1 failed, 7 passed`, green `8 passed`, health route conflicts `120 passed`, ruff/black passed, and schema-only OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0` | Superseded by G2.104 TradingView getter-retirement closeout |
-| `backend-tradingview-getter-retirement-closeout-2026-05-26.md` | G | G2.104 closeout prepared at `81cd619`: records PR `#256` merge, confirms `get_tradingview_service` app refs=`0`, route/API refs=`0`, tests=`3`, package exports=`0`, confirms `_tradingview_service` app refs=`0`, route/API refs=`0`, tests=`2`, package exports=`0`, and preserves `TradingViewWidgetService`, install/close helpers, and dependency provider as active surfaces | Human review / PR merge decision; if accepted, create the next service lifecycle candidate refresh before another implementation lane |
+| `backend-tradingview-getter-retirement-closeout-2026-05-26.md` | G | G2.104 closeout accepted in PR `#257` at `750fa31`: records PR `#256` merge, confirms `get_tradingview_service` app refs=`0`, route/API refs=`0`, tests=`3`, package exports=`0`, confirms `_tradingview_service` app refs=`0`, route/API refs=`0`, tests=`2`, package exports=`0`, and preserves `TradingViewWidgetService`, install/close helpers, and dependency provider as active surfaces | Superseded by G2.105 service lifecycle candidate refresh after TradingView |
+| `backend-service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.md` | G | G2.105 candidate refresh prepared at `750fa31`: current scan has service files=`152`, app files=`575`, API files=`219`, test files=`1008`, getter definitions=`17`, candidate-like definitions=`3`, holds=`14`; no direct implementation lane is selected because remaining candidate-like rows are the completed announcement hold and duplicate logical `get_email_service` rows | Human review / PR merge decision; if accepted, create G2.106 email duplicate getter ownership decision before any email getter source edit |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.json
+++ b/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.json
@@ -1,0 +1,95 @@
+{
+  "artifact": "service-lifecycle-candidate-refresh-after-tradingview-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T00:48:19+08:00",
+  "branch": "g2-105-service-lifecycle-candidate-refresh-after-tradingview",
+  "current_head": "750fa311eb716ff54c577748e5658329736632b4",
+  "parent_pr": {
+    "number": 257,
+    "state": "MERGED",
+    "url": "https://github.com/chengjon/mystocks/pull/257",
+    "merge_commit": "750fa311eb716ff54c577748e5658329736632b4"
+  },
+  "scan_summary": {
+    "service_files": 152,
+    "app_files": 575,
+    "api_files": 219,
+    "test_files": 1008,
+    "getter_definitions": 17,
+    "candidate_like_definitions": 3,
+    "holds": 14
+  },
+  "candidate_rows": [
+    {
+      "symbol": "get_announcement_service",
+      "file": "web/backend/app/services/announcement_service.py",
+      "line": 526,
+      "app_refs": 2,
+      "route_api_refs": 0,
+      "test_refs": 1,
+      "package_export_refs": 0,
+      "disposition": "hold_completed_announcement_di_lane_not_reopened_here"
+    },
+    {
+      "symbol": "get_email_service",
+      "file": "web/backend/app/services/email_notification_service.py",
+      "line": 324,
+      "app_refs": 3,
+      "route_api_refs": 0,
+      "test_refs": 3,
+      "package_export_refs": 0,
+      "disposition": "hold_duplicate_logical_getter_name_requires_email_ownership_decision"
+    },
+    {
+      "symbol": "get_email_service",
+      "file": "web/backend/app/services/email_service.py",
+      "line": 325,
+      "app_refs": 3,
+      "route_api_refs": 0,
+      "test_refs": 3,
+      "package_export_refs": 0,
+      "disposition": "hold_duplicate_logical_getter_name_requires_email_ownership_decision"
+    }
+  ],
+  "selected_next_lane": {
+    "workline": "G2.106",
+    "candidate": "email_duplicate_getter_ownership_decision",
+    "symbol": "get_email_service",
+    "decision": "prepare a future email duplicate getter ownership decision packet only",
+    "source_edit_authorized_by_this_packet": false,
+    "service_deletion_authorized": false,
+    "future_authorization_required": true,
+    "reason": "No clean standalone getter-retirement implementation candidate remains after TradingView; email has duplicate logical getter names across email_service.py and email_notification_service.py."
+  },
+  "gitnexus": {
+    "analyze": {
+      "command": "gitnexus analyze --with-gitignore",
+      "result": "repository indexed successfully",
+      "graph_size_note": "Graph node/edge/cluster counts are non-gating for this doc-only candidate refresh because added governance artifacts can alter index size between amendments."
+    },
+    "email_service_getter": {
+      "file": "web/backend/app/services/email_service.py",
+      "context_incoming_calls": 6,
+      "impact_risk": "MEDIUM",
+      "impact_count": 6,
+      "affected_processes": 0
+    },
+    "email_notification_service_getter": {
+      "file": "web/backend/app/services/email_notification_service.py",
+      "context_incoming_calls": 0,
+      "affected_processes": 0
+    }
+  },
+  "boundary": {
+    "candidate_refresh_only": true,
+    "source_changes": false,
+    "test_changes": false,
+    "route_api_changes": false,
+    "openapi_exposure_changes": false,
+    "frontend_changes": false,
+    "pm2_execution": false,
+    "openspec_changes": false,
+    "github_issue_label_changes": false
+  },
+  "next_gate": "Human review / PR merge decision for G2.105; if accepted, create G2.106 email duplicate getter ownership decision before any email getter source edit."
+}

--- a/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.md
+++ b/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.md
@@ -1,0 +1,104 @@
+# Backend Service Lifecycle Candidate Refresh After TradingView - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.105 service lifecycle candidate refresh after TradingView
+Status: ready for review
+
+## Purpose
+
+Refresh the service lifecycle getter candidate inventory after G2.104 closed the
+TradingView getter-retirement lane. This packet selects no source implementation
+lane. It records that the remaining candidate-like rows require a duplicate
+email getter ownership decision before any email getter source edit.
+
+## Input State
+
+| Field | Value |
+|---|---|
+| Parent closeout PR | `#257` |
+| Parent closeout state | `MERGED` |
+| Parent closeout merge commit | `750fa311eb716ff54c577748e5658329736632b4` |
+| Current HEAD | `750fa311eb716ff54c577748e5658329736632b4` |
+
+## Current-Head Scan Summary
+
+| Metric | Value |
+|---|---:|
+| Service files scanned | `152` |
+| Backend app files scanned | `575` |
+| API files scanned | `219` |
+| Test files scanned | `1008` |
+| Getter definitions | `17` |
+| Candidate-like definitions | `3` |
+| Holds | `14` |
+
+`get_tradingview_service` is no longer present as a service getter definition.
+
+## Candidate Rows
+
+| Symbol | File | Line | App refs | Route/API refs | Test refs | Package export refs | Disposition |
+|---|---|---:|---:|---:|---:|---:|---|
+| `get_announcement_service` | `web/backend/app/services/announcement_service.py` | `526` | `2` | `0` | `1` | `0` | hold completed announcement DI lane; do not reopen here |
+| `get_email_service` | `web/backend/app/services/email_notification_service.py` | `324` | `3` | `0` | `3` | `0` | hold duplicate logical getter name; requires email ownership decision |
+| `get_email_service` | `web/backend/app/services/email_service.py` | `325` | `3` | `0` | `3` | `0` | hold duplicate logical getter name; requires email ownership decision |
+
+## Selected Next Lane
+
+Do not select a direct source implementation lane from this refresh.
+
+Prepare G2.106 as an email duplicate getter ownership decision packet only.
+
+Rationale:
+
+- The only remaining candidate-like non-completed service area is email.
+- Email has duplicate logical getter names in
+  `web/backend/app/services/email_service.py` and
+  `web/backend/app/services/email_notification_service.py`.
+- `web/backend/app/services/email_service.py` also owns the active
+  `get_email_service_dependency` route dependency seam, so getter retirement
+  must not be inferred from name-only counts.
+- GitNexus reports `get_email_service` in `email_service.py` as MEDIUM impact
+  with impacted count `6` and affected processes `0`, while the
+  `email_notification_service.py` getter has no incoming graph callers.
+- The next packet must decide ownership and implementation boundaries before
+  any source edit.
+
+Boundary:
+
+- This selection does not authorize editing email services or notification
+  routes.
+- This selection does not authorize deleting either `get_email_service`
+  definition.
+- This selection does not authorize changing routes, response models, response
+  shapes, OpenAPI exposure, frontend code, PM2 state, OpenSpec files, or issue
+  labels.
+
+## Verification Evidence
+
+| Check | Result |
+|---|---|
+| GitNexus index | Refreshed with `gitnexus analyze --with-gitignore`; graph size is non-gating for this doc-only packet because added governance artifacts can alter index counts between amendments |
+| Getter candidate scan | `152` service files, `575` app files, `219` API files, `1008` test files, `17` getter definitions, `3` candidate-like definitions, `14` holds |
+| Email service getter impact | `get_email_service` in `email_service.py`: MEDIUM, impacted count `6`, affected processes `0` |
+| Email notification getter context | `get_email_service` in `email_notification_service.py`: incoming graph callers `0`, affected processes `0` |
+
+## Boundary
+
+This packet does not:
+
+- edit backend source or tests;
+- delete, rename, or migrate any email service symbol;
+- change routes, response models, response shapes, or OpenAPI exposure;
+- change frontend files, generated clients, PM2 state, OpenSpec files, or
+  GitHub issue labels;
+- authorize G2.106 implementation work.
+
+## Next Gate
+
+Human review / PR merge decision for this G2.105 governance packet.
+
+If accepted, create G2.106 as an email duplicate getter ownership decision
+packet before any email getter source edit.

--- a/governance/mainline/task-cards/pr-258.yaml
+++ b/governance/mainline/task-cards/pr-258.yaml
@@ -1,0 +1,108 @@
+version: "v0.2"
+
+task:
+  id: "pr-258"
+  title: "Refresh service lifecycle candidates after TradingView"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-service-lifecycle-candidate-refresh-after-tradingview"
+  objective: "refresh service lifecycle getter candidates after TradingView getter retirement closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-candidate-refresh"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-candidate-refresh-after-tradingview"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate-refresh-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.json"
+    - "docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-258.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not delete either get_email_service definition"
+  - "Do not migrate email_service.py or email_notification_service.py"
+  - "Do not change notification routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not authorize G2.106 implementation work"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 257 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-258.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-258.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet is treated as source authorization, duplicate email getter work could start without ownership decision"
+    - "If duplicate get_email_service rows are collapsed into one symbol, the wrong service boundary could be edited"
+  rollback_plan: "revert this governance-only PR and keep G2.104 as the latest accepted service lifecycle closeout evidence"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh service lifecycle candidates after TradingView getter retirement"
+    modified_scope: "steward tree, candidate-refresh report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; candidate-refresh-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if parent PR evidence, candidate scan, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T00:48:19+08:00"
+    approval_note: "G2.104 closeout PR #257 was merged; this packet refreshes service lifecycle candidates and routes the remaining email duplicate getter rows to a decision-only next gate"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Refresh service lifecycle getter candidates after TradingView getter retirement closeout.
- Record current-head scan: 152 service files, 575 app files, 219 API files, 1008 test files, 17 getter definitions, 3 candidate-like definitions, 14 holds.
- Select no direct implementation lane; route the remaining duplicate get_email_service rows to a future G2.106 email ownership decision packet.
- Update steward tree, generated artifact, report, and PR #258 task card only.

## Verification
- Parent PR #257: MERGED.
- Getter candidate scan completed at current HEAD 750fa311eb716ff54c577748e5658329736632b4.
- GitNexus analyze refreshed; final confirmation returned Already up to date.
- GitNexus staged detect_changes: low risk, changed_count=0, affected_count=0.
- Markdown governance: checked_files=2, errors=0.
- JSON/YAML parse checks passed.
- Post-commit mainline scope gate: pass=True.

## Boundary
Candidate-refresh-only. No backend source/test edits, route/API changes, OpenAPI exposure changes, frontend changes, PM2 execution, OpenSpec changes, issue label changes, or G2.106 implementation authorization.