### PR TITLE
G2.125 Authorize StockSearchService getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2055,7 +2055,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                implementation authorization, next-lane authorization, or
 │   │                issue-label change is made here
 │   ├── G2.124 Service lifecycle candidate refresh after EmailService
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#277` merged at
+│   │   │          `4ce4abf60fec2719644d9f64cd657bb0b7d3c8c5`
 │   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-email-2026-05-26.md`
 │   │   ├── Current HEAD: `0b761555dd96865e571f7c9ebc1959b8254f52ef`
 │   │   ├── Result: refreshes the getter candidate pool after EmailService
@@ -2075,10 +2076,30 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                getter deletion, implementation authorization, or
 │   │                issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.124; if accepted,
-│                  create a G2.125 `get_stock_search_service` authorization
-│                  packet with explicit CRITICAL GitNexus risk disclosure and
-│                  d=1 route/test acceptance criteria before any source edit
+│   ├── G2.125 StockSearchService getter-retirement authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-stock-search-service-getter-retirement-authorization-2026-05-26.md`
+│   │   ├── Current HEAD: `4ce4abf60fec2719644d9f64cd657bb0b7d3c8c5`
+│   │   ├── Result: authorizes only a future G2.126 implementation branch to
+│   │   │          retire `stock_search_service.py` `_stock_search_service` and
+│   │   │          `get_stock_search_service`, while preserving
+│   │   │          `StockSearchService`, `install_stock_search_service`,
+│   │   │          `get_stock_search_service_dependency`, route paths, response
+│   │   │          contracts, and OpenAPI exposure
+│   │   ├── Risk note: GitNexus impact is CRITICAL with impacted count=`6` and
+│   │   │          affected processes=`11`; future implementation must update
+│   │   │          d=1 route/test acceptance criteria before source edit
+│   │   ├── Evidence note: text scan shows API direct getter calls=`0`, route
+│   │   │          dependency handlers=`6`, service self-calls=`2`, and existing
+│   │   │          P0 regression tests still assert the retired singleton/getter
+│   │   │          behavior and must be rewritten during implementation
+│   │   └── Boundary: authorization-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                implementation, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.125; if accepted,
+│                  create G2.126 StockSearchService getter-retirement
+│                  implementation with TDD red and CRITICAL-risk d=1 route/test
+│                  acceptance criteria before any source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/stock-search-service-getter-retirement-authorization-2026-05-26.json
+++ b/.planning/codebase/generated/stock-search-service-getter-retirement-authorization-2026-05-26.json
@@ -1,0 +1,154 @@
+{
+  "artifact": "stock-search-service-getter-retirement-authorization-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T09:21:33+08:00",
+  "branch": "g2-125-stock-search-service-getter-authorization",
+  "current_head": "4ce4abf60fec2719644d9f64cd657bb0b7d3c8c5",
+  "current_head_checked_at_review": "2026-05-26T09:21:33+08:00",
+  "parent_refresh": {
+    "node": "G2.124 Service lifecycle candidate refresh after EmailService",
+    "pr": 277,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T01:17:26Z",
+    "merge_commit": "4ce4abf60fec2719644d9f64cd657bb0b7d3c8c5",
+    "url": "https://github.com/chengjon/mystocks/pull/277"
+  },
+  "authorization": {
+    "authorized_future_node": "G2.126 StockSearchService getter-retirement implementation",
+    "authorization_only": true,
+    "source_edits_in_this_packet": false,
+    "future_allowed_paths": [
+      "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "web/backend/tests/test_stock_search_service_lifecycle_di.py",
+      "web/backend/tests/test_runtime_regressions_p0.py",
+      "web/backend/tests/test_stock_search_service_getter_retirement.py",
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/stock-search-service-getter-retirement-implementation-2026-05-26.json",
+      "docs/reports/quality/backend-stock-search-service-getter-retirement-implementation-2026-05-26.md",
+      "governance/mainline/task-cards/pr-279.yaml"
+    ],
+    "future_forbidden_paths_without_separate_approval": [
+      "web/backend/app/api/**",
+      "web/frontend/**",
+      "src/**",
+      "docs/api/**",
+      "docs/guides/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ],
+    "must_preserve": [
+      "StockSearchService",
+      "install_stock_search_service",
+      "get_stock_search_service_dependency",
+      "stock search route paths",
+      "market kline route path",
+      "response contracts",
+      "OpenAPI exposure"
+    ],
+    "may_retire_in_future_implementation": [
+      "_stock_search_service",
+      "get_stock_search_service"
+    ]
+  },
+  "current_head_scan": {
+    "target_getter_definitions": 1,
+    "target_singleton_variable_tokens": 5,
+    "api_direct_getter_calls": 0,
+    "app_direct_getter_calls": 2,
+    "route_dependency_handlers": 6,
+    "dependency_refs": 12,
+    "route_dependency_files": [
+      "web/backend/app/api/stock_search/stock_search_result.py",
+      "web/backend/app/api/market/market_data_request.py"
+    ],
+    "existing_tests_that_reference_legacy_getter_or_singleton": [
+      "web/backend/tests/test_stock_search_service_lifecycle_di.py",
+      "web/backend/tests/test_runtime_regressions_p0.py"
+    ]
+  },
+  "gitnexus": {
+    "context": {
+      "symbol": "get_stock_search_service",
+      "file": "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "start_line": 168,
+      "end_line": 173,
+      "incoming_callers": [
+        "web/backend/app/api/stock_search/stock_search_result.py:search_stocks",
+        "web/backend/app/api/stock_search/stock_search_result.py:get_stock_quote",
+        "web/backend/app/api/stock_search/stock_search_result.py:get_stock_news",
+        "web/backend/app/api/stock_search/stock_search_result.py:get_market_news",
+        "web/backend/app/api/stock_search/stock_search_result.py:clear_search_cache",
+        "web/backend/app/api/market/market_data_request.py:get_kline_data"
+      ]
+    },
+    "impact": {
+      "risk": "CRITICAL",
+      "impacted_count": 6,
+      "direct": 6,
+      "processes_affected": 11,
+      "modules_affected": 2
+    }
+  },
+  "required_future_tdd_and_acceptance": {
+    "tdd_red": "Add a getter-retirement regression test proving get_stock_search_service and _stock_search_service are absent before implementation, and observe it fail.",
+    "focused_green": [
+      "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_getter_retirement.py web/backend/tests/test_stock_search_service_lifecycle_di.py web/backend/tests/test_runtime_regressions_p0.py -q --no-cov --tb=short",
+      "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+    ],
+    "route_d1_acceptance": [
+      "search_stocks",
+      "get_stock_quote",
+      "get_stock_news",
+      "get_market_news",
+      "clear_search_cache",
+      "get_kline_data"
+    ],
+    "post_change_scan_required": [
+      "target_getter_definitions=0",
+      "target_singleton_variable_tokens=0",
+      "api_direct_getter_calls=0",
+      "route_dependency_handlers=6",
+      "get_stock_search_service_dependency remains importable"
+    ]
+  },
+  "verification": {
+    "parent_pr_state": {
+      "command": "gh pr view 277 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title",
+      "result": "MERGED"
+    },
+    "stock_search_lifecycle_tests_baseline": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_lifecycle_di.py -q --no-cov --tb=short",
+      "result": "4 passed"
+    },
+    "health_route_conflicts_baseline": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "120 passed"
+    },
+    "gitnexus_context_and_impact": {
+      "result": "context found target at stock_search_service.py:168-173; impact risk=CRITICAL impacted_count=6 processes_affected=11"
+    },
+    "gitnexus_staged_detect_changes": {
+      "scope": "staged",
+      "risk_level": "low",
+      "changed_count": 0,
+      "changed_files": 4,
+      "affected_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "boundary": {
+    "authorization_only": true,
+    "source_edits": false,
+    "test_edits": false,
+    "route_or_api_edits": false,
+    "openapi_edits": false,
+    "frontend_edits": false,
+    "pm2_edits": false,
+    "openspec_edits": false,
+    "issue_label_changes": false,
+    "implementation_executed": false
+  },
+  "next_gate": "Review and merge this authorization. If accepted, create G2.126 StockSearchService getter-retirement implementation with TDD red, CRITICAL-risk disclosure, d=1 route/test acceptance criteria, staged GitNexus detect_changes, and post-commit mainline gate."
+}

--- a/docs/reports/quality/backend-stock-search-service-getter-retirement-authorization-2026-05-26.md
+++ b/docs/reports/quality/backend-stock-search-service-getter-retirement-authorization-2026-05-26.md
@@ -1,0 +1,136 @@
+# Backend StockSearchService Getter Retirement Authorization - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Ready for review.
+
+This packet authorizes only a future G2.126 implementation branch. It does not
+edit source or tests in this PR. The target is higher risk than the recent
+AnnouncementService and EmailService getter retirements, so this authorization
+records the CRITICAL GitNexus impact and d=1 acceptance criteria before any
+source edit is allowed.
+
+## Parent State
+
+| Field | Value |
+|---|---|
+| Parent node | G2.124 Service lifecycle candidate refresh after EmailService |
+| Parent PR | `#277` |
+| Parent state | `MERGED` |
+| Parent merge commit | `4ce4abf60fec2719644d9f64cd657bb0b7d3c8c5` |
+| Parent merged at | `2026-05-26T01:17:26Z` |
+| Current HEAD | `4ce4abf60fec2719644d9f64cd657bb0b7d3c8c5` |
+
+## Authorization Decision
+
+A future G2.126 implementation branch may retire only:
+
+- `web/backend/app/services/stock_search_service/stock_search_service.py`
+  `_stock_search_service`
+- `web/backend/app/services/stock_search_service/stock_search_service.py`
+  `get_stock_search_service`
+
+The future implementation must preserve:
+
+- `StockSearchService`
+- `install_stock_search_service`
+- `get_stock_search_service_dependency`
+- stock search route paths
+- market kline route path
+- response contracts
+- OpenAPI exposure
+
+## Current-Head Evidence
+
+| Check | Result |
+|---|---:|
+| Target getter definitions | `1` |
+| Target singleton variable tokens | `5` |
+| API direct getter calls | `0` |
+| App direct getter calls | `2` service self-calls |
+| Route dependency handlers | `6` |
+| Dependency refs | `12` |
+
+Route dependency files:
+
+- `web/backend/app/api/stock_search/stock_search_result.py`
+- `web/backend/app/api/market/market_data_request.py`
+
+Existing tests that reference the legacy singleton/getter and must be rewritten
+in the future implementation:
+
+- `web/backend/tests/test_stock_search_service_lifecycle_di.py`
+- `web/backend/tests/test_runtime_regressions_p0.py`
+
+## GitNexus Risk
+
+| Field | Value |
+|---|---|
+| Target | `web/backend/app/services/stock_search_service/stock_search_service.py:get_stock_search_service` |
+| Context lines | `168-173` |
+| Risk | `CRITICAL` |
+| Impacted count | `6` |
+| Direct callers | `6` |
+| Affected processes | `11` |
+| Affected modules | `2` |
+
+d=1 route callers:
+
+- `search_stocks`
+- `get_stock_quote`
+- `get_stock_news`
+- `get_market_news`
+- `clear_search_cache`
+- `get_kline_data`
+
+This CRITICAL risk is accepted only for preparing a future implementation
+authorization. It is not approval to edit source in this packet.
+
+## Future G2.126 Acceptance Criteria
+
+The future implementation must:
+
+- Start with a TDD red test proving `get_stock_search_service` and
+  `_stock_search_service` are absent before implementation.
+- Update existing tests that still assert legacy singleton/getter behavior.
+- Keep `get_stock_search_service_dependency` importable and route-compatible.
+- Preserve all route paths, response contracts, and OpenAPI exposure.
+- Verify the d=1 route callers listed above through focused tests or route-table
+  evidence.
+- Run focused tests:
+  `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_getter_retirement.py web/backend/tests/test_stock_search_service_lifecycle_di.py web/backend/tests/test_runtime_regressions_p0.py -q --no-cov --tb=short`
+- Run route conflict guard:
+  `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short`
+- Run touched-file lint/format checks.
+- Run staged GitNexus `detect_changes(scope="staged")`.
+- Run post-commit mainline scope gate.
+
+## Verification
+
+| Check | Command | Result |
+|---|---|---|
+| Parent PR state | `gh pr view 277 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title` | `MERGED`, merge commit `4ce4abf60fec2719644d9f64cd657bb0b7d3c8c5` |
+| Stock search lifecycle baseline | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_lifecycle_di.py -q --no-cov --tb=short` | `4 passed` |
+| Health route conflicts baseline | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `120 passed` |
+| GitNexus context / impact | `context` and `impact(direction="upstream")` | target found; risk=`CRITICAL`, impacted=`6`, affected processes=`11` |
+| GitNexus staged detect changes | `detect_changes(scope="staged")` | risk=`low`; changed count=`0`; changed files=`4`; affected count=`0`; affected processes=`0` |
+
+## Boundary Confirmation
+
+- No backend source or test files are edited in this authorization packet.
+- No route path, response model, response shape, or OpenAPI exposure is changed.
+- No frontend, PM2, OpenSpec, issue-label, or runtime configuration file is changed.
+- No getter deletion is performed here.
+- Future source work must happen in G2.126 after this authorization is reviewed
+  and accepted.
+
+## Next Gate
+
+Review and merge this authorization. If accepted, create G2.126
+StockSearchService getter-retirement implementation with TDD red, explicit
+CRITICAL-risk handling, d=1 route/test acceptance criteria, staged GitNexus
+scope check, and post-commit mainline gate.

--- a/governance/mainline/task-cards/pr-278.yaml
+++ b/governance/mainline/task-cards/pr-278.yaml
@@ -1,0 +1,120 @@
+version: "v0.2"
+
+task:
+  id: "pr-278"
+  title: "Authorize StockSearchService getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-stock-search-service-getter-retirement-authorization"
+  objective: "authorize a future StockSearchService getter retirement implementation with explicit CRITICAL risk and d=1 acceptance criteria"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-stock-search-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-stock-search-service-getter-retirement-authorization"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/stock-search-service-getter-retirement-authorization-2026-05-26.json"
+    - "docs/reports/quality/backend-stock-search-service-getter-retirement-authorization-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-278.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not edit stock search or market route handlers"
+  - "Do not modify route paths, response models, response shapes, or OpenAPI exposure"
+  - "Do not modify frontend code"
+  - "Do not modify PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not delete get_stock_search_service in this packet"
+  - "Do not delete _stock_search_service in this packet"
+  - "Do not perform implementation in this packet"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 277 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "stock-search-lifecycle-baseline"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts-baseline"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "gitnexus-context-impact"
+      command: "GitNexus context and impact for get_stock_search_service"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-stock-search-service-getter-retirement-authorization-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/stock-search-service-getter-retirement-authorization-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-278.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-278.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this authorization is mistaken for implementation, a CRITICAL-risk getter edit could proceed without TDD red or d=1 route/test acceptance criteria"
+    - "If route/API files are included in the future implementation without separate approval, stock search and market route contracts could drift"
+  rollback_plan: "revert this governance-only authorization PR and keep G2.124 as the latest accepted candidate refresh"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize future StockSearchService getter retirement"
+    modified_scope: "steward tree, authorization report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; authorization-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent PR state, baseline tests, GitNexus risk recording, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T09:21:33+08:00"
+    approval_note: "Authorization-only packet after PR #277 merge; implementation is deferred to future G2.126 with CRITICAL risk acceptance"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- authorize a future G2.126 StockSearchService getter-retirement implementation only
- record CRITICAL GitNexus impact for get_stock_search_service before any source edit
- define the future allowed files, forbidden paths, preserved symbols, TDD red, and d=1 route/test acceptance criteria
- update steward tree, generated evidence, authorization report, and task card

## Verification
- parent PR #277: MERGED at 4ce4abf60fec2719644d9f64cd657bb0b7d3c8c5
- stock search lifecycle baseline: 4 passed
- health route conflicts baseline: 120 passed
- GitNexus context found target at stock_search_service.py:168-173
- GitNexus impact: CRITICAL, impacted_count=6, affected_processes=11
- markdown governance: errors=0
- JSON/YAML parse: passed
- GitNexus staged detect_changes: low, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: completed