### PR TITLE
docs(governance): close out market data getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1825,7 +1825,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                service migration, or issue-label change is made here
 │   ├── G2.112 MarketDataService getter-retirement implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#265` merged at
+│   │   │          `b5ca0c5fcf65de77e7bf336091c4ae3f220019ef`
 │   │   ├── Evidence: `backend-market-data-service-getter-retirement-implementation-2026-05-26.md`
 │   │   ├── Current HEAD: `88a8ae4e50ca29c21580db2e0c3f33c0a303ad2d`
 │   │   ├── Change: retired package-level
@@ -1846,9 +1847,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                no route/API, OpenAPI, frontend, PM2, OpenSpec,
 │   │                root-level services getter, service consolidation, or
 │   │                issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.112; if accepted,
-│                  create G2.113 closeout/current-head refresh before selecting
-│                  another service getter candidate
+│   ├── G2.113 MarketDataService getter-retirement closeout/current-head refresh
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-market-data-service-getter-retirement-closeout-2026-05-26.md`
+│   │   ├── Current HEAD: `b5ca0c5fcf65de77e7bf336091c4ae3f220019ef`
+│   │   ├── Result: current scan covers backend app/test Python files=`775`;
+│   │   │          package-level getter definitions=`0`, target singleton tokens=`0`,
+│   │   │          package getter imports=`0`, adapter getter calls=`0`, and
+│   │   │          root-level `web/backend/app/services/__init__.py:get_market_data_service`
+│   │   │          remains preserved
+│   │   ├── Verification: focused market-data tests `7 passed`; health route
+│   │   │          conflicts `120 passed`
+│   │   └── Boundary: closeout-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                service consolidation, candidate selection, or issue-label
+│   │                change is made here
+│   └── Next gate: human review / PR merge decision for G2.113; if accepted,
+│                  run a fresh service lifecycle candidate refresh before
+│                  selecting another service getter candidate
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/market-data-service-getter-retirement-closeout-2026-05-26.json
+++ b/.planning/codebase/generated/market-data-service-getter-retirement-closeout-2026-05-26.json
@@ -1,0 +1,52 @@
+{
+  "artifact": "market-data-service-getter-retirement-closeout-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T02:58:00+08:00",
+  "branch": "g2-113-market-data-service-getter-retirement-closeout",
+  "base_head": "b5ca0c5fcf65de77e7bf336091c4ae3f220019ef",
+  "current_head_checked_at_review": "2026-05-26T02:58:00+08:00",
+  "parent_implementation": {
+    "node": "G2.112",
+    "pr": 265,
+    "merge_commit": "b5ca0c5fcf65de77e7bf336091c4ae3f220019ef"
+  },
+  "governance_node": {
+    "id": "G2.113",
+    "lane": "service_lifecycle_di",
+    "type": "closeout_current_head_refresh",
+    "state": "ready_for_review"
+  },
+  "changed_runtime_files": [],
+  "changed_test_files": [],
+  "current_head_scan": {
+    "scanned_backend_app_and_test_python_files": 775,
+    "target_getter_definitions": 0,
+    "target_singleton_tokens": 0,
+    "package_getter_imports": 0,
+    "adapter_getter_calls": 0,
+    "root_level_services_getter_preserved": true,
+    "test_assertion_singleton_mentions": 1
+  },
+  "verification": {
+    "focused_market_data_tests": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_getter_retirement.py web/backend/tests/test_market_data_service_lifecycle_di.py -q --no-cov --tb=short",
+      "result": "7 passed"
+    },
+    "health_route_conflicts": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "120 passed"
+    }
+  },
+  "boundary": {
+    "source_changed": false,
+    "tests_changed": false,
+    "routes_changed": false,
+    "openapi_changed": false,
+    "frontend_changed": false,
+    "pm2_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "candidate_selected": false
+  },
+  "next_gate": "Human review / PR merge decision for G2.113; if accepted, run a fresh service lifecycle candidate refresh before selecting another service getter candidate."
+}

--- a/docs/reports/quality/backend-market-data-service-getter-retirement-closeout-2026-05-26.md
+++ b/docs/reports/quality/backend-market-data-service-getter-retirement-closeout-2026-05-26.md
@@ -1,0 +1,68 @@
+# Backend MarketDataService Getter Retirement Closeout - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.113 MarketDataService getter-retirement closeout/current-head refresh
+Status: ready for review
+
+## Purpose
+
+Close out the G2.111 -> G2.112 MarketDataService package-level getter retirement
+lane after PR `#265` was merged.
+
+This is a governance-only current-head refresh. It does not edit backend source,
+tests, route/API contracts, OpenAPI exposure, frontend code, PM2 workflows,
+OpenSpec changes, GitHub issue labels, or service lifecycle implementation
+logic.
+
+## Parent Gate
+
+| Gate | Result |
+|---|---|
+| Parent implementation | G2.112 accepted in PR `#265` |
+| Parent merge commit | `b5ca0c5fcf65de77e7bf336091c4ae3f220019ef` |
+| Current closeout base | `b5ca0c5fcf65de77e7bf336091c4ae3f220019ef` |
+| Closeout scope | current-head scan, regression evidence, steward tree update, generated artifact, and task card |
+
+## Current-Head Scan
+
+| Surface | Result |
+|---|---|
+| Backend app/test Python files scanned | `775` |
+| `market_data_service/get_market_data_service.py:def get_market_data_service` | `0` |
+| `market_data_service/get_market_data_service.py:_market_data_service` | `0` |
+| `from app.services.market_data_service import get_market_data_service` | `0` |
+| `market_data_adapter.py` calls to `get_market_data_service()` | `0` |
+| Root-level `web/backend/app/services/__init__.py:get_market_data_service` | preserved |
+
+The remaining test-file mention of `_market_data_service` is the retirement
+assertion in `test_market_data_service_getter_retirement.py`.
+
+## Verification
+
+| Check | Command | Result |
+|---|---|---|
+| Focused market-data tests | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_getter_retirement.py web/backend/tests/test_market_data_service_lifecycle_di.py -q --no-cov --tb=short` | `7 passed` |
+| Health route conflicts | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `120 passed` |
+
+## Boundary
+
+This PR does not:
+
+- modify backend source or tests
+- modify route paths, response models, response shapes, or OpenAPI exposure
+- modify frontend code
+- modify PM2 workflows
+- create or modify OpenSpec proposals/specs
+- change GitHub issue labels or readiness state
+- delete or rename any service symbol
+- select the next service getter candidate
+
+## Next Gate
+
+Human review / PR merge decision for G2.113.
+
+If accepted, run a fresh service lifecycle candidate refresh before selecting
+another service getter candidate.

--- a/governance/mainline/task-cards/pr-266.yaml
+++ b/governance/mainline/task-cards/pr-266.yaml
@@ -1,0 +1,114 @@
+version: "v0.2"
+
+task:
+  id: "pr-266"
+  title: "Close out MarketDataService getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-market-data-service-getter-retirement-closeout"
+  objective: "record current-head closeout evidence for the merged MarketDataService package getter retirement"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-market-data-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-market-data-service-getter-retirement-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only evidence packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/market-data-service-getter-retirement-closeout-2026-05-26.json"
+    - "docs/reports/quality/backend-market-data-service-getter-retirement-closeout-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-266.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not select the next service getter candidate in this PR"
+  - "Do not modify route/API behavior or OpenAPI exposure"
+  - "Do not change frontend code"
+  - "Do not change PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 265 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "focused-market-data-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_getter_retirement.py web/backend/tests/test_market_data_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-market-data-service-getter-retirement-closeout-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/market-data-service-getter-retirement-closeout-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-266.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-266.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet edits backend source or tests, it would exceed closeout scope"
+    - "If the next service getter candidate is selected here, candidate refresh evidence could become stale"
+  rollback_plan: "revert this governance-only closeout PR and keep G2.112 implementation as the latest accepted market-data getter state"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out merged MarketDataService package getter retirement"
+    modified_scope: "steward tree, closeout report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; closeout-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if current-head scan, focused tests, health route conflicts, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T02:58:00+08:00"
+    approval_note: "G2.112 PR #265 was merged; this packet records closeout/current-head evidence only"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- close out the merged G2.112 MarketDataService package getter retirement
- record current-head scan: target getter definitions 0, target singleton tokens 0, package getter imports 0, adapter getter calls 0
- preserve root-level services getter as explicitly out of scope
- update steward tree, closeout report, generated evidence, and pr-266 task card only

## Verification
- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_service_getter_retirement.py web/backend/tests/test_market_data_service_lifecycle_di.py -q --no-cov --tb=short -> 7 passed
- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short -> 120 passed
- markdown governance -> passed
- JSON/YAML parse -> passed
- GitNexus staged detect_changes -> LOW, changed_count=0, affected_count=0
- post-commit mainline scope -> pass=True
- gitnexus analyze --with-gitignore -> indexed successfully

## Boundary
Closeout-only. No backend source/test, route/API, OpenAPI, frontend, PM2, OpenSpec, issue-label, service consolidation, or next-candidate selection changes.