### PR TITLE
docs(governance): close out email notification getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1751,7 +1751,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                service migration, or issue-label change is made here
 │   ├── G2.108 EmailNotificationService getter-retirement implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#261` merged at
+│   │   │          `9cb643dbcd78bae76afc8201dad65b6f431a801c`
 │   │   ├── Evidence: `backend-email-notification-getter-retirement-implementation-2026-05-26.md`
 │   │   ├── Current HEAD: `d120d6d28d391daeb9e3d6accbd2b9ee0acfe931`
 │   │   ├── Result: removes only
@@ -1769,9 +1770,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                `notification.py`, route/API, OpenAPI exposure, frontend,
 │   │                PM2, OpenSpec, service consolidation, class deletion, or
 │   │                issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.108; if accepted,
-│                  create G2.109 closeout/current-head refresh before selecting
-│                  another service getter candidate
+│   ├── G2.109 EmailNotificationService getter-retirement closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-email-notification-getter-retirement-closeout-2026-05-26.md`
+│   │   ├── Current HEAD: `9cb643dbcd78bae76afc8201dad65b6f431a801c`
+│   │   ├── Result: records PR `#261` merge, confirms
+│   │   │          `email_notification_service.py:get_email_service` refs=`0`,
+│   │   │          `email_notification_service.py:_email_service` refs=`0`,
+│   │   │          route/API direct `email_notification_service` refs=`0`, and
+│   │   │          preserves `EmailNotificationService` plus route-backed
+│   │   │          `email_service.py:get_email_service_dependency`
+│   │   ├── Verification: focused tests `5 passed`, health route conflicts
+│   │   │          `120 passed`, touched-target ruff passed, black check passed
+│   │   └── Boundary: closeout-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, service
+│   │                consolidation, class deletion, getter deletion, or
+│   │                issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.109; if accepted,
+│                  create a fresh service lifecycle candidate refresh before
+│                  selecting another service getter candidate
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1865,7 +1882,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-candidate-refresh-after-tradingview-2026-05-26.md` | G | G2.105 candidate refresh accepted in PR `#258` at `9ac90c1`: current scan has service files=`152`, app files=`575`, API files=`219`, test files=`1008`, getter definitions=`17`, candidate-like definitions=`3`, holds=`14`; no direct implementation lane is selected because remaining candidate-like rows are the completed announcement hold and duplicate logical `get_email_service` rows | Superseded by G2.106 email duplicate getter ownership decision |
 | `backend-email-duplicate-getter-ownership-decision-2026-05-26.md` | G | G2.106 decision accepted in PR `#259` at `6e10c49`: separates route-backed `email_service.py` ownership from legacy/helper `email_notification_service.py` ownership, records combined `get_email_service` app refs=`3`, route/API refs=`0`, tests=`3`, records active `get_email_service_dependency` route/API refs=`7`, and selects only a future G2.107 EmailNotificationService getter-retirement authorization packet | Superseded by G2.107 EmailNotificationService getter-retirement authorization |
 | `backend-email-notification-getter-retirement-authorization-2026-05-26.md` | G | G2.107 authorization accepted in PR `#260` at `d120d6d`: authorizes only a future G2.108 implementation branch to retire `email_notification_service.py` module-level `_email_service` and `get_email_service`, preserves `EmailNotificationService`, keeps route-backed `email_service.py`, `get_email_service_dependency`, notification routes, OpenAPI, PM2, and OpenSpec out of scope, and records that file-path GitNexus context for `email_notification_service.py:get_email_service` has no incoming graph callers while bare `get_email_service` impact resolves to the separate route-backed `email_service.py` symbol | Superseded by G2.108 EmailNotificationService getter-retirement implementation |
-| `backend-email-notification-getter-retirement-implementation-2026-05-26.md` | G | G2.108 implementation prepared at `d120d6d`: removes only `email_notification_service.py:_email_service` and `email_notification_service.py:get_email_service`, preserves `EmailNotificationService`, leaves route-backed `email_service.py`, `get_email_service_dependency`, and notification routes untouched, records TDD red `1 failed`, focused green `5 passed`, health route conflicts `120 passed`, touched-file ruff and black checks passed, and exact post-change scan shows target getter refs=`0` and target singleton refs=`0` | Human review / PR merge decision; if accepted, create G2.109 closeout/current-head refresh before selecting another service getter candidate |
+| `backend-email-notification-getter-retirement-implementation-2026-05-26.md` | G | G2.108 implementation accepted in PR `#261` at `9cb643d`: removes only `email_notification_service.py:_email_service` and `email_notification_service.py:get_email_service`, preserves `EmailNotificationService`, leaves route-backed `email_service.py`, `get_email_service_dependency`, and notification routes untouched, records TDD red `1 failed`, focused green `5 passed`, health route conflicts `120 passed`, touched-file ruff and black checks passed, and exact post-change scan shows target getter refs=`0` and target singleton refs=`0` | Superseded by G2.109 EmailNotificationService getter-retirement closeout |
+| `backend-email-notification-getter-retirement-closeout-2026-05-26.md` | G | G2.109 closeout prepared at `9cb643d`: records PR `#261` merge, confirms current-head `email_notification_service.py:get_email_service` refs=`0`, `_email_service` refs=`0`, route/API direct `email_notification_service` refs=`0`, preserves `EmailNotificationService` and route-backed `get_email_service_dependency`, and re-runs focused tests `5 passed`, health route conflicts `120 passed`, ruff, and black checks | Human review / PR merge decision; if accepted, create a fresh service lifecycle candidate refresh before selecting another service getter candidate |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/email-notification-getter-retirement-closeout-2026-05-26.json
+++ b/.planning/codebase/generated/email-notification-getter-retirement-closeout-2026-05-26.json
@@ -1,0 +1,62 @@
+{
+  "artifact": "email-notification-getter-retirement-closeout-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T02:05:00+08:00",
+  "branch": "g2-109-email-notification-getter-retirement-closeout",
+  "current_head": "9cb643dbcd78bae76afc8201dad65b6f431a801c",
+  "current_head_checked_at_review": "2026-05-26T02:05:00+08:00",
+  "parent": {
+    "node": "G2.108",
+    "pr": 261,
+    "state": "MERGED",
+    "merged_at": "2026-05-25T17:56:05Z",
+    "merge_commit": "9cb643dbcd78bae76afc8201dad65b6f431a801c"
+  },
+  "governance_node": {
+    "id": "G2.109",
+    "lane": "service_lifecycle_di",
+    "type": "closeout_current_head_refresh",
+    "state": "ready_for_review"
+  },
+  "current_head_scan": {
+    "email_notification_service_getter_refs": 0,
+    "email_notification_service_singleton_refs": 0,
+    "route_email_notification_refs": 0,
+    "notification_route_get_email_service_dependency_refs": 7,
+    "email_service_get_email_service_dependency_refs": 1,
+    "email_notification_class_preserved": true,
+    "email_service_route_backed_seam_preserved": true
+  },
+  "verification": {
+    "focused_tests": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_notification_service_getter_retirement.py web/backend/tests/test_email_notification_service_logging.py -q --no-cov --tb=short",
+      "result": "5 passed"
+    },
+    "health_route_conflicts": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "120 passed"
+    },
+    "ruff_target_files": {
+      "command": "ruff check web/backend/app/services/email_notification_service.py web/backend/tests/test_email_notification_service_getter_retirement.py",
+      "result": "passed"
+    },
+    "black_target_files": {
+      "command": "black --check web/backend/app/services/email_notification_service.py web/backend/tests/test_email_notification_service_getter_retirement.py",
+      "result": "passed"
+    }
+  },
+  "boundary": {
+    "backend_source_changed": false,
+    "backend_tests_changed": false,
+    "email_service_py_changed": false,
+    "notification_route_changed": false,
+    "openapi_changed": false,
+    "frontend_changed": false,
+    "pm2_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "email_notification_service_class_deleted": false
+  },
+  "decision": "EmailNotificationService legacy/helper getter-retirement lane is closed after human review and merge of this closeout packet.",
+  "next_gate": "After G2.109 is accepted, create a fresh service lifecycle candidate refresh before selecting another service getter candidate."
+}

--- a/docs/reports/quality/backend-email-notification-getter-retirement-closeout-2026-05-26.md
+++ b/docs/reports/quality/backend-email-notification-getter-retirement-closeout-2026-05-26.md
@@ -1,0 +1,79 @@
+# Backend EmailNotificationService Getter Retirement Closeout - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.109 EmailNotificationService getter-retirement closeout
+Status: ready for review
+
+## Purpose
+
+Close out G2.108 by verifying the merged current head after PR `#261`. This
+packet records that the legacy/helper `EmailNotificationService` getter surface
+is retired and that route-backed email dependency injection remains outside this
+lane.
+
+This is closeout-only. It does not modify backend source, tests, routes,
+OpenAPI, frontend, PM2, OpenSpec, or issue labels.
+
+## Parent Merge
+
+| Item | Value |
+|---|---|
+| Parent PR | `#261` |
+| Parent state | `MERGED` |
+| Parent merged at | `2026-05-25T17:56:05Z` |
+| Parent merge commit | `9cb643dbcd78bae76afc8201dad65b6f431a801c` |
+| Current HEAD | `9cb643dbcd78bae76afc8201dad65b6f431a801c` |
+
+## Current-Head Scan
+
+| Surface | Result |
+|---|---|
+| `email_notification_service.py:get_email_service` | refs=`0` |
+| `email_notification_service.py:_email_service` | refs=`0` |
+| `web/backend/app/api/*` direct `email_notification_service` refs | refs=`0` |
+| `get_email_service_dependency` | retained: `notification.py` refs=`7`, `email_service.py` refs=`1` |
+| `EmailNotificationService` app refs | retained in `email_notification_service.py` and `core/unified_email_service.py` |
+| `EmailNotificationService` test refs | retained in `test_email_notification_service_getter_retirement.py` and `test_email_notification_service_logging.py` |
+
+## Verification
+
+| Check | Command | Result |
+|---|---|---|
+| Focused tests | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_notification_service_getter_retirement.py web/backend/tests/test_email_notification_service_logging.py -q --no-cov --tb=short` | `5 passed` |
+| Health route conflicts | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `120 passed` |
+| Ruff target files | `ruff check web/backend/app/services/email_notification_service.py web/backend/tests/test_email_notification_service_getter_retirement.py` | passed |
+| Black target files | `black --check web/backend/app/services/email_notification_service.py web/backend/tests/test_email_notification_service_getter_retirement.py` | passed |
+| Exact scan | scripted current-head text scan | target getter refs=`0`; target singleton refs=`0`; route direct refs=`0` |
+
+## Closeout Decision
+
+The EmailNotificationService legacy/helper getter-retirement lane is closed
+pending human review and PR merge of this closeout packet.
+
+Do not select the next service getter candidate from stale pre-#261 evidence.
+After this packet is accepted, run a fresh service lifecycle candidate refresh
+from the merged head.
+
+## Boundary
+
+This packet does not:
+
+- modify backend source or tests
+- modify `web/backend/app/services/email_service.py`
+- modify `web/backend/app/api/notification.py`
+- change routes, response contracts, or OpenAPI exposure
+- change frontend code
+- change PM2 workflows
+- create or modify OpenSpec changes/specs
+- change GitHub issue labels or readiness state
+- delete or rename `EmailNotificationService`
+
+## Next Gate
+
+Human review / PR merge decision for G2.109.
+
+If accepted, create a fresh service lifecycle candidate refresh before selecting
+another service getter candidate.

--- a/governance/mainline/task-cards/pr-262.yaml
+++ b/governance/mainline/task-cards/pr-262.yaml
@@ -1,0 +1,123 @@
+version: "v0.2"
+
+task:
+  id: "pr-262"
+  title: "Close out EmailNotificationService getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-email-notification-getter-retirement-closeout"
+  objective: "record current-head closeout for EmailNotificationService legacy getter retirement before selecting another service getter candidate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-email-notification-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-email-notification-getter-retirement-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/email-notification-getter-retirement-closeout-2026-05-26.json"
+    - "docs/reports/quality/backend-email-notification-getter-retirement-closeout-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-262.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not modify route-backed email_service.py"
+  - "Do not modify notification.py or notification route contracts"
+  - "Do not delete or rename EmailNotificationService"
+  - "Do not change OpenAPI exposure"
+  - "Do not change frontend code"
+  - "Do not change PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not select the next service getter candidate in this PR"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 261 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "focused-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_notification_service_getter_retirement.py web/backend/tests/test_email_notification_service_logging.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-target-files"
+      command: "ruff check web/backend/app/services/email_notification_service.py web/backend/tests/test_email_notification_service_getter_retirement.py"
+      required: true
+    - id: "black-target-files"
+      command: "black --check web/backend/app/services/email_notification_service.py web/backend/tests/test_email_notification_service_getter_retirement.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-email-notification-getter-retirement-closeout-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/email-notification-getter-retirement-closeout-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-262.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-262.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is skipped, the next service getter candidate could be selected from stale pre-#261 evidence"
+    - "If this packet edits source, it would exceed closeout scope"
+  rollback_plan: "revert this governance-only PR and keep G2.108 implementation as the latest accepted lane state"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out EmailNotificationService legacy getter retirement at current head"
+    modified_scope: "steward tree, closeout report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; closeout-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if parent PR state, current-head scan, verification evidence, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T02:05:00+08:00"
+    approval_note: "G2.108 PR #261 was merged; this packet closes the EmailNotificationService getter-retirement lane and requires a fresh candidate refresh before selecting the next service getter candidate"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- close out G2.108 after PR #261 merge
- record current-head scan: email_notification_service.py getter/singleton refs are 0
- keep next gate as a fresh service lifecycle candidate refresh before selecting another getter

## Verification
- focused tests: 5 passed
- health route conflicts: 120 passed
- ruff target files: passed
- black target files: passed
- markdown governance: 2 checked, 0 errors
- JSON/YAML parse: ok
- GitNexus staged detect_changes: low risk, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: indexed successfully

## Boundary
Closeout-only. No backend source, tests, route/API, OpenAPI, frontend, PM2, OpenSpec, or issue-label changes.