### PR TITLE
G2.123 Close out EmailService getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2015,7 +2015,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                implementation, or issue-label change is made here
 │   ├── G2.122 EmailService getter-retirement implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#275` merged at
+│   │   │          `22021dc8e4faf5b2f206878fbd50bf553635ffc3`
 │   │   ├── Evidence: `backend-email-service-getter-retirement-implementation-2026-05-26.md`
 │   │   ├── Current HEAD: `5b944a53a8a6f960ec1420cfd2a885c364d97bf3`
 │   │   ├── Result: removes only `email_service.py` `_email_service` and
@@ -2036,9 +2037,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                update; no route/API, OpenAPI exposure, frontend, PM2,
 │   │                OpenSpec, `EmailService` deletion, dependency deletion,
 │   │                or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.122; if accepted,
-│                  create G2.123 EmailService getter-retirement closeout before
-│                  selecting the next service lifecycle getter lane
+│   ├── G2.123 EmailService getter-retirement closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-email-service-getter-retirement-closeout-2026-05-26.md`
+│   │   ├── Current HEAD: `22021dc8e4faf5b2f206878fbd50bf553635ffc3`
+│   │   ├── Result: records PR `#275` as merged, verifies current-head
+│   │   │          getter-retirement state, and closes the EmailService getter
+│   │   │          retirement lane as implementation-complete pending review
+│   │   ├── Verification: parent PR `#275` state=`MERGED`, focused tests
+│   │   │          `7 passed`, health route conflicts `120 passed`, exact scan
+│   │   │          reports target getter definitions=`0`, target singleton
+│   │   │          variable tokens=`0`, app/API direct getter refs=`0`, and
+│   │   │          route dependency handlers=`6`
+│   │   └── Boundary: closeout-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                implementation authorization, next-lane authorization, or
+│   │                issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.123; if accepted,
+│                  select the next service lifecycle getter lane from the latest
+│                  candidate refresh instead of reusing stale pre-G2.122 counts
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/email-service-getter-retirement-closeout-2026-05-26.json
+++ b/.planning/codebase/generated/email-service-getter-retirement-closeout-2026-05-26.json
@@ -1,0 +1,74 @@
+{
+  "artifact": "email-service-getter-retirement-closeout-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T08:58:17+08:00",
+  "branch": "g2-123-email-service-getter-retirement-closeout",
+  "current_head": "22021dc8e4faf5b2f206878fbd50bf553635ffc3",
+  "current_head_checked_at_review": "2026-05-26T08:58:17+08:00",
+  "parent_implementation": {
+    "node": "G2.122 EmailService getter-retirement implementation",
+    "pr": 275,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T00:53:06Z",
+    "merge_commit": "22021dc8e4faf5b2f206878fbd50bf553635ffc3",
+    "url": "https://github.com/chengjon/mystocks/pull/275"
+  },
+  "governance_node": {
+    "current": "G2.123 EmailService getter-retirement closeout",
+    "next_gate": "human review / PR merge decision for G2.123; if accepted, select the next service lifecycle getter lane from the latest candidate refresh"
+  },
+  "current_head_scan": {
+    "backend_app_and_test_python_files_scanned": 777,
+    "target_getter_definitions": 0,
+    "target_singleton_variable_tokens": 0,
+    "api_direct_getter_call_refs": 0,
+    "app_direct_getter_call_refs": 0,
+    "test_direct_getter_call_refs": 0,
+    "dependency_refs": 12,
+    "route_dependency_handlers": 6,
+    "installer_refs": 3,
+    "notes": [
+      "`_email_service` singleton variable token is absent. Substring appearances only remain inside preserved names such as `install_email_service` and `get_email_service_dependency`.",
+      "`get_email_service_dependency` remains preserved because notification routes still depend on the app-state dependency boundary."
+    ]
+  },
+  "verification": {
+    "focused_tests": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_service_getter_retirement.py web/backend/tests/test_email_service_lifecycle_di.py web/backend/tests/test_notification_logging.py -q --no-cov --tb=short",
+      "result": "7 passed"
+    },
+    "health_route_conflicts": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "120 passed"
+    },
+    "parent_pr_state": {
+      "command": "gh pr view 275 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title",
+      "result": "MERGED"
+    },
+    "exact_scan": {
+      "result": "target_getter_definitions=0; target_singleton_variable_tokens=0; api_direct_getter_call_refs=0; app_direct_getter_call_refs=0; route_dependency_handlers=6"
+    },
+    "gitnexus_staged_detect_changes": {
+      "scope": "staged",
+      "risk_level": "low",
+      "changed_count": 0,
+      "changed_files": 4,
+      "affected_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "boundary": {
+    "closeout_only": true,
+    "source_edits": false,
+    "test_edits": false,
+    "route_or_api_edits": false,
+    "openapi_edits": false,
+    "frontend_edits": false,
+    "pm2_edits": false,
+    "openspec_edits": false,
+    "issue_label_changes": false,
+    "next_lane_authorization": false
+  },
+  "closeout_decision": "EmailService getter retirement implementation is merged and current-head verified. This packet closes the lane for review but does not authorize the next implementation lane.",
+  "next_gate": "Review and merge this closeout. After acceptance, use the latest service lifecycle candidate refresh to select the next getter lane."
+}

--- a/docs/reports/quality/backend-email-service-getter-retirement-closeout-2026-05-26.md
+++ b/docs/reports/quality/backend-email-service-getter-retirement-closeout-2026-05-26.md
@@ -1,0 +1,88 @@
+# Backend EmailService Getter Retirement Closeout - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Ready for review.
+
+This is a closeout-only governance packet for the merged G2.122 EmailService
+getter retirement implementation. It records the parent merge, verifies the
+current-head state, updates the steward tree, and preserves the next-gate
+boundary.
+
+## Parent Merge
+
+| Field | Value |
+|---|---|
+| Parent node | G2.122 EmailService getter-retirement implementation |
+| Parent PR | `#275` |
+| Parent state | `MERGED` |
+| Parent merge commit | `22021dc8e4faf5b2f206878fbd50bf553635ffc3` |
+| Parent merged at | `2026-05-26T00:53:06Z` |
+| Parent URL | `https://github.com/chengjon/mystocks/pull/275` |
+| Closeout branch | `g2-123-email-service-getter-retirement-closeout` |
+| Current HEAD | `22021dc8e4faf5b2f206878fbd50bf553635ffc3` |
+
+## Closeout Decision
+
+G2.122 is accepted as the implementation-complete parent for the EmailService
+getter retirement lane.
+
+The current checkout verifies that `web/backend/app/services/email_service.py`
+no longer defines the module-level `get_email_service` getter or `_email_service`
+singleton variable. The preserved service boundary remains:
+
+- `EmailService`
+- `install_email_service`
+- `get_email_service_dependency`
+- notification route paths, response contracts, and OpenAPI exposure
+
+This packet does not authorize the next implementation lane. After this closeout
+is reviewed and merged, the next lane must be selected from the latest service
+lifecycle candidate refresh instead of reusing stale pre-G2.122 counts.
+
+## Current-Head Evidence
+
+| Check | Result |
+|---|---|
+| Backend app/test Python files scanned | `777` |
+| Target getter definitions | `0` |
+| Target singleton variable tokens | `0` |
+| API direct getter call refs | `0` |
+| App direct getter call refs | `0` |
+| Test direct getter call refs | `0` |
+| Dependency refs | `12` |
+| Route dependency handlers | `6` |
+| Installer refs | `3` |
+
+Note: substring appearances of `_email_service` only remain inside preserved
+names such as `install_email_service` and `get_email_service_dependency`. The
+standalone singleton variable token is absent.
+
+## Verification
+
+| Check | Command | Result |
+|---|---|---|
+| Parent PR state | `gh pr view 275 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title` | `MERGED`, merge commit `22021dc8e4faf5b2f206878fbd50bf553635ffc3` |
+| Focused tests | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_service_getter_retirement.py web/backend/tests/test_email_service_lifecycle_di.py web/backend/tests/test_notification_logging.py -q --no-cov --tb=short` | `7 passed` |
+| Health route conflicts | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `120 passed` |
+| Current-head scan | scripted text scan | getter=`0`, singleton variable=`0`, app/API direct refs=`0`, route dependency handlers=`6` |
+| GitNexus staged detect changes | `detect_changes(scope="staged")` | risk=`low`; changed count=`0`; changed files=`4`; affected count=`0`; affected processes=`0` |
+
+## Boundary Confirmation
+
+- No backend source or test files are edited in this closeout.
+- No route path, response model, response shape, or OpenAPI exposure is changed.
+- No frontend, PM2, OpenSpec, issue-label, or runtime configuration file is changed.
+- No next service lifecycle getter lane is authorized here.
+- No `EmailService`, `install_email_service`, or `get_email_service_dependency`
+  deletion is authorized here.
+
+## Next Gate
+
+Review and merge this closeout. After acceptance, select the next service
+lifecycle getter lane from the latest candidate refresh and create a separate
+authorization packet before any source edit.

--- a/governance/mainline/task-cards/pr-276.yaml
+++ b/governance/mainline/task-cards/pr-276.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-276"
+  title: "Close out EmailService getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-email-service-getter-retirement-closeout"
+  objective: "record the merged EmailService getter retirement and verify current-head closeout evidence"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-email-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-email-service-getter-retirement-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/email-service-getter-retirement-closeout-2026-05-26.json"
+    - "docs/reports/quality/backend-email-service-getter-retirement-closeout-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-276.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not edit notification route handlers"
+  - "Do not modify route paths, response models, response shapes, or OpenAPI exposure"
+  - "Do not modify frontend code"
+  - "Do not modify PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not authorize the next implementation lane"
+  - "Do not delete or alter EmailService"
+  - "Do not delete or alter install_email_service"
+  - "Do not delete or alter get_email_service_dependency"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 275 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "focused-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_email_service_getter_retirement.py web/backend/tests/test_email_service_lifecycle_di.py web/backend/tests/test_notification_logging.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-email-service-getter-retirement-closeout-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/email-service-getter-retirement-closeout-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-276.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-276.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If closeout is mistaken for implementation authorization, a next source lane could skip candidate refresh"
+    - "If parent PR state is not verified, the steward tree could record an unmerged implementation as closed"
+  rollback_plan: "revert this governance-only closeout PR and keep G2.122 as the latest implementation gate"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out merged EmailService getter retirement"
+    modified_scope: "steward tree, closeout report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; closeout-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent PR state, current-head scan, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T08:58:17+08:00"
+    approval_note: "Closeout-only packet after PR #275 merge; next implementation lane is not authorized here"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record PR #275 as merged for G2.122 EmailService getter retirement
- verify current-head EmailService getter retirement state
- add G2.123 closeout report, generated evidence, task card, and steward tree update
- preserve the boundary that no next implementation lane is authorized here

## Verification
- parent PR #275: MERGED at 22021dc8e4faf5b2f206878fbd50bf553635ffc3
- focused tests: 7 passed
- health route conflicts: 120 passed
- exact scan: target getter definitions=0, singleton variable tokens=0, app/API direct getter refs=0, route dependency handlers=6
- markdown governance: errors=0
- JSON/YAML parse: passed
- GitNexus staged detect_changes: low, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: completed