### PR TITLE
docs(governance): map medium route-backed consumers

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1884,7 +1884,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, service migration, or issue-label change
 │   │                is made here
 │   ├── G2.115 Service lifecycle strategy re-triage
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#268` merged at
+│   │   │          `dabe473f5d2616cfeda6c41ceeecee1bc5c57fb6`
 │   │   ├── Evidence: `backend-service-lifecycle-strategy-retriage-2026-05-26.md`
 │   │   ├── Current HEAD: `3d0b72b68114effc9ba76aa3bea2d64edca15216`
 │   │   ├── Decision: split the remaining 8 candidates into strategy lanes:
@@ -1899,9 +1900,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: strategy-only; no backend source/test edit, route/API,
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                implementation authorization, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.115; if accepted,
-│                  create G2.116 medium route-backed exact consumer matrix before
-│                  selecting another service getter implementation candidate
+│   ├── G2.116 Medium route-backed exact consumer matrix
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-medium-route-backed-service-consumer-matrix-2026-05-26.md`
+│   │   ├── Current HEAD: `dabe473f5d2616cfeda6c41ceeecee1bc5c57fb6`
+│   │   ├── Result: `get_announcement_service` has no direct API/adapter
+│   │   │          getter consumers; routes use `get_announcement_service_dependency`
+│   │   │          in 11 handlers; `get_email_service` is also route-dependency
+│   │   │          backed but remains behind announcement; `get_watchlist_service`
+│   │   │          still has 2 adapter files directly importing/calling the getter
+│   │   ├── Decision: select `get_announcement_service` only as the next
+│   │   │          authorization-candidate packet; do not authorize implementation
+│   │   │          or source edits in this matrix
+│   │   └── Boundary: evidence-matrix-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                implementation authorization, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.116; if accepted,
+│                  create G2.117 AnnouncementService getter-retirement
+│                  authorization before any announcement service source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/medium-route-backed-service-consumer-matrix-2026-05-26.json
+++ b/.planning/codebase/generated/medium-route-backed-service-consumer-matrix-2026-05-26.json
@@ -1,0 +1,94 @@
+{
+  "artifact": "medium-route-backed-service-consumer-matrix-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T03:34:00+08:00",
+  "branch": "g2-116-medium-route-backed-consumer-matrix",
+  "base_head": "dabe473f5d2616cfeda6c41ceeecee1bc5c57fb6",
+  "current_head_checked_at_review": "2026-05-26T03:34:00+08:00",
+  "parent_strategy": {
+    "node": "G2.115",
+    "pr": 268,
+    "merge_commit": "dabe473f5d2616cfeda6c41ceeecee1bc5c57fb6"
+  },
+  "governance_node": {
+    "id": "G2.116",
+    "lane": "service_lifecycle_di",
+    "type": "consumer_matrix",
+    "state": "ready_for_review"
+  },
+  "candidates": [
+    {
+      "name": "get_announcement_service",
+      "file": "web/backend/app/services/announcement_service.py",
+      "direct_getter_refs": {
+        "total": 3,
+        "files": 2,
+        "api_refs": 0,
+        "adapter_refs": 0,
+        "test_refs": 1
+      },
+      "dependency_refs": {
+        "name": "get_announcement_service_dependency",
+        "total": 14,
+        "files": 3,
+        "api_route_dependency_refs": 11
+      },
+      "decision": "select_next_authorization_candidate"
+    },
+    {
+      "name": "get_email_service",
+      "file": "web/backend/app/services/email_service.py",
+      "direct_getter_refs": {
+        "total": 6,
+        "files": 4,
+        "api_refs": 0,
+        "adapter_refs": 0,
+        "test_refs": 4
+      },
+      "dependency_refs": {
+        "name": "get_email_service_dependency",
+        "total": 11,
+        "files": 4,
+        "api_route_dependency_refs": 6
+      },
+      "decision": "hold_behind_announcement"
+    },
+    {
+      "name": "get_watchlist_service",
+      "file": "web/backend/app/services/watchlist_service.py",
+      "direct_getter_refs": {
+        "total": 8,
+        "files": 5,
+        "api_refs": 0,
+        "adapter_refs": 4,
+        "adapter_files": 2,
+        "test_refs": 2
+      },
+      "dependency_refs": {
+        "name": "get_watchlist_service_dependency",
+        "total": 10,
+        "files": 3,
+        "api_route_dependency_refs": 7
+      },
+      "decision": "hold_until_adapter_consumer_ownership"
+    }
+  ],
+  "selected_next_authorization_candidate": {
+    "name": "get_announcement_service",
+    "file": "web/backend/app/services/announcement_service.py",
+    "source_edit_authorized": false,
+    "implementation_authorized": false,
+    "next_packet": "G2.117 AnnouncementService getter-retirement authorization"
+  },
+  "boundary": {
+    "source_changed": false,
+    "tests_changed": false,
+    "routes_changed": false,
+    "openapi_changed": false,
+    "frontend_changed": false,
+    "pm2_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "implementation_authorized": false
+  }
+}

--- a/docs/reports/quality/backend-medium-route-backed-service-consumer-matrix-2026-05-26.md
+++ b/docs/reports/quality/backend-medium-route-backed-service-consumer-matrix-2026-05-26.md
@@ -1,0 +1,74 @@
+# Backend Medium Route-Backed Service Consumer Matrix - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.116 medium route-backed exact consumer matrix
+Status: ready for review
+
+## Purpose
+
+Build the exact consumer matrix requested by G2.115 for the remaining medium
+route-backed service getter candidates:
+
+- `get_announcement_service`
+- `get_email_service`
+- `get_watchlist_service`
+
+This is an evidence-only matrix. It does not modify backend source, tests,
+route/API contracts, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec
+changes, GitHub issue labels, or service implementation logic.
+
+## Parent Gate
+
+| Gate | Result |
+|---|---|
+| Parent strategy packet | G2.115 accepted in PR `#268` |
+| Parent merge commit | `dabe473f5d2616cfeda6c41ceeecee1bc5c57fb6` |
+| Current matrix base | `dabe473f5d2616cfeda6c41ceeecee1bc5c57fb6` |
+
+## Matrix
+
+| Candidate | Direct getter refs | Dependency refs | Adapter refs | Tests | Decision |
+|---|---:|---:|---:|---:|---|
+| `get_announcement_service` | `3 refs / 2 files`: service definition, installer fallback, lifecycle test monkeypatch | `14 refs / 3 files`; 11 route handlers in `announcement/routes.py` use `Depends(get_announcement_service_dependency)` | `0` | `test_announcement_service_lifecycle_di.py` | Select as next authorization-candidate packet only |
+| `get_email_service` | `6 refs / 4 files`: service definition, installer fallback, tests / fake modules | `11 refs / 4 files`; 6 notification endpoints use `Depends(get_email_service_dependency)` | `0` | `test_email_service_lifecycle_di.py`, `test_notification_logging.py`, email-notification retirement assertion | Hold behind announcement to avoid overlapping email-service lane churn |
+| `get_watchlist_service` | `8 refs / 5 files`: service definition, installer fallback, adapters, tests | `10 refs / 3 files`; 7 watchlist handlers use `Depends(get_watchlist_service_dependency)` | `4 refs / 2 files`: `services/adapters/watchlist_adapter.py`, `services/data_adapters/watchlist.py` | `test_watchlist_service_lifecycle_di.py`, `test_watchlist_helper_lifecycle_di.py` | Hold until adapter consumer ownership is planned |
+
+## Decision
+
+Select `web/backend/app/services/announcement_service.py:get_announcement_service`
+as the next authorization-candidate packet.
+
+This matrix does not authorize implementation. The next packet should be a
+G2.117 authorization-only packet that explicitly preserves:
+
+- `AnnouncementService`
+- `install_announcement_service`
+- `get_announcement_service_dependency`
+- announcement route contracts and OpenAPI exposure
+- existing announcement route dependency injection
+
+The future implementation, if separately approved, should be limited to retiring
+the service module singleton/getter fallback surface and updating focused tests.
+
+## Boundary
+
+This PR does not:
+
+- modify backend source or tests
+- authorize source edits
+- delete any getter
+- modify route paths, response models, response shapes, or OpenAPI exposure
+- modify frontend code
+- modify PM2 workflows
+- create or modify OpenSpec proposals/specs
+- change GitHub issue labels or readiness state
+
+## Next Gate
+
+Human review / PR merge decision for G2.116.
+
+If accepted, create G2.117 AnnouncementService getter-retirement authorization
+before any announcement service source edit.

--- a/governance/mainline/task-cards/pr-269.yaml
+++ b/governance/mainline/task-cards/pr-269.yaml
@@ -1,0 +1,109 @@
+version: "v0.2"
+
+task:
+  id: "pr-269"
+  title: "Build medium route-backed service consumer matrix"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-medium-route-backed-service-consumer-matrix"
+  objective: "record exact consumers for announcement, email, and watchlist service getters before authorization"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-consumer-matrix"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-medium-route-backed-service-consumer-matrix"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Consumer-matrix-only evidence packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/medium-route-backed-service-consumer-matrix-2026-05-26.json"
+    - "docs/reports/quality/backend-medium-route-backed-service-consumer-matrix-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-269.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not authorize source implementation"
+  - "Do not delete any getter"
+  - "Do not modify route/API behavior or OpenAPI exposure"
+  - "Do not change frontend code"
+  - "Do not change PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 268 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-medium-route-backed-service-consumer-matrix-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/medium-route-backed-service-consumer-matrix-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-269.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-269.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this packet is interpreted as source authorization, the service lifecycle lane could skip the required authorization packet"
+    - "If watchlist adapter consumers are ignored, a future getter deletion could break adapter flows"
+  rollback_plan: "revert this governance-only matrix and keep G2.115 as the latest accepted strategy packet"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record exact consumer matrix for medium route-backed service getters"
+    modified_scope: "steward tree, consumer matrix report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; matrix-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent PR state, consumer evidence, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T03:34:00+08:00"
+    approval_note: "G2.115 PR #268 was merged; this packet records exact consumers and selects only a future authorization candidate"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- build exact consumer matrix for get_announcement_service, get_email_service, and get_watchlist_service
- record direct getter refs, dependency refs, adapter refs, tests, and route dependency counts
- select AnnouncementService only as the next authorization-candidate packet
- do not authorize source implementation in this PR

## Verification
- parent PR #268 state -> MERGED
- exact consumer scans completed for three candidates
- markdown governance -> passed
- JSON/YAML parse -> passed
- GitNexus staged detect_changes -> LOW, changed_count=0, affected_count=0
- post-commit mainline scope -> pass=True
- gitnexus analyze --with-gitignore -> indexed successfully

## Boundary
Matrix-only. No backend source/test, route/API, OpenAPI, frontend, PM2, OpenSpec, issue-label, getter deletion, or implementation authorization changes.