### PR TITLE
docs(governance): refresh candidates after market data

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1848,7 +1848,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                root-level services getter, service consolidation, or
 │   │                issue-label change is made here
 │   ├── G2.113 MarketDataService getter-retirement closeout/current-head refresh
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#266` merged at
+│   │   │          `18af895af5fd09c1dff832b6f8bc968227711a28`
 │   │   ├── Evidence: `backend-market-data-service-getter-retirement-closeout-2026-05-26.md`
 │   │   ├── Current HEAD: `b5ca0c5fcf65de77e7bf336091c4ae3f220019ef`
 │   │   ├── Result: current scan covers backend app/test Python files=`775`;
@@ -1862,9 +1863,28 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                service consolidation, candidate selection, or issue-label
 │   │                change is made here
-│   └── Next gate: human review / PR merge decision for G2.113; if accepted,
-│                  run a fresh service lifecycle candidate refresh before
-│                  selecting another service getter candidate
+│   ├── G2.114 Service lifecycle candidate refresh after MarketDataService
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-market-data-2026-05-26.md`
+│   │   ├── Current HEAD: `18af895af5fd09c1dff832b6f8bc968227711a28`
+│   │   ├── Result: current scan covers service files=`152`, backend app
+│   │   │          files=`575`, API files=`219`, backend test files=`200`,
+│   │   │          service getter definitions=`15`, and candidate-like
+│   │   │          definitions=`8`; the retired package-level
+│   │   │          `market_data_service:get_market_data_service` no longer
+│   │   │          appears as a candidate
+│   │   ├── Decision: no LOW-risk direct implementation candidate is selected
+│   │   │          from this refresh; remaining candidates are route-backed,
+│   │   │          adapter-backed, Socket.IO-backed, dashboard-backed, task-backed,
+│   │   │          or process-affected and require strategy/authorization before
+│   │   │          source edits
+│   │   └── Boundary: candidate-refresh-only; no backend source/test edit,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                getter deletion, service migration, or issue-label change
+│   │                is made here
+│   └── Next gate: human review / PR merge decision for G2.114; if accepted,
+│                  create a service lifecycle strategy re-triage packet before
+│                  selecting another service getter implementation candidate
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-market-data-2026-05-26.json
+++ b/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-market-data-2026-05-26.json
@@ -1,0 +1,172 @@
+{
+  "artifact": "service-lifecycle-candidate-refresh-after-market-data-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T03:12:00+08:00",
+  "branch": "g2-114-service-lifecycle-candidate-refresh-after-market-data",
+  "base_head": "18af895af5fd09c1dff832b6f8bc968227711a28",
+  "current_head_checked_at_review": "2026-05-26T03:12:00+08:00",
+  "parent_closeout": {
+    "node": "G2.113",
+    "pr": 266,
+    "merge_commit": "18af895af5fd09c1dff832b6f8bc968227711a28"
+  },
+  "governance_node": {
+    "id": "G2.114",
+    "lane": "service_lifecycle_di",
+    "type": "candidate_refresh",
+    "state": "ready_for_review"
+  },
+  "counts": {
+    "service_files": 152,
+    "backend_app_files": 575,
+    "api_files": 219,
+    "backend_test_files": 200,
+    "service_getter_definitions": 15,
+    "candidate_like_definitions": 8
+  },
+  "candidate_pool_delta": {
+    "market_data_service_package_getter_present": false,
+    "market_data_service_package_getter_status": "retired_by_g2_112_and_closed_out_by_g2_113"
+  },
+  "candidates": [
+    {
+      "name": "get_streaming_service",
+      "file": "web/backend/app/services/realtime_streaming_service.py",
+      "line": 424,
+      "kind": "module-lazy",
+      "app_refs": 12,
+      "app_ref_files": 3,
+      "api_refs": 0,
+      "api_ref_files": 0,
+      "backend_test_refs": 19,
+      "backend_test_ref_files": 2,
+      "gitnexus_risk": "HIGH",
+      "gitnexus_impacted_count": 9,
+      "disposition": "hold_streaming_socketio_seam"
+    },
+    {
+      "name": "get_tdx_service",
+      "file": "web/backend/app/services/tdx_service.py",
+      "line": 275,
+      "kind": "module-lazy",
+      "app_refs": 4,
+      "app_ref_files": 2,
+      "api_refs": 2,
+      "api_ref_files": 1,
+      "backend_test_refs": 2,
+      "backend_test_ref_files": 2,
+      "gitnexus_risk": "CRITICAL",
+      "gitnexus_impacted_count": 6,
+      "affected_processes": 5,
+      "disposition": "hold_dashboard_route_process_seam"
+    },
+    {
+      "name": "get_announcement_service",
+      "file": "web/backend/app/services/announcement_service.py",
+      "line": 526,
+      "kind": "module-lazy",
+      "app_refs": 2,
+      "app_ref_files": 1,
+      "api_refs": 0,
+      "api_ref_files": 0,
+      "backend_test_refs": 1,
+      "backend_test_ref_files": 1,
+      "gitnexus_risk": "MEDIUM",
+      "gitnexus_impacted_count": 11,
+      "disposition": "hold_completed_route_backed_seam"
+    },
+    {
+      "name": "get_email_service",
+      "file": "web/backend/app/services/email_service.py",
+      "line": 325,
+      "kind": "module-lazy",
+      "app_refs": 2,
+      "app_ref_files": 1,
+      "api_refs": 0,
+      "api_ref_files": 0,
+      "backend_test_refs": 4,
+      "backend_test_ref_files": 3,
+      "gitnexus_risk": "MEDIUM",
+      "gitnexus_impacted_count": 6,
+      "disposition": "hold_route_backed_email_service_seam"
+    },
+    {
+      "name": "get_watchlist_service",
+      "file": "web/backend/app/services/watchlist_service.py",
+      "line": 613,
+      "kind": "module-lazy",
+      "app_refs": 6,
+      "app_ref_files": 3,
+      "api_refs": 0,
+      "api_ref_files": 0,
+      "backend_test_refs": 2,
+      "backend_test_ref_files": 2,
+      "gitnexus_risk": "MEDIUM",
+      "gitnexus_impacted_count": 15,
+      "disposition": "hold_route_adapter_seam"
+    },
+    {
+      "name": "get_data_service",
+      "file": "web/backend/app/services/data_service.py",
+      "line": 466,
+      "kind": "module-lazy",
+      "app_refs": 6,
+      "app_ref_files": 3,
+      "api_refs": 5,
+      "api_ref_files": 2,
+      "backend_test_refs": 6,
+      "backend_test_ref_files": 2,
+      "gitnexus_risk": "CRITICAL",
+      "gitnexus_impacted_count": 5,
+      "affected_processes": 7,
+      "disposition": "hold_indicator_strategy_route_process_seam"
+    },
+    {
+      "name": "get_strategy_service",
+      "file": "web/backend/app/services/strategy_service.py",
+      "line": 455,
+      "kind": "module-lazy",
+      "app_refs": 11,
+      "app_ref_files": 5,
+      "api_refs": 4,
+      "api_ref_files": 1,
+      "backend_test_refs": 1,
+      "backend_test_ref_files": 1,
+      "gitnexus_risk": "CRITICAL",
+      "gitnexus_impacted_count": 13,
+      "disposition": "hold_strategy_task_adapter_seam"
+    },
+    {
+      "name": "get_stock_search_service",
+      "file": "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "line": 171,
+      "kind": "module-lazy",
+      "app_refs": 4,
+      "app_ref_files": 2,
+      "api_refs": 0,
+      "api_ref_files": 0,
+      "backend_test_refs": 6,
+      "backend_test_ref_files": 4,
+      "gitnexus_risk": "CRITICAL",
+      "gitnexus_impacted_count": 6,
+      "affected_processes": 11,
+      "disposition": "hold_stock_search_route_process_seam"
+    }
+  ],
+  "decision": {
+    "selected_next_implementation_candidate": null,
+    "reason": "No LOW-risk direct implementation candidate remains after MarketDataService package getter retirement.",
+    "next_gate": "service lifecycle strategy re-triage packet before selecting another service getter implementation candidate"
+  },
+  "boundary": {
+    "source_changed": false,
+    "tests_changed": false,
+    "routes_changed": false,
+    "openapi_changed": false,
+    "frontend_changed": false,
+    "pm2_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "candidate_selected": false
+  }
+}

--- a/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-market-data-2026-05-26.md
+++ b/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-market-data-2026-05-26.md
@@ -1,0 +1,90 @@
+# Backend Service Lifecycle Candidate Refresh After MarketDataService - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.114 service lifecycle candidate refresh after MarketDataService
+Status: ready for review
+
+## Purpose
+
+Refresh the service lifecycle getter candidate pool after the G2.112
+MarketDataService package-level getter retirement and G2.113 closeout were
+merged.
+
+This is a governance-only scan and routing packet. It does not modify backend
+source, tests, route/API contracts, OpenAPI exposure, frontend code, PM2
+workflows, OpenSpec changes, GitHub issue labels, or service implementation
+logic.
+
+## Parent Gate
+
+| Gate | Result |
+|---|---|
+| Parent closeout | G2.113 accepted in PR `#266` |
+| Parent merge commit | `18af895af5fd09c1dff832b6f8bc968227711a28` |
+| Current refresh base | `18af895af5fd09c1dff832b6f8bc968227711a28` |
+
+## Inventory
+
+| Metric | Count |
+|---|---:|
+| Service files scanned | `152` |
+| Backend app Python files scanned | `575` |
+| API Python files scanned | `219` |
+| Backend test Python files scanned | `200` |
+| Service getter definitions | `15` |
+| Candidate-like module-lazy definitions | `8` |
+
+The retired package-level
+`web/backend/app/services/market_data_service/get_market_data_service.py:get_market_data_service`
+no longer appears in the candidate pool.
+
+## Candidate Matrix
+
+| Candidate | File | App refs | API refs | Test refs | GitNexus | Disposition |
+|---|---|---:|---:|---:|---|---|
+| `get_streaming_service` | `web/backend/app/services/realtime_streaming_service.py:424` | `12 / 3 files` | `0 / 0 files` | `19 / 2 files` | HIGH / `9` | hold: Socket.IO / streaming bridge seam |
+| `get_tdx_service` | `web/backend/app/services/tdx_service.py:275` | `4 / 2 files` | `2 / 1 file` | `2 / 2 files` | CRITICAL / `6`, affected processes=`5` | hold: dashboard route process seam |
+| `get_announcement_service` | `web/backend/app/services/announcement_service.py:526` | `2 / 1 file` | `0 / 0 files` | `1 / 1 file` | MEDIUM / `11` | hold: completed route-backed seam; do not reopen without new evidence |
+| `get_email_service` | `web/backend/app/services/email_service.py:325` | `2 / 1 file` | `0 / 0 files` | `4 / 3 files` | MEDIUM / `6` | hold: route-backed email service seam |
+| `get_watchlist_service` | `web/backend/app/services/watchlist_service.py:613` | `6 / 3 files` | `0 / 0 files` | `2 / 2 files` | MEDIUM / `15` | hold: route + adapter seam |
+| `get_data_service` | `web/backend/app/services/data_service.py:466` | `6 / 3 files` | `5 / 2 files` | `6 / 2 files` | CRITICAL / `5`, affected processes=`7` | hold: indicator / strategy route process seam |
+| `get_strategy_service` | `web/backend/app/services/strategy_service.py:455` | `11 / 5 files` | `4 / 1 file` | `1 / 1 file` | CRITICAL / `13` | hold: strategy task / adapter seam |
+| `get_stock_search_service` | `web/backend/app/services/stock_search_service/stock_search_service.py:171` | `4 / 2 files` | `0 / 0 files` | `6 / 4 files` | CRITICAL / `6`, affected processes=`11` | hold: stock search route/process seam |
+
+## Decision
+
+No LOW-risk direct implementation candidate is selected from this refresh.
+
+The remaining candidates are route-backed, adapter-backed, Socket.IO-backed,
+dashboard-backed, task-backed, or process-affected. The next step should be a
+strategy re-triage packet that decides whether to:
+
+- split route-backed medium-risk candidates into explicit route-provider
+  authorization lanes,
+- build consumer matrices for adapter-backed candidates before authorizing code,
+- keep Socket.IO / dashboard / task-backed candidates on hold until dedicated
+  runtime evidence exists.
+
+## Boundary
+
+This PR does not:
+
+- modify backend source or tests
+- authorize source edits for any candidate
+- delete any getter
+- select the next implementation candidate
+- modify route paths, response models, response shapes, or OpenAPI exposure
+- modify frontend code
+- modify PM2 workflows
+- create or modify OpenSpec proposals/specs
+- change GitHub issue labels or readiness state
+
+## Next Gate
+
+Human review / PR merge decision for G2.114.
+
+If accepted, create a service lifecycle strategy re-triage packet before
+selecting another service getter implementation candidate.

--- a/governance/mainline/task-cards/pr-267.yaml
+++ b/governance/mainline/task-cards/pr-267.yaml
@@ -1,0 +1,109 @@
+version: "v0.2"
+
+task:
+  id: "pr-267"
+  title: "Refresh service lifecycle candidates after MarketDataService"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-service-lifecycle-candidate-refresh-after-market-data"
+  objective: "refresh service lifecycle getter candidates after MarketDataService package getter retirement closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-candidate-refresh"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-candidate-refresh-after-market-data"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate-refresh-only evidence packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-candidate-refresh-after-market-data-2026-05-26.json"
+    - "docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-market-data-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-267.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not select or authorize the next service getter implementation candidate"
+  - "Do not delete any getter"
+  - "Do not modify route/API behavior or OpenAPI exposure"
+  - "Do not change frontend code"
+  - "Do not change PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 266 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-market-data-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-candidate-refresh-after-market-data-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-267.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-267.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet selects a source candidate, it would exceed candidate-refresh scope"
+    - "If backend source or tests are edited, it would exceed governance-only scope"
+  rollback_plan: "revert this governance-only candidate refresh PR and keep G2.113 as the latest accepted service lifecycle state"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh service lifecycle candidates after MarketDataService package getter retirement"
+    modified_scope: "steward tree, candidate refresh report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; candidate-refresh-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent PR state, candidate evidence, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T03:12:00+08:00"
+    approval_note: "G2.113 PR #266 was merged; this packet records candidate refresh only and intentionally selects no implementation candidate"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- refresh service lifecycle getter candidates after MarketDataService package getter retirement closeout
- confirm MarketDataService package getter no longer appears in the module-lazy candidate pool
- record 8 remaining module-lazy candidates and their current GitNexus risk/disposition
- intentionally select no next implementation candidate because no LOW-risk direct candidate remains

## Verification
- parent PR #266 state -> MERGED
- candidate scan: service files 152, backend app files 575, API files 219, backend test files 200, service getter definitions 15, candidate-like definitions 8
- gitnexus analyze --with-gitignore -> indexed successfully
- GitNexus impacts recorded for all 8 remaining candidates
- markdown governance -> passed
- JSON/YAML parse -> passed
- GitNexus staged detect_changes -> LOW, changed_count=0, affected_count=0
- post-commit mainline scope -> pass=True

## Boundary
Candidate-refresh-only. No backend source/test, route/API, OpenAPI, frontend, PM2, OpenSpec, issue-label, getter deletion, implementation authorization, or candidate selection changes.