### PR TITLE
G2.118 Retire AnnouncementService module getter

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1917,7 +1917,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                implementation authorization, or issue-label change is made here
 │   ├── G2.117 AnnouncementService getter-retirement authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#270` merged at
+│   │   │          `ca1ad8da694f0174b5a80d414cc624d05865ec8f`
 │   │   ├── Evidence: `backend-announcement-service-getter-retirement-authorization-2026-05-26.md`
 │   │   ├── Current HEAD: `618820c89888887a7352999e32ec4285ccad836a`
 │   │   ├── Decision: authorize only a future G2.118 implementation branch to
@@ -1933,9 +1934,32 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: authorization-only; no backend source/test edit, route/API,
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                service migration, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.117; if accepted,
-│                  create G2.118 AnnouncementService getter-retirement
-│                  implementation before any announcement service source edit
+│   ├── G2.118 AnnouncementService getter-retirement implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-announcement-service-getter-retirement-implementation-2026-05-26.md`
+│   │   ├── Current HEAD: `ca1ad8da694f0174b5a80d414cc624d05865ec8f`
+│   │   ├── Result: removes only `announcement_service.py`
+│   │   │          `_announcement_service` and `get_announcement_service`,
+│   │   │          changes the installer fallback to construct
+│   │   │          `AnnouncementService()` directly, and updates focused
+│   │   │          lifecycle coverage to patch the class seam instead of the
+│   │   │          retired getter
+│   │   ├── Verification: TDD red `1 failed`, focused green `4 passed`,
+│   │   │          health route conflicts `120 passed`, touched-file ruff and
+│   │   │          black checks passed; exact scan reports target getter
+│   │   │          definitions=`0`, target singleton tokens=`0`, API direct
+│   │   │          getter refs=`0`, route dependency handlers preserved=`11`
+│   │   └── Boundary: source-capable but limited to `announcement_service.py`,
+│   │                `test_announcement_service_lifecycle_di.py`,
+│   │                `test_announcement_service_getter_retirement.py`,
+│   │                governance report, generated artifact, task card, and
+│   │                steward-tree update; no route/API, OpenAPI exposure,
+│   │                frontend, PM2, OpenSpec, `AnnouncementService` deletion,
+│   │                dependency deletion, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.118; if accepted,
+│                  create G2.119 AnnouncementService getter-retirement
+│                  closeout before selecting the next medium route-backed
+│                  getter lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/announcement-service-getter-retirement-implementation-2026-05-26.json
+++ b/.planning/codebase/generated/announcement-service-getter-retirement-implementation-2026-05-26.json
@@ -1,0 +1,120 @@
+{
+  "artifact": "announcement-service-getter-retirement-implementation-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T07:38:02+08:00",
+  "branch": "g2-118-announcement-service-getter-retirement-implementation",
+  "base_head": "ca1ad8da694f0174b5a80d414cc624d05865ec8f",
+  "current_head_checked_at_review": "2026-05-26T07:38:02+08:00",
+  "parent_authorization": {
+    "node": "G2.117",
+    "pr": 270,
+    "state": "MERGED",
+    "merged_at": "2026-05-25T19:34:08Z",
+    "merge_commit": "ca1ad8da694f0174b5a80d414cc624d05865ec8f",
+    "authorized_scope": "retire announcement_service.py _announcement_service and get_announcement_service while preserving AnnouncementService, install_announcement_service, get_announcement_service_dependency, announcement routes, and OpenAPI exposure"
+  },
+  "governance_node": {
+    "id": "G2.118",
+    "lane": "service_lifecycle_di",
+    "type": "implementation",
+    "state": "ready_for_review"
+  },
+  "changed_runtime_files": [
+    "web/backend/app/services/announcement_service.py"
+  ],
+  "changed_test_files": [
+    "web/backend/tests/test_announcement_service_lifecycle_di.py",
+    "web/backend/tests/test_announcement_service_getter_retirement.py"
+  ],
+  "preserved_symbols": [
+    "AnnouncementService",
+    "install_announcement_service",
+    "get_announcement_service_dependency",
+    "ANNOUNCEMENT_SERVICE_STATE_KEY"
+  ],
+  "retired_symbols": [
+    "web/backend/app/services/announcement_service.py:_announcement_service",
+    "web/backend/app/services/announcement_service.py:get_announcement_service"
+  ],
+  "pre_edit_evidence": {
+    "standards_read": true,
+    "gitnexus_analyze_before_edit": "success",
+    "target_context": {
+      "target": "web/backend/app/services/announcement_service.py:get_announcement_service",
+      "graph_route_callers": 11,
+      "processes": 0
+    },
+    "target_impact": {
+      "target": "get_announcement_service",
+      "risk": "MEDIUM",
+      "impacted_count": 11,
+      "affected_processes": 0
+    }
+  },
+  "implementation": {
+    "announcement_service_py": [
+      "removed module-level _announcement_service",
+      "removed get_announcement_service",
+      "changed install_announcement_service fallback to construct AnnouncementService() directly"
+    ],
+    "test_announcement_service_lifecycle_di_py": [
+      "changed fallback installation test to monkeypatch AnnouncementService instead of the retired getter"
+    ],
+    "test_announcement_service_getter_retirement_py": [
+      "added focused absence/preservation regression coverage"
+    ]
+  },
+  "post_change_scan": {
+    "target_getter_definitions": 0,
+    "target_singleton_tokens_in_service": 0,
+    "api_direct_getter_refs": 0,
+    "dependency_refs": 15,
+    "route_depends_refs": 11,
+    "install_refs": 3,
+    "files_scanned": 776
+  },
+  "verification": {
+    "tdd_red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_announcement_service_getter_retirement.py -q --no-cov --tb=short",
+      "result": "1 failed",
+      "expected_failure": "get_announcement_service still existed before implementation"
+    },
+    "focused_green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_announcement_service_getter_retirement.py web/backend/tests/test_announcement_service_lifecycle_di.py -q --no-cov --tb=short",
+      "result": "4 passed"
+    },
+    "health_route_conflicts": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "120 passed"
+    },
+    "ruff_touched_files": {
+      "command": "ruff check web/backend/app/services/announcement_service.py web/backend/tests/test_announcement_service_lifecycle_di.py web/backend/tests/test_announcement_service_getter_retirement.py",
+      "result": "passed"
+    },
+    "black_touched_files": {
+      "command": "black --check web/backend/app/services/announcement_service.py web/backend/tests/test_announcement_service_lifecycle_di.py web/backend/tests/test_announcement_service_getter_retirement.py",
+      "result": "passed"
+    },
+    "gitnexus_staged_detect_changes": {
+      "scope": "staged",
+      "risk_level": "low",
+      "changed_count": 15,
+      "changed_files": 7,
+      "affected_count": 0,
+      "affected_processes": 0,
+      "note": "GitNexus reported several symbols in announcement_service.py as modified from the staged file diff; no affected execution flow was reported"
+    }
+  },
+  "boundary": {
+    "routes_changed": false,
+    "openapi_changed": false,
+    "frontend_changed": false,
+    "pm2_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "announcement_service_class_deleted": false,
+    "install_announcement_service_deleted": false,
+    "dependency_deleted": false
+  },
+  "next_gate": "human review / PR merge decision for G2.118; if accepted, create G2.119 closeout before selecting the next medium route-backed getter lane"
+}

--- a/docs/reports/quality/backend-announcement-service-getter-retirement-implementation-2026-05-26.md
+++ b/docs/reports/quality/backend-announcement-service-getter-retirement-implementation-2026-05-26.md
@@ -1,0 +1,118 @@
+# Backend AnnouncementService Getter Retirement Implementation - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Ready for review.
+
+## Parent Gate
+
+| Field | Value |
+|---|---|
+| Parent node | G2.117 AnnouncementService getter-retirement authorization |
+| Parent PR | `#270` |
+| Parent state | `MERGED` |
+| Parent merge commit | `ca1ad8da694f0174b5a80d414cc624d05865ec8f` |
+| Parent merged at | `2026-05-25T19:34:08Z` |
+| Implementation branch | `g2-118-announcement-service-getter-retirement-implementation` |
+| Implementation base HEAD | `ca1ad8da694f0174b5a80d414cc624d05865ec8f` |
+
+G2.117 authorized one narrow source-capable implementation branch:
+retire `web/backend/app/services/announcement_service.py`
+`_announcement_service` and `get_announcement_service`, while preserving
+`AnnouncementService`, `install_announcement_service`,
+`get_announcement_service_dependency`, announcement route behavior, and OpenAPI
+exposure.
+
+## Scope
+
+Changed files:
+
+- `web/backend/app/services/announcement_service.py`
+- `web/backend/tests/test_announcement_service_lifecycle_di.py`
+- `web/backend/tests/test_announcement_service_getter_retirement.py`
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/announcement-service-getter-retirement-implementation-2026-05-26.json`
+- `governance/mainline/task-cards/pr-271.yaml`
+
+No route/API files, OpenAPI artifacts, frontend files, PM2 workflows,
+OpenSpec changes/specs, or issue-label state were changed.
+
+## Pre-Edit Evidence
+
+| Gate | Result |
+|---|---|
+| `architecture/STANDARDS.md` | read before source edit |
+| GitNexus analyze | completed before source edit |
+| GitNexus context | `get_announcement_service` located in `web/backend/app/services/announcement_service.py`; graph still reports 11 route callers |
+| GitNexus impact | `MEDIUM`, impacted count `11`, affected processes `0` |
+
+The graph callers were treated as the route-dependency seam to verify, not as
+permission to edit route handlers.
+
+## Implementation
+
+`web/backend/app/services/announcement_service.py`:
+
+- removed the module-level `_announcement_service`
+- removed `get_announcement_service`
+- changed `install_announcement_service` to construct `AnnouncementService()`
+  directly when no explicit service is supplied
+
+`web/backend/tests/test_announcement_service_lifecycle_di.py`:
+
+- changed the app-state fallback test to monkeypatch `AnnouncementService`
+  rather than the retired getter
+
+`web/backend/tests/test_announcement_service_getter_retirement.py`:
+
+- added focused regression coverage proving the legacy getter and singleton are
+  absent while the app-state installer and dependency remain importable
+
+## Verification
+
+| Check | Command | Result |
+|---|---|---|
+| TDD red | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_announcement_service_getter_retirement.py -q --no-cov --tb=short` | `1 failed`; failure proved `get_announcement_service` still existed before implementation |
+| Focused green | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_announcement_service_getter_retirement.py web/backend/tests/test_announcement_service_lifecycle_di.py -q --no-cov --tb=short` | `4 passed` |
+| Health route conflicts | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `120 passed` |
+| Ruff touched files | `ruff check web/backend/app/services/announcement_service.py web/backend/tests/test_announcement_service_lifecycle_di.py web/backend/tests/test_announcement_service_getter_retirement.py` | passed |
+| Black touched files | `black --check web/backend/app/services/announcement_service.py web/backend/tests/test_announcement_service_lifecycle_di.py web/backend/tests/test_announcement_service_getter_retirement.py` | passed |
+| Exact post-change scan | scripted text scan over backend app/tests | target getter definitions=`0`; target singleton tokens in service=`0`; API direct getter refs=`0`; dependency refs=`15`; route dependency handlers=`11`; install refs=`3`; files scanned=`776` |
+| GitNexus staged detect changes | `detect_changes(scope="staged")` | risk=`low`; changed count=`15`; changed files=`7`; affected count=`0`; affected processes=`0` |
+
+## Boundary Confirmation
+
+Preserved:
+
+- `AnnouncementService`
+- `install_announcement_service`
+- `get_announcement_service_dependency`
+- `ANNOUNCEMENT_SERVICE_STATE_KEY`
+- announcement route dependency injection
+- OpenAPI exposure
+
+Retired:
+
+- `web/backend/app/services/announcement_service.py:_announcement_service`
+- `web/backend/app/services/announcement_service.py:get_announcement_service`
+
+Not changed:
+
+- announcement route handlers
+- route paths, response models, response shapes, or OpenAPI exposure
+- frontend code
+- PM2 workflows
+- OpenSpec proposals/specs
+- GitHub issue labels or readiness state
+- broader announcement service behavior
+
+## Next Gate
+
+Human review and PR merge decision for G2.118.
+
+If accepted, create G2.119 as a closeout/current-head verification packet before
+selecting the next medium route-backed getter lane.

--- a/governance/mainline/task-cards/pr-271.yaml
+++ b/governance/mainline/task-cards/pr-271.yaml
@@ -1,0 +1,127 @@
+version: "v0.2"
+
+task:
+  id: "pr-271"
+  title: "Retire AnnouncementService module-level getter"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-announcement-service-getter-retirement-implementation"
+  objective: "retire the AnnouncementService module-level getter and singleton while preserving app-state dependency injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-announcement-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-announcement-service-getter-retirement-implementation"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow service getter retirement; no route, public API surface, OpenAPI exposure, frontend behavior, or OpenSpec capability is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/announcement-service-getter-retirement-implementation-2026-05-26.json"
+    - "docs/reports/quality/backend-announcement-service-getter-retirement-implementation-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-271.yaml"
+    - "web/backend/app/services/announcement_service.py"
+    - "web/backend/tests/test_announcement_service_lifecycle_di.py"
+    - "web/backend/tests/test_announcement_service_getter_retirement.py"
+  forbidden_paths:
+    - "web/backend/app/api/**"
+    - "web/backend/app/main.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit announcement route handlers"
+  - "Do not modify route paths, response models, response shapes, or OpenAPI exposure"
+  - "Do not modify frontend code"
+  - "Do not modify PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not delete or rename AnnouncementService"
+  - "Do not delete or alter install_announcement_service"
+  - "Do not delete or alter get_announcement_service_dependency"
+  - "Do not perform broader announcement service consolidation"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 270 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "focused-green-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_announcement_service_getter_retirement.py web/backend/tests/test_announcement_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-files"
+      command: "ruff check web/backend/app/services/announcement_service.py web/backend/tests/test_announcement_service_lifecycle_di.py web/backend/tests/test_announcement_service_getter_retirement.py"
+      required: true
+    - id: "black-touched-files"
+      command: "black --check web/backend/app/services/announcement_service.py web/backend/tests/test_announcement_service_lifecycle_di.py web/backend/tests/test_announcement_service_getter_retirement.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-announcement-service-getter-retirement-implementation-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/announcement-service-getter-retirement-implementation-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-271.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-271.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If route/API files are edited, announcement route contracts or OpenAPI exposure could drift outside the authorization"
+    - "If install_announcement_service or get_announcement_service_dependency are removed, route dependency injection could regress"
+    - "If the graph-level route callers are ignored without focused health-route verification, route registration regressions could be missed"
+  rollback_plan: "revert this narrow implementation PR and keep G2.117 authorization as the latest accepted announcement getter gate"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "retire AnnouncementService module-level getter and singleton"
+    modified_scope: "one service file, two focused tests, steward tree, implementation report, generated artifact, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "module-level getter removed; app-state installer and dependency preserved"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, health route conflicts, touched-file lint/format, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T07:38:02+08:00"
+    approval_note: "G2.117 PR #270 authorized this narrow implementation; no route/API, OpenAPI, frontend, PM2, OpenSpec, or issue-label change is allowed"
+    secondary_approved: false

--- a/web/backend/app/services/announcement_service.py
+++ b/web/backend/app/services/announcement_service.py
@@ -518,23 +518,11 @@ class AnnouncementService:
         }
 
 
-# 全局单例
-_announcement_service = None
 ANNOUNCEMENT_SERVICE_STATE_KEY = "announcement_service"
 
 
-def get_announcement_service() -> AnnouncementService:
-    """获取公告服务单例"""
-    global _announcement_service
-    if _announcement_service is None:
-        _announcement_service = AnnouncementService()
-    return _announcement_service
-
-
-def install_announcement_service(
-    app: Any, service: AnnouncementService | None = None
-) -> AnnouncementService:
-    selected_service = service if service is not None else get_announcement_service()
+def install_announcement_service(app: Any, service: AnnouncementService | None = None) -> AnnouncementService:
+    selected_service = service if service is not None else AnnouncementService()
     setattr(app.state, ANNOUNCEMENT_SERVICE_STATE_KEY, selected_service)
     return selected_service
 

--- a/web/backend/tests/test_announcement_service_getter_retirement.py
+++ b/web/backend/tests/test_announcement_service_getter_retirement.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from app.services import announcement_service
+
+
+def test_legacy_getter_and_module_singleton_are_retired():
+    assert hasattr(announcement_service, "AnnouncementService")
+    assert hasattr(announcement_service, "install_announcement_service")
+    assert hasattr(announcement_service, "get_announcement_service_dependency")
+    assert not hasattr(announcement_service, "get_announcement_service")
+    assert not hasattr(announcement_service, "_announcement_service")

--- a/web/backend/tests/test_announcement_service_lifecycle_di.py
+++ b/web/backend/tests/test_announcement_service_lifecycle_di.py
@@ -15,7 +15,7 @@ def test_announcement_service_dependency_installs_app_state_when_missing(monkeyp
     fake_app = SimpleNamespace(state=SimpleNamespace())
     request = SimpleNamespace(app=fake_app)
 
-    monkeypatch.setattr(announcement_service, "get_announcement_service", lambda: fake_service)
+    monkeypatch.setattr(announcement_service, "AnnouncementService", lambda: fake_service)
 
     assert announcement_service.get_announcement_service_dependency(request) is fake_service
     assert getattr(fake_app.state, announcement_service.ANNOUNCEMENT_SERVICE_STATE_KEY) is fake_service


### PR DESCRIPTION
## Summary
- retire announcement_service.py module-level _announcement_service and get_announcement_service
- keep AnnouncementService, install_announcement_service, and get_announcement_service_dependency intact
- update steward tree, generated evidence, implementation report, and mainline task card

## Verification
- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_announcement_service_getter_retirement.py web/backend/tests/test_announcement_service_lifecycle_di.py -q --no-cov --tb=short: 4 passed
- PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short: 120 passed
- ruff check touched files: passed
- black --check touched files: passed
- markdown governance: errors=0
- GitNexus staged detect_changes: low, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: completed