### PR TITLE
G2.126 Amend StockSearchService getter authorization

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2077,7 +2077,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, implementation authorization, or
 │   │                issue-label change is made here
 │   ├── G2.125 StockSearchService getter-retirement authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#278` merged at
+│   │   │          `d2f5a952740db94c382534b0810ba11588660132`
 │   │   ├── Evidence: `backend-stock-search-service-getter-retirement-authorization-2026-05-26.md`
 │   │   ├── Current HEAD: `4ce4abf60fec2719644d9f64cd657bb0b7d3c8c5`
 │   │   ├── Result: authorizes only a future G2.126 implementation branch to
@@ -2096,10 +2097,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: authorization-only; no backend source/test edit, route/API,
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                implementation, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.125; if accepted,
-│                  create G2.126 StockSearchService getter-retirement
-│                  implementation with TDD red and CRITICAL-risk d=1 route/test
-│                  acceptance criteria before any source edit
+│   ├── G2.126 StockSearchService getter-retirement authorization amendment
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-stock-search-service-getter-retirement-authorization-amendment-2026-05-26.md`
+│   │   ├── Current HEAD: `d2f5a952740db94c382534b0810ba11588660132`
+│   │   ├── Result: amends the future implementation scope before source work:
+│   │   │          `stock_search_service/__init__.py` must also be allowed
+│   │   │          because it re-exports `get_stock_search_service` in both the
+│   │   │          import list and `__all__`
+│   │   ├── Evidence: package re-export has legacy import at line `9` and
+│   │   │          legacy `__all__` entry at line `20`; lifecycle baseline
+│   │   │          `4 passed`, health route conflicts `120 passed`
+│   │   └── Boundary: amendment-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                implementation, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.126; if accepted,
+│                  create G2.127 StockSearchService getter-retirement
+│                  implementation with TDD red, package re-export update, and
+│                  CRITICAL-risk d=1 route/test acceptance criteria before any
+│                  source edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/stock-search-service-getter-retirement-authorization-amendment-2026-05-26.json
+++ b/.planning/codebase/generated/stock-search-service-getter-retirement-authorization-amendment-2026-05-26.json
@@ -1,0 +1,102 @@
+{
+  "artifact": "stock-search-service-getter-retirement-authorization-amendment-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T09:37:34+08:00",
+  "branch": "g2-126-stock-search-service-getter-authorization-amendment",
+  "current_head": "d2f5a952740db94c382534b0810ba11588660132",
+  "current_head_checked_at_review": "2026-05-26T09:37:34+08:00",
+  "parent_authorization": {
+    "node": "G2.125 StockSearchService getter-retirement authorization",
+    "pr": 278,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T01:30:40Z",
+    "merge_commit": "d2f5a952740db94c382534b0810ba11588660132",
+    "url": "https://github.com/chengjon/mystocks/pull/278"
+  },
+  "amendment_reason": {
+    "summary": "G2.125 authorized the target service module and tests but omitted the package re-export file. Removing get_stock_search_service from the implementation module would break package imports unless web/backend/app/services/stock_search_service/__init__.py is updated.",
+    "package_re_export_file": "web/backend/app/services/stock_search_service/__init__.py",
+    "legacy_import_line": 9,
+    "legacy_all_line": 20,
+    "has_legacy_import": true,
+    "has_legacy_all_entry": true
+  },
+  "amended_future_implementation": {
+    "authorized_future_node": "G2.127 StockSearchService getter-retirement implementation",
+    "future_allowed_paths": [
+      "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "web/backend/app/services/stock_search_service/__init__.py",
+      "web/backend/tests/test_stock_search_service_lifecycle_di.py",
+      "web/backend/tests/test_runtime_regressions_p0.py",
+      "web/backend/tests/test_stock_search_service_getter_retirement.py",
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/stock-search-service-getter-retirement-implementation-2026-05-26.json",
+      "docs/reports/quality/backend-stock-search-service-getter-retirement-implementation-2026-05-26.md",
+      "governance/mainline/task-cards/pr-280.yaml"
+    ],
+    "future_forbidden_paths_without_separate_approval": [
+      "web/backend/app/api/**",
+      "web/frontend/**",
+      "src/**",
+      "docs/api/**",
+      "docs/guides/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ],
+    "must_preserve": [
+      "StockSearchService",
+      "install_stock_search_service",
+      "get_stock_search_service_dependency",
+      "stock search route paths",
+      "market kline route path",
+      "response contracts",
+      "OpenAPI exposure"
+    ],
+    "may_retire_in_future_implementation": [
+      "_stock_search_service",
+      "get_stock_search_service",
+      "package re-export of get_stock_search_service"
+    ]
+  },
+  "verification": {
+    "parent_pr_state": {
+      "command": "gh pr view 278 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title",
+      "result": "MERGED"
+    },
+    "package_re_export_evidence": {
+      "command": "scripted scan of web/backend/app/services/stock_search_service/__init__.py",
+      "result": "legacy import line=9; legacy __all__ entry line=20"
+    },
+    "stock_search_lifecycle_tests_baseline": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_lifecycle_di.py -q --no-cov --tb=short",
+      "result": "4 passed"
+    },
+    "health_route_conflicts_baseline": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "120 passed"
+    },
+    "gitnexus_staged_detect_changes": {
+      "scope": "staged",
+      "risk_level": "low",
+      "changed_count": 0,
+      "changed_files": 4,
+      "affected_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "boundary": {
+    "amendment_only": true,
+    "source_edits": false,
+    "test_edits": false,
+    "route_or_api_edits": false,
+    "openapi_edits": false,
+    "frontend_edits": false,
+    "pm2_edits": false,
+    "openspec_edits": false,
+    "issue_label_changes": false,
+    "implementation_executed": false
+  },
+  "next_gate": "Review and merge this amendment. If accepted, create G2.127 StockSearchService getter-retirement implementation with TDD red, package re-export update, CRITICAL-risk disclosure, d=1 route/test acceptance criteria, staged GitNexus detect_changes, and post-commit mainline gate."
+}

--- a/docs/reports/quality/backend-stock-search-service-getter-retirement-authorization-amendment-2026-05-26.md
+++ b/docs/reports/quality/backend-stock-search-service-getter-retirement-authorization-amendment-2026-05-26.md
@@ -1,0 +1,98 @@
+# Backend StockSearchService Getter Retirement Authorization Amendment - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Ready for review.
+
+This is an amendment-only governance packet. It does not edit backend source or
+tests. It corrects the future implementation scope approved in G2.125 by adding
+the package re-export file that must be updated when the legacy getter is
+retired.
+
+## Parent State
+
+| Field | Value |
+|---|---|
+| Parent node | G2.125 StockSearchService getter-retirement authorization |
+| Parent PR | `#278` |
+| Parent state | `MERGED` |
+| Parent merge commit | `d2f5a952740db94c382534b0810ba11588660132` |
+| Parent merged at | `2026-05-26T01:30:40Z` |
+| Current HEAD | `d2f5a952740db94c382534b0810ba11588660132` |
+
+## Amendment
+
+G2.125 omitted:
+
+- `web/backend/app/services/stock_search_service/__init__.py`
+
+That file currently re-exports `get_stock_search_service`. If the future
+implementation removes the getter from
+`web/backend/app/services/stock_search_service/stock_search_service.py` without
+updating the package re-export, imports from `app.services.stock_search_service`
+will fail.
+
+Evidence:
+
+| Check | Result |
+|---|---|
+| Legacy import | line `9`, `from .stock_search_service import get_stock_search_service` |
+| Legacy `__all__` entry | line `20`, `"get_stock_search_service"` |
+
+## Amended Future Scope
+
+A future G2.127 implementation may edit only:
+
+- `web/backend/app/services/stock_search_service/stock_search_service.py`
+- `web/backend/app/services/stock_search_service/__init__.py`
+- `web/backend/tests/test_stock_search_service_lifecycle_di.py`
+- `web/backend/tests/test_runtime_regressions_p0.py`
+- `web/backend/tests/test_stock_search_service_getter_retirement.py`
+- steward tree, generated implementation evidence, implementation report, and
+  task card
+
+The future implementation must preserve:
+
+- `StockSearchService`
+- `install_stock_search_service`
+- `get_stock_search_service_dependency`
+- stock search route paths
+- market kline route path
+- response contracts
+- OpenAPI exposure
+
+The future implementation may retire:
+
+- `_stock_search_service`
+- `get_stock_search_service`
+- package re-export of `get_stock_search_service`
+
+## Verification
+
+| Check | Command | Result |
+|---|---|---|
+| Parent PR state | `gh pr view 278 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title` | `MERGED`, merge commit `d2f5a952740db94c382534b0810ba11588660132` |
+| Package re-export evidence | scripted scan of `web/backend/app/services/stock_search_service/__init__.py` | legacy import line=`9`; legacy `__all__` line=`20` |
+| Stock search lifecycle baseline | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_lifecycle_di.py -q --no-cov --tb=short` | `4 passed` |
+| Health route conflicts baseline | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `120 passed` |
+| GitNexus staged detect changes | `detect_changes(scope="staged")` | risk=`low`; changed count=`0`; changed files=`4`; affected count=`0`; affected processes=`0` |
+
+## Boundary Confirmation
+
+- No backend source or test files are edited in this amendment packet.
+- No route path, response model, response shape, or OpenAPI exposure is changed.
+- No frontend, PM2, OpenSpec, issue-label, or runtime configuration file is changed.
+- No getter deletion is performed here.
+- Future source work must happen in G2.127 after this amendment is reviewed and
+  accepted.
+
+## Next Gate
+
+Review and merge this amendment. If accepted, create G2.127 StockSearchService
+getter-retirement implementation with TDD red, package re-export update,
+explicit CRITICAL-risk handling, d=1 route/test acceptance criteria, staged
+GitNexus scope check, and post-commit mainline gate.

--- a/governance/mainline/task-cards/pr-279.yaml
+++ b/governance/mainline/task-cards/pr-279.yaml
@@ -1,0 +1,120 @@
+version: "v0.2"
+
+task:
+  id: "pr-279"
+  title: "Amend StockSearchService getter retirement authorization"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-stock-search-service-getter-retirement-authorization-amendment"
+  objective: "add the stock_search_service package re-export file to the future implementation scope before source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-stock-search-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-stock-search-service-getter-retirement-authorization-amendment"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-amendment-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/stock-search-service-getter-retirement-authorization-amendment-2026-05-26.json"
+    - "docs/reports/quality/backend-stock-search-service-getter-retirement-authorization-amendment-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-279.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not edit stock search or market route handlers"
+  - "Do not modify route paths, response models, response shapes, or OpenAPI exposure"
+  - "Do not modify frontend code"
+  - "Do not modify PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not delete get_stock_search_service in this packet"
+  - "Do not delete _stock_search_service in this packet"
+  - "Do not perform implementation in this packet"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 278 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "package-re-export-evidence"
+      command: "scripted scan of web/backend/app/services/stock_search_service/__init__.py for get_stock_search_service import and __all__ entry"
+      required: true
+    - id: "stock-search-lifecycle-baseline"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts-baseline"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-stock-search-service-getter-retirement-authorization-amendment-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/stock-search-service-getter-retirement-authorization-amendment-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-279.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-279.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this amendment is skipped, a future implementation could remove the getter from the module but leave a broken package re-export"
+    - "If this amendment is mistaken for implementation, a CRITICAL-risk getter edit could proceed without TDD red or d=1 route/test acceptance criteria"
+  rollback_plan: "revert this governance-only amendment PR and keep G2.125 as the latest accepted authorization gate"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "amend future StockSearchService getter retirement scope"
+    modified_scope: "steward tree, amendment report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; amendment-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent PR state, package re-export evidence, baseline tests, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T09:37:34+08:00"
+    approval_note: "Authorization amendment only after PR #278 merge; implementation is deferred to future G2.127"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- amend G2.125 StockSearchService getter-retirement authorization before source implementation
- add stock_search_service/__init__.py to the future implementation scope because it re-exports get_stock_search_service
- keep this packet governance-only: no source/test edit, no getter deletion, no route/OpenAPI change
- shift source implementation to future G2.127

## Verification
- parent PR #278: MERGED at d2f5a952740db94c382534b0810ba11588660132
- package re-export evidence: legacy import line=9, legacy __all__ entry line=20
- stock search lifecycle baseline: 4 passed
- health route conflicts baseline: 120 passed
- markdown governance: errors=0
- JSON/YAML parse: passed
- GitNexus staged detect_changes: low, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: completed