### PR TITLE
docs(governance): retriage service lifecycle strategy

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1864,7 +1864,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                service consolidation, candidate selection, or issue-label
 │   │                change is made here
 │   ├── G2.114 Service lifecycle candidate refresh after MarketDataService
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#267` merged at
+│   │   │          `3d0b72b68114effc9ba76aa3bea2d64edca15216`
 │   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-market-data-2026-05-26.md`
 │   │   ├── Current HEAD: `18af895af5fd09c1dff832b6f8bc968227711a28`
 │   │   ├── Result: current scan covers service files=`152`, backend app
@@ -1882,8 +1883,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                getter deletion, service migration, or issue-label change
 │   │                is made here
-│   └── Next gate: human review / PR merge decision for G2.114; if accepted,
-│                  create a service lifecycle strategy re-triage packet before
+│   ├── G2.115 Service lifecycle strategy re-triage
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-service-lifecycle-strategy-retriage-2026-05-26.md`
+│   │   ├── Current HEAD: `3d0b72b68114effc9ba76aa3bea2d64edca15216`
+│   │   ├── Decision: split the remaining 8 candidates into strategy lanes:
+│   │   │          medium route-backed candidates need an exact consumer matrix,
+│   │   │          adapter-backed candidates need adapter/route ownership evidence,
+│   │   │          Socket.IO/dashboard/task/process candidates stay on hold until
+│   │   │          dedicated runtime or process evidence exists
+│   │   ├── Next packet: create G2.116 exact consumer matrix for the medium
+│   │   │          route-backed candidates
+│   │   │          `get_announcement_service`, `get_email_service`, and
+│   │   │          `get_watchlist_service`; do not authorize implementation yet
+│   │   └── Boundary: strategy-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                implementation authorization, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.115; if accepted,
+│                  create G2.116 medium route-backed exact consumer matrix before
 │                  selecting another service getter implementation candidate
 │
 ├── H. Decision-Only Track: CSRF composition root

--- a/.planning/codebase/generated/service-lifecycle-strategy-retriage-2026-05-26.json
+++ b/.planning/codebase/generated/service-lifecycle-strategy-retriage-2026-05-26.json
@@ -1,0 +1,92 @@
+{
+  "artifact": "service-lifecycle-strategy-retriage-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T03:22:00+08:00",
+  "branch": "g2-115-service-lifecycle-strategy-retriage",
+  "base_head": "3d0b72b68114effc9ba76aa3bea2d64edca15216",
+  "current_head_checked_at_review": "2026-05-26T03:22:00+08:00",
+  "parent_refresh": {
+    "node": "G2.114",
+    "pr": 267,
+    "merge_commit": "3d0b72b68114effc9ba76aa3bea2d64edca15216"
+  },
+  "governance_node": {
+    "id": "G2.115",
+    "lane": "service_lifecycle_di",
+    "type": "strategy_retriage",
+    "state": "ready_for_review"
+  },
+  "input_finding": {
+    "remaining_module_lazy_candidates": 8,
+    "low_risk_direct_implementation_candidates": 0,
+    "source_edit_authorized": false
+  },
+  "strategy_lanes": [
+    {
+      "lane": "medium_route_backed_exact_matrix",
+      "candidates": [
+        "get_announcement_service",
+        "get_email_service",
+        "get_watchlist_service"
+      ],
+      "decision": "create G2.116 exact consumer matrix before choosing one authorization target"
+    },
+    {
+      "lane": "socketio_streaming_hold",
+      "candidates": [
+        "get_streaming_service"
+      ],
+      "decision": "hold until Socket.IO manager and streaming bridge runtime ownership are modeled"
+    },
+    {
+      "lane": "dashboard_process_hold",
+      "candidates": [
+        "get_tdx_service"
+      ],
+      "decision": "hold until dashboard route/process evidence exists"
+    },
+    {
+      "lane": "indicator_strategy_route_process_hold",
+      "candidates": [
+        "get_data_service"
+      ],
+      "decision": "hold until indicator and strategy route ownership evidence exists"
+    },
+    {
+      "lane": "strategy_task_adapter_hold",
+      "candidates": [
+        "get_strategy_service"
+      ],
+      "decision": "hold until task and adapter ownership evidence exists"
+    },
+    {
+      "lane": "stock_search_route_process_hold",
+      "candidates": [
+        "get_stock_search_service"
+      ],
+      "decision": "hold until stock-search route/process evidence exists"
+    }
+  ],
+  "next_packet": {
+    "id": "G2.116",
+    "name": "medium route-backed exact consumer matrix",
+    "candidates": [
+      "web/backend/app/services/announcement_service.py:get_announcement_service",
+      "web/backend/app/services/email_service.py:get_email_service",
+      "web/backend/app/services/watchlist_service.py:get_watchlist_service"
+    ],
+    "source_edit_authorized": false,
+    "implementation_authorized": false
+  },
+  "boundary": {
+    "source_changed": false,
+    "tests_changed": false,
+    "routes_changed": false,
+    "openapi_changed": false,
+    "frontend_changed": false,
+    "pm2_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "candidate_selected_for_implementation": false
+  }
+}

--- a/docs/reports/quality/backend-service-lifecycle-strategy-retriage-2026-05-26.md
+++ b/docs/reports/quality/backend-service-lifecycle-strategy-retriage-2026-05-26.md
@@ -1,0 +1,81 @@
+# Backend Service Lifecycle Strategy Re-Triage - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.115 service lifecycle strategy re-triage
+Status: ready for review
+
+## Purpose
+
+Route the remaining service lifecycle getter candidates after G2.114 confirmed
+that no LOW-risk direct implementation candidate remains.
+
+This is a governance-only strategy packet. It does not modify backend source,
+tests, route/API contracts, OpenAPI exposure, frontend code, PM2 workflows,
+OpenSpec changes, GitHub issue labels, or service implementation logic.
+
+## Parent Gate
+
+| Gate | Result |
+|---|---|
+| Parent refresh | G2.114 accepted in PR `#267` |
+| Parent merge commit | `3d0b72b68114effc9ba76aa3bea2d64edca15216` |
+| Current strategy base | `3d0b72b68114effc9ba76aa3bea2d64edca15216` |
+
+## Re-Triage Decision
+
+G2.114 left 8 module-lazy candidates and selected no LOW-risk direct
+implementation candidate. The next step is not another source edit. The next
+step is an exact consumer matrix for medium-risk route-backed candidates.
+
+| Lane | Candidates | Decision |
+|---|---|---|
+| Medium route-backed exact matrix | `get_announcement_service`, `get_email_service`, `get_watchlist_service` | Create G2.116 consumer matrix before choosing one authorization target |
+| Socket.IO / streaming | `get_streaming_service` | Hold until Socket.IO manager and streaming bridge runtime ownership are modeled |
+| Dashboard process | `get_tdx_service` | Hold until dashboard route/process evidence exists |
+| Indicator / strategy route process | `get_data_service` | Hold until indicator and strategy route ownership evidence exists |
+| Strategy task / adapter | `get_strategy_service` | Hold until task and adapter ownership evidence exists |
+| Stock-search route/process | `get_stock_search_service` | Hold until stock-search route/process evidence exists |
+
+## G2.116 Scope
+
+The next packet should collect exact consumer evidence for:
+
+- `web/backend/app/services/announcement_service.py:get_announcement_service`
+- `web/backend/app/services/email_service.py:get_email_service`
+- `web/backend/app/services/watchlist_service.py:get_watchlist_service`
+
+It should record:
+
+- direct text refs and GitNexus graph refs
+- API route consumers
+- adapter consumers
+- existing route-provider or dependency seams
+- test coverage currently proving the seam
+- whether the candidate is already completed, should remain retained, or needs
+  a future route-provider authorization packet
+
+G2.116 must not edit source, delete getters, or authorize implementation.
+
+## Boundary
+
+This PR does not:
+
+- modify backend source or tests
+- authorize source edits for any candidate
+- delete any getter
+- select a concrete implementation candidate
+- modify route paths, response models, response shapes, or OpenAPI exposure
+- modify frontend code
+- modify PM2 workflows
+- create or modify OpenSpec proposals/specs
+- change GitHub issue labels or readiness state
+
+## Next Gate
+
+Human review / PR merge decision for G2.115.
+
+If accepted, create G2.116 medium route-backed exact consumer matrix before
+selecting another service getter implementation candidate.

--- a/governance/mainline/task-cards/pr-268.yaml
+++ b/governance/mainline/task-cards/pr-268.yaml
@@ -1,0 +1,109 @@
+version: "v0.2"
+
+task:
+  id: "pr-268"
+  title: "Re-triage service lifecycle candidate strategy"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-service-lifecycle-strategy-retriage"
+  objective: "route remaining service lifecycle getter candidates after the no-LOW-candidate refresh"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-strategy"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-strategy-retriage"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Strategy-only evidence packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-strategy-retriage-2026-05-26.json"
+    - "docs/reports/quality/backend-service-lifecycle-strategy-retriage-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-268.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not select or authorize the next service getter implementation candidate"
+  - "Do not delete any getter"
+  - "Do not modify route/API behavior or OpenAPI exposure"
+  - "Do not change frontend code"
+  - "Do not change PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 267 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-strategy-retriage-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-strategy-retriage-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-268.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-268.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet selects a source candidate, it would exceed strategy-only scope"
+    - "If backend source or tests are edited, it would exceed governance-only scope"
+  rollback_plan: "revert this governance-only strategy packet and keep G2.114 as the latest accepted candidate refresh"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "route remaining service lifecycle candidates after no LOW-risk direct candidate remained"
+    modified_scope: "steward tree, strategy report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; strategy-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent PR state, strategy routing, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T03:22:00+08:00"
+    approval_note: "G2.114 PR #267 was merged; this packet routes remaining candidates and intentionally does not authorize implementation"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- route the remaining 8 service lifecycle getter candidates after G2.114 found no LOW-risk direct candidate
- split candidates into medium route-backed exact-matrix, Socket.IO/streaming hold, dashboard-process hold, indicator/strategy route-process hold, strategy task/adapter hold, and stock-search route/process hold
- select G2.116 as an exact consumer matrix for get_announcement_service, get_email_service, and get_watchlist_service
- intentionally do not authorize implementation or select a concrete source candidate

## Verification
- parent PR #267 state -> MERGED
- markdown governance -> passed
- JSON/YAML parse -> passed
- GitNexus staged detect_changes -> LOW, changed_count=0, affected_count=0
- post-commit mainline scope -> pass=True
- gitnexus analyze --with-gitignore -> indexed successfully

## Boundary
Strategy-only. No backend source/test, route/API, OpenAPI, frontend, PM2, OpenSpec, issue-label, getter deletion, implementation authorization, or concrete candidate selection changes.