### PR TITLE
G2.122 Retire EmailService module getter

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -1997,7 +1997,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, implementation authorization, or
 │   │                issue-label change is made here
 │   ├── G2.121 EmailService getter-retirement authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#274` merged at
+│   │   │          `5b944a53a8a6f960ec1420cfd2a885c364d97bf3`
 │   │   ├── Evidence: `backend-email-service-getter-retirement-authorization-2026-05-26.md`
 │   │   ├── Current HEAD: `1f117e1c7aa0333b6c0de272d697043f59f56bc9`
 │   │   ├── Result: authorizes only a future G2.122 implementation branch to
@@ -2013,9 +2014,31 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: authorization-only; no backend source/test edit, route/API,
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                implementation, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.121; if accepted,
-│                  create G2.122 EmailService getter-retirement implementation
-│                  before any email service source edit
+│   ├── G2.122 EmailService getter-retirement implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-email-service-getter-retirement-implementation-2026-05-26.md`
+│   │   ├── Current HEAD: `5b944a53a8a6f960ec1420cfd2a885c364d97bf3`
+│   │   ├── Result: removes only `email_service.py` `_email_service` and
+│   │   │          `get_email_service`, changes the installer fallback to
+│   │   │          construct `EmailService()` directly, removes obsolete fake
+│   │   │          getter exposure from focused tests, and adds retirement
+│   │   │          regression coverage
+│   │   ├── Verification: TDD red `1 failed`, focused green `7 passed`,
+│   │   │          health route conflicts `120 passed`, touched-file ruff and
+│   │   │          black checks passed; exact scan reports target getter
+│   │   │          definitions=`0`, target singleton tokens=`0`, app/API
+│   │   │          direct getter refs=`0`, and route dependency handlers=`6`
+│   │   └── Boundary: source-capable but limited to `email_service.py`,
+│   │                `test_email_service_lifecycle_di.py`,
+│   │                `test_notification_logging.py`,
+│   │                `test_email_service_getter_retirement.py`, governance
+│   │                report, generated artifact, task card, and steward-tree
+│   │                update; no route/API, OpenAPI exposure, frontend, PM2,
+│   │                OpenSpec, `EmailService` deletion, dependency deletion,
+│   │                or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.122; if accepted,
+│                  create G2.123 EmailService getter-retirement closeout before
+│                  selecting the next service lifecycle getter lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/email-service-getter-retirement-implementation-2026-05-26.json
+++ b/.planning/codebase/generated/email-service-getter-retirement-implementation-2026-05-26.json
@@ -1,0 +1,130 @@
+{
+  "artifact": "email-service-getter-retirement-implementation-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T08:40:12+08:00",
+  "branch": "g2-122-email-service-getter-retirement-implementation",
+  "base_head": "5b944a53a8a6f960ec1420cfd2a885c364d97bf3",
+  "current_head_checked_at_review": "2026-05-26T08:40:12+08:00",
+  "parent_authorization": {
+    "node": "G2.121",
+    "pr": 274,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T00:33:28Z",
+    "merge_commit": "5b944a53a8a6f960ec1420cfd2a885c364d97bf3",
+    "authorized_scope": "retire email_service.py _email_service and get_email_service while preserving EmailService, install_email_service, get_email_service_dependency, notification routes, and OpenAPI exposure"
+  },
+  "governance_node": {
+    "id": "G2.122",
+    "lane": "service_lifecycle_di",
+    "type": "implementation",
+    "state": "ready_for_review"
+  },
+  "changed_runtime_files": [
+    "web/backend/app/services/email_service.py"
+  ],
+  "changed_test_files": [
+    "web/backend/tests/test_email_service_lifecycle_di.py",
+    "web/backend/tests/test_notification_logging.py",
+    "web/backend/tests/test_email_service_getter_retirement.py"
+  ],
+  "preserved_symbols": [
+    "EmailService",
+    "install_email_service",
+    "get_email_service_dependency",
+    "EMAIL_SERVICE_STATE_KEY"
+  ],
+  "retired_symbols": [
+    "web/backend/app/services/email_service.py:_email_service",
+    "web/backend/app/services/email_service.py:get_email_service"
+  ],
+  "pre_edit_evidence": {
+    "standards_read": true,
+    "parent_pr_state": "MERGED",
+    "target_context": {
+      "target": "web/backend/app/services/email_service.py:get_email_service",
+      "graph_route_callers": 6,
+      "processes": 0
+    },
+    "target_impact": {
+      "target": "get_email_service",
+      "risk": "MEDIUM",
+      "impacted_count": 6,
+      "affected_processes": 0
+    }
+  },
+  "implementation": {
+    "email_service_py": [
+      "removed module-level _email_service",
+      "removed get_email_service",
+      "changed install_email_service fallback to construct EmailService() directly"
+    ],
+    "test_email_service_lifecycle_di_py": [
+      "removed obsolete fake module get_email_service exposure",
+      "changed fallback installation test to monkeypatch EmailService instead of the retired getter"
+    ],
+    "test_notification_logging_py": [
+      "removed obsolete fake module get_email_service exposure"
+    ],
+    "test_email_service_getter_retirement_py": [
+      "added focused absence/preservation regression coverage"
+    ]
+  },
+  "post_change_scan": {
+    "target_getter_definitions": 0,
+    "target_singleton_tokens_in_service": 0,
+    "api_direct_getter_refs": 0,
+    "api_direct_getter_ref_files": 0,
+    "app_direct_getter_refs": 0,
+    "app_direct_getter_ref_files": 0,
+    "test_direct_getter_refs": 2,
+    "test_direct_getter_ref_files": 2,
+    "dependency_refs": 8,
+    "route_depends_refs": 6,
+    "install_refs": 2,
+    "files_scanned": 777
+  },
+  "verification": {
+    "tdd_red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_service_getter_retirement.py -q --no-cov --tb=short",
+      "result": "1 failed",
+      "expected_failure": "get_email_service still existed before implementation"
+    },
+    "focused_green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_service_getter_retirement.py web/backend/tests/test_email_service_lifecycle_di.py web/backend/tests/test_notification_logging.py -q --no-cov --tb=short",
+      "result": "7 passed"
+    },
+    "health_route_conflicts": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "120 passed"
+    },
+    "ruff_touched_files": {
+      "command": "ruff check web/backend/app/services/email_service.py web/backend/tests/test_email_service_lifecycle_di.py web/backend/tests/test_notification_logging.py web/backend/tests/test_email_service_getter_retirement.py",
+      "result": "passed"
+    },
+    "black_touched_files": {
+      "command": "black --check web/backend/app/services/email_service.py web/backend/tests/test_email_service_lifecycle_di.py web/backend/tests/test_notification_logging.py web/backend/tests/test_email_service_getter_retirement.py",
+      "result": "passed"
+    },
+    "gitnexus_staged_detect_changes": {
+      "scope": "staged",
+      "risk_level": "low",
+      "changed_count": 18,
+      "changed_files": 8,
+      "affected_count": 0,
+      "affected_processes": 0,
+      "note": "GitNexus reported several symbols in email_service.py and test_notification_logging.py as modified from the staged file diff; no affected execution flow was reported"
+    }
+  },
+  "boundary": {
+    "routes_changed": false,
+    "openapi_changed": false,
+    "frontend_changed": false,
+    "pm2_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "email_service_class_deleted": false,
+    "install_email_service_deleted": false,
+    "dependency_deleted": false
+  },
+  "next_gate": "human review / PR merge decision for G2.122; if accepted, create G2.123 closeout before selecting the next service lifecycle getter lane"
+}

--- a/docs/reports/quality/backend-email-service-getter-retirement-implementation-2026-05-26.md
+++ b/docs/reports/quality/backend-email-service-getter-retirement-implementation-2026-05-26.md
@@ -1,0 +1,117 @@
+# Backend EmailService Getter Retirement Implementation - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Ready for review.
+
+## Parent Gate
+
+| Field | Value |
+|---|---|
+| Parent node | G2.121 EmailService getter-retirement authorization |
+| Parent PR | `#274` |
+| Parent state | `MERGED` |
+| Parent merge commit | `5b944a53a8a6f960ec1420cfd2a885c364d97bf3` |
+| Parent merged at | `2026-05-26T00:33:28Z` |
+| Implementation branch | `g2-122-email-service-getter-retirement-implementation` |
+| Implementation base HEAD | `5b944a53a8a6f960ec1420cfd2a885c364d97bf3` |
+
+## Scope
+
+Changed files:
+
+- `web/backend/app/services/email_service.py`
+- `web/backend/tests/test_email_service_lifecycle_di.py`
+- `web/backend/tests/test_notification_logging.py`
+- `web/backend/tests/test_email_service_getter_retirement.py`
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/email-service-getter-retirement-implementation-2026-05-26.json`
+- `governance/mainline/task-cards/pr-275.yaml`
+
+No route/API files, OpenAPI artifacts, frontend files, PM2 workflows,
+OpenSpec changes/specs, or issue-label state were changed.
+
+## Pre-Edit Evidence
+
+| Gate | Result |
+|---|---|
+| `architecture/STANDARDS.md` | read before source edit |
+| Parent PR `#274` | `MERGED` |
+| GitNexus context | `get_email_service` located in `web/backend/app/services/email_service.py`; graph reports 6 notification route callers |
+| GitNexus impact | `MEDIUM`, impacted count `6`, affected processes `0` |
+
+Exact text scan before implementation showed API direct getter refs=`0` and
+routes using `get_email_service_dependency`.
+
+## Implementation
+
+`web/backend/app/services/email_service.py`:
+
+- removed the module-level `_email_service`
+- removed `get_email_service`
+- changed `install_email_service` to construct `EmailService()` directly when no
+  explicit service is supplied
+
+`web/backend/tests/test_email_service_lifecycle_di.py`:
+
+- removed obsolete fake module `get_email_service` exposure
+- changed the app-state fallback test to monkeypatch `EmailService` rather than
+  the retired getter
+
+`web/backend/tests/test_notification_logging.py`:
+
+- removed obsolete fake module `get_email_service` exposure
+
+`web/backend/tests/test_email_service_getter_retirement.py`:
+
+- added focused regression coverage proving the legacy getter and singleton are
+  absent while the app-state installer and dependency remain importable
+
+## Verification
+
+| Check | Command | Result |
+|---|---|---|
+| TDD red | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_service_getter_retirement.py -q --no-cov --tb=short` | `1 failed`; failure proved `get_email_service` still existed before implementation |
+| Focused green | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_service_getter_retirement.py web/backend/tests/test_email_service_lifecycle_di.py web/backend/tests/test_notification_logging.py -q --no-cov --tb=short` | `7 passed` |
+| Health route conflicts | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `120 passed` |
+| Ruff touched files | `ruff check web/backend/app/services/email_service.py web/backend/tests/test_email_service_lifecycle_di.py web/backend/tests/test_notification_logging.py web/backend/tests/test_email_service_getter_retirement.py` | passed |
+| Black touched files | `black --check web/backend/app/services/email_service.py web/backend/tests/test_email_service_lifecycle_di.py web/backend/tests/test_notification_logging.py web/backend/tests/test_email_service_getter_retirement.py` | passed |
+| Exact post-change scan | scripted text scan over backend app/tests | target getter definitions=`0`; target singleton tokens in service=`0`; app/API direct getter refs=`0`; test direct getter refs=`2` in absence assertions; dependency refs=`8`; route dependency handlers=`6`; install refs=`2`; files scanned=`777` |
+| GitNexus staged detect changes | `detect_changes(scope="staged")` | risk=`low`; changed count=`18`; changed files=`8`; affected count=`0`; affected processes=`0` |
+
+## Boundary Confirmation
+
+Preserved:
+
+- `EmailService`
+- `install_email_service`
+- `get_email_service_dependency`
+- `EMAIL_SERVICE_STATE_KEY`
+- notification route dependency injection
+- OpenAPI exposure
+
+Retired:
+
+- `web/backend/app/services/email_service.py:_email_service`
+- `web/backend/app/services/email_service.py:get_email_service`
+
+Not changed:
+
+- notification route handlers
+- route paths, response models, response shapes, or OpenAPI exposure
+- frontend code
+- PM2 workflows
+- OpenSpec proposals/specs
+- GitHub issue labels or readiness state
+- broader email service behavior
+
+## Next Gate
+
+Human review and PR merge decision for G2.122.
+
+If accepted, create G2.123 as a closeout/current-head verification packet before
+selecting the next service lifecycle getter lane.

--- a/governance/mainline/task-cards/pr-275.yaml
+++ b/governance/mainline/task-cards/pr-275.yaml
@@ -1,0 +1,127 @@
+version: "v0.2"
+
+task:
+  id: "pr-275"
+  title: "Retire EmailService module-level getter"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-email-service-getter-retirement-implementation"
+  objective: "retire the EmailService module-level getter and singleton while preserving app-state dependency injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-email-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-email-service-getter-retirement-implementation"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow service getter retirement; no route, public API surface, OpenAPI exposure, frontend behavior, or OpenSpec capability is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/email-service-getter-retirement-implementation-2026-05-26.json"
+    - "docs/reports/quality/backend-email-service-getter-retirement-implementation-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-275.yaml"
+    - "web/backend/app/services/email_service.py"
+    - "web/backend/tests/test_email_service_lifecycle_di.py"
+    - "web/backend/tests/test_notification_logging.py"
+    - "web/backend/tests/test_email_service_getter_retirement.py"
+  forbidden_paths:
+    - "web/backend/app/api/**"
+    - "web/backend/app/main.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit notification route handlers"
+  - "Do not modify route paths, response models, response shapes, or OpenAPI exposure"
+  - "Do not modify frontend code"
+  - "Do not modify PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not delete or rename EmailService"
+  - "Do not delete or alter install_email_service"
+  - "Do not delete or alter get_email_service_dependency"
+  - "Do not perform broader email service consolidation"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 274 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url"
+      required: true
+    - id: "focused-green-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_service_getter_retirement.py web/backend/tests/test_email_service_lifecycle_di.py web/backend/tests/test_notification_logging.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-files"
+      command: "ruff check web/backend/app/services/email_service.py web/backend/tests/test_email_service_lifecycle_di.py web/backend/tests/test_notification_logging.py web/backend/tests/test_email_service_getter_retirement.py"
+      required: true
+    - id: "black-touched-files"
+      command: "black --check web/backend/app/services/email_service.py web/backend/tests/test_email_service_lifecycle_di.py web/backend/tests/test_notification_logging.py web/backend/tests/test_email_service_getter_retirement.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-email-service-getter-retirement-implementation-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/email-service-getter-retirement-implementation-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-275.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-275.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If route/API files are edited, notification route contracts or OpenAPI exposure could drift outside the authorization"
+    - "If install_email_service or get_email_service_dependency are removed, route dependency injection could regress"
+  rollback_plan: "revert this narrow implementation PR and keep G2.121 authorization as the latest accepted email getter gate"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "retire EmailService module-level getter and singleton"
+    modified_scope: "one service file, three focused tests, steward tree, implementation report, generated artifact, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "module-level getter removed; app-state installer and dependency preserved"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, health route conflicts, touched-file lint/format, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T08:40:12+08:00"
+    approval_note: "G2.121 PR #274 authorized this narrow implementation; no route/API, OpenAPI, frontend, PM2, OpenSpec, or issue-label change is allowed"
+    secondary_approved: false

--- a/web/backend/app/services/email_service.py
+++ b/web/backend/app/services/email_service.py
@@ -317,27 +317,12 @@ class EmailService:
         )
 
 
-# 全局邮件服务实例（单例模式）
-_email_service = None
 EMAIL_SERVICE_STATE_KEY = "email_service"
-
-
-def get_email_service() -> EmailService:
-    """
-    获取邮件服务实例（单例）
-
-    Returns:
-        EmailService: 邮件服务实例
-    """
-    global _email_service
-    if _email_service is None:
-        _email_service = EmailService()
-    return _email_service
 
 
 def install_email_service(app: Any, service: EmailService | None = None) -> EmailService:
     """Install the email service instance on FastAPI app.state."""
-    selected_service = service if service is not None else get_email_service()
+    selected_service = service if service is not None else EmailService()
     setattr(app.state, EMAIL_SERVICE_STATE_KEY, selected_service)
     return selected_service
 

--- a/web/backend/tests/test_email_service_getter_retirement.py
+++ b/web/backend/tests/test_email_service_getter_retirement.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from app.services import email_service
+
+
+def test_legacy_getter_and_module_singleton_are_retired():
+    assert hasattr(email_service, "EmailService")
+    assert hasattr(email_service, "install_email_service")
+    assert hasattr(email_service, "get_email_service_dependency")
+    assert not hasattr(email_service, "get_email_service")
+    assert not hasattr(email_service, "_email_service")

--- a/web/backend/tests/test_email_service_lifecycle_di.py
+++ b/web/backend/tests/test_email_service_lifecycle_di.py
@@ -59,7 +59,6 @@ def load_notification_module():
     fake_auth.get_current_user = lambda: None
     fake_auth.get_current_active_user = lambda: None
     fake_email_service.EmailService = FakeEmailService
-    fake_email_service.get_email_service = lambda: FakeEmailService()
     fake_email_service.get_email_service_dependency = lambda: FakeEmailService()
 
     previous = {
@@ -110,7 +109,7 @@ def test_email_service_dependency_installs_app_state_when_missing(monkeypatch):
     fake_app = SimpleNamespace(state=SimpleNamespace())
     request = SimpleNamespace(app=fake_app)
 
-    monkeypatch.setattr(module, "get_email_service", lambda: fake_service)
+    monkeypatch.setattr(module, "EmailService", lambda: fake_service)
 
     assert module.get_email_service_dependency(request) is fake_service
     assert getattr(fake_app.state, module.EMAIL_SERVICE_STATE_KEY) is fake_service

--- a/web/backend/tests/test_notification_logging.py
+++ b/web/backend/tests/test_notification_logging.py
@@ -38,7 +38,6 @@ def load_notification_module():
     fake_auth.get_current_user = lambda: None
     fake_auth.get_current_active_user = lambda: None
     fake_email_service.EmailService = SimpleNamespace
-    fake_email_service.get_email_service = lambda: SimpleNamespace(is_configured=lambda: False)
     fake_email_service.get_email_service_dependency = lambda: SimpleNamespace(is_configured=lambda: False)
 
     previous = {


### PR DESCRIPTION
## Summary
- retire email_service.py module-level _email_service and get_email_service
- keep EmailService, install_email_service, and get_email_service_dependency intact
- update lifecycle/logging fakes and add focused getter-retirement regression coverage
- update steward tree, generated evidence, implementation report, and task card

## Verification
- TDD red: 1 failed before implementation
- focused tests: 7 passed
- health route conflicts: 120 passed
- ruff check touched files: passed
- black --check touched files: passed
- exact scan: target getter definitions=0, singleton tokens=0, app/API direct getter refs=0, route dependency handlers=6
- markdown governance: errors=0
- JSON/YAML parse and cached diff check: passed
- GitNexus staged detect_changes: low, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: completed