### PR TITLE
refactor(services): retire market data package getter

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1807,7 +1807,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, service migration, or issue-label change
 │   │                is made here
 │   ├── G2.111 MarketDataService getter-retirement authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#264` merged at
+│   │   │          `88a8ae4e50ca29c21580db2e0c3f33c0a303ad2d`
 │   │   ├── Evidence: `backend-market-data-service-getter-retirement-authorization-2026-05-26.md`
 │   │   ├── Current HEAD: `c4abd4e8c4705f07a7d86e13c2090d30575e95e9`
 │   │   ├── Decision: authorize only a future G2.112 implementation branch to
@@ -1823,9 +1824,31 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: authorization-only; no backend source/test edit, route/API,
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                service migration, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.111; if accepted,
-│                  create G2.112 MarketDataService getter-retirement
-│                  implementation before any market-data service source edit
+│   ├── G2.112 MarketDataService getter-retirement implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-market-data-service-getter-retirement-implementation-2026-05-26.md`
+│   │   ├── Current HEAD: `88a8ae4e50ca29c21580db2e0c3f33c0a303ad2d`
+│   │   ├── Change: retired package-level
+│   │   │          `market_data_service/get_market_data_service.py`
+│   │   │          `_market_data_service` and `get_market_data_service`, removed
+│   │   │          the package export, and retargeted `market_data_adapter.py`
+│   │   │          to an adapter-local `MarketDataService` lazy instance
+│   │   ├── Preservation: `MarketDataService`, `install_market_data_service`,
+│   │   │          `get_market_data_service_dependency`, route/API contracts,
+│   │   │          OpenAPI exposure, PM2, OpenSpec, frontend, and root-level
+│   │   │          `web/backend/app/services/__init__.py:get_market_data_service`
+│   │   │          remain unchanged
+│   │   ├── Verification: TDD red produced `2 failed`; focused tests
+│   │   │          `7 passed`; health route conflicts `120 passed`; touched-file
+│   │   │          ruff and black passed; `app.main` import passes when required
+│   │   │          environment variables are supplied
+│   │   └── Boundary: implementation-only for the authorized package getter;
+│   │                no route/API, OpenAPI, frontend, PM2, OpenSpec,
+│   │                root-level services getter, service consolidation, or
+│   │                issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.112; if accepted,
+│                  create G2.113 closeout/current-head refresh before selecting
+│                  another service getter candidate
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/market-data-service-getter-retirement-implementation-2026-05-26.json
+++ b/.planning/codebase/generated/market-data-service-getter-retirement-implementation-2026-05-26.json
@@ -1,0 +1,122 @@
+{
+  "artifact": "market-data-service-getter-retirement-implementation-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T02:45:00+08:00",
+  "branch": "g2-112-market-data-service-getter-retirement-implementation",
+  "base_head": "88a8ae4e50ca29c21580db2e0c3f33c0a303ad2d",
+  "current_head_checked_at_review": "2026-05-26T02:45:00+08:00",
+  "parent_authorization": {
+    "node": "G2.111",
+    "pr": 264,
+    "merge_commit": "88a8ae4e50ca29c21580db2e0c3f33c0a303ad2d",
+    "authorized_scope": "retire package-level market_data_service _market_data_service and get_market_data_service after adapter/package cleanup"
+  },
+  "governance_node": {
+    "id": "G2.112",
+    "lane": "service_lifecycle_di",
+    "type": "implementation",
+    "state": "ready_for_review"
+  },
+  "changed_runtime_files": [
+    "web/backend/app/services/market_data_service/get_market_data_service.py",
+    "web/backend/app/services/market_data_service/__init__.py",
+    "web/backend/app/services/market_data_adapter.py"
+  ],
+  "changed_test_files": [
+    "web/backend/tests/test_market_data_service_lifecycle_di.py",
+    "web/backend/tests/test_market_data_service_getter_retirement.py"
+  ],
+  "removed_symbols": [
+    "web/backend/app/services/market_data_service/get_market_data_service.py:_market_data_service",
+    "web/backend/app/services/market_data_service/get_market_data_service.py:get_market_data_service",
+    "web/backend/app/services/market_data_service/__init__.py:get_market_data_service export"
+  ],
+  "preserved_surfaces": [
+    "web/backend/app/services/market_data_service/market_data_service.py:MarketDataService",
+    "web/backend/app/services/market_data_service/get_market_data_service.py:install_market_data_service",
+    "web/backend/app/services/market_data_service/get_market_data_service.py:get_market_data_service_dependency",
+    "web/backend/app/services/__init__.py:get_market_data_service",
+    "market route contracts",
+    "OpenAPI exposure"
+  ],
+  "pre_edit_evidence": {
+    "standards_read": true,
+    "openspec_agents_read": true,
+    "gitnexus_analyze_before_edit": "success",
+    "target_context": {
+      "target": "web/backend/app/services/market_data_service/get_market_data_service.py:get_market_data_service",
+      "incoming_callers": 0,
+      "outgoing_calls": 0,
+      "processes": 0
+    },
+    "target_impact": {
+      "target": "get_market_data_service",
+      "risk": "LOW",
+      "impacted_count": 0
+    },
+    "adapter_impact": {
+      "class": {
+        "target": "MarketDataSourceAdapter",
+        "risk": "LOW",
+        "impacted_count": 0
+      },
+      "method": {
+        "target": "_get_market_service",
+        "risk": "LOW",
+        "impacted_count": 6,
+        "direct_callers": 4,
+        "scope": "all impacted symbols are in market_data_adapter.py"
+      }
+    }
+  },
+  "post_change_scan": {
+    "target_getter_definitions": 0,
+    "target_singleton_tokens": 0,
+    "package_getter_imports": 0,
+    "adapter_getter_calls": 0,
+    "root_level_services_getter_preserved": true
+  },
+  "verification": {
+    "tdd_red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_getter_retirement.py -q --no-cov --tb=short",
+      "result": "2 failed",
+      "expected_failures": [
+        "package getter export still existed",
+        "market_data_adapter module did not expose MarketDataService for local factory use"
+      ]
+    },
+    "focused_green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_getter_retirement.py web/backend/tests/test_market_data_service_lifecycle_di.py -q --no-cov --tb=short",
+      "result": "7 passed"
+    },
+    "health_route_conflicts": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "120 passed"
+    },
+    "ruff_touched_files": {
+      "command": "ruff check web/backend/app/services/market_data_service/get_market_data_service.py web/backend/app/services/market_data_service/__init__.py web/backend/app/services/market_data_adapter.py web/backend/tests/test_market_data_service_lifecycle_di.py web/backend/tests/test_market_data_service_getter_retirement.py",
+      "result": "passed"
+    },
+    "black_touched_files": {
+      "command": "black --check web/backend/app/services/market_data_service/get_market_data_service.py web/backend/app/services/market_data_service/__init__.py web/backend/app/services/market_data_adapter.py web/backend/tests/test_market_data_service_lifecycle_di.py web/backend/tests/test_market_data_service_getter_retirement.py",
+      "result": "passed"
+    },
+    "app_main_import": {
+      "raw_result": "blocked by missing required environment variables",
+      "env_complete_result": "passed"
+    }
+  },
+  "boundary": {
+    "routes_changed": false,
+    "openapi_changed": false,
+    "frontend_changed": false,
+    "pm2_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "market_data_service_class_deleted": false,
+    "install_market_data_service_deleted": false,
+    "dependency_deleted": false,
+    "root_level_services_getter_changed": false
+  },
+  "next_gate": "Human review / PR merge decision for G2.112; if accepted, create G2.113 closeout/current-head refresh before selecting another service getter candidate."
+}

--- a/docs/reports/quality/backend-market-data-service-getter-retirement-implementation-2026-05-26.md
+++ b/docs/reports/quality/backend-market-data-service-getter-retirement-implementation-2026-05-26.md
@@ -1,0 +1,124 @@
+# Backend MarketDataService Getter Retirement Implementation - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.112 MarketDataService getter-retirement implementation
+Status: ready for review
+
+## Purpose
+
+Implement the G2.111 authorization by retiring the package-level
+`MarketDataService` lazy singleton getter in
+`web/backend/app/services/market_data_service/get_market_data_service.py`.
+
+This implementation is intentionally narrow. It does not change market routes,
+OpenAPI exposure, PM2 workflows, OpenSpec changes, frontend code, GitHub issue
+labels, service consolidation, or the root-level
+`web/backend/app/services/__init__.py:get_market_data_service` surface.
+
+## Parent Gate
+
+| Gate | Result |
+|---|---|
+| Parent authorization | G2.111 accepted in PR `#264` |
+| Parent merge commit | `88a8ae4e50ca29c21580db2e0c3f33c0a303ad2d` |
+| Current implementation base | `88a8ae4e50ca29c21580db2e0c3f33c0a303ad2d` |
+| Authorized provider target | `web/backend/app/services/market_data_service/get_market_data_service.py` |
+| Authorized adapter target | `web/backend/app/services/market_data_adapter.py` |
+| Authorized package target | `web/backend/app/services/market_data_service/__init__.py` |
+| Authorized removals | package-level `_market_data_service`, package-level `get_market_data_service`, package export for package-level getter |
+| Required preservation | `MarketDataService`, `install_market_data_service`, `get_market_data_service_dependency`, route/API contracts, OpenAPI exposure, root-level services getter |
+
+## Pre-Edit Evidence
+
+| Evidence | Result |
+|---|---|
+| `architecture/STANDARDS.md` | Read before source edit; deletion requires explicit closure and evidence |
+| `openspec/AGENTS.md` | Read before continuing architecture implementation work |
+| GitNexus analyze | `gitnexus analyze --with-gitignore`; indexed successfully before edit |
+| File-path GitNexus context | `market_data_service/get_market_data_service.py:get_market_data_service` has no incoming graph callers, no outgoing graph calls, and no process participation |
+| Target GitNexus impact | `get_market_data_service`; LOW / `0` impacted symbols |
+| Adapter class GitNexus impact | `MarketDataSourceAdapter`; LOW / `0` impacted symbols |
+| Adapter method GitNexus impact | `_get_market_service`; LOW / `6` impacted symbols, all within `market_data_adapter.py` |
+| Exact pre-change target evidence | direct API refs=`0`; package export and `market_data_adapter.py` were the expected implementation consumers |
+
+## Change
+
+Removed the package-level lazy singleton surface from
+`web/backend/app/services/market_data_service/get_market_data_service.py`:
+
+- `_market_data_service`
+- `get_market_data_service`
+
+Kept the route dependency seam and app-state installer:
+
+- `MARKET_DATA_SERVICE_STATE_KEY`
+- `install_market_data_service`
+- `get_market_data_service_dependency`
+
+Adjusted the authorized consumers:
+
+- `web/backend/app/services/market_data_service/__init__.py` no longer exports
+  package-level `get_market_data_service`
+- `web/backend/app/services/market_data_adapter.py` no longer imports or calls
+  the package getter; it now lazily creates an adapter-local
+  `MarketDataService` instance for non-mock mode
+
+Added focused regression coverage:
+
+- `web/backend/tests/test_market_data_service_getter_retirement.py`
+
+Updated existing lifecycle coverage:
+
+- `web/backend/tests/test_market_data_service_lifecycle_di.py`
+
+## Verification
+
+| Check | Command | Result |
+|---|---|---|
+| TDD red | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_getter_retirement.py -q --no-cov --tb=short` | `2 failed`; failures proved package getter export and adapter getter dependency still existed |
+| Focused green | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_getter_retirement.py web/backend/tests/test_market_data_service_lifecycle_di.py -q --no-cov --tb=short` | `7 passed` |
+| Health route conflicts | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `120 passed` |
+| Ruff touched files | `ruff check web/backend/app/services/market_data_service/get_market_data_service.py web/backend/app/services/market_data_service/__init__.py web/backend/app/services/market_data_adapter.py web/backend/tests/test_market_data_service_lifecycle_di.py web/backend/tests/test_market_data_service_getter_retirement.py` | passed |
+| Black touched files | `black --check web/backend/app/services/market_data_service/get_market_data_service.py web/backend/app/services/market_data_service/__init__.py web/backend/app/services/market_data_adapter.py web/backend/tests/test_market_data_service_lifecycle_di.py web/backend/tests/test_market_data_service_getter_retirement.py` | passed |
+| Exact post-change scan | scripted text scan | target getter definition=`0`; target singleton token=`0`; package getter imports=`0`; adapter getter calls=`0`; root-level services getter preserved |
+| Raw `app.main` import | `PYTHONPATH=web/backend python -c 'import app.main'` | blocked by missing required environment variables, not by this change |
+| Env-complete `app.main` import | same import with required dummy env vars | passed |
+
+## Post-Change Scan
+
+| Surface | Result |
+|---|---|
+| `market_data_service/get_market_data_service.py:def get_market_data_service` | `0` |
+| `market_data_service/get_market_data_service.py:_market_data_service` | `0` |
+| `from app.services.market_data_service import get_market_data_service` | `0` |
+| `market_data_adapter.py` calls to `get_market_data_service()` | `0` |
+| `web/backend/app/services/__init__.py:get_market_data_service` | preserved; explicitly out of scope |
+| `MarketDataService` | preserved |
+| `install_market_data_service` | preserved |
+| `get_market_data_service_dependency` | preserved |
+
+## Boundary
+
+This PR does not:
+
+- modify market route handlers
+- modify route paths, response models, response shapes, or OpenAPI exposure
+- modify frontend code
+- modify PM2 workflows
+- create or modify OpenSpec proposals/specs
+- change GitHub issue labels or readiness state
+- delete or rename `MarketDataService`
+- delete or alter `install_market_data_service`
+- delete or alter `get_market_data_service_dependency`
+- modify root-level `web/backend/app/services/__init__.py:get_market_data_service`
+- perform broader market-data service consolidation
+
+## Next Gate
+
+Human review / PR merge decision for G2.112.
+
+If accepted, create G2.113 closeout/current-head refresh before selecting another
+service getter candidate.

--- a/governance/mainline/task-cards/pr-265.yaml
+++ b/governance/mainline/task-cards/pr-265.yaml
@@ -1,0 +1,131 @@
+version: "v0.2"
+
+task:
+  id: "pr-265"
+  title: "Retire MarketDataService package-level getter"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-market-data-service-getter-retirement-implementation"
+  objective: "remove the package-level MarketDataService lazy getter while preserving app-state dependency injection and route/API contracts"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-market-data-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-market-data-service-getter-retirement-implementation"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow package-level service getter retirement; no route, public API surface, OpenAPI exposure, frontend behavior, or OpenSpec capability is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/market-data-service-getter-retirement-implementation-2026-05-26.json"
+    - "docs/reports/quality/backend-market-data-service-getter-retirement-implementation-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-265.yaml"
+    - "web/backend/app/services/market_data_service/get_market_data_service.py"
+    - "web/backend/app/services/market_data_service/__init__.py"
+    - "web/backend/app/services/market_data_adapter.py"
+    - "web/backend/tests/test_market_data_service_lifecycle_di.py"
+    - "web/backend/tests/test_market_data_service_getter_retirement.py"
+  forbidden_paths:
+    - "web/backend/app/services/__init__.py"
+    - "web/backend/app/api/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not modify market route handlers or route contracts"
+  - "Do not modify OpenAPI exposure"
+  - "Do not modify root-level web/backend/app/services/__init__.py:get_market_data_service"
+  - "Do not delete or rename MarketDataService"
+  - "Do not delete or alter install_market_data_service"
+  - "Do not delete or alter get_market_data_service_dependency"
+  - "Do not change frontend code"
+  - "Do not change PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not select the next service getter candidate in this PR"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 264 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "focused-green-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_getter_retirement.py web/backend/tests/test_market_data_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-files"
+      command: "ruff check web/backend/app/services/market_data_service/get_market_data_service.py web/backend/app/services/market_data_service/__init__.py web/backend/app/services/market_data_adapter.py web/backend/tests/test_market_data_service_lifecycle_di.py web/backend/tests/test_market_data_service_getter_retirement.py"
+      required: true
+    - id: "black-touched-files"
+      command: "black --check web/backend/app/services/market_data_service/get_market_data_service.py web/backend/app/services/market_data_service/__init__.py web/backend/app/services/market_data_adapter.py web/backend/tests/test_market_data_service_lifecycle_di.py web/backend/tests/test_market_data_service_getter_retirement.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-market-data-service-getter-retirement-implementation-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/market-data-service-getter-retirement-implementation-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-265.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-265.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If route/API files are edited, market route contracts or OpenAPI exposure could drift outside the authorization"
+    - "If root-level services/__init__.py:get_market_data_service is confused with the package target, an unrelated surface could be changed"
+    - "If install_market_data_service or get_market_data_service_dependency are removed, route dependency injection could regress"
+  rollback_plan: "revert this narrow implementation PR and keep G2.111 authorization as the latest accepted market-data getter gate"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "retire package-level MarketDataService getter and module singleton"
+    modified_scope: "three service files, two focused tests, steward tree, implementation report, generated artifact, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "package-level getter removed; app-state installer/dependency and root-level services getter preserved"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, health route conflicts, touched-file lint/format, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T02:45:00+08:00"
+    approval_note: "G2.111 PR #264 authorized only this narrow package-level MarketDataService getter retirement implementation"
+    secondary_approved: false

--- a/web/backend/app/services/market_data_adapter.py
+++ b/web/backend/app/services/market_data_adapter.py
@@ -13,6 +13,7 @@ from app.services.data_source_interface import (
     HealthStatusEnum,
     IDataSource,
 )
+from app.services.market_data_service import MarketDataService
 
 logger = __import__("logging").getLogger(__name__)
 
@@ -61,9 +62,7 @@ class MarketDataSourceAdapter(IDataSource):
         """Lazy initialization of market service"""
         if self._market_service is None and self.mode != "mock":
             try:
-                from app.services.market_data_service import get_market_data_service
-
-                self._market_service = get_market_data_service()
+                self._market_service = MarketDataService()
             except Exception as e:
                 self._market_service = None
                 raise RuntimeError(f"Failed to initialize market service: {e}")

--- a/web/backend/app/services/market_data_service/__init__.py
+++ b/web/backend/app/services/market_data_service/__init__.py
@@ -3,7 +3,6 @@
 from .market_data_service import MarketDataService  # noqa: F401
 from .get_market_data_service import (  # noqa: F401
     MARKET_DATA_SERVICE_STATE_KEY,
-    get_market_data_service,
     get_market_data_service_dependency,
     install_market_data_service,
 )
@@ -11,7 +10,6 @@ from .get_market_data_service import (  # noqa: F401
 __all__ = [
     "MarketDataService",
     "MARKET_DATA_SERVICE_STATE_KEY",
-    "get_market_data_service",
     "get_market_data_service_dependency",
     "install_market_data_service",
 ]

--- a/web/backend/app/services/market_data_service/get_market_data_service.py
+++ b/web/backend/app/services/market_data_service/get_market_data_service.py
@@ -13,7 +13,7 @@
 """
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from fastapi import Request
 
@@ -21,21 +21,12 @@ from .market_data_service import MarketDataService
 
 logger = logging.getLogger(__name__)
 
-_market_data_service: Optional[MarketDataService] = None
 MARKET_DATA_SERVICE_STATE_KEY = "market_data_service"
-
-
-def get_market_data_service() -> MarketDataService:
-    """获取市场数据服务单例"""
-    global _market_data_service
-    if _market_data_service is None:
-        _market_data_service = MarketDataService()
-    return _market_data_service
 
 
 def install_market_data_service(app: Any, service: MarketDataService | None = None) -> MarketDataService:
     """Install the market data service instance on FastAPI app.state."""
-    selected_service = service if service is not None else get_market_data_service()
+    selected_service = service if service is not None else MarketDataService()
     setattr(app.state, MARKET_DATA_SERVICE_STATE_KEY, selected_service)
     return selected_service
 

--- a/web/backend/tests/test_market_data_service_getter_retirement.py
+++ b/web/backend/tests/test_market_data_service_getter_retirement.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_market_data_service_package_getter_and_singleton_are_retired():
+    service_package = importlib.import_module("app.services.market_data_service")
+    provider_module = importlib.import_module("app.services.market_data_service.get_market_data_service")
+
+    assert hasattr(service_package, "MarketDataService")
+    assert "get_market_data_service" not in service_package.__all__
+    assert not callable(getattr(service_package, "get_market_data_service", None))
+    assert not hasattr(provider_module, "get_market_data_service")
+    assert not hasattr(provider_module, "_market_data_service")
+
+
+def test_market_data_adapter_uses_local_service_factory_without_package_getter(monkeypatch):
+    adapter_module = importlib.import_module("app.services.market_data_adapter")
+
+    class FakeMarketDataService:
+        pass
+
+    monkeypatch.setattr(adapter_module, "MarketDataService", FakeMarketDataService)
+
+    adapter = adapter_module.MarketDataSourceAdapter({"mode": "live"})
+
+    service = adapter._get_market_service()
+
+    assert isinstance(service, FakeMarketDataService)
+    assert adapter._get_market_service() is service

--- a/web/backend/tests/test_market_data_service_lifecycle_di.py
+++ b/web/backend/tests/test_market_data_service_lifecycle_di.py
@@ -31,15 +31,15 @@ def test_market_data_service_package_reexports_provider_symbols():
 
 
 def test_market_data_service_dependency_installs_app_state_when_missing(monkeypatch):
-    getter_module = importlib.import_module("app.services.market_data_service.get_market_data_service")
+    provider_module = importlib.import_module("app.services.market_data_service.get_market_data_service")
     fake_service = object()
     fake_app = SimpleNamespace(state=SimpleNamespace())
     request = SimpleNamespace(app=fake_app)
 
-    monkeypatch.setattr(getter_module, "get_market_data_service", lambda: fake_service)
+    monkeypatch.setattr(provider_module, "MarketDataService", lambda: fake_service)
 
-    assert getter_module.get_market_data_service_dependency(request) is fake_service
-    assert getattr(fake_app.state, getter_module.MARKET_DATA_SERVICE_STATE_KEY) is fake_service
+    assert provider_module.get_market_data_service_dependency(request) is fake_service
+    assert getattr(fake_app.state, provider_module.MARKET_DATA_SERVICE_STATE_KEY) is fake_service
 
 
 def test_install_market_data_service_accepts_explicit_service():


### PR DESCRIPTION
## Summary
- retire the package-level MarketDataService lazy getter and module singleton
- preserve MarketDataService, install_market_data_service, get_market_data_service_dependency, route/API contracts, OpenAPI exposure, and root-level services getter
- retarget market_data_adapter.py to an adapter-local MarketDataService lazy instance
- update steward tree, generated evidence, implementation report, and pr-265 task card

## Verification
- TDD red: 2 expected failures before implementation
- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_getter_retirement.py web/backend/tests/test_market_data_service_lifecycle_di.py -q --no-cov --tb=short -> 7 passed
- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short -> 120 passed
- ruff check touched files -> passed
- black --check touched files -> passed
- app.main import with required dummy env -> passed
- GitNexus staged detect_changes -> LOW, affected_count=0
- post-commit mainline scope -> pass=True
- gitnexus analyze --with-gitignore -> indexed successfully

## Boundary
No route/API, OpenAPI, frontend, PM2, OpenSpec, issue-label, root-level services getter, or broader service consolidation changes.