### PR TITLE
docs(governance): authorize market data service getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1788,7 +1788,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                consolidation, class deletion, getter deletion, or
 │   │                issue-label change is made here
 │   ├── G2.110 Service lifecycle candidate refresh after EmailNotificationService
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#263` merged at
+│   │   │          `c4abd4e8c4705f07a7d86e13c2090d30575e95e9`
 │   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-email-notification-2026-05-26.md`
 │   │   ├── Current HEAD: `ae6d2f287ddb8d71119ce52ef4ebaf00d64dc7b5`
 │   │   ├── Result: current scan covers service files=`152`, backend app files=`575`,
@@ -1805,9 +1806,26 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                getter deletion, service migration, or issue-label change
 │   │                is made here
-│   └── Next gate: human review / PR merge decision for G2.110; if accepted,
-│                  create G2.111 MarketDataService getter-retirement
-│                  authorization before any market-data service source edit
+│   ├── G2.111 MarketDataService getter-retirement authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-market-data-service-getter-retirement-authorization-2026-05-26.md`
+│   │   ├── Current HEAD: `c4abd4e8c4705f07a7d86e13c2090d30575e95e9`
+│   │   ├── Decision: authorize only a future G2.112 implementation branch to
+│   │   │          retire the package-level
+│   │   │          `market_data_service/get_market_data_service.py`
+│   │   │          `_market_data_service` and `get_market_data_service` surface,
+│   │   │          while preserving `MarketDataService`, `install_market_data_service`,
+│   │   │          and `get_market_data_service_dependency`
+│   │   ├── Result: GitNexus impact is LOW / `0`; direct API refs=`0`, but
+│   │   │          app refs exist in `market_data_adapter.py` and package exports,
+│   │   │          so the future implementation must include adapter/package
+│   │   │          cleanup and focused tests rather than deleting the getter alone
+│   │   └── Boundary: authorization-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                service migration, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.111; if accepted,
+│                  create G2.112 MarketDataService getter-retirement
+│                  implementation before any market-data service source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -1903,7 +1921,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-email-notification-getter-retirement-authorization-2026-05-26.md` | G | G2.107 authorization accepted in PR `#260` at `d120d6d`: authorizes only a future G2.108 implementation branch to retire `email_notification_service.py` module-level `_email_service` and `get_email_service`, preserves `EmailNotificationService`, keeps route-backed `email_service.py`, `get_email_service_dependency`, notification routes, OpenAPI, PM2, and OpenSpec out of scope, and records that file-path GitNexus context for `email_notification_service.py:get_email_service` has no incoming graph callers while bare `get_email_service` impact resolves to the separate route-backed `email_service.py` symbol | Superseded by G2.108 EmailNotificationService getter-retirement implementation |
 | `backend-email-notification-getter-retirement-implementation-2026-05-26.md` | G | G2.108 implementation accepted in PR `#261` at `9cb643d`: removes only `email_notification_service.py:_email_service` and `email_notification_service.py:get_email_service`, preserves `EmailNotificationService`, leaves route-backed `email_service.py`, `get_email_service_dependency`, and notification routes untouched, records TDD red `1 failed`, focused green `5 passed`, health route conflicts `120 passed`, touched-file ruff and black checks passed, and exact post-change scan shows target getter refs=`0` and target singleton refs=`0` | Superseded by G2.109 EmailNotificationService getter-retirement closeout |
 | `backend-email-notification-getter-retirement-closeout-2026-05-26.md` | G | G2.109 closeout accepted in PR `#262` at `ae6d2f2`: records PR `#261` merge, confirms current-head `email_notification_service.py:get_email_service` refs=`0`, `_email_service` refs=`0`, route/API direct `email_notification_service` refs=`0`, preserves `EmailNotificationService` and route-backed `get_email_service_dependency`, and re-runs focused tests `5 passed`, health route conflicts `120 passed`, ruff, and black checks | Superseded by G2.110 service lifecycle candidate refresh after EmailNotificationService |
-| `backend-service-lifecycle-candidate-refresh-after-email-notification-2026-05-26.md` | G | G2.110 candidate refresh prepared at `ae6d2f2`: scans service files=`152`, backend app files=`575`, API files=`219`, backend test files=`199`, all test files=`1211`, getter definitions=`16`, candidate-like definitions=`9`; confirms retired `email_notification_service.py:get_email_service` is gone, records `get_market_data_service` as the only LOW / `0` next authorization candidate with route/API direct refs=`0`, and keeps streaming HIGH, TDX/data/strategy/stock search CRITICAL, and email/watchlist/announcement holds out of source scope | Human review / PR merge decision; if accepted, create G2.111 MarketDataService getter-retirement authorization before any market-data service source edit |
+| `backend-service-lifecycle-candidate-refresh-after-email-notification-2026-05-26.md` | G | G2.110 candidate refresh accepted in PR `#263` at `c4abd4e`: scans service files=`152`, backend app files=`575`, API files=`219`, backend test files=`199`, all test files=`1211`, getter definitions=`16`, candidate-like definitions=`9`; confirms retired `email_notification_service.py:get_email_service` is gone, records `get_market_data_service` as the only LOW / `0` next authorization candidate with route/API direct refs=`0`, and keeps streaming HIGH, TDX/data/strategy/stock search CRITICAL, and email/watchlist/announcement holds out of source scope | Superseded by G2.111 MarketDataService getter-retirement authorization |
+| `backend-market-data-service-getter-retirement-authorization-2026-05-26.md` | G | G2.111 authorization prepared at `c4abd4e`: authorizes only a future G2.112 implementation branch for the package-level `market_data_service/get_market_data_service.py` `_market_data_service` and `get_market_data_service` retirement; preserves `MarketDataService`, `install_market_data_service`, and `get_market_data_service_dependency`, records GitNexus impact LOW / `0`, direct API refs=`0`, and requires future adapter/package export cleanup because `market_data_adapter.py` and package `__init__.py` still reference the getter | Human review / PR merge decision; if accepted, create G2.112 MarketDataService getter-retirement implementation before any market-data service source edit |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/market-data-service-getter-retirement-authorization-2026-05-26.json
+++ b/.planning/codebase/generated/market-data-service-getter-retirement-authorization-2026-05-26.json
@@ -1,0 +1,104 @@
+{
+  "artifact": "market-data-service-getter-retirement-authorization-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T02:30:00+08:00",
+  "branch": "g2-111-market-data-service-getter-retirement-authorization",
+  "current_head": "c4abd4e8c4705f07a7d86e13c2090d30575e95e9",
+  "current_head_checked_at_review": "2026-05-26T02:30:00+08:00",
+  "parent": {
+    "node": "G2.110",
+    "pr": 263,
+    "merge_commit": "c4abd4e8c4705f07a7d86e13c2090d30575e95e9",
+    "decision": "select MarketDataService getter-retirement authorization as next lane"
+  },
+  "governance_node": {
+    "id": "G2.111",
+    "lane": "service_lifecycle_di",
+    "type": "authorization_only",
+    "state": "ready_for_review"
+  },
+  "target": {
+    "file": "web/backend/app/services/market_data_service/get_market_data_service.py",
+    "getter": {
+      "name": "get_market_data_service",
+      "line": 28
+    },
+    "singleton": {
+      "name": "_market_data_service",
+      "line": 24
+    },
+    "preserved_surfaces": [
+      "MarketDataService",
+      "install_market_data_service",
+      "get_market_data_service_dependency"
+    ]
+  },
+  "evidence": {
+    "gitnexus_context": {
+      "incoming_callers": 0,
+      "outgoing_calls": 0,
+      "processes": 0
+    },
+    "gitnexus_impact": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct": 0,
+      "processes_affected": 0
+    },
+    "text_scan": {
+      "app_refs": 8,
+      "app_ref_files": 4,
+      "api_refs": 0,
+      "api_ref_files": 0,
+      "backend_test_refs": 13,
+      "backend_test_ref_files": 4,
+      "private_singleton_refs": 5
+    },
+    "known_future_touchpoints": [
+      "web/backend/app/services/market_data_adapter.py",
+      "web/backend/app/services/market_data_service/__init__.py",
+      "web/backend/app/services/market_data_service/get_market_data_service.py",
+      "web/backend/tests/test_market_data_service_lifecycle_di.py"
+    ]
+  },
+  "authorized_future_g2_112_scope": {
+    "allowed_source_paths": [
+      "web/backend/app/services/market_data_service/get_market_data_service.py",
+      "web/backend/app/services/market_data_service/__init__.py",
+      "web/backend/app/services/market_data_adapter.py"
+    ],
+    "allowed_test_paths": [
+      "web/backend/tests/test_market_data_service_lifecycle_di.py",
+      "web/backend/tests/test_market_data_service_getter_retirement.py"
+    ],
+    "allowed_governance_paths": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/market-data-service-getter-retirement-implementation-2026-05-26.json",
+      "docs/reports/quality/backend-market-data-service-getter-retirement-implementation-2026-05-26.md",
+      "governance/mainline/task-cards/pr-265.yaml"
+    ],
+    "may_remove": [
+      "market_data_service/get_market_data_service.py:_market_data_service",
+      "market_data_service/get_market_data_service.py:get_market_data_service",
+      "market_data_service/__init__.py package export for get_market_data_service"
+    ],
+    "must_preserve": [
+      "MarketDataService",
+      "install_market_data_service",
+      "get_market_data_service_dependency",
+      "route/API contracts",
+      "OpenAPI exposure",
+      "root-level web/backend/app/services/__init__.py:get_market_data_service unless separately authorized"
+    ]
+  },
+  "forbidden_scope": [
+    "route/API behavior",
+    "OpenAPI exposure",
+    "frontend code",
+    "PM2 workflows",
+    "OpenSpec proposals or specs",
+    "GitHub issue labels or readiness states",
+    "broad market-data service refactoring"
+  ],
+  "next_gate": "Human review / PR merge decision for G2.111; if accepted, create G2.112 MarketDataService getter-retirement implementation before any market-data service source edit."
+}

--- a/docs/reports/quality/backend-market-data-service-getter-retirement-authorization-2026-05-26.md
+++ b/docs/reports/quality/backend-market-data-service-getter-retirement-authorization-2026-05-26.md
@@ -1,0 +1,120 @@
+# Backend MarketDataService Getter Retirement Authorization - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.111 MarketDataService getter-retirement authorization
+Status: ready for review
+
+## Purpose
+
+Authorize only a future G2.112 implementation branch for retiring the
+package-level lazy getter in
+`web/backend/app/services/market_data_service/get_market_data_service.py`.
+
+This packet does not edit backend source, tests, routes, OpenAPI, frontend,
+PM2, OpenSpec, or issue labels.
+
+## Parent Gate
+
+| Item | Value |
+|---|---|
+| Parent candidate refresh | G2.110 |
+| Parent PR | `#263` |
+| Parent merge commit | `c4abd4e8c4705f07a7d86e13c2090d30575e95e9` |
+| Current HEAD | `c4abd4e8c4705f07a7d86e13c2090d30575e95e9` |
+
+## Target Evidence
+
+| Evidence | Result |
+|---|---|
+| Target getter | `web/backend/app/services/market_data_service/get_market_data_service.py:get_market_data_service` at line `28` |
+| Target singleton | `_market_data_service` at line `24` |
+| Preserved class | `MarketDataService` imported from `.market_data_service` |
+| Preserved lifecycle helpers | `install_market_data_service`, `get_market_data_service_dependency` |
+| GitNexus context | no incoming graph callers, no outgoing graph calls, no process participation |
+| GitNexus impact | LOW / impacted count `0` |
+| Direct API refs | `0` |
+| App refs | `8` refs across `4` files |
+| Backend test refs | `13` refs across `4` files |
+
+## Disambiguation
+
+The low GitNexus impact does not mean the implementation may delete the getter
+alone. Exact text scan shows non-API app/package references that must be handled
+in the future implementation branch:
+
+- `web/backend/app/services/market_data_adapter.py` imports and calls
+  `get_market_data_service`.
+- `web/backend/app/services/market_data_service/__init__.py` exports
+  `get_market_data_service`.
+- `web/backend/app/services/__init__.py` has a separate root-level
+  `get_market_data_service` surface and must not be confused with the package
+  target.
+- Existing tests patch or assert the package getter and must be updated by TDD.
+
+## Authorized Future G2.112 Scope
+
+If this authorization packet is accepted, G2.112 may touch only:
+
+- `web/backend/app/services/market_data_service/get_market_data_service.py`
+- `web/backend/app/services/market_data_service/__init__.py`
+- `web/backend/app/services/market_data_adapter.py`
+- focused market-data service lifecycle tests
+- steward tree, generated evidence JSON, implementation report, and PR task card
+
+The future implementation may remove:
+
+- `market_data_service/get_market_data_service.py:_market_data_service`
+- `market_data_service/get_market_data_service.py:get_market_data_service`
+- package export of the package-level `get_market_data_service`
+
+The future implementation must preserve:
+
+- `MarketDataService`
+- `install_market_data_service`
+- `get_market_data_service_dependency`
+- route/API contracts and OpenAPI exposure
+- root-level `web/backend/app/services/__init__.py:get_market_data_service`,
+  unless a separate authorization explicitly handles that different surface
+
+## Required Future G2.112 Verification
+
+G2.112 must:
+
+1. Re-read `architecture/STANDARDS.md`.
+2. Run GitNexus context/impact for the package-level
+   `get_market_data_service`.
+3. Write a focused red test proving the package getter and singleton still
+   exist before implementation.
+4. Retarget `market_data_adapter.py` away from the public package getter.
+5. Preserve `install_market_data_service` and
+   `get_market_data_service_dependency`.
+6. Remove the package-level getter and package export only after tests fail red.
+7. Run focused market-data lifecycle tests and relevant adapter tests.
+8. Run health route conflicts.
+9. Run ruff/black on touched backend files.
+10. Stage only authorized paths and run GitNexus `detect_changes` with
+    `scope="staged"`.
+11. Run mainline scope, markdown, JSON, YAML, and diff checks.
+
+## Boundary
+
+This packet does not:
+
+- edit backend source or tests
+- delete any getter
+- alter route/API behavior or OpenAPI exposure
+- change frontend code
+- change PM2 workflows
+- create or modify OpenSpec changes/specs
+- change GitHub issue labels or readiness state
+- authorize broad market-data service refactoring
+
+## Next Gate
+
+Human review / PR merge decision for G2.111.
+
+If accepted, create G2.112 as the MarketDataService getter-retirement
+implementation branch before any market-data service source edit.

--- a/governance/mainline/task-cards/pr-264.yaml
+++ b/governance/mainline/task-cards/pr-264.yaml
@@ -1,0 +1,111 @@
+version: "v0.2"
+
+task:
+  id: "pr-264"
+  title: "Authorize MarketDataService getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-market-data-service-getter-retirement-authorization"
+  objective: "authorize a future implementation branch for retiring the package-level MarketDataService lazy getter"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-market-data-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-market-data-service-getter-retirement-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/market-data-service-getter-retirement-authorization-2026-05-26.json"
+    - "docs/reports/quality/backend-market-data-service-getter-retirement-authorization-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-264.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not delete any MarketDataService getter in this PR"
+  - "Do not modify market_data_adapter.py in this PR"
+  - "Do not modify package exports in this PR"
+  - "Do not modify route/API behavior or OpenAPI exposure"
+  - "Do not change frontend code"
+  - "Do not change PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not authorize implementation beyond future G2.112"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 263 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-market-data-service-getter-retirement-authorization-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/market-data-service-getter-retirement-authorization-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-264.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-264.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If future implementation deletes the getter without adapter/package cleanup, market_data_adapter.py and package imports can regress"
+    - "If root-level services/__init__.py:get_market_data_service is confused with the package target, an unrelated surface could be edited"
+  rollback_plan: "revert this governance-only PR and keep G2.110 as the latest accepted service lifecycle candidate refresh evidence"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize future package-level MarketDataService getter retirement"
+    modified_scope: "steward tree, authorization report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; authorization-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if parent PR evidence, target disambiguation, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T02:30:00+08:00"
+    approval_note: "G2.110 PR #263 was merged; this packet authorizes only a future G2.112 implementation branch for package-level MarketDataService getter retirement"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- add G2.111 authorization-only packet for package-level MarketDataService getter retirement
- preserve MarketDataService, install_market_data_service, and get_market_data_service_dependency
- require future G2.112 to handle market_data_adapter.py and package export refs before removing the getter

## Verification
- parent PR #263 merged
- GitNexus context: target has no incoming callers/processes
- GitNexus impact: LOW, impacted_count=0
- exact text scan: direct API refs=0; app refs exist in market_data_adapter.py/package exports and are documented
- markdown governance: 2 checked, 0 errors
- JSON/YAML parse: ok
- GitNexus staged detect_changes: low risk, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: indexed successfully

## Boundary
Authorization-only. No backend source, tests, route/API, OpenAPI, frontend, PM2, OpenSpec, or issue-label changes.