### PR TITLE
docs(governance): decide email getter ownership

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1694,7 +1694,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                deletion, lifecycle helper deletion, or issue-label change
 │   │                is made here
 │   ├── G2.105 Service lifecycle candidate refresh after TradingView
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#258` merged at
+│   │   │          `9ac90c14acd14b851bf49271f48fba30c8b10e41`
 │   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.md`
 │   │   ├── Current HEAD: `750fa311eb716ff54c577748e5658329736632b4`
 │   │   ├── Result: scan covers service files=`152`, backend app files=`575`,
@@ -1708,9 +1709,28 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                getter deletion, service migration, or issue-label change
 │   │                is made here
-│   └── Next gate: human review / PR merge decision for G2.105; if accepted,
-│                  create a G2.106 email duplicate getter ownership decision
-│                  packet before any email getter source edit
+│   ├── G2.106 Email duplicate getter ownership decision
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-email-duplicate-getter-ownership-decision-2026-05-26.md`
+│   │   ├── Current HEAD: `9ac90c14acd14b851bf49271f48fba30c8b10e41`
+│   │   ├── Decision: treat `web/backend/app/services/email_service.py` as the
+│   │   │          route-backed `EmailService` lifecycle owner and
+│   │   │          `web/backend/app/services/email_notification_service.py` as a
+│   │   │          separate legacy/helper notification owner; do not collapse the
+│   │   │          duplicate `get_email_service` rows into one source edit
+│   │   ├── Result: current text scan shows combined `get_email_service` app
+│   │   │          refs=`3`, route/API refs=`0`, tests=`3`, while
+│   │   │          `get_email_service_dependency` remains active with app refs=`8`,
+│   │   │          route/API refs=`7`, tests=`3`; GitNexus impact for
+│   │   │          `email_service.py:get_email_service` is MEDIUM / `6`, and
+│   │   │          `email_notification_service.py:get_email_service` has no
+│   │   │          incoming graph callers
+│   │   └── Boundary: decision-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                service migration, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.106; if accepted,
+│                  create G2.107 EmailNotificationService getter-retirement
+│                  authorization before any email source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1801,7 +1821,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-tradingview-getter-retirement-authorization-2026-05-25.md` | G | G2.102 authorization accepted in PR `#255` at `a0cfa4f`: authorizes only future G2.103 removal of `get_tradingview_service` after TDD red/green; current scan shows getter refs app=`2` / route/API=`0` / tests=`2` / package exports=`0`, direct caller `install_tradingview_service`, GitNexus impact LOW / `1`, and `TradingViewWidgetService` class plus dependency provider remain active and outside deletion scope | Superseded by G2.103 TradingView getter-retirement implementation |
 | `backend-tradingview-getter-retirement-implementation-2026-05-26.md` | G | G2.103 implementation accepted in PR `#256` at `81cd619`: removed only `get_tradingview_service` and `_tradingview_service`, preserved `TradingViewWidgetService`, install/close helpers, and dependency provider, changed install fallback to direct `TradingViewWidgetService()` construction, recorded TDD red `1 failed, 7 passed`, green `8 passed`, health route conflicts `120 passed`, ruff/black passed, and schema-only OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0` | Superseded by G2.104 TradingView getter-retirement closeout |
 | `backend-tradingview-getter-retirement-closeout-2026-05-26.md` | G | G2.104 closeout accepted in PR `#257` at `750fa31`: records PR `#256` merge, confirms `get_tradingview_service` app refs=`0`, route/API refs=`0`, tests=`3`, package exports=`0`, confirms `_tradingview_service` app refs=`0`, route/API refs=`0`, tests=`2`, package exports=`0`, and preserves `TradingViewWidgetService`, install/close helpers, and dependency provider as active surfaces | Superseded by G2.105 service lifecycle candidate refresh after TradingView |
-| `backend-service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.md` | G | G2.105 candidate refresh prepared at `750fa31`: current scan has service files=`152`, app files=`575`, API files=`219`, test files=`1008`, getter definitions=`17`, candidate-like definitions=`3`, holds=`14`; no direct implementation lane is selected because remaining candidate-like rows are the completed announcement hold and duplicate logical `get_email_service` rows | Human review / PR merge decision; if accepted, create G2.106 email duplicate getter ownership decision before any email getter source edit |
+| `backend-service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.md` | G | G2.105 candidate refresh accepted in PR `#258` at `9ac90c1`: current scan has service files=`152`, app files=`575`, API files=`219`, test files=`1008`, getter definitions=`17`, candidate-like definitions=`3`, holds=`14`; no direct implementation lane is selected because remaining candidate-like rows are the completed announcement hold and duplicate logical `get_email_service` rows | Superseded by G2.106 email duplicate getter ownership decision |
+| `backend-email-duplicate-getter-ownership-decision-2026-05-26.md` | G | G2.106 decision prepared at `9ac90c1`: separates route-backed `email_service.py` ownership from legacy/helper `email_notification_service.py` ownership, records combined `get_email_service` app refs=`3`, route/API refs=`0`, tests=`3`, records active `get_email_service_dependency` route/API refs=`7`, and selects only a future G2.107 EmailNotificationService getter-retirement authorization packet | Human review / PR merge decision; if accepted, create G2.107 authorization before any email source edit |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/email-duplicate-getter-ownership-decision-2026-05-26.json
+++ b/.planning/codebase/generated/email-duplicate-getter-ownership-decision-2026-05-26.json
@@ -1,0 +1,136 @@
+{
+  "artifact": "email-duplicate-getter-ownership-decision-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T01:12:15+08:00",
+  "branch": "g2-106-email-duplicate-getter-ownership-decision",
+  "current_head": "9ac90c14acd14b851bf49271f48fba30c8b10e41",
+  "parent_pr": {
+    "number": 258,
+    "state": "MERGED",
+    "url": "https://github.com/chengjon/mystocks/pull/258",
+    "merge_commit": "9ac90c14acd14b851bf49271f48fba30c8b10e41"
+  },
+  "decision": {
+    "type": "ownership_decision_only",
+    "route_backed_owner": {
+      "file": "web/backend/app/services/email_service.py",
+      "service_class": "EmailService",
+      "active_lifecycle_surfaces": [
+        "install_email_service",
+        "get_email_service_dependency",
+        "EMAIL_SERVICE_STATE_KEY"
+      ],
+      "source_edit_status": "held_for_separate_future_authorization"
+    },
+    "legacy_helper_owner": {
+      "file": "web/backend/app/services/email_notification_service.py",
+      "service_class": "EmailNotificationService",
+      "getter": "get_email_service",
+      "source_edit_status": "candidate_for_future_G2_107_authorization_only"
+    },
+    "selected_next_lane": {
+      "workline": "G2.107",
+      "name": "EmailNotificationService getter-retirement authorization",
+      "source_edit_authorized_by_this_packet": false,
+      "implementation_authorized": false
+    }
+  },
+  "current_head_reference_scan": {
+    "combined_get_email_service": {
+      "app_refs": 3,
+      "route_api_refs": 0,
+      "test_refs": 3,
+      "app_files": [
+        "web/backend/app/services/email_notification_service.py",
+        "web/backend/app/services/email_service.py"
+      ],
+      "test_files": [
+        "web/backend/tests/test_notification_logging.py",
+        "web/backend/tests/test_email_service_lifecycle_di.py"
+      ]
+    },
+    "combined_private_email_service": {
+      "app_refs": 10,
+      "route_api_refs": 0,
+      "test_refs": 0,
+      "app_files": [
+        "web/backend/app/services/email_notification_service.py",
+        "web/backend/app/services/email_service.py"
+      ]
+    },
+    "get_email_service_dependency": {
+      "app_refs": 8,
+      "route_api_refs": 7,
+      "test_refs": 3,
+      "app_files": [
+        "web/backend/app/services/email_service.py",
+        "web/backend/app/api/notification.py"
+      ],
+      "route_api_files": [
+        "web/backend/app/api/notification.py"
+      ]
+    },
+    "install_email_service": {
+      "app_refs": 2,
+      "route_api_refs": 0,
+      "test_refs": 0,
+      "app_files": [
+        "web/backend/app/services/email_service.py"
+      ]
+    },
+    "EmailNotificationService": {
+      "app_refs": 9,
+      "route_api_refs": 0,
+      "test_refs": 3,
+      "app_files": [
+        "web/backend/app/services/email_notification_service.py",
+        "web/backend/app/core/unified_email_service.py"
+      ]
+    },
+    "EmailService": {
+      "app_refs": 19,
+      "route_api_refs": 7,
+      "test_refs": 4,
+      "app_files": [
+        "web/backend/app/services/email_service.py",
+        "web/backend/app/api/notification.py",
+        "web/backend/app/core/unified_email_service.py"
+      ],
+      "route_api_files": [
+        "web/backend/app/api/notification.py"
+      ]
+    }
+  },
+  "gitnexus": {
+    "analyze": {
+      "command": "gitnexus analyze --with-gitignore",
+      "result": "repository indexed successfully after G2.106 commit",
+      "graph_size_note": "Graph node/edge/cluster counts are non-gating for this decision-only packet because added governance artifacts can alter index size between amendments."
+    },
+    "email_service_getter": {
+      "file": "web/backend/app/services/email_service.py",
+      "context_incoming_calls": 6,
+      "impact_risk": "MEDIUM",
+      "impact_count": 6,
+      "affected_processes": 0
+    },
+    "email_notification_service_getter": {
+      "file": "web/backend/app/services/email_notification_service.py",
+      "context_incoming_calls": 0,
+      "affected_processes": 0
+    }
+  },
+  "boundary": {
+    "decision_only": true,
+    "source_changes": false,
+    "test_changes": false,
+    "route_api_changes": false,
+    "openapi_exposure_changes": false,
+    "frontend_changes": false,
+    "pm2_execution": false,
+    "openspec_changes": false,
+    "github_issue_label_changes": false,
+    "implementation_authorized": false
+  },
+  "next_gate": "Human review / PR merge decision for G2.106; if accepted, create G2.107 EmailNotificationService getter-retirement authorization before any email source edit."
+}

--- a/docs/reports/quality/backend-email-duplicate-getter-ownership-decision-2026-05-26.md
+++ b/docs/reports/quality/backend-email-duplicate-getter-ownership-decision-2026-05-26.md
@@ -1,0 +1,95 @@
+# Backend Email Duplicate Getter Ownership Decision - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.106 email duplicate getter ownership decision
+Status: ready for review
+
+## Purpose
+
+Resolve the ownership question exposed by G2.105: two service modules define a
+function named `get_email_service`, but they do not represent the same lifecycle
+surface. This packet is decision-only and does not authorize any source edit.
+
+## Input State
+
+| Field | Value |
+|---|---|
+| Parent candidate refresh PR | `#258` |
+| Parent candidate refresh state | `MERGED` |
+| Parent candidate refresh merge commit | `9ac90c14acd14b851bf49271f48fba30c8b10e41` |
+| Current HEAD | `9ac90c14acd14b851bf49271f48fba30c8b10e41` |
+
+## Decision
+
+Treat the two `get_email_service` definitions as separate ownership surfaces:
+
+| Owner | File | Service class | Disposition |
+|---|---|---|---|
+| Route-backed email lifecycle owner | `web/backend/app/services/email_service.py` | `EmailService` | Hold for separate future authorization because it owns `install_email_service`, `get_email_service_dependency`, and route dependency state |
+| Legacy/helper notification owner | `web/backend/app/services/email_notification_service.py` | `EmailNotificationService` | Candidate for a future G2.107 authorization-only packet |
+
+Do not collapse the duplicate function names into one source edit.
+
+## Current-Head Reference Scan
+
+| Signal | App refs | Route/API refs | Test refs | Relevant files |
+|---|---:|---:|---:|---|
+| `get_email_service` combined | `3` | `0` | `3` | `email_service.py`, `email_notification_service.py`, `test_notification_logging.py`, `test_email_service_lifecycle_di.py` |
+| `_email_service` combined | `10` | `0` | `0` | `email_service.py`, `email_notification_service.py` |
+| `get_email_service_dependency` | `8` | `7` | `3` | `email_service.py`, `notification.py`, focused tests |
+| `install_email_service` | `2` | `0` | `0` | `email_service.py` |
+| `EmailNotificationService` | `9` | `0` | `3` | `email_notification_service.py`, `unified_email_service.py`, focused tests |
+| `EmailService` | `19` | `7` | `4` | `email_service.py`, `notification.py`, `unified_email_service.py`, focused tests |
+
+`web/backend/app/api/notification.py` imports `EmailService` and
+`get_email_service_dependency` from `email_service.py`; it does not directly
+import either `get_email_service` function.
+
+## GitNexus Evidence
+
+| Symbol | File | Graph context / impact |
+|---|---|---|
+| `get_email_service` | `web/backend/app/services/email_service.py` | context incoming calls=`6`; impact MEDIUM, impacted count=`6`, affected processes=`0` |
+| `get_email_service` | `web/backend/app/services/email_notification_service.py` | context incoming calls=`0`, affected processes=`0` |
+
+The graph impact for `email_service.py:get_email_service` is intentionally
+treated as a reason to hold route-backed email lifecycle work behind a later
+authorization packet. Current text scan still shows route code using
+`get_email_service_dependency`, not direct getter imports.
+
+## Selected Next Lane
+
+Create G2.107 as an EmailNotificationService getter-retirement authorization
+packet only.
+
+G2.107 must:
+
+- target `web/backend/app/services/email_notification_service.py`;
+- keep `web/backend/app/services/email_service.py` out of scope;
+- keep notification routes and `get_email_service_dependency` out of scope;
+- require a fresh GitNexus impact/context check before any source edit;
+- require TDD red/green in the later implementation packet.
+
+## Boundary
+
+This packet does not:
+
+- edit backend source or tests;
+- delete either `get_email_service` definition;
+- delete or rename `_email_service` in either module;
+- migrate `EmailService` or `EmailNotificationService`;
+- change notification routes, response models, response shapes, or OpenAPI
+  exposure;
+- change frontend files, generated clients, PM2 state, OpenSpec files, or
+  GitHub issue labels;
+- authorize G2.107 implementation work.
+
+## Next Gate
+
+Human review / PR merge decision for this G2.106 decision packet.
+
+If accepted, create G2.107 as an EmailNotificationService getter-retirement
+authorization packet before any email source edit.

--- a/governance/mainline/task-cards/pr-259.yaml
+++ b/governance/mainline/task-cards/pr-259.yaml
@@ -1,0 +1,109 @@
+version: "v0.2"
+
+task:
+  id: "pr-259"
+  title: "Decide email duplicate getter ownership"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-email-duplicate-getter-ownership-decision"
+  objective: "record ownership boundaries for duplicate get_email_service definitions before any email getter edit"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-email-duplicate-getter-ownership"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-email-duplicate-getter-ownership-decision"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/email-duplicate-getter-ownership-decision-2026-05-26.json"
+    - "docs/reports/quality/backend-email-duplicate-getter-ownership-decision-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-259.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not delete either get_email_service definition"
+  - "Do not delete or rename _email_service in either email module"
+  - "Do not migrate EmailService or EmailNotificationService"
+  - "Do not change notification routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not authorize G2.107 implementation work"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 258 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-email-duplicate-getter-ownership-decision-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/email-duplicate-getter-ownership-decision-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-259.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-259.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If duplicate get_email_service definitions are treated as one source symbol, the route-backed EmailService seam could be edited accidentally"
+    - "If this packet is treated as source authorization, G2.107 could skip the required authorization-only gate"
+  rollback_plan: "revert this governance-only PR and keep G2.105 as the latest accepted service lifecycle candidate refresh evidence"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "decide email duplicate getter ownership before any email getter source edit"
+    modified_scope: "steward tree, decision report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; decision-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if parent PR evidence, ownership scan, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T01:12:15+08:00"
+    approval_note: "G2.105 candidate refresh PR #258 was merged; this packet separates route-backed email_service.py ownership from legacy/helper email_notification_service.py ownership and routes the next step to G2.107 authorization-only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Decide ownership for the duplicate get_email_service definitions before any email getter source edit.
- Treat web/backend/app/services/email_service.py as the route-backed EmailService lifecycle owner.
- Treat web/backend/app/services/email_notification_service.py as the legacy/helper notification owner and select only a future G2.107 authorization packet.
- Update steward tree, generated artifact, decision report, and PR #259 task card only.

## Verification
- Parent PR #258: MERGED.
- Current text scan: combined get_email_service app refs=3, route/API refs=0, tests=3.
- Active route dependency seam: get_email_service_dependency route/API refs=7.
- GitNexus context: email_service.py getter incoming calls=6; impact MEDIUM, impacted_count=6, affected_processes=0.
- GitNexus context: email_notification_service.py getter incoming calls=0, affected_processes=0.
- GitNexus analyze refreshed successfully after commit.
- GitNexus staged detect_changes: low risk, changed_count=0, affected_count=0.
- Markdown governance: checked_files=2, errors=0.
- JSON/YAML parse checks passed.
- Post-commit mainline scope gate: pass=True.

## Boundary
Decision-only. No backend source/test edits, no route/API changes, no OpenAPI exposure changes, no frontend changes, no PM2 execution, no OpenSpec changes, no issue label changes, and no G2.107 implementation authorization.