### PR TITLE
G2.120 Refresh service lifecycle candidates after AnnouncementService

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1958,7 +1958,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                frontend, PM2, OpenSpec, `AnnouncementService` deletion,
 │   │                dependency deletion, or issue-label change is made here
 │   ├── G2.119 AnnouncementService getter-retirement closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#272` merged at
+│   │   │          `550ce654219385afa65fc4fbfaf6129b2d2a4ca3`
 │   │   ├── Evidence: `backend-announcement-service-getter-retirement-closeout-2026-05-26.md`
 │   │   ├── Current HEAD: `4a2a21272deff876bc9fb5f1058c0682a7f4b5de`
 │   │   ├── Result: records PR `#271` merge and closes the AnnouncementService
@@ -1972,9 +1973,31 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: closeout-only; no backend source/test edit, route/API,
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                implementation authorization, or issue-label change is made here
-│   └── Next gate: create G2.120 service lifecycle candidate refresh after
-│                  AnnouncementService before selecting the next medium
-│                  route-backed getter lane
+│   ├── G2.120 Service lifecycle candidate refresh after AnnouncementService
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-announcement-2026-05-26.md`
+│   │   ├── Current HEAD: `550ce654219385afa65fc4fbfaf6129b2d2a4ca3`
+│   │   ├── Result: current text scan confirms service files=`152`,
+│   │   │          backend app files=`575`, API files=`219`, backend test
+│   │   │          files=`201`, getter definitions=`14`, and module-lazy
+│   │   │          candidates=`7`; `get_announcement_service` remains retired
+│   │   │          in text scan and is removed from the active candidate pool
+│   │   ├── Decision: select `get_email_service` as the next authorization
+│   │   │          candidate because exact text scan shows no API or adapter
+│   │   │          direct getter refs and notification routes use
+│   │   │          `get_email_service_dependency`; hold `get_watchlist_service`
+│   │   │          because two adapter files still import/call the getter
+│   │   ├── Evidence note: GitNexus MCP still resolves retired
+│   │   │          `get_announcement_service` graph callers after analyze, so
+│   │   │          this packet treats exact current-head text scan as the
+│   │   │          retirement truth and does not reopen the announcement lane
+│   │   └── Boundary: candidate-refresh-only; no backend source/test edit,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                getter deletion, implementation authorization, or
+│   │                issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.120; if accepted,
+│                  create G2.121 EmailService getter-retirement authorization
+│                  before any email service source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-announcement-2026-05-26.json
+++ b/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-announcement-2026-05-26.json
@@ -1,0 +1,202 @@
+{
+  "artifact": "service-lifecycle-candidate-refresh-after-announcement-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T08:13:36+08:00",
+  "branch": "g2-120-service-lifecycle-candidate-refresh-after-announcement",
+  "current_head": "550ce654219385afa65fc4fbfaf6129b2d2a4ca3",
+  "current_head_checked_at_review": "2026-05-26T08:13:36+08:00",
+  "parent_closeout": {
+    "node": "G2.119",
+    "pr": 272,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T00:07:41Z",
+    "merge_commit": "550ce654219385afa65fc4fbfaf6129b2d2a4ca3"
+  },
+  "governance_node": {
+    "id": "G2.120",
+    "lane": "service_lifecycle_di",
+    "type": "candidate_refresh",
+    "state": "ready_for_review"
+  },
+  "scan_summary": {
+    "service_files": 152,
+    "backend_app_files": 575,
+    "api_files": 219,
+    "backend_test_files": 201,
+    "getter_definitions": 14,
+    "module_lazy_candidates": 7,
+    "announcement_getter_definitions": 0,
+    "announcement_singleton_tokens_in_service": 0
+  },
+  "candidates": [
+    {
+      "name": "get_streaming_service",
+      "file": "web/backend/app/services/realtime_streaming_service.py",
+      "line": 424,
+      "kind": "module-lazy",
+      "app_refs": 12,
+      "app_ref_files": 3,
+      "api_refs": 0,
+      "api_ref_files": 0,
+      "backend_test_refs": 19,
+      "backend_test_ref_files": 2,
+      "gitnexus_risk": "HIGH",
+      "gitnexus_impacted_count": 9,
+      "affected_processes": 0,
+      "disposition": "hold_streaming_socketio_seam"
+    },
+    {
+      "name": "get_tdx_service",
+      "file": "web/backend/app/services/tdx_service.py",
+      "line": 275,
+      "kind": "module-lazy",
+      "app_refs": 4,
+      "app_ref_files": 2,
+      "api_refs": 2,
+      "api_ref_files": 1,
+      "backend_test_refs": 2,
+      "backend_test_ref_files": 2,
+      "gitnexus_risk": "CRITICAL",
+      "gitnexus_impacted_count": 6,
+      "affected_processes": 5,
+      "disposition": "hold_dashboard_route_process_seam"
+    },
+    {
+      "name": "get_email_service",
+      "file": "web/backend/app/services/email_service.py",
+      "line": 325,
+      "kind": "module-lazy",
+      "app_refs": 2,
+      "app_ref_files": 1,
+      "api_refs": 0,
+      "api_ref_files": 0,
+      "backend_test_refs": 4,
+      "backend_test_ref_files": 3,
+      "gitnexus_risk": "MEDIUM",
+      "gitnexus_impacted_count": 6,
+      "affected_processes": 0,
+      "disposition": "select_next_authorization_candidate"
+    },
+    {
+      "name": "get_watchlist_service",
+      "file": "web/backend/app/services/watchlist_service.py",
+      "line": 613,
+      "kind": "module-lazy",
+      "app_refs": 6,
+      "app_ref_files": 3,
+      "api_refs": 0,
+      "api_ref_files": 0,
+      "backend_test_refs": 2,
+      "backend_test_ref_files": 2,
+      "gitnexus_risk": "MEDIUM",
+      "gitnexus_impacted_count": 15,
+      "affected_processes": 0,
+      "disposition": "hold_route_adapter_seam"
+    },
+    {
+      "name": "get_data_service",
+      "file": "web/backend/app/services/data_service.py",
+      "line": 466,
+      "kind": "module-lazy",
+      "app_refs": 6,
+      "app_ref_files": 3,
+      "api_refs": 5,
+      "api_ref_files": 2,
+      "backend_test_refs": 6,
+      "backend_test_ref_files": 2,
+      "gitnexus_risk": "CRITICAL",
+      "gitnexus_impacted_count": 5,
+      "affected_processes": 7,
+      "disposition": "hold_indicator_strategy_route_process_seam"
+    },
+    {
+      "name": "get_strategy_service",
+      "file": "web/backend/app/services/strategy_service.py",
+      "line": 455,
+      "kind": "module-lazy",
+      "app_refs": 11,
+      "app_ref_files": 5,
+      "api_refs": 4,
+      "api_ref_files": 1,
+      "backend_test_refs": 1,
+      "backend_test_ref_files": 1,
+      "gitnexus_risk": "CRITICAL",
+      "gitnexus_impacted_count": 13,
+      "affected_processes": 0,
+      "disposition": "hold_strategy_task_adapter_seam"
+    },
+    {
+      "name": "get_stock_search_service",
+      "file": "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "line": 171,
+      "kind": "module-lazy",
+      "app_refs": 4,
+      "app_ref_files": 2,
+      "api_refs": 0,
+      "api_ref_files": 0,
+      "backend_test_refs": 6,
+      "backend_test_ref_files": 4,
+      "gitnexus_risk": "CRITICAL",
+      "gitnexus_impacted_count": 6,
+      "affected_processes": 11,
+      "disposition": "hold_stock_search_route_process_seam"
+    }
+  ],
+  "email_consumer_detail": {
+    "direct_getter_api_refs": 0,
+    "direct_getter_adapter_refs": 0,
+    "dependency_refs": 8,
+    "dependency_api_refs": 7,
+    "route_depends_refs": 6,
+    "backend_test_direct_getter_refs": 4,
+    "backend_test_direct_getter_ref_files": 3
+  },
+  "watchlist_consumer_detail": {
+    "direct_getter_api_refs": 0,
+    "direct_getter_adapter_refs": 4,
+    "direct_getter_adapter_ref_files": 2,
+    "dependency_api_refs": 8,
+    "route_depends_refs": 7
+  },
+  "gitnexus_stale_note": {
+    "retired_symbol": "get_announcement_service",
+    "text_scan_getter_definitions": 0,
+    "text_scan_singleton_tokens": 0,
+    "mcp_context_after_analyze": "still resolved retired route-call graph callers",
+    "decision": "do not reopen AnnouncementService lane from stale graph result; use exact current-head text scan as retirement truth"
+  },
+  "decision": {
+    "selected_next_authorization_candidate": "get_email_service",
+    "reason": "EmailService has no exact API or adapter direct getter refs; notification routes use get_email_service_dependency, while WatchlistService still has two adapter files directly importing/calling get_watchlist_service.",
+    "next_gate": "human review / PR merge decision for G2.120; if accepted, create G2.121 EmailService getter-retirement authorization before any email service source edit"
+  },
+  "verification": {
+    "parent_pr_state": {
+      "command": "gh pr view 272 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url",
+      "result": "MERGED"
+    },
+    "gitnexus_analyze": {
+      "command": "gitnexus analyze --with-gitignore",
+      "result": "completed"
+    },
+    "gitnexus_staged_detect_changes": {
+      "scope": "staged",
+      "risk_level": "low",
+      "changed_count": 0,
+      "changed_files": 4,
+      "affected_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "boundary": {
+    "backend_source_changed": false,
+    "backend_tests_changed": false,
+    "routes_changed": false,
+    "openapi_changed": false,
+    "frontend_changed": false,
+    "pm2_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "implementation_authorized": false
+  }
+}

--- a/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-announcement-2026-05-26.md
+++ b/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-announcement-2026-05-26.md
@@ -1,0 +1,114 @@
+# Backend Service Lifecycle Candidate Refresh After AnnouncementService - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Ready for review.
+
+## Parent Gate
+
+| Field | Value |
+|---|---|
+| Parent node | G2.119 AnnouncementService getter-retirement closeout |
+| Parent PR | `#272` |
+| Parent state | `MERGED` |
+| Parent merge commit | `550ce654219385afa65fc4fbfaf6129b2d2a4ca3` |
+| Parent merged at | `2026-05-26T00:07:41Z` |
+| Current HEAD | `550ce654219385afa65fc4fbfaf6129b2d2a4ca3` |
+
+## Scan Summary
+
+| Metric | Value |
+|---|---:|
+| Service Python files | 152 |
+| Backend app Python files | 575 |
+| API Python files | 219 |
+| Backend test Python files | 201 |
+| `get_*service` definitions found in services | 14 |
+| Module-lazy candidates | 7 |
+| `get_announcement_service` definitions | 0 |
+| `_announcement_service` tokens in `announcement_service.py` | 0 |
+
+`get_announcement_service` is removed from the active candidate pool by exact
+current-head text scan.
+
+## Candidate Matrix
+
+| Candidate | File | Risk | Impact | Exact API refs | Exact adapter refs | Disposition |
+|---|---|---:|---:|---:|---:|---|
+| `get_streaming_service` | `web/backend/app/services/realtime_streaming_service.py:424` | HIGH | 9 | 0 | n/a | hold: Socket.IO / streaming seam |
+| `get_tdx_service` | `web/backend/app/services/tdx_service.py:275` | CRITICAL | 6 | 2 | n/a | hold: dashboard route process seam |
+| `get_email_service` | `web/backend/app/services/email_service.py:325` | MEDIUM | 6 | 0 | 0 | select next authorization candidate |
+| `get_watchlist_service` | `web/backend/app/services/watchlist_service.py:613` | MEDIUM | 15 | 0 | 4 across 2 adapter files | hold: route + adapter seam |
+| `get_data_service` | `web/backend/app/services/data_service.py:466` | CRITICAL | 5 | 5 | n/a | hold: indicator / strategy route process seam |
+| `get_strategy_service` | `web/backend/app/services/strategy_service.py:455` | CRITICAL | 13 | 4 | n/a | hold: strategy task / adapter seam |
+| `get_stock_search_service` | `web/backend/app/services/stock_search_service/stock_search_service.py:171` | CRITICAL | 6 | 0 | n/a | hold: stock-search route process seam |
+
+## Email Candidate Detail
+
+Exact text scan:
+
+- direct `get_email_service` refs in API files: `0`
+- direct `get_email_service` refs in adapter files: `0`
+- `get_email_service_dependency` refs in backend app: `8`
+- `get_email_service_dependency` refs in API: `7`
+- `Depends(get_email_service_dependency)` route refs: `6`
+- backend test direct getter refs: `4` across `3` files
+
+GitNexus impact reports `MEDIUM`, impacted count `6`, affected processes `0`.
+Its direct API caller list corresponds to notification route dependency
+consumers, while exact text scan shows those routes no longer directly reference
+the getter.
+
+## Watchlist Hold Detail
+
+`get_watchlist_service` remains behind EmailService because exact text scan still
+finds `4` direct getter refs across:
+
+- `web/backend/app/services/adapters/watchlist_adapter.py`
+- `web/backend/app/services/data_adapters/watchlist.py`
+
+Watchlist routes also have `7` `Depends(get_watchlist_service_dependency)` refs,
+but the adapter seam must be resolved before a simple getter-retirement
+authorization packet.
+
+## GitNexus Stale Note
+
+After `gitnexus analyze --with-gitignore` in this worktree, GitNexus MCP still
+resolved the retired `get_announcement_service` symbol and its historical route
+callers. Exact current-head text scan reports:
+
+- `get_announcement_service` definitions: `0`
+- `_announcement_service` tokens in `announcement_service.py`: `0`
+- API direct getter refs: `0`
+
+Do not reopen the AnnouncementService lane from this stale graph result.
+
+## Decision
+
+Select `get_email_service` as the next authorization candidate.
+
+This packet does not authorize source edits. If G2.120 is accepted, create
+G2.121 as an authorization-only packet before any EmailService source edit.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Parent PR `#272` state | `MERGED`, merge commit `550ce654219385afa65fc4fbfaf6129b2d2a4ca3` |
+| `gitnexus analyze --with-gitignore` | completed in this worktree |
+| GitNexus staged detect changes | risk=`low`; changed count=`0`; changed files=`4`; affected count=`0`; affected processes=`0` |
+| Markdown governance | errors=`0` |
+| JSON / YAML parse | passed |
+| Cached diff check | passed |
+
+## Boundary Confirmation
+
+This is a candidate-refresh-only packet.
+
+No backend source files, backend tests, route/API files, OpenAPI artifacts,
+frontend files, PM2 workflows, OpenSpec changes/specs, or GitHub issue labels
+are changed here.

--- a/governance/mainline/task-cards/pr-273.yaml
+++ b/governance/mainline/task-cards/pr-273.yaml
@@ -1,0 +1,110 @@
+version: "v0.2"
+
+task:
+  id: "pr-273"
+  title: "Refresh service lifecycle candidates after AnnouncementService"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-service-lifecycle-candidate-refresh-after-announcement"
+  objective: "refresh the service lifecycle candidate pool after AnnouncementService getter retirement and select the next authorization candidate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-candidate-refresh"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-candidate-refresh-after-announcement"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate-refresh-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-candidate-refresh-after-announcement-2026-05-26.json"
+    - "docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-announcement-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-273.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not edit route handlers"
+  - "Do not modify route paths, response models, response shapes, or OpenAPI exposure"
+  - "Do not modify frontend code"
+  - "Do not modify PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not delete any getter in this PR"
+  - "Do not authorize EmailService implementation beyond a future authorization packet"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 272 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-candidate-refresh-after-announcement-2026-05-26.json >/dev/null"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-announcement-2026-05-26.md"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-273.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-273.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If GitNexus stale announcement data is treated as current truth, the completed AnnouncementService lane could be reopened incorrectly"
+    - "If this packet is mistaken for implementation authorization, EmailService source edits could skip G2.121 authorization"
+  rollback_plan: "revert this governance-only candidate refresh PR and keep G2.119 closeout as the latest accepted service lifecycle gate"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh service lifecycle candidates after AnnouncementService"
+    modified_scope: "steward tree, candidate refresh report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; candidate-refresh-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent PR state, candidate evidence, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T08:13:36+08:00"
+    approval_note: "Candidate-refresh-only packet after PR #272 merge; selects get_email_service for a future authorization packet but does not authorize source edits"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- refresh service lifecycle candidate pool after AnnouncementService getter retirement closeout
- confirm current HEAD removes get_announcement_service from the active text-scan candidate pool
- select get_email_service as the next authorization candidate; no source edits are authorized

## Key evidence
- service files=152, backend app files=575, API files=219, backend test files=201
- getter definitions=14, module-lazy candidates=7
- get_announcement_service definitions=0 and _announcement_service tokens=0 by exact text scan
- get_email_service exact API direct getter refs=0 and adapter direct getter refs=0; notification routes use get_email_service_dependency
- get_watchlist_service remains held because 2 adapter files still directly import/call the getter

## Verification
- parent PR #272: MERGED at 550ce654219385afa65fc4fbfaf6129b2d2a4ca3
- markdown governance: errors=0
- JSON/YAML parse and cached diff check: passed
- GitNexus staged detect_changes: low, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: completed