### PR TITLE
G2.124 Refresh service lifecycle candidates after EmailService

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2038,7 +2038,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenSpec, `EmailService` deletion, dependency deletion,
 │   │                or issue-label change is made here
 │   ├── G2.123 EmailService getter-retirement closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#276` merged at
+│   │   │          `0b761555dd96865e571f7c9ebc1959b8254f52ef`
 │   │   ├── Evidence: `backend-email-service-getter-retirement-closeout-2026-05-26.md`
 │   │   ├── Current HEAD: `22021dc8e4faf5b2f206878fbd50bf553635ffc3`
 │   │   ├── Result: records PR `#275` as merged, verifies current-head
@@ -2053,9 +2054,31 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                implementation authorization, next-lane authorization, or
 │   │                issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.123; if accepted,
-│                  select the next service lifecycle getter lane from the latest
-│                  candidate refresh instead of reusing stale pre-G2.122 counts
+│   ├── G2.124 Service lifecycle candidate refresh after EmailService
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-email-2026-05-26.md`
+│   │   ├── Current HEAD: `0b761555dd96865e571f7c9ebc1959b8254f52ef`
+│   │   ├── Result: refreshes the getter candidate pool after EmailService
+│   │   │          retirement; confirms AnnouncementService and EmailService
+│   │   │          getter definitions and singleton variables remain absent
+│   │   ├── Candidate note: no low-risk direct implementation candidate is
+│   │   │          selected here; `get_stock_search_service` is the next
+│   │   │          authorization candidate only because text scan shows no API
+│   │   │          or adapter direct getter calls, but GitNexus impact is
+│   │   │          CRITICAL and must be explicitly accepted before any source edit
+│   │   ├── Hold notes: `get_watchlist_service` remains held behind service
+│   │   │          adapter seams; `get_market_data_service` requires symbol
+│   │   │          disambiguation because text scan and GitNexus impact disagree;
+│   │   │          `get_tdx_service`, `get_data_service`, `get_strategy_service`,
+│   │   │          and `get_streaming_service` remain high/critical-risk lanes
+│   │   └── Boundary: candidate-refresh-only; no backend source/test edit,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                getter deletion, implementation authorization, or
+│   │                issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.124; if accepted,
+│                  create a G2.125 `get_stock_search_service` authorization
+│                  packet with explicit CRITICAL GitNexus risk disclosure and
+│                  d=1 route/test acceptance criteria before any source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-email-2026-05-26.json
+++ b/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-email-2026-05-26.json
@@ -1,0 +1,164 @@
+{
+  "artifact": "service-lifecycle-candidate-refresh-after-email-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T09:10:16+08:00",
+  "branch": "g2-124-service-lifecycle-candidate-refresh-after-email",
+  "current_head": "0b761555dd96865e571f7c9ebc1959b8254f52ef",
+  "current_head_checked_at_review": "2026-05-26T09:10:16+08:00",
+  "parent_closeout": {
+    "node": "G2.123 EmailService getter-retirement closeout",
+    "pr": 276,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T01:06:19Z",
+    "merge_commit": "0b761555dd96865e571f7c9ebc1959b8254f52ef",
+    "url": "https://github.com/chengjon/mystocks/pull/276"
+  },
+  "scan_scope": {
+    "service_files": 152,
+    "backend_app_files": 575,
+    "api_files": 219,
+    "adapter_files": 8,
+    "backend_test_files": 202
+  },
+  "retired_getter_check": {
+    "get_announcement_service_definitions": 0,
+    "get_email_service_definitions": 0,
+    "announcement_singleton_variable_tokens": 0,
+    "email_singleton_variable_tokens": 0
+  },
+  "candidate_pool": {
+    "getter_definitions": 13,
+    "bucket_counts": {
+      "hold_app_direct_calls": 9,
+      "needs_review": 2,
+      "route_dependency_candidate": 2
+    },
+    "selected_next_authorization_candidate": "get_stock_search_service",
+    "selected_next_authorization_candidate_reason": "Text scan shows no API or adapter direct getter calls and routes already use the dependency boundary, but GitNexus impact is CRITICAL, so this is authorization-only and not implementation-ready.",
+    "candidates": [
+      {
+        "name": "get_stock_search_service",
+        "file": "web/backend/app/services/stock_search_service/stock_search_service.py",
+        "text_bucket": "route_dependency_candidate",
+        "api_direct_calls": 0,
+        "adapter_direct_calls": 0,
+        "route_dependency_handlers": 6,
+        "dependency_refs": 12,
+        "gitnexus_risk": "CRITICAL",
+        "gitnexus_impacted_count": 6,
+        "gitnexus_processes_affected": 11,
+        "disposition": "next authorization candidate only; source edit requires explicit CRITICAL-risk acceptance"
+      },
+      {
+        "name": "get_watchlist_service",
+        "file": "web/backend/app/services/watchlist_service.py",
+        "text_bucket": "route_dependency_candidate_with_service_adapter_direct_calls",
+        "api_direct_calls": 0,
+        "service_adapter_direct_call_files": [
+          "web/backend/app/services/adapters/watchlist_adapter.py",
+          "web/backend/app/services/data_adapters/watchlist.py"
+        ],
+        "route_dependency_handlers": 7,
+        "dependency_refs": 10,
+        "gitnexus_risk": "MEDIUM",
+        "gitnexus_impacted_count": 15,
+        "gitnexus_processes_affected": 0,
+        "disposition": "hold behind service adapter seam"
+      },
+      {
+        "name": "get_market_data_service",
+        "file": "web/backend/app/services/__init__.py",
+        "text_bucket": "needs_review",
+        "api_direct_calls": 3,
+        "route_dependency_handlers": 7,
+        "dependency_refs": 16,
+        "gitnexus_risk": "LOW",
+        "gitnexus_impacted_count": 0,
+        "gitnexus_processes_affected": 0,
+        "disposition": "hold for symbol disambiguation because text scan and GitNexus impact disagree"
+      },
+      {
+        "name": "get_tdx_service",
+        "file": "web/backend/app/services/tdx_service.py",
+        "text_bucket": "needs_review",
+        "api_direct_calls": 3,
+        "route_dependency_handlers": 5,
+        "dependency_refs": 9,
+        "gitnexus_risk": "CRITICAL",
+        "gitnexus_impacted_count": 6,
+        "gitnexus_processes_affected": 5,
+        "disposition": "hold dashboard/process seam"
+      },
+      {
+        "name": "get_data_service",
+        "file": "web/backend/app/services/data_service.py",
+        "text_bucket": "hold_app_direct_calls",
+        "api_direct_calls": 7,
+        "route_dependency_handlers": 0,
+        "dependency_refs": 0,
+        "gitnexus_risk": "CRITICAL",
+        "gitnexus_impacted_count": 5,
+        "gitnexus_processes_affected": 7,
+        "disposition": "hold indicators/strategy seam"
+      },
+      {
+        "name": "get_strategy_service",
+        "file": "web/backend/app/services/strategy_service.py",
+        "text_bucket": "hold_app_direct_calls",
+        "api_direct_calls": 3,
+        "route_dependency_handlers": 0,
+        "dependency_refs": 0,
+        "gitnexus_risk": "CRITICAL",
+        "gitnexus_impacted_count": 13,
+        "gitnexus_processes_affected": 0,
+        "disposition": "hold adapters/tasks/strategy-management seam"
+      },
+      {
+        "name": "get_streaming_service",
+        "file": "web/backend/app/services/realtime_streaming_service.py",
+        "text_bucket": "hold_app_direct_calls",
+        "api_direct_calls": 0,
+        "route_dependency_handlers": 0,
+        "dependency_refs": 0,
+        "gitnexus_risk": "HIGH",
+        "gitnexus_impacted_count": 9,
+        "gitnexus_processes_affected": 0,
+        "disposition": "hold Socket.IO/streaming seam"
+      }
+    ]
+  },
+  "verification": {
+    "parent_pr_state": {
+      "command": "gh pr view 276 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title",
+      "result": "MERGED"
+    },
+    "candidate_scan": {
+      "command": "scripted current-head text scan over web/backend/app/services, web/backend/app/api, web/backend/app/adapters, and web/backend/tests",
+      "result": "13 getter definitions; AnnouncementService and EmailService retired getter/singleton tokens remain 0"
+    },
+    "gitnexus_impact_sampling": {
+      "result": "stock_search=CRITICAL/6/11 processes; watchlist=MEDIUM/15/0 processes; market_data=LOW/0/0 with symbol mismatch; tdx=CRITICAL/6/5 processes; data=CRITICAL/5/7 processes; strategy=CRITICAL/13/0 processes; streaming=HIGH/9/0 processes"
+    },
+    "gitnexus_staged_detect_changes": {
+      "scope": "staged",
+      "risk_level": "low",
+      "changed_count": 0,
+      "changed_files": 4,
+      "affected_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "boundary": {
+    "candidate_refresh_only": true,
+    "source_edits": false,
+    "test_edits": false,
+    "route_or_api_edits": false,
+    "openapi_edits": false,
+    "frontend_edits": false,
+    "pm2_edits": false,
+    "openspec_edits": false,
+    "issue_label_changes": false,
+    "implementation_authorization": false
+  },
+  "next_gate": "Review and merge this candidate refresh. If accepted, create a G2.125 get_stock_search_service authorization packet with explicit CRITICAL GitNexus risk disclosure and d=1 route/test acceptance criteria before any source edit."
+}

--- a/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-email-2026-05-26.md
+++ b/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-email-2026-05-26.md
@@ -1,0 +1,94 @@
+# Backend Service Lifecycle Candidate Refresh After EmailService - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Ready for review.
+
+This is a candidate-refresh-only governance packet after the merged G2.123
+EmailService getter-retirement closeout. It refreshes the service getter pool at
+current HEAD and selects only the next authorization candidate. It does not
+authorize source implementation.
+
+## Parent State
+
+| Field | Value |
+|---|---|
+| Parent node | G2.123 EmailService getter-retirement closeout |
+| Parent PR | `#276` |
+| Parent state | `MERGED` |
+| Parent merge commit | `0b761555dd96865e571f7c9ebc1959b8254f52ef` |
+| Parent merged at | `2026-05-26T01:06:19Z` |
+| Current HEAD | `0b761555dd96865e571f7c9ebc1959b8254f52ef` |
+
+## Scan Scope
+
+| Scope | Count |
+|---|---:|
+| Service files | `152` |
+| Backend app Python files | `575` |
+| API files | `219` |
+| Adapter files | `8` |
+| Backend test Python files | `202` |
+| Service getter definitions | `13` |
+
+## Retired Getter Confirmation
+
+| Check | Result |
+|---|---:|
+| `get_announcement_service` definitions | `0` |
+| `get_email_service` definitions | `0` |
+| `_announcement_service` singleton variable tokens | `0` |
+| `_email_service` singleton variable tokens | `0` |
+
+## Candidate Findings
+
+| Getter | Text-scan disposition | GitNexus risk | Decision |
+|---|---|---|---|
+| `get_stock_search_service` | No API or adapter direct getter calls; `6` route dependency handlers | `CRITICAL`, impacted=`6`, affected processes=`11` | Next authorization candidate only; requires explicit CRITICAL-risk acceptance |
+| `get_watchlist_service` | Route dependency candidate, but service adapter direct call files remain | `MEDIUM`, impacted=`15`, affected processes=`0` | Hold behind service adapter seam |
+| `get_market_data_service` | `3` API direct getter calls and `7` route dependency handlers | `LOW`, impacted=`0` | Hold for symbol disambiguation because text scan and GitNexus impact disagree |
+| `get_tdx_service` | Dashboard direct/API seam remains | `CRITICAL`, impacted=`6`, affected processes=`5` | Hold dashboard/process seam |
+| `get_data_service` | Indicator/strategy API direct calls remain | `CRITICAL`, impacted=`5`, affected processes=`7` | Hold indicators/strategy seam |
+| `get_strategy_service` | Adapter/task/strategy-management callers remain | `CRITICAL`, impacted=`13`, affected processes=`0` | Hold adapters/tasks/strategy-management seam |
+| `get_streaming_service` | Socket.IO/core streaming callers remain | `HIGH`, impacted=`9`, affected processes=`0` | Hold streaming seam |
+
+The remaining wrapper getters in `web/backend/app/services/__init__.py` are not
+selected in this refresh because they are package-level compatibility helpers
+or need symbol-disambiguation work before a source implementation plan.
+
+## Decision
+
+No low-risk direct implementation candidate is selected.
+
+The next gate is a G2.125 `get_stock_search_service` authorization packet only.
+That packet must explicitly disclose the CRITICAL GitNexus impact and must list
+d=1 route/test acceptance criteria before any source edit is allowed.
+
+## Verification
+
+| Check | Command | Result |
+|---|---|---|
+| Parent PR state | `gh pr view 276 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title` | `MERGED`, merge commit `0b761555dd96865e571f7c9ebc1959b8254f52ef` |
+| Candidate scan | scripted current-head text scan | `13` getter definitions; AnnouncementService and EmailService retired getter/singleton tokens remain `0` |
+| GitNexus impact sampling | `impact(direction="upstream")` for selected candidate set | stock search=`CRITICAL`; watchlist=`MEDIUM`; market data=`LOW` with symbol mismatch; tdx/data/strategy=`CRITICAL`; streaming=`HIGH` |
+| GitNexus staged detect changes | `detect_changes(scope="staged")` | risk=`low`; changed count=`0`; changed files=`4`; affected count=`0`; affected processes=`0` |
+
+## Boundary Confirmation
+
+- No backend source or test files are edited in this refresh.
+- No route path, response model, response shape, or OpenAPI exposure is changed.
+- No frontend, PM2, OpenSpec, issue-label, or runtime configuration file is changed.
+- No getter deletion or next implementation lane is authorized here.
+- Future `get_stock_search_service` work must start as an authorization packet,
+  not as a direct implementation branch.
+
+## Next Gate
+
+Review and merge this candidate refresh. If accepted, create a G2.125
+`get_stock_search_service` authorization packet with explicit CRITICAL
+GitNexus risk disclosure and d=1 route/test acceptance criteria before any
+source edit.

--- a/governance/mainline/task-cards/pr-277.yaml
+++ b/governance/mainline/task-cards/pr-277.yaml
@@ -1,0 +1,116 @@
+version: "v0.2"
+
+task:
+  id: "pr-277"
+  title: "Refresh service lifecycle candidates after EmailService"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-service-lifecycle-candidate-refresh-after-email"
+  objective: "refresh the service getter candidate pool after EmailService retirement and select only the next authorization candidate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-candidate-refresh"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-candidate-refresh-after-email"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate-refresh-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-candidate-refresh-after-email-2026-05-26.json"
+    - "docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-email-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-277.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not edit route handlers"
+  - "Do not modify route paths, response models, response shapes, or OpenAPI exposure"
+  - "Do not modify frontend code"
+  - "Do not modify PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not authorize implementation"
+  - "Do not delete or alter any service getter"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 276 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "candidate-scan"
+      command: "scripted current-head text scan over service getter definitions, retired getter tokens, route dependency handlers, and direct getter calls"
+      required: true
+    - id: "gitnexus-impact-sampling"
+      command: "GitNexus impact sampling for stock_search, watchlist, market_data, tdx, data, strategy, and streaming getters"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-email-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-candidate-refresh-after-email-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-277.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-277.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this refresh is mistaken for implementation authorization, a CRITICAL-risk stock search getter edit could proceed without d=1 route/test acceptance criteria"
+    - "If stale pre-G2.122 counts are reused, the next service lifecycle lane could be selected from obsolete evidence"
+  rollback_plan: "revert this governance-only refresh PR and keep G2.123 as the latest accepted closeout gate"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh service lifecycle getter candidates after EmailService retirement"
+    modified_scope: "steward tree, candidate refresh report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; refresh-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent PR state, candidate scan, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T09:10:16+08:00"
+    approval_note: "Candidate-refresh-only packet after PR #276 merge; next implementation lane is not authorized here"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- refresh service lifecycle getter candidates after EmailService retirement closeout
- confirm AnnouncementService and EmailService getter/singleton tokens remain retired
- select get_stock_search_service as the next authorization candidate only
- record CRITICAL GitNexus risk and prevent direct implementation authorization

## Verification
- parent PR #276: MERGED at 0b761555dd96865e571f7c9ebc1959b8254f52ef
- current-head scan: 13 service getter definitions; retired announcement/email getter and singleton tokens=0
- candidate finding: get_stock_search_service has no API/adapter direct getter calls, 6 route dependency handlers, GitNexus CRITICAL risk
- hold findings: watchlist behind service adapter seam; market_data symbol mismatch; tdx/data/strategy/streaming high or critical seams
- markdown governance: errors=0
- JSON/YAML parse: passed
- GitNexus staged detect_changes: low, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: completed