### PR TITLE
refactor(services): retire email notification getter

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1730,7 +1730,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                service migration, or issue-label change is made here
 │   ├── G2.107 EmailNotificationService getter-retirement authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#260` merged at
+│   │   │          `d120d6d28d391daeb9e3d6accbd2b9ee0acfe931`
 │   │   ├── Evidence: `backend-email-notification-getter-retirement-authorization-2026-05-26.md`
 │   │   ├── Current HEAD: `6e10c496a4e3c68c21b93a2ddfec09ef74f1aa30`
 │   │   ├── Decision: authorize only a future G2.108 implementation branch to
@@ -1749,9 +1750,28 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: authorization-only; no backend source/test edit, route/API,
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                service migration, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.107; if accepted,
-│                  create G2.108 EmailNotificationService getter-retirement
-│                  implementation before any email notification source edit
+│   ├── G2.108 EmailNotificationService getter-retirement implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-email-notification-getter-retirement-implementation-2026-05-26.md`
+│   │   ├── Current HEAD: `d120d6d28d391daeb9e3d6accbd2b9ee0acfe931`
+│   │   ├── Result: removes only
+│   │   │          `email_notification_service.py:_email_service` and
+│   │   │          `email_notification_service.py:get_email_service`; preserves
+│   │   │          `EmailNotificationService`, keeps route-backed
+│   │   │          `email_service.py:get_email_service_dependency` untouched,
+│   │   │          and leaves notification routes with `0` direct
+│   │   │          `email_notification_service` refs
+│   │   ├── Verification: TDD red `1 failed`, focused green `5 passed`,
+│   │   │          health route conflicts `120 passed`, touched-file ruff passed,
+│   │   │          black check passed, exact post-change scan shows target getter
+│   │   │          refs=`0` and target singleton refs=`0`
+│   │   └── Boundary: source-capable but narrow; no `email_service.py`,
+│   │                `notification.py`, route/API, OpenAPI exposure, frontend,
+│   │                PM2, OpenSpec, service consolidation, class deletion, or
+│   │                issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.108; if accepted,
+│                  create G2.109 closeout/current-head refresh before selecting
+│                  another service getter candidate
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1844,7 +1864,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-tradingview-getter-retirement-closeout-2026-05-26.md` | G | G2.104 closeout accepted in PR `#257` at `750fa31`: records PR `#256` merge, confirms `get_tradingview_service` app refs=`0`, route/API refs=`0`, tests=`3`, package exports=`0`, confirms `_tradingview_service` app refs=`0`, route/API refs=`0`, tests=`2`, package exports=`0`, and preserves `TradingViewWidgetService`, install/close helpers, and dependency provider as active surfaces | Superseded by G2.105 service lifecycle candidate refresh after TradingView |
 | `backend-service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.md` | G | G2.105 candidate refresh accepted in PR `#258` at `9ac90c1`: current scan has service files=`152`, app files=`575`, API files=`219`, test files=`1008`, getter definitions=`17`, candidate-like definitions=`3`, holds=`14`; no direct implementation lane is selected because remaining candidate-like rows are the completed announcement hold and duplicate logical `get_email_service` rows | Superseded by G2.106 email duplicate getter ownership decision |
 | `backend-email-duplicate-getter-ownership-decision-2026-05-26.md` | G | G2.106 decision accepted in PR `#259` at `6e10c49`: separates route-backed `email_service.py` ownership from legacy/helper `email_notification_service.py` ownership, records combined `get_email_service` app refs=`3`, route/API refs=`0`, tests=`3`, records active `get_email_service_dependency` route/API refs=`7`, and selects only a future G2.107 EmailNotificationService getter-retirement authorization packet | Superseded by G2.107 EmailNotificationService getter-retirement authorization |
-| `backend-email-notification-getter-retirement-authorization-2026-05-26.md` | G | G2.107 authorization prepared at `6e10c49`: authorizes only a future G2.108 implementation branch to retire `email_notification_service.py` module-level `_email_service` and `get_email_service`, preserves `EmailNotificationService`, keeps route-backed `email_service.py`, `get_email_service_dependency`, notification routes, OpenAPI, PM2, and OpenSpec out of scope, and records that file-path GitNexus context for `email_notification_service.py:get_email_service` has no incoming graph callers while bare `get_email_service` impact resolves to the separate route-backed `email_service.py` symbol | Human review / PR merge decision; if accepted, create G2.108 implementation before any email notification source edit |
+| `backend-email-notification-getter-retirement-authorization-2026-05-26.md` | G | G2.107 authorization accepted in PR `#260` at `d120d6d`: authorizes only a future G2.108 implementation branch to retire `email_notification_service.py` module-level `_email_service` and `get_email_service`, preserves `EmailNotificationService`, keeps route-backed `email_service.py`, `get_email_service_dependency`, notification routes, OpenAPI, PM2, and OpenSpec out of scope, and records that file-path GitNexus context for `email_notification_service.py:get_email_service` has no incoming graph callers while bare `get_email_service` impact resolves to the separate route-backed `email_service.py` symbol | Superseded by G2.108 EmailNotificationService getter-retirement implementation |
+| `backend-email-notification-getter-retirement-implementation-2026-05-26.md` | G | G2.108 implementation prepared at `d120d6d`: removes only `email_notification_service.py:_email_service` and `email_notification_service.py:get_email_service`, preserves `EmailNotificationService`, leaves route-backed `email_service.py`, `get_email_service_dependency`, and notification routes untouched, records TDD red `1 failed`, focused green `5 passed`, health route conflicts `120 passed`, touched-file ruff and black checks passed, and exact post-change scan shows target getter refs=`0` and target singleton refs=`0` | Human review / PR merge decision; if accepted, create G2.109 closeout/current-head refresh before selecting another service getter candidate |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/email-notification-getter-retirement-implementation-2026-05-26.json
+++ b/.planning/codebase/generated/email-notification-getter-retirement-implementation-2026-05-26.json
@@ -1,0 +1,103 @@
+{
+  "artifact": "email-notification-getter-retirement-implementation-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T01:55:00+08:00",
+  "branch": "g2-108-email-notification-getter-retirement-implementation",
+  "base_head": "d120d6d28d391daeb9e3d6accbd2b9ee0acfe931",
+  "current_head_checked_at_review": "2026-05-26T01:55:00+08:00",
+  "parent_authorization": {
+    "node": "G2.107",
+    "pr": 260,
+    "merge_commit": "d120d6d28d391daeb9e3d6accbd2b9ee0acfe931",
+    "authorized_scope": "retire email_notification_service.py _email_service and get_email_service only"
+  },
+  "governance_node": {
+    "id": "G2.108",
+    "lane": "service_lifecycle_di",
+    "type": "implementation",
+    "state": "ready_for_review"
+  },
+  "changed_runtime_files": [
+    "web/backend/app/services/email_notification_service.py"
+  ],
+  "changed_test_files": [
+    "web/backend/tests/test_email_notification_service_getter_retirement.py"
+  ],
+  "removed_symbols": [
+    "web/backend/app/services/email_notification_service.py:_email_service",
+    "web/backend/app/services/email_notification_service.py:get_email_service"
+  ],
+  "preserved_surfaces": [
+    "web/backend/app/services/email_notification_service.py:EmailNotificationService",
+    "web/backend/app/services/email_service.py",
+    "web/backend/app/services/email_service.py:get_email_service_dependency",
+    "web/backend/app/api/notification.py",
+    "notification route contracts",
+    "OpenAPI exposure"
+  ],
+  "pre_edit_evidence": {
+    "standards_read": true,
+    "gitnexus_analyze_before_edit": "success",
+    "file_path_context": {
+      "target": "web/backend/app/services/email_notification_service.py:get_email_service",
+      "incoming_callers": 0,
+      "outgoing_calls": 0,
+      "processes": 0
+    },
+    "bare_impact_disambiguation": {
+      "bare_target": "get_email_service",
+      "resolved_to": "web/backend/app/services/email_service.py:get_email_service",
+      "risk": "MEDIUM",
+      "impacted_count": 6,
+      "used_as_target_gate": false
+    },
+    "exact_pre_change_scan": {
+      "email_notification_service_getter_refs": 1,
+      "route_email_notification_refs": 0,
+      "notification_route_get_email_service_dependency_refs": 7,
+      "email_service_get_email_service_dependency_refs": 1
+    }
+  },
+  "post_change_scan": {
+    "email_notification_service_getter_refs": 0,
+    "email_notification_service_singleton_refs": 0,
+    "route_email_notification_refs": 0,
+    "notification_route_get_email_service_dependency_refs": 7,
+    "email_service_get_email_service_dependency_refs": 1,
+    "email_notification_class_preserved": true
+  },
+  "verification": {
+    "tdd_red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_notification_service_getter_retirement.py -q --no-cov --tb=short",
+      "result": "1 failed",
+      "expected_failure": "hasattr(module, \"get_email_service\") was True"
+    },
+    "focused_green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_notification_service_getter_retirement.py web/backend/tests/test_email_notification_service_logging.py -q --no-cov --tb=short",
+      "result": "5 passed"
+    },
+    "health_route_conflicts": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "120 passed"
+    },
+    "ruff_touched_files": {
+      "command": "ruff check web/backend/app/services/email_notification_service.py web/backend/tests/test_email_notification_service_getter_retirement.py",
+      "result": "passed"
+    },
+    "black_touched_files": {
+      "command": "black --check web/backend/app/services/email_notification_service.py web/backend/tests/test_email_notification_service_getter_retirement.py",
+      "result": "passed"
+    }
+  },
+  "boundary": {
+    "email_service_py_changed": false,
+    "notification_route_changed": false,
+    "openapi_changed": false,
+    "frontend_changed": false,
+    "pm2_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "email_notification_service_class_deleted": false
+  },
+  "next_gate": "Human review / PR merge decision for G2.108; if accepted, create G2.109 closeout/current-head refresh before selecting another service getter candidate."
+}

--- a/docs/reports/quality/backend-email-notification-getter-retirement-implementation-2026-05-26.md
+++ b/docs/reports/quality/backend-email-notification-getter-retirement-implementation-2026-05-26.md
@@ -1,0 +1,105 @@
+# Backend EmailNotificationService Getter Retirement Implementation - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.108 EmailNotificationService getter-retirement implementation
+Status: ready for review
+
+## Purpose
+
+Implement the G2.107 authorization by retiring the legacy/helper
+`get_email_service` singleton surface in
+`web/backend/app/services/email_notification_service.py`.
+
+This implementation is intentionally narrow. It does not change the route-backed
+email lifecycle seam in `web/backend/app/services/email_service.py`, notification
+routes, OpenAPI exposure, PM2 workflows, OpenSpec changes, frontend code, or
+issue labels.
+
+## Parent Gate
+
+| Gate | Result |
+|---|---|
+| Parent authorization | G2.107 accepted in PR `#260` |
+| Parent merge commit | `d120d6d28d391daeb9e3d6accbd2b9ee0acfe931` |
+| Current implementation base | `d120d6d28d391daeb9e3d6accbd2b9ee0acfe931` |
+| Authorized target | `web/backend/app/services/email_notification_service.py` |
+| Authorized removals | `_email_service`, `get_email_service` |
+| Required preservation | `EmailNotificationService`, route-backed `email_service.py`, `get_email_service_dependency`, notification routes |
+
+## Pre-Edit Evidence
+
+| Evidence | Result |
+|---|---|
+| `architecture/STANDARDS.md` | Read before source edit; deletion requires explicit closure and evidence |
+| GitNexus analyze | `gitnexus analyze --with-gitignore`; indexed successfully before edit |
+| File-path GitNexus context | `email_notification_service.py:get_email_service` has no incoming graph callers, no outgoing graph calls, and no process participation |
+| Bare GitNexus impact | `impact(get_email_service)` resolves to the separate route-backed `email_service.py:get_email_service` symbol with MEDIUM / `6`; this was treated as a disambiguation warning, not as the target symbol |
+| Exact pre-change target scan | `email_notification_service.py:get_email_service` refs=`1`; `_email_service` refs present only in the target file |
+| Route/API boundary | `web/backend/app/api/notification.py` has `0` `email_notification_service` refs |
+| Route-backed dependency | `get_email_service_dependency` remains active in `notification.py` with `7` refs and in `email_service.py` with `1` ref |
+
+## Change
+
+Removed only the legacy/helper lazy singleton surface from
+`web/backend/app/services/email_notification_service.py`:
+
+- `_email_service`
+- `get_email_service`
+
+Added a focused regression test:
+
+- `web/backend/tests/test_email_notification_service_getter_retirement.py`
+
+The test asserts that `EmailNotificationService` remains importable while the
+legacy getter and module singleton are absent.
+
+## Verification
+
+| Check | Command | Result |
+|---|---|---|
+| TDD red | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_notification_service_getter_retirement.py -q --no-cov --tb=short` | `1 failed`; failure was `hasattr(module, "get_email_service")` |
+| Focused green | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_notification_service_getter_retirement.py web/backend/tests/test_email_notification_service_logging.py -q --no-cov --tb=short` | `5 passed` |
+| Health route conflicts | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `120 passed` |
+| Ruff touched files | `ruff check web/backend/app/services/email_notification_service.py web/backend/tests/test_email_notification_service_getter_retirement.py` | passed |
+| Black touched files | `black --check web/backend/app/services/email_notification_service.py web/backend/tests/test_email_notification_service_getter_retirement.py` | passed |
+| Exact post-change scan | scripted text scan | target getter refs=`0`; target singleton refs=`0`; route `email_notification_service` refs=`0` |
+
+Note: an exploratory ruff run that included the unchanged
+`test_email_notification_service_logging.py` surfaced existing PT018 style in
+that file. The file was used for behavior verification but not modified, and
+the final ruff gate was scoped to actual touched backend files.
+
+## Post-Change Scan
+
+| Surface | Result |
+|---|---|
+| `email_notification_service.py:get_email_service` | `0` refs |
+| `email_notification_service.py:_email_service` | `0` refs |
+| `web/backend/app/api/*` direct `email_notification_service` refs | `0` |
+| `get_email_service_dependency` | unchanged: `notification.py` refs=`7`, `email_service.py` refs=`1` |
+| `EmailNotificationService` app refs | retained in `email_notification_service.py` and `core/unified_email_service.py` |
+| `EmailNotificationService` test refs | retained in `test_email_notification_service_getter_retirement.py` and `test_email_notification_service_logging.py` |
+
+## Boundary
+
+This PR does not:
+
+- modify `web/backend/app/services/email_service.py`
+- modify `web/backend/app/api/notification.py`
+- alter route paths, response models, response shapes, or OpenAPI exposure
+- alter frontend code
+- alter PM2 workflows
+- create or modify OpenSpec proposals/specs
+- change GitHub issue labels or readiness state
+- delete or rename `EmailNotificationService`
+- consolidate email services beyond the authorized getter retirement
+
+## Next Gate
+
+Human review / PR merge decision for G2.108.
+
+If accepted, create G2.109 closeout/current-head refresh before selecting
+another service getter candidate.

--- a/governance/mainline/task-cards/pr-261.yaml
+++ b/governance/mainline/task-cards/pr-261.yaml
@@ -1,0 +1,126 @@
+version: "v0.2"
+
+task:
+  id: "pr-261"
+  title: "Retire EmailNotificationService legacy getter"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-email-notification-getter-retirement-implementation"
+  objective: "remove the legacy/helper EmailNotificationService lazy getter while preserving the route-backed EmailService lifecycle seam"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-email-notification-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-email-notification-getter-retirement-implementation"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow legacy/helper getter retirement; no runtime route, public API surface, frontend behavior, or OpenSpec capability is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/email-notification-getter-retirement-implementation-2026-05-26.json"
+    - "docs/reports/quality/backend-email-notification-getter-retirement-implementation-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-261.yaml"
+    - "web/backend/app/services/email_notification_service.py"
+    - "web/backend/tests/test_email_notification_service_getter_retirement.py"
+  forbidden_paths:
+    - "web/backend/app/services/email_service.py"
+    - "web/backend/app/api/notification.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not modify route-backed email_service.py"
+  - "Do not modify notification.py or notification route contracts"
+  - "Do not delete or rename EmailNotificationService"
+  - "Do not change get_email_service_dependency or install_email_service"
+  - "Do not change OpenAPI exposure"
+  - "Do not change frontend code"
+  - "Do not change PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not select the next service getter candidate in this PR"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 260 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "focused-green-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_notification_service_getter_retirement.py web/backend/tests/test_email_notification_service_logging.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-files"
+      command: "ruff check web/backend/app/services/email_notification_service.py web/backend/tests/test_email_notification_service_getter_retirement.py"
+      required: true
+    - id: "black-touched-files"
+      command: "black --check web/backend/app/services/email_notification_service.py web/backend/tests/test_email_notification_service_getter_retirement.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-email-notification-getter-retirement-implementation-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/email-notification-getter-retirement-implementation-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-261.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-261.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the route-backed email_service.py seam is edited, notification route dependency injection could regress"
+    - "If EmailNotificationService is deleted instead of only the legacy getter, unified_email_service.py and logging tests could break"
+  rollback_plan: "revert this narrow implementation PR and keep G2.107 authorization as the latest accepted email notification getter gate"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "retire email_notification_service.py legacy getter and module singleton"
+    modified_scope: "one service file, one focused test, steward tree, implementation report, generated artifact, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "legacy/helper getter removed; EmailNotificationService class and route-backed EmailService seam preserved"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, health route conflicts, touched-file lint/format, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T01:55:00+08:00"
+    approval_note: "G2.107 PR #260 authorized only this narrow EmailNotificationService getter retirement implementation"
+    secondary_approved: false

--- a/web/backend/app/services/email_notification_service.py
+++ b/web/backend/app/services/email_notification_service.py
@@ -315,20 +315,3 @@ class EmailNotificationService:
         """
 
         return self.send_email([user_email], subject, content, "html")
-
-
-# 创建全局实例
-_email_service = None
-
-
-def get_email_service() -> EmailNotificationService:
-    """
-    获取邮件服务实例（单例模式）
-
-    Returns:
-        EmailNotificationService: 邮件服务实例
-    """
-    global _email_service
-    if _email_service is None:
-        _email_service = EmailNotificationService()
-    return _email_service

--- a/web/backend/tests/test_email_notification_service_getter_retirement.py
+++ b/web/backend/tests/test_email_notification_service_getter_retirement.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_email_notification_module():
+    module_path = Path("web/backend/app/services/email_notification_service.py")
+    module_name = "test_email_notification_service_getter_retirement_module"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
+    assert spec.loader is not None
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_legacy_getter_and_module_singleton_are_retired():
+    module = load_email_notification_module()
+
+    assert hasattr(module, "EmailNotificationService")
+    assert not hasattr(module, "get_email_service")
+    assert not hasattr(module, "_email_service")


### PR DESCRIPTION
## Summary
- remove only email_notification_service.py legacy _email_service and get_email_service
- preserve EmailNotificationService and the route-backed email_service.py lifecycle seam
- add a focused absence regression test and update the steward tree with G2.108 evidence

## Verification
- TDD red: 1 failed on existing get_email_service
- focused green: 5 passed
- health route conflicts: 120 passed
- ruff touched files: passed
- black touched files: passed
- markdown governance: 2 checked, 0 errors
- JSON/YAML parse: ok
- GitNexus staged/compare: low risk, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: indexed successfully

## Boundary
No email_service.py, notification.py, route/API, OpenAPI, frontend, PM2, OpenSpec, or issue-label changes.