### PR TITLE
G2.121 Authorize EmailService getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1974,7 +1974,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                implementation authorization, or issue-label change is made here
 │   ├── G2.120 Service lifecycle candidate refresh after AnnouncementService
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#273` merged at
+│   │   │          `1f117e1c7aa0333b6c0de272d697043f59f56bc9`
 │   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-announcement-2026-05-26.md`
 │   │   ├── Current HEAD: `550ce654219385afa65fc4fbfaf6129b2d2a4ca3`
 │   │   ├── Result: current text scan confirms service files=`152`,
@@ -1995,8 +1996,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                getter deletion, implementation authorization, or
 │   │                issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.120; if accepted,
-│                  create G2.121 EmailService getter-retirement authorization
+│   ├── G2.121 EmailService getter-retirement authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-email-service-getter-retirement-authorization-2026-05-26.md`
+│   │   ├── Current HEAD: `1f117e1c7aa0333b6c0de272d697043f59f56bc9`
+│   │   ├── Result: authorizes only a future G2.122 implementation branch to
+│   │   │          retire `email_service.py` `_email_service` and
+│   │   │          `get_email_service`, while preserving `EmailService`,
+│   │   │          `install_email_service`, `get_email_service_dependency`,
+│   │   │          notification routes, and OpenAPI exposure
+│   │   ├── Evidence note: exact scan shows direct API getter refs=`0`,
+│   │   │          direct adapter getter refs=`0`, route dependency handlers=`6`,
+│   │   │          and GitNexus impact MEDIUM / `6` with affected processes=`0`;
+│   │   │          future implementation may update only the listed service and
+│   │   │          focused tests after TDD red
+│   │   └── Boundary: authorization-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                implementation, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.121; if accepted,
+│                  create G2.122 EmailService getter-retirement implementation
 │                  before any email service source edit
 │
 ├── H. Decision-Only Track: CSRF composition root

--- a/.planning/codebase/generated/email-service-getter-retirement-authorization-2026-05-26.json
+++ b/.planning/codebase/generated/email-service-getter-retirement-authorization-2026-05-26.json
@@ -1,0 +1,111 @@
+{
+  "artifact": "email-service-getter-retirement-authorization-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T08:24:45+08:00",
+  "branch": "g2-121-email-service-getter-retirement-authorization",
+  "current_head": "1f117e1c7aa0333b6c0de272d697043f59f56bc9",
+  "current_head_checked_at_review": "2026-05-26T08:24:45+08:00",
+  "parent_candidate_refresh": {
+    "node": "G2.120",
+    "pr": 273,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T00:21:15Z",
+    "merge_commit": "1f117e1c7aa0333b6c0de272d697043f59f56bc9"
+  },
+  "governance_node": {
+    "id": "G2.121",
+    "lane": "service_lifecycle_di",
+    "type": "authorization",
+    "state": "ready_for_review"
+  },
+  "target": {
+    "service_file": "web/backend/app/services/email_service.py",
+    "getter": "get_email_service",
+    "singleton": "_email_service",
+    "getter_line": 325,
+    "singleton_line": 321,
+    "installer": "install_email_service",
+    "dependency": "get_email_service_dependency",
+    "service_class": "EmailService"
+  },
+  "current_scan": {
+    "get_email_service_definitions": 1,
+    "email_singleton_tokens": 5,
+    "direct_getter_app_refs": 2,
+    "direct_getter_app_ref_files": 1,
+    "direct_getter_api_refs": 0,
+    "direct_getter_api_ref_files": 0,
+    "direct_getter_services_refs": 2,
+    "direct_getter_services_ref_files": 1,
+    "direct_getter_tests_refs": 4,
+    "direct_getter_tests_ref_files": 3,
+    "dependency_app_refs": 8,
+    "dependency_api_refs": 7,
+    "dependency_tests_refs": 3,
+    "route_depends_refs": 6,
+    "api_files_scanned": 219,
+    "backend_test_files_scanned": 201
+  },
+  "gitnexus_impact": {
+    "target": "get_email_service",
+    "risk": "MEDIUM",
+    "impacted_count": 6,
+    "direct": 6,
+    "affected_processes": 0,
+    "modules_affected": 1,
+    "note": "GitNexus reports notification route callers; exact text scan shows notification routes import and call get_email_service_dependency rather than the getter"
+  },
+  "verification": {
+    "parent_pr_state": {
+      "command": "gh pr view 273 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url",
+      "result": "MERGED"
+    },
+    "gitnexus_staged_detect_changes": {
+      "scope": "staged",
+      "risk_level": "low",
+      "changed_count": 0,
+      "changed_files": 4,
+      "affected_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "authorized_future_scope": {
+    "future_node": "G2.122",
+    "allowed_paths": [
+      "web/backend/app/services/email_service.py",
+      "web/backend/tests/test_email_service_lifecycle_di.py",
+      "web/backend/tests/test_notification_logging.py",
+      "web/backend/tests/test_email_service_getter_retirement.py",
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/email-service-getter-retirement-implementation-2026-05-26.json",
+      "docs/reports/quality/backend-email-service-getter-retirement-implementation-2026-05-26.md",
+      "governance/mainline/task-cards/pr-274.yaml"
+    ],
+    "allowed_actions": [
+      "remove email_service.py _email_service",
+      "remove email_service.py get_email_service",
+      "change install_email_service fallback to construct EmailService() directly",
+      "update focused lifecycle/logging fakes that still expose the retired getter",
+      "add focused getter-retirement regression coverage"
+    ],
+    "must_preserve": [
+      "EmailService",
+      "install_email_service",
+      "get_email_service_dependency",
+      "EMAIL_SERVICE_STATE_KEY",
+      "notification route paths and OpenAPI exposure"
+    ]
+  },
+  "boundary": {
+    "backend_source_changed": false,
+    "backend_tests_changed": false,
+    "routes_changed": false,
+    "openapi_changed": false,
+    "frontend_changed": false,
+    "pm2_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "implementation_performed": false
+  },
+  "next_gate": "human review / PR merge decision for G2.121; if accepted, create G2.122 EmailService getter-retirement implementation before any email service source edit"
+}

--- a/docs/reports/quality/backend-email-service-getter-retirement-authorization-2026-05-26.md
+++ b/docs/reports/quality/backend-email-service-getter-retirement-authorization-2026-05-26.md
@@ -1,0 +1,111 @@
+# Backend EmailService Getter Retirement Authorization - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Ready for review.
+
+## Parent Gate
+
+| Field | Value |
+|---|---|
+| Parent node | G2.120 Service lifecycle candidate refresh after AnnouncementService |
+| Parent PR | `#273` |
+| Parent state | `MERGED` |
+| Parent merge commit | `1f117e1c7aa0333b6c0de272d697043f59f56bc9` |
+| Parent merged at | `2026-05-26T00:21:15Z` |
+| Current HEAD | `1f117e1c7aa0333b6c0de272d697043f59f56bc9` |
+
+## Authorization Decision
+
+Authorize only a future G2.122 implementation branch to retire the
+`EmailService` module-level getter:
+
+- `web/backend/app/services/email_service.py:_email_service`
+- `web/backend/app/services/email_service.py:get_email_service`
+
+The future implementation must preserve:
+
+- `EmailService`
+- `install_email_service`
+- `get_email_service_dependency`
+- `EMAIL_SERVICE_STATE_KEY`
+- notification route paths, response contracts, and OpenAPI exposure
+
+## Current Evidence
+
+| Check | Value |
+|---|---:|
+| `get_email_service` definitions in `email_service.py` | 1 |
+| `_email_service` tokens in `email_service.py` | 5 |
+| Exact direct getter refs in API files | 0 |
+| Exact direct getter refs in adapter files | 0 |
+| Exact direct getter refs in backend tests | 4 across 3 files |
+| `get_email_service_dependency` refs in API | 7 |
+| `Depends(get_email_service_dependency)` route refs | 6 |
+| API files scanned | 219 |
+| Backend test files scanned | 201 |
+
+GitNexus impact for `get_email_service`:
+
+- risk: MEDIUM
+- impacted count: 6
+- affected processes: 0
+- modules affected: 1
+
+GitNexus reports notification route callers. Exact text scan shows those routes
+import and use `get_email_service_dependency`, not the getter itself.
+
+GitNexus staged detect changes for this authorization packet is low risk with
+changed count `0`, changed files `4`, affected count `0`, and affected
+processes `0`.
+
+## Future G2.122 Maximum Scope
+
+If this packet is reviewed and accepted, G2.122 may be created with this maximum
+source/test scope:
+
+| Path | Future allowed action |
+|---|---|
+| `web/backend/app/services/email_service.py` | Remove `_email_service` and `get_email_service`; change `install_email_service` fallback to construct `EmailService()` directly |
+| `web/backend/tests/test_email_service_lifecycle_di.py` | Update fallback installation coverage to patch `EmailService` rather than the retired getter |
+| `web/backend/tests/test_notification_logging.py` | Remove obsolete fake getter exposure if required by focused tests |
+| `web/backend/tests/test_email_service_getter_retirement.py` | Add focused absence/preservation regression coverage |
+| `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md` | Record implementation status after the branch runs |
+| `.planning/codebase/generated/email-service-getter-retirement-implementation-2026-05-26.json` | Record generated implementation evidence |
+| `docs/reports/quality/backend-email-service-getter-retirement-implementation-2026-05-26.md` | Record implementation evidence |
+| `governance/mainline/task-cards/pr-274.yaml` | Record implementation task-card gate |
+
+## Future G2.122 Required Gates
+
+Before any source edit:
+
+- read `architecture/STANDARDS.md`
+- run GitNexus context/impact for `get_email_service`
+- write a failing TDD test proving the getter/singleton still exist
+
+Before commit:
+
+- focused EmailService getter-retirement tests pass
+- `test_email_service_lifecycle_di.py` passes
+- `test_notification_logging.py` passes if touched
+- `test_health_route_conflicts.py` passes
+- ruff and black pass on touched files
+- exact post-change scan shows target getter definitions=`0`, target singleton
+  tokens=`0`, direct API getter refs=`0`
+- GitNexus staged detect changes is low/expected
+- mainline scope gate passes after commit
+
+## Boundary Confirmation
+
+This is an authorization-only packet.
+
+No backend source files, backend tests, route/API files, OpenAPI artifacts,
+frontend files, PM2 workflows, OpenSpec changes/specs, or GitHub issue labels
+are changed here.
+
+This packet does not perform the getter retirement. It only authorizes the
+future G2.122 implementation boundary.

--- a/governance/mainline/task-cards/pr-274.yaml
+++ b/governance/mainline/task-cards/pr-274.yaml
@@ -1,0 +1,110 @@
+version: "v0.2"
+
+task:
+  id: "pr-274"
+  title: "Authorize EmailService getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-email-service-getter-retirement-authorization"
+  objective: "authorize a future implementation branch for retiring the EmailService module-level getter"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-email-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-email-service-getter-retirement-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/email-service-getter-retirement-authorization-2026-05-26.json"
+    - "docs/reports/quality/backend-email-service-getter-retirement-authorization-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-274.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not delete EmailService getter in this PR"
+  - "Do not modify notification routes or route contracts"
+  - "Do not modify OpenAPI exposure"
+  - "Do not change frontend code"
+  - "Do not change PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not authorize implementation beyond future G2.122"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 273 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-email-service-getter-retirement-authorization-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/email-service-getter-retirement-authorization-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-274.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-274.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If future implementation ignores GitNexus route callers, notification dependency injection could regress"
+    - "If this packet is treated as implementation authorization, source edits could skip G2.122 review"
+  rollback_plan: "revert this governance-only authorization PR and keep G2.120 as the latest accepted candidate refresh"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize future EmailService module getter retirement"
+    modified_scope: "steward tree, authorization report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; authorization-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent PR state, authorization evidence, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T08:24:45+08:00"
+    approval_note: "G2.120 PR #273 selected EmailService as the next authorization candidate; this PR does not implement it"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- authorize future G2.122 implementation branch for retiring email_service.py _email_service and get_email_service
- preserve EmailService, install_email_service, get_email_service_dependency, notification routes, and OpenAPI exposure
- no source/test/API/OpenAPI/frontend/PM2/OpenSpec/issue-label changes are made here

## Evidence
- parent PR #273: MERGED at 1f117e1c7aa0333b6c0de272d697043f59f56bc9
- get_email_service definitions=1; _email_service tokens=5
- exact API direct getter refs=0; exact adapter direct getter refs=0
- route Depends(get_email_service_dependency) refs=6
- GitNexus impact: MEDIUM, impacted_count=6, affected_processes=0

## Verification
- markdown governance: errors=0
- JSON/YAML parse and cached diff check: passed
- GitNexus staged detect_changes: low, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: completed