### PR TITLE
docs(governance): authorize announcement getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1901,7 +1901,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                implementation authorization, or issue-label change is made here
 │   ├── G2.116 Medium route-backed exact consumer matrix
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#269` merged at
+│   │   │          `618820c89888887a7352999e32ec4285ccad836a`
 │   │   ├── Evidence: `backend-medium-route-backed-service-consumer-matrix-2026-05-26.md`
 │   │   ├── Current HEAD: `dabe473f5d2616cfeda6c41ceeecee1bc5c57fb6`
 │   │   ├── Result: `get_announcement_service` has no direct API/adapter
@@ -1915,9 +1916,26 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: evidence-matrix-only; no backend source/test edit, route/API,
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                implementation authorization, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.116; if accepted,
-│                  create G2.117 AnnouncementService getter-retirement
-│                  authorization before any announcement service source edit
+│   ├── G2.117 AnnouncementService getter-retirement authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-announcement-service-getter-retirement-authorization-2026-05-26.md`
+│   │   ├── Current HEAD: `618820c89888887a7352999e32ec4285ccad836a`
+│   │   ├── Decision: authorize only a future G2.118 implementation branch to
+│   │   │          retire `announcement_service.py` `_announcement_service` and
+│   │   │          `get_announcement_service`, while preserving
+│   │   │          `AnnouncementService`, `install_announcement_service`,
+│   │   │          `get_announcement_service_dependency`, announcement routes,
+│   │   │          and OpenAPI exposure
+│   │   ├── Evidence note: exact text scan has no API/adapter direct getter
+│   │   │          consumers, but GitNexus graph still reports 11 route callers;
+│   │   │          future implementation must verify route dependency behavior with
+│   │   │          focused tests and exact post-change scans
+│   │   └── Boundary: authorization-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                service migration, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.117; if accepted,
+│                  create G2.118 AnnouncementService getter-retirement
+│                  implementation before any announcement service source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/announcement-service-getter-retirement-authorization-2026-05-26.json
+++ b/.planning/codebase/generated/announcement-service-getter-retirement-authorization-2026-05-26.json
@@ -1,0 +1,67 @@
+{
+  "artifact": "announcement-service-getter-retirement-authorization-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T03:45:00+08:00",
+  "branch": "g2-117-announcement-service-getter-retirement-authorization",
+  "base_head": "618820c89888887a7352999e32ec4285ccad836a",
+  "current_head_checked_at_review": "2026-05-26T03:45:00+08:00",
+  "parent_matrix": {
+    "node": "G2.116",
+    "pr": 269,
+    "merge_commit": "618820c89888887a7352999e32ec4285ccad836a"
+  },
+  "governance_node": {
+    "id": "G2.117",
+    "lane": "service_lifecycle_di",
+    "type": "authorization",
+    "state": "ready_for_review"
+  },
+  "authorized_future_scope": {
+    "may_remove": [
+      "web/backend/app/services/announcement_service.py:_announcement_service",
+      "web/backend/app/services/announcement_service.py:get_announcement_service"
+    ],
+    "must_preserve": [
+      "web/backend/app/services/announcement_service.py:AnnouncementService",
+      "web/backend/app/services/announcement_service.py:install_announcement_service",
+      "web/backend/app/services/announcement_service.py:get_announcement_service_dependency",
+      "announcement route contracts",
+      "OpenAPI exposure"
+    ],
+    "implementation_authorized_now": false,
+    "future_node": "G2.118"
+  },
+  "evidence": {
+    "exact_direct_getter_refs": {
+      "total": 3,
+      "files": 2,
+      "api_refs": 0,
+      "adapter_refs": 0,
+      "test_refs": 1
+    },
+    "dependency_refs": {
+      "name": "get_announcement_service_dependency",
+      "total": 14,
+      "files": 3,
+      "api_route_dependency_refs": 11
+    },
+    "gitnexus": {
+      "context_route_callers": 11,
+      "impact_risk": "MEDIUM",
+      "impacted_count": 11,
+      "affected_processes": 0,
+      "interpretation": "graph-level dependency-injection signal, not direct text consumers"
+    }
+  },
+  "boundary": {
+    "source_changed": false,
+    "tests_changed": false,
+    "routes_changed": false,
+    "openapi_changed": false,
+    "frontend_changed": false,
+    "pm2_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "getter_deleted": false
+  }
+}

--- a/docs/reports/quality/backend-announcement-service-getter-retirement-authorization-2026-05-26.md
+++ b/docs/reports/quality/backend-announcement-service-getter-retirement-authorization-2026-05-26.md
@@ -1,0 +1,92 @@
+# Backend AnnouncementService Getter Retirement Authorization - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Workline: G2.117 AnnouncementService getter-retirement authorization
+Status: ready for review
+
+## Purpose
+
+Authorize a future implementation branch for retiring the module-level
+`AnnouncementService` lazy singleton getter in
+`web/backend/app/services/announcement_service.py`.
+
+This authorization does not modify backend source, tests, routes, OpenAPI,
+frontend code, PM2 workflows, OpenSpec changes, GitHub issue labels, or service
+implementation logic.
+
+## Parent Gate
+
+| Gate | Result |
+|---|---|
+| Parent consumer matrix | G2.116 accepted in PR `#269` |
+| Parent merge commit | `618820c89888887a7352999e32ec4285ccad836a` |
+| Current authorization base | `618820c89888887a7352999e32ec4285ccad836a` |
+
+## Target
+
+| Surface | Status |
+|---|---|
+| `AnnouncementService` | preserve |
+| `_announcement_service` | authorized for future removal |
+| `get_announcement_service` | authorized for future removal |
+| `install_announcement_service` | preserve |
+| `get_announcement_service_dependency` | preserve |
+| Announcement routes / OpenAPI exposure | preserve |
+
+## Evidence
+
+| Evidence | Result |
+|---|---|
+| Exact direct getter scan | `3 refs / 2 files`: service definition, installer fallback, lifecycle test monkeypatch |
+| Exact API direct getter refs | `0` |
+| Exact adapter direct getter refs | `0` |
+| Dependency refs | `14 refs / 3 files`; 11 announcement route handlers use `Depends(get_announcement_service_dependency)` |
+| GitNexus context | graph reports 11 route callers for `get_announcement_service` |
+| GitNexus impact | MEDIUM / `11`, affected processes=`0` |
+
+The GitNexus route callers are treated as a graph-level dependency-injection
+signal, not as direct text consumers. A future implementation must verify this
+with focused tests and exact post-change scans.
+
+## Authorized Future Scope
+
+Future G2.118 may modify only:
+
+- `web/backend/app/services/announcement_service.py`
+- `web/backend/tests/test_announcement_service_lifecycle_di.py`
+- a focused getter-retirement regression test if needed
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/announcement-service-getter-retirement-implementation-2026-05-26.json`
+- `docs/reports/quality/backend-announcement-service-getter-retirement-implementation-2026-05-26.md`
+- a future task card, expected `governance/mainline/task-cards/pr-271.yaml`
+
+Future G2.118 must preserve:
+
+- `AnnouncementService`
+- `install_announcement_service`
+- `get_announcement_service_dependency`
+- announcement route contracts and OpenAPI exposure
+- frontend, PM2, OpenSpec, and issue-label state
+
+## Boundary
+
+This PR does not:
+
+- modify backend source or tests
+- delete any getter
+- modify route paths, response models, response shapes, or OpenAPI exposure
+- modify frontend code
+- modify PM2 workflows
+- create or modify OpenSpec proposals/specs
+- change GitHub issue labels or readiness state
+- authorize any implementation beyond future G2.118
+
+## Next Gate
+
+Human review / PR merge decision for G2.117.
+
+If accepted, create G2.118 AnnouncementService getter-retirement implementation
+before any announcement service source edit.

--- a/governance/mainline/task-cards/pr-270.yaml
+++ b/governance/mainline/task-cards/pr-270.yaml
@@ -1,0 +1,110 @@
+version: "v0.2"
+
+task:
+  id: "pr-270"
+  title: "Authorize AnnouncementService getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-announcement-service-getter-retirement-authorization"
+  objective: "authorize a future implementation branch for retiring the AnnouncementService module-level getter"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-announcement-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-announcement-service-getter-retirement-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/announcement-service-getter-retirement-authorization-2026-05-26.json"
+    - "docs/reports/quality/backend-announcement-service-getter-retirement-authorization-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-270.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not delete AnnouncementService getter in this PR"
+  - "Do not modify announcement routes or route contracts"
+  - "Do not modify OpenAPI exposure"
+  - "Do not change frontend code"
+  - "Do not change PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not authorize implementation beyond future G2.118"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 269 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-announcement-service-getter-retirement-authorization-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/announcement-service-getter-retirement-authorization-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-270.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-270.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If future implementation ignores GitNexus graph route callers, route dependency injection could regress"
+    - "If this packet is treated as implementation authorization, source edits could skip G2.118 review"
+  rollback_plan: "revert this governance-only authorization PR and keep G2.116 as the latest accepted consumer matrix"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize future AnnouncementService module getter retirement"
+    modified_scope: "steward tree, authorization report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; authorization-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent PR state, authorization evidence, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T03:45:00+08:00"
+    approval_note: "G2.116 PR #269 selected AnnouncementService only as a future authorization candidate; this PR does not implement it"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- authorize a future G2.118 implementation branch for retiring AnnouncementService module-level _announcement_service and get_announcement_service
- preserve AnnouncementService, install_announcement_service, get_announcement_service_dependency, announcement routes, and OpenAPI exposure
- record exact consumer evidence and GitNexus graph note
- do not edit source or tests in this PR

## Verification
- parent PR #269 state -> MERGED
- exact target facts recorded
- GitNexus context/impact: MEDIUM / 11, affected_processes=0
- markdown governance -> passed
- JSON/YAML parse -> passed
- GitNexus staged detect_changes -> LOW, changed_count=0, affected_count=0
- post-commit mainline scope -> pass=True
- gitnexus analyze --with-gitignore -> indexed successfully

## Boundary
Authorization-only. No backend source/test, route/API, OpenAPI, frontend, PM2, OpenSpec, issue-label, getter deletion, or implementation changes.