### PR TITLE
docs(governance): authorize email notification getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1710,7 +1710,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, service migration, or issue-label change
 │   │                is made here
 │   ├── G2.106 Email duplicate getter ownership decision
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#259` merged at
+│   │   │          `6e10c496a4e3c68c21b93a2ddfec09ef74f1aa30`
 │   │   ├── Evidence: `backend-email-duplicate-getter-ownership-decision-2026-05-26.md`
 │   │   ├── Current HEAD: `9ac90c14acd14b851bf49271f48fba30c8b10e41`
 │   │   ├── Decision: treat `web/backend/app/services/email_service.py` as the
@@ -1728,9 +1729,29 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: decision-only; no backend source/test edit, route/API,
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                service migration, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.106; if accepted,
-│                  create G2.107 EmailNotificationService getter-retirement
-│                  authorization before any email source edit
+│   ├── G2.107 EmailNotificationService getter-retirement authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-email-notification-getter-retirement-authorization-2026-05-26.md`
+│   │   ├── Current HEAD: `6e10c496a4e3c68c21b93a2ddfec09ef74f1aa30`
+│   │   ├── Decision: authorize only a future G2.108 implementation branch to
+│   │   │          retire `web/backend/app/services/email_notification_service.py`
+│   │   │          module-level `_email_service` and `get_email_service`; preserve
+│   │   │          `EmailNotificationService` and do not touch route-backed
+│   │   │          `web/backend/app/services/email_service.py`
+│   │   ├── Result: file-path GitNexus context shows
+│   │   │          `email_notification_service.py:get_email_service` has no
+│   │   │          incoming graph callers or process participation; exact text
+│   │   │          scan shows route/API uses remain on
+│   │   │          `email_service.py:get_email_service_dependency`; bare
+│   │   │          `get_email_service` impact resolves to the route-backed
+│   │   │          `email_service.py` symbol and must not be used as the sole
+│   │   │          future implementation gate
+│   │   └── Boundary: authorization-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                service migration, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.107; if accepted,
+│                  create G2.108 EmailNotificationService getter-retirement
+│                  implementation before any email notification source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1822,7 +1843,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-tradingview-getter-retirement-implementation-2026-05-26.md` | G | G2.103 implementation accepted in PR `#256` at `81cd619`: removed only `get_tradingview_service` and `_tradingview_service`, preserved `TradingViewWidgetService`, install/close helpers, and dependency provider, changed install fallback to direct `TradingViewWidgetService()` construction, recorded TDD red `1 failed, 7 passed`, green `8 passed`, health route conflicts `120 passed`, ruff/black passed, and schema-only OpenAPI routes=`548`, paths=`500`, duplicate operation IDs=`0` | Superseded by G2.104 TradingView getter-retirement closeout |
 | `backend-tradingview-getter-retirement-closeout-2026-05-26.md` | G | G2.104 closeout accepted in PR `#257` at `750fa31`: records PR `#256` merge, confirms `get_tradingview_service` app refs=`0`, route/API refs=`0`, tests=`3`, package exports=`0`, confirms `_tradingview_service` app refs=`0`, route/API refs=`0`, tests=`2`, package exports=`0`, and preserves `TradingViewWidgetService`, install/close helpers, and dependency provider as active surfaces | Superseded by G2.105 service lifecycle candidate refresh after TradingView |
 | `backend-service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.md` | G | G2.105 candidate refresh accepted in PR `#258` at `9ac90c1`: current scan has service files=`152`, app files=`575`, API files=`219`, test files=`1008`, getter definitions=`17`, candidate-like definitions=`3`, holds=`14`; no direct implementation lane is selected because remaining candidate-like rows are the completed announcement hold and duplicate logical `get_email_service` rows | Superseded by G2.106 email duplicate getter ownership decision |
-| `backend-email-duplicate-getter-ownership-decision-2026-05-26.md` | G | G2.106 decision prepared at `9ac90c1`: separates route-backed `email_service.py` ownership from legacy/helper `email_notification_service.py` ownership, records combined `get_email_service` app refs=`3`, route/API refs=`0`, tests=`3`, records active `get_email_service_dependency` route/API refs=`7`, and selects only a future G2.107 EmailNotificationService getter-retirement authorization packet | Human review / PR merge decision; if accepted, create G2.107 authorization before any email source edit |
+| `backend-email-duplicate-getter-ownership-decision-2026-05-26.md` | G | G2.106 decision accepted in PR `#259` at `6e10c49`: separates route-backed `email_service.py` ownership from legacy/helper `email_notification_service.py` ownership, records combined `get_email_service` app refs=`3`, route/API refs=`0`, tests=`3`, records active `get_email_service_dependency` route/API refs=`7`, and selects only a future G2.107 EmailNotificationService getter-retirement authorization packet | Superseded by G2.107 EmailNotificationService getter-retirement authorization |
+| `backend-email-notification-getter-retirement-authorization-2026-05-26.md` | G | G2.107 authorization prepared at `6e10c49`: authorizes only a future G2.108 implementation branch to retire `email_notification_service.py` module-level `_email_service` and `get_email_service`, preserves `EmailNotificationService`, keeps route-backed `email_service.py`, `get_email_service_dependency`, notification routes, OpenAPI, PM2, and OpenSpec out of scope, and records that file-path GitNexus context for `email_notification_service.py:get_email_service` has no incoming graph callers while bare `get_email_service` impact resolves to the separate route-backed `email_service.py` symbol | Human review / PR merge decision; if accepted, create G2.108 implementation before any email notification source edit |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/email-notification-getter-retirement-authorization-2026-05-26.json
+++ b/.planning/codebase/generated/email-notification-getter-retirement-authorization-2026-05-26.json
@@ -1,0 +1,143 @@
+{
+  "artifact": "email-notification-getter-retirement-authorization-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T01:29:37+08:00",
+  "branch": "g2-107-email-notification-getter-retirement-authorization",
+  "current_head": "6e10c496a4e3c68c21b93a2ddfec09ef74f1aa30",
+  "current_head_checked_at_review": "2026-05-26T01:29:37+08:00",
+  "parent": {
+    "node": "G2.106",
+    "pr": 259,
+    "merge_commit": "6e10c496a4e3c68c21b93a2ddfec09ef74f1aa30",
+    "decision": "separate route-backed email_service.py ownership from legacy/helper email_notification_service.py ownership"
+  },
+  "governance_node": {
+    "id": "G2.107",
+    "lane": "service_lifecycle_di",
+    "type": "authorization_only",
+    "state": "ready_for_review"
+  },
+  "target": {
+    "file": "web/backend/app/services/email_notification_service.py",
+    "getter": {
+      "name": "get_email_service",
+      "line": 324,
+      "gitnexus_uid": "Function:web/backend/app/services/email_notification_service.py:get_email_service"
+    },
+    "singleton": {
+      "name": "_email_service",
+      "line": 321
+    },
+    "preserved_class": {
+      "name": "EmailNotificationService",
+      "line": 23
+    }
+  },
+  "evidence": {
+    "gitnexus_context": {
+      "target": "web/backend/app/services/email_notification_service.py:get_email_service",
+      "incoming_callers": 0,
+      "outgoing_calls": 0,
+      "processes": 0
+    },
+    "gitnexus_disambiguation": {
+      "bare_impact_target": "get_email_service",
+      "bare_impact_resolves_to": "web/backend/app/services/email_service.py:get_email_service",
+      "bare_impact_risk": "MEDIUM",
+      "bare_impact_impacted_count": 6,
+      "required_future_rule": "future G2.108 must use file-path context plus exact text scan, not bare impact alone"
+    },
+    "exact_text_scan": {
+      "email_notification_service_getter_refs_in_app": [
+        {
+          "file": "web/backend/app/services/email_notification_service.py",
+          "count": 1
+        }
+      ],
+      "email_service_getter_refs_in_app": [
+        {
+          "file": "web/backend/app/services/email_service.py",
+          "count": 2
+        }
+      ],
+      "email_service_getter_refs_in_tests": [
+        {
+          "file": "web/backend/tests/test_email_service_lifecycle_di.py",
+          "count": 2
+        },
+        {
+          "file": "web/backend/tests/test_notification_logging.py",
+          "count": 1
+        }
+      ],
+      "email_notification_service_imports_in_app": [
+        {
+          "file": "web/backend/app/core/unified_email_service.py",
+          "count": 1
+        }
+      ],
+      "email_notification_service_imports_in_tests": [],
+      "route_email_notification_refs": [],
+      "email_service_dependency_refs": [
+        {
+          "file": "web/backend/app/api/notification.py",
+          "count": 7
+        },
+        {
+          "file": "web/backend/app/services/email_service.py",
+          "count": 1
+        }
+      ]
+    }
+  },
+  "authorized_future_g2_108_scope": {
+    "allowed_source_paths": [
+      "web/backend/app/services/email_notification_service.py"
+    ],
+    "allowed_test_paths": [
+      "web/backend/tests/test_email_notification_service_getter_retirement.py",
+      "web/backend/tests/test_email_notification_service_logging.py"
+    ],
+    "allowed_governance_paths": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/email-notification-getter-retirement-implementation-2026-05-26.json",
+      "docs/reports/quality/backend-email-notification-getter-retirement-implementation-2026-05-26.md",
+      "governance/mainline/task-cards/pr-261.yaml"
+    ],
+    "may_remove": [
+      "email_notification_service.py:_email_service",
+      "email_notification_service.py:get_email_service"
+    ],
+    "must_preserve": [
+      "EmailNotificationService",
+      "EmailNotificationService constructor behavior",
+      "email_service.py route-backed lifecycle seam",
+      "get_email_service_dependency",
+      "install_email_service",
+      "notification route contracts"
+    ]
+  },
+  "forbidden_scope": [
+    "web/backend/app/services/email_service.py",
+    "web/backend/app/api/notification.py",
+    "frontend code",
+    "PM2 workflows",
+    "OpenSpec proposals or specs",
+    "GitHub issue labels or readiness states",
+    "EmailNotificationService deletion or rename",
+    "broader email service consolidation"
+  ],
+  "verification_required_for_future_g2_108": [
+    "fresh architecture/STANDARDS.md read",
+    "GitNexus file-path context for email_notification_service.py:get_email_service",
+    "exact text scan for target getter, route/API refs, and preserved class refs",
+    "TDD red focused absence test",
+    "focused green tests",
+    "test_email_notification_service_logging.py",
+    "ruff/black on touched backend files",
+    "staged GitNexus detect_changes",
+    "mainline scope gate",
+    "markdown, JSON, YAML, and diff checks"
+  ],
+  "next_gate": "Human review / PR merge decision for G2.107; if accepted, create G2.108 EmailNotificationService getter-retirement implementation before any email notification source edit."
+}

--- a/docs/reports/quality/backend-email-notification-getter-retirement-authorization-2026-05-26.md
+++ b/docs/reports/quality/backend-email-notification-getter-retirement-authorization-2026-05-26.md
@@ -1,0 +1,126 @@
+# Backend EmailNotificationService Getter Retirement Authorization - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- State: ready for review
+- Governance node: G2.107
+- Scope: authorization-only
+- Created at: 2026-05-26T01:29:37+08:00
+- Current HEAD: `6e10c496a4e3c68c21b93a2ddfec09ef74f1aa30`
+- Parent decision: G2.106 accepted in PR `#259`
+
+This packet does not edit backend source, tests, route contracts, OpenAPI
+exposure, PM2 workflows, OpenSpec changes, or issue labels. It only records
+the gate for a future implementation branch.
+
+## Purpose
+
+G2.106 separated two same-named email getters:
+
+- `web/backend/app/services/email_service.py:get_email_service` is part of
+  the route-backed `EmailService` lifecycle seam.
+- `web/backend/app/services/email_notification_service.py:get_email_service`
+  is a legacy/helper lazy getter around `EmailNotificationService`.
+
+This packet authorizes only the next step: a future G2.108 implementation
+branch may retire the `email_notification_service.py` module-level
+`_email_service` singleton and `get_email_service` helper after it completes
+the required pre-edit impact and TDD gates.
+
+## Current Evidence
+
+| Evidence | Result |
+|---|---|
+| Current checkout | `6e10c496a4e3c68c21b93a2ddfec09ef74f1aa30` |
+| Parent PR | `#259`, merged as `6e10c496a4e3c68c21b93a2ddfec09ef74f1aa30` |
+| Target file | `web/backend/app/services/email_notification_service.py` |
+| Target singleton | `_email_service` at line `321` |
+| Target getter | `get_email_service` at line `324` |
+| Preserved class | `EmailNotificationService` at line `23` |
+| GitNexus context | `email_notification_service.py:get_email_service` has no incoming graph callers, no outgoing graph calls, and no process participation |
+| GitNexus disambiguation warning | Bare `impact(get_email_service)` resolves to the separate route-backed `email_service.py:get_email_service` symbol with MEDIUM / `6`; future implementation must use file-path context plus text scan |
+| Route/API boundary | `web/backend/app/api/notification.py` imports `EmailService` and `get_email_service_dependency` from `app.services.email_service`; it has no `email_notification_service` refs |
+| Active route-backed dependency | `get_email_service_dependency` exact refs: `notification.py` has `7`, `email_service.py` has `1` |
+| Class usage retained | `web/backend/app/core/unified_email_service.py` imports `EmailNotificationService`; `test_email_notification_service_logging.py` instantiates the class directly |
+
+## Authorized Future G2.108 Scope
+
+If this packet is accepted, G2.108 may modify only the minimum source and test
+surface needed to remove the legacy/helper lazy getter:
+
+- `web/backend/app/services/email_notification_service.py`
+- A focused backend test proving the getter and module singleton are retired,
+  for example `web/backend/tests/test_email_notification_service_getter_retirement.py`
+- Steward-tree update
+- Generated G2.108 evidence JSON
+- G2.108 implementation report
+- G2.108 mainline task card
+
+The future implementation may remove:
+
+- `email_notification_service.py:_email_service`
+- `email_notification_service.py:get_email_service`
+
+The future implementation must preserve:
+
+- `EmailNotificationService`
+- Existing `EmailNotificationService` constructor behavior
+- Existing logging behavior covered by `test_email_notification_service_logging.py`
+- `web/backend/app/core/unified_email_service.py` class import behavior unless
+  a separate authorization packet approves that change
+
+## Forbidden Future G2.108 Scope
+
+The authorization does not allow changes to:
+
+- `web/backend/app/services/email_service.py`
+- `web/backend/app/api/notification.py`
+- `get_email_service_dependency`
+- `install_email_service`
+- notification route paths, response models, response shapes, or OpenAPI
+  exposure
+- frontend code
+- PM2 workflows
+- OpenSpec proposals or specs
+- GitHub issue labels or readiness states
+- deletion or rename of `EmailNotificationService`
+- broader email service consolidation
+
+## Required Future G2.108 Verification
+
+G2.108 must run fresh checks in its own isolated worktree before source edits:
+
+1. Re-read `architecture/STANDARDS.md`.
+2. Run GitNexus file-path context for
+   `web/backend/app/services/email_notification_service.py:get_email_service`.
+3. Treat bare `impact(get_email_service)` as ambiguous because it resolves to
+   the route-backed `email_service.py` symbol.
+4. Re-run an exact text scan for `email_notification_service.py` getter refs,
+   route/API refs, and `EmailNotificationService` class refs.
+5. Write the focused absence test first and capture the red result.
+6. Remove only the authorized getter and singleton.
+7. Run the focused green test and existing
+   `test_email_notification_service_logging.py`.
+8. Run ruff/black checks on touched backend files.
+9. Stage only authorized paths and run GitNexus `detect_changes` with
+   `scope="staged"`.
+10. Run the mainline scope gate and markdown / JSON / YAML governance checks.
+
+## Boundary
+
+This is not implementation approval for this branch. G2.107 makes no runtime
+change. It only creates the review gate for G2.108.
+
+If this packet is rejected, keep G2.106 as the latest accepted email getter
+ownership decision and do not edit either email getter.
+
+## Next Gate
+
+Human review / PR merge decision for G2.107.
+
+If accepted, create G2.108 as the EmailNotificationService getter-retirement
+implementation branch before any email notification source edit.

--- a/governance/mainline/task-cards/pr-260.yaml
+++ b/governance/mainline/task-cards/pr-260.yaml
@@ -1,0 +1,111 @@
+version: "v0.2"
+
+task:
+  id: "pr-260"
+  title: "Authorize EmailNotificationService getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-email-notification-getter-retirement-authorization"
+  objective: "authorize a future implementation branch for retiring the legacy/helper EmailNotificationService getter without touching route-backed EmailService"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-email-notification-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-email-notification-getter-retirement-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/email-notification-getter-retirement-authorization-2026-05-26.json"
+    - "docs/reports/quality/backend-email-notification-getter-retirement-authorization-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-260.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not delete get_email_service in this PR"
+  - "Do not delete or rename _email_service in this PR"
+  - "Do not migrate EmailNotificationService in this PR"
+  - "Do not touch web/backend/app/services/email_service.py"
+  - "Do not touch web/backend/app/api/notification.py"
+  - "Do not change notification routes, response models, response shapes, or OpenAPI exposure"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not authorize implementation beyond future G2.108"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 259 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-email-notification-getter-retirement-authorization-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/email-notification-getter-retirement-authorization-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-260.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-260.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If future G2.108 treats bare get_email_service impact as sufficient, it can accidentally edit the route-backed EmailService seam"
+    - "If this packet is treated as implementation approval for this PR, backend source could be changed before the focused TDD gate exists"
+  rollback_plan: "revert this governance-only PR and keep G2.106 as the latest accepted email getter ownership decision"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize future EmailNotificationService getter retirement before any email notification source edit"
+    modified_scope: "steward tree, authorization report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; authorization-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if parent PR evidence, disambiguation evidence, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T01:29:37+08:00"
+    approval_note: "G2.106 PR #259 was merged; this packet authorizes only a future G2.108 implementation branch for email_notification_service.py getter retirement and keeps route-backed email_service.py out of scope"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- add G2.107 authorization-only packet for retiring the legacy/helper EmailNotificationService getter in a future branch
- update the steward tree with #259 accepted state and the next G2.108 gate
- record file-path GitNexus disambiguation so route-backed email_service.py remains out of scope

## Verification
- markdown governance: 2 checked, 0 errors
- JSON parse: ok
- YAML parse: ok
- git diff --check / cached diff --check: ok
- GitNexus staged detect_changes: low risk, changed_count=0, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: indexed successfully

## Boundary
Authorization-only. No backend source, tests, OpenAPI, PM2, OpenSpec, frontend, or issue-label changes.