### PR TITLE
G2.119 Close out AnnouncementService getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1935,7 +1935,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                service migration, or issue-label change is made here
 │   ├── G2.118 AnnouncementService getter-retirement implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#271` merged at
+│   │   │          `4a2a21272deff876bc9fb5f1058c0682a7f4b5de`
 │   │   ├── Evidence: `backend-announcement-service-getter-retirement-implementation-2026-05-26.md`
 │   │   ├── Current HEAD: `ca1ad8da694f0174b5a80d414cc624d05865ec8f`
 │   │   ├── Result: removes only `announcement_service.py`
@@ -1956,10 +1957,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                steward-tree update; no route/API, OpenAPI exposure,
 │   │                frontend, PM2, OpenSpec, `AnnouncementService` deletion,
 │   │                dependency deletion, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.118; if accepted,
-│                  create G2.119 AnnouncementService getter-retirement
-│                  closeout before selecting the next medium route-backed
-│                  getter lane
+│   ├── G2.119 AnnouncementService getter-retirement closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-announcement-service-getter-retirement-closeout-2026-05-26.md`
+│   │   ├── Current HEAD: `4a2a21272deff876bc9fb5f1058c0682a7f4b5de`
+│   │   ├── Result: records PR `#271` merge and closes the AnnouncementService
+│   │   │          getter-retirement implementation lane; current-head scan
+│   │   │          confirms target getter definitions=`0`, target singleton
+│   │   │          tokens=`0`, API direct getter refs=`0`, route dependency
+│   │   │          handlers preserved=`11`, and focused route-dependency
+│   │   │          regression coverage remains green
+│   │   ├── Verification: focused tests `4 passed`, health route conflicts
+│   │   │          `120 passed`, current-head exact scan files=`776`
+│   │   └── Boundary: closeout-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                implementation authorization, or issue-label change is made here
+│   └── Next gate: create G2.120 service lifecycle candidate refresh after
+│                  AnnouncementService before selecting the next medium
+│                  route-backed getter lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/announcement-service-getter-retirement-closeout-2026-05-26.json
+++ b/.planning/codebase/generated/announcement-service-getter-retirement-closeout-2026-05-26.json
@@ -1,0 +1,65 @@
+{
+  "artifact": "announcement-service-getter-retirement-closeout-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T08:00:23+08:00",
+  "branch": "g2-119-announcement-service-getter-retirement-closeout",
+  "current_head": "4a2a21272deff876bc9fb5f1058c0682a7f4b5de",
+  "current_head_checked_at_review": "2026-05-26T08:00:23+08:00",
+  "parent_implementation": {
+    "node": "G2.118",
+    "pr": 271,
+    "state": "MERGED",
+    "merged_at": "2026-05-25T23:56:18Z",
+    "merge_commit": "4a2a21272deff876bc9fb5f1058c0682a7f4b5de"
+  },
+  "governance_node": {
+    "id": "G2.119",
+    "lane": "service_lifecycle_di",
+    "type": "closeout",
+    "state": "ready_for_review"
+  },
+  "current_head_scan": {
+    "target_getter_definitions": 0,
+    "target_singleton_tokens_in_service": 0,
+    "api_direct_getter_refs": 0,
+    "dependency_refs": 15,
+    "route_depends_refs": 11,
+    "install_refs": 3,
+    "files_scanned": 776
+  },
+  "verification": {
+    "focused_tests": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_announcement_service_getter_retirement.py web/backend/tests/test_announcement_service_lifecycle_di.py -q --no-cov --tb=short",
+      "result": "4 passed"
+    },
+    "health_route_conflicts": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "120 passed"
+    },
+    "parent_pr_state": {
+      "command": "gh pr view 271 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url",
+      "result": "MERGED"
+    },
+    "gitnexus_staged_detect_changes": {
+      "scope": "staged",
+      "risk_level": "low",
+      "changed_count": 0,
+      "changed_files": 4,
+      "affected_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "boundary": {
+    "backend_source_changed": false,
+    "backend_tests_changed": false,
+    "routes_changed": false,
+    "openapi_changed": false,
+    "frontend_changed": false,
+    "pm2_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "new_implementation_authorized": false
+  },
+  "closeout_decision": "AnnouncementService getter-retirement implementation lane is closed at current head",
+  "next_gate": "create G2.120 service lifecycle candidate refresh after AnnouncementService before selecting the next medium route-backed getter lane"
+}

--- a/docs/reports/quality/backend-announcement-service-getter-retirement-closeout-2026-05-26.md
+++ b/docs/reports/quality/backend-announcement-service-getter-retirement-closeout-2026-05-26.md
@@ -1,0 +1,77 @@
+# Backend AnnouncementService Getter Retirement Closeout - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Ready for review.
+
+## Parent Merge
+
+| Field | Value |
+|---|---|
+| Parent node | G2.118 AnnouncementService getter-retirement implementation |
+| Parent PR | `#271` |
+| Parent state | `MERGED` |
+| Parent merge commit | `4a2a21272deff876bc9fb5f1058c0682a7f4b5de` |
+| Parent merged at | `2026-05-25T23:56:18Z` |
+| Closeout branch | `g2-119-announcement-service-getter-retirement-closeout` |
+| Current HEAD | `4a2a21272deff876bc9fb5f1058c0682a7f4b5de` |
+
+## Closeout Decision
+
+The AnnouncementService getter-retirement implementation lane is closed at
+current HEAD.
+
+This closeout records that PR `#271` merged the narrow implementation that
+removed only:
+
+- `web/backend/app/services/announcement_service.py:_announcement_service`
+- `web/backend/app/services/announcement_service.py:get_announcement_service`
+
+It also confirms that the following surfaces remain present:
+
+- `AnnouncementService`
+- `install_announcement_service`
+- `get_announcement_service_dependency`
+- announcement route dependency injection
+
+## Current-Head Evidence
+
+| Check | Result |
+|---|---|
+| Target getter definitions | `0` |
+| Target singleton tokens in `announcement_service.py` | `0` |
+| API direct getter refs | `0` |
+| Dependency refs | `15` |
+| Route dependency handlers | `11` |
+| Installer refs | `3` |
+| Backend app/test Python files scanned | `776` |
+
+## Verification
+
+| Check | Command | Result |
+|---|---|---|
+| Parent PR state | `gh pr view 271 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url` | `MERGED`, merge commit `4a2a21272deff876bc9fb5f1058c0682a7f4b5de` |
+| Focused tests | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_announcement_service_getter_retirement.py web/backend/tests/test_announcement_service_lifecycle_di.py -q --no-cov --tb=short` | `4 passed` |
+| Health route conflicts | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `120 passed` |
+| Current-head scan | scripted text scan | getter=`0`, singleton=`0`, API direct refs=`0`, route dependency handlers=`11` |
+| GitNexus staged detect changes | `detect_changes(scope="staged")` | risk=`low`; changed count=`0`; changed files=`4`; affected count=`0`; affected processes=`0` |
+
+## Boundary Confirmation
+
+This is a closeout-only packet.
+
+No backend source files, backend tests, route/API files, OpenAPI artifacts,
+frontend files, PM2 workflows, OpenSpec changes/specs, or GitHub issue labels
+are changed here.
+
+This packet does not authorize the next implementation lane. It only records
+that G2.118 is merged and verified at current HEAD.
+
+## Next Gate
+
+Create G2.120 as a service lifecycle candidate refresh after AnnouncementService
+before selecting the next medium route-backed getter lane.

--- a/governance/mainline/task-cards/pr-272.yaml
+++ b/governance/mainline/task-cards/pr-272.yaml
@@ -1,0 +1,115 @@
+version: "v0.2"
+
+task:
+  id: "pr-272"
+  title: "Close out AnnouncementService getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-announcement-service-getter-retirement-closeout"
+  objective: "record the merged AnnouncementService getter retirement and verify current-head closeout evidence"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-announcement-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-announcement-service-getter-retirement-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/announcement-service-getter-retirement-closeout-2026-05-26.json"
+    - "docs/reports/quality/backend-announcement-service-getter-retirement-closeout-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-272.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not edit announcement route handlers"
+  - "Do not modify route paths, response models, response shapes, or OpenAPI exposure"
+  - "Do not modify frontend code"
+  - "Do not modify PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not authorize the next implementation lane"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 271 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "focused-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_announcement_service_getter_retirement.py web/backend/tests/test_announcement_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-announcement-service-getter-retirement-closeout-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/announcement-service-getter-retirement-closeout-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-272.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-272.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If closeout is mistaken for implementation authorization, a next source lane could skip candidate refresh"
+    - "If parent PR state is not verified, the steward tree could record an unmerged implementation as closed"
+  rollback_plan: "revert this governance-only closeout PR and keep G2.118 as the latest implementation gate"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out merged AnnouncementService getter retirement"
+    modified_scope: "steward tree, closeout report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; closeout-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent PR state, current-head scan, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T08:00:23+08:00"
+    approval_note: "Closeout-only packet after PR #271 merge; next implementation lane is not authorized here"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record PR #271 merge and close out the AnnouncementService getter-retirement lane
- verify current HEAD still has target getter definitions=0, singleton tokens=0, API direct getter refs=0, and route dependency handlers=11
- update steward tree, closeout evidence JSON, closeout report, and mainline task card only

## Verification
- gh pr view 271: MERGED at 4a2a21272deff876bc9fb5f1058c0682a7f4b5de
- current-head exact scan: getter=0, singleton=0, API direct getter refs=0, route dependency handlers=11
- focused tests: 4 passed
- health route conflicts: 120 passed
- markdown governance: errors=0
- JSON/YAML parse and cached diff check: passed
- GitNexus staged detect_changes: low, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: completed