### PR TITLE
G2.127 Retire StockSearchService module getter

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2098,7 +2098,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                implementation, or issue-label change is made here
 │   ├── G2.126 StockSearchService getter-retirement authorization amendment
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#279` merged at
+│   │   │          `d23a4cf1de28972f3880495cce659540064b2576`
 │   │   ├── Evidence: `backend-stock-search-service-getter-retirement-authorization-amendment-2026-05-26.md`
 │   │   ├── Current HEAD: `d2f5a952740db94c382534b0810ba11588660132`
 │   │   ├── Result: amends the future implementation scope before source work:
@@ -2111,11 +2112,29 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: amendment-only; no backend source/test edit, route/API,
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                implementation, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.126; if accepted,
-│                  create G2.127 StockSearchService getter-retirement
-│                  implementation with TDD red, package re-export update, and
-│                  CRITICAL-risk d=1 route/test acceptance criteria before any
-│                  source edit
+│   ├── G2.127 StockSearchService getter-retirement implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-stock-search-service-getter-retirement-implementation-2026-05-26.md`
+│   │   ├── Current HEAD: `d23a4cf1de28972f3880495cce659540064b2576`
+│   │   ├── Result: removes `stock_search_service.py` `_stock_search_service`
+│   │   │          and `get_stock_search_service`, removes package re-export,
+│   │   │          changes installer fallback to construct `StockSearchService()`,
+│   │   │          updates legacy tests, and adds retirement regression coverage
+│   │   ├── Verification: TDD red `1 failed`, focused green `12 passed`, health
+│   │   │          route conflicts `120 passed`, touched-file ruff and black
+│   │   │          checks passed, package import smoke passed; exact scan reports
+│   │   │          target getter definitions=`0`, target singleton tokens=`0`,
+│   │   │          package re-export=`0`, app/API/test direct getter calls=`0`,
+│   │   │          and route dependency handlers=`6`
+│   │   └── Boundary: source-capable but limited to stock search service module,
+│   │                package re-export, focused tests, governance report,
+│   │                generated artifact, task card, and steward-tree update; no
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                `StockSearchService` deletion, dependency deletion, or
+│   │                issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.127; if accepted,
+│                  create G2.128 StockSearchService getter-retirement closeout
+│                  before selecting another service lifecycle getter lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/stock-search-service-getter-retirement-implementation-2026-05-26.json
+++ b/.planning/codebase/generated/stock-search-service-getter-retirement-implementation-2026-05-26.json
@@ -1,0 +1,118 @@
+{
+  "artifact": "stock-search-service-getter-retirement-implementation-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T09:51:06+08:00",
+  "branch": "g2-127-stock-search-service-getter-retirement-implementation",
+  "current_head": "d23a4cf1de28972f3880495cce659540064b2576",
+  "current_head_checked_at_review": "2026-05-26T09:51:06+08:00",
+  "parent_authorization_amendment": {
+    "node": "G2.126 StockSearchService getter-retirement authorization amendment",
+    "pr": 279,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T01:44:33Z",
+    "merge_commit": "d23a4cf1de28972f3880495cce659540064b2576",
+    "url": "https://github.com/chengjon/mystocks/pull/279"
+  },
+  "pre_edit_gitnexus": {
+    "target": "web/backend/app/services/stock_search_service/stock_search_service.py:get_stock_search_service",
+    "risk": "CRITICAL",
+    "impacted_count": 6,
+    "direct_callers": 6,
+    "processes_affected": 11,
+    "modules_affected": 2,
+    "d1_callers": [
+      "search_stocks",
+      "get_stock_quote",
+      "get_stock_news",
+      "get_market_news",
+      "clear_search_cache",
+      "get_kline_data"
+    ]
+  },
+  "implementation": {
+    "retired": [
+      "web/backend/app/services/stock_search_service/stock_search_service.py:_stock_search_service",
+      "web/backend/app/services/stock_search_service/stock_search_service.py:get_stock_search_service",
+      "web/backend/app/services/stock_search_service/__init__.py:get_stock_search_service re-export"
+    ],
+    "preserved": [
+      "StockSearchService",
+      "STOCK_SEARCH_SERVICE_STATE_KEY",
+      "install_stock_search_service",
+      "get_stock_search_service_dependency",
+      "stock search route paths",
+      "market kline route path",
+      "response contracts",
+      "OpenAPI exposure"
+    ],
+    "touched_files": [
+      "web/backend/app/services/stock_search_service/stock_search_service.py",
+      "web/backend/app/services/stock_search_service/__init__.py",
+      "web/backend/tests/test_stock_search_service_lifecycle_di.py",
+      "web/backend/tests/test_runtime_regressions_p0.py",
+      "web/backend/tests/test_stock_search_service_getter_retirement.py",
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/stock-search-service-getter-retirement-implementation-2026-05-26.json",
+      "docs/reports/quality/backend-stock-search-service-getter-retirement-implementation-2026-05-26.md",
+      "governance/mainline/task-cards/pr-280.yaml"
+    ]
+  },
+  "post_change_scan": {
+    "target_getter_definitions": 0,
+    "target_singleton_variable_tokens": 0,
+    "package_getter_import_exact": false,
+    "package_getter_all_exact": false,
+    "api_direct_getter_calls": 0,
+    "app_direct_getter_calls": 0,
+    "test_direct_getter_calls": 0,
+    "dependency_refs": 14,
+    "route_dependency_handlers": 6,
+    "installer_refs": 7
+  },
+  "verification": {
+    "tdd_red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_getter_retirement.py -q --no-cov --tb=short",
+      "result": "1 failed before implementation"
+    },
+    "focused_green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_getter_retirement.py web/backend/tests/test_stock_search_service_lifecycle_di.py web/backend/tests/test_runtime_regressions_p0.py -q --no-cov --tb=short",
+      "result": "12 passed"
+    },
+    "health_route_conflicts": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "120 passed"
+    },
+    "ruff_touched_files": {
+      "command": "ruff check touched files",
+      "result": "passed"
+    },
+    "black_touched_files": {
+      "command": "black --check touched files",
+      "result": "5 files would be left unchanged"
+    },
+    "package_import_smoke": {
+      "command": "PYTHONPATH=web/backend python import smoke for app.services.stock_search_service",
+      "result": "passed"
+    },
+    "gitnexus_staged_detect_changes": {
+      "scope": "staged",
+      "risk_level": "low",
+      "changed_count": 22,
+      "changed_files": 9,
+      "affected_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "boundary": {
+    "source_capable": true,
+    "route_or_api_edits": false,
+    "openapi_edits": false,
+    "frontend_edits": false,
+    "pm2_edits": false,
+    "openspec_edits": false,
+    "issue_label_changes": false,
+    "deleted_stock_search_service_class": false,
+    "deleted_dependency": false
+  },
+  "next_gate": "Review and merge this implementation. If accepted, create G2.128 StockSearchService getter-retirement closeout before selecting another service lifecycle getter lane."
+}

--- a/docs/reports/quality/backend-stock-search-service-getter-retirement-implementation-2026-05-26.md
+++ b/docs/reports/quality/backend-stock-search-service-getter-retirement-implementation-2026-05-26.md
@@ -1,0 +1,116 @@
+# Backend StockSearchService Getter Retirement Implementation - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Ready for review.
+
+This implementation retires the StockSearchService module-level singleton getter
+under the G2.125 authorization and G2.126 authorization amendment. The work
+keeps the app-state dependency boundary and does not edit route/API files.
+
+## Parent Authorization
+
+| Field | Value |
+|---|---|
+| Parent node | G2.126 StockSearchService getter-retirement authorization amendment |
+| Parent PR | `#279` |
+| Parent state | `MERGED` |
+| Parent merge commit | `d23a4cf1de28972f3880495cce659540064b2576` |
+| Parent merged at | `2026-05-26T01:44:33Z` |
+| Current HEAD | `d23a4cf1de28972f3880495cce659540064b2576` |
+
+## Risk Confirmation
+
+GitNexus pre-edit impact for `get_stock_search_service` remained CRITICAL:
+
+| Field | Value |
+|---|---|
+| Target | `web/backend/app/services/stock_search_service/stock_search_service.py:get_stock_search_service` |
+| Risk | `CRITICAL` |
+| Impacted count | `6` |
+| Direct callers | `6` |
+| Affected processes | `11` |
+| Affected modules | `2` |
+
+d=1 route callers remain route-dependency consumers and were not edited:
+
+- `search_stocks`
+- `get_stock_quote`
+- `get_stock_news`
+- `get_market_news`
+- `clear_search_cache`
+- `get_kline_data`
+
+## Implementation
+
+Retired:
+
+- `web/backend/app/services/stock_search_service/stock_search_service.py`
+  `_stock_search_service`
+- `web/backend/app/services/stock_search_service/stock_search_service.py`
+  `get_stock_search_service`
+- `web/backend/app/services/stock_search_service/__init__.py`
+  `get_stock_search_service` package re-export
+
+Preserved:
+
+- `StockSearchService`
+- `STOCK_SEARCH_SERVICE_STATE_KEY`
+- `install_stock_search_service`
+- `get_stock_search_service_dependency`
+- stock search route paths
+- market kline route path
+- response contracts
+- OpenAPI exposure
+
+`install_stock_search_service(app, service=None)` now constructs
+`StockSearchService()` directly when an explicit service is not supplied. The
+route dependency still reads and installs the app-state service through
+`get_stock_search_service_dependency`.
+
+## Post-Change Evidence
+
+| Check | Result |
+|---|---:|
+| Target getter definitions | `0` |
+| Target singleton variable tokens | `0` |
+| Exact package getter import | `false` |
+| Exact package `__all__` getter entry | `false` |
+| API direct getter calls | `0` |
+| App direct getter calls | `0` |
+| Test direct getter calls | `0` |
+| Dependency refs | `14` |
+| Route dependency handlers | `6` |
+| Installer refs | `7` |
+
+## Verification
+
+| Check | Command | Result |
+|---|---|---|
+| TDD red | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_getter_retirement.py -q --no-cov --tb=short` | `1 failed` before implementation |
+| Focused green | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_getter_retirement.py web/backend/tests/test_stock_search_service_lifecycle_di.py web/backend/tests/test_runtime_regressions_p0.py -q --no-cov --tb=short` | `12 passed` |
+| Health route conflicts | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `120 passed` |
+| Touched-file lint | `ruff check ...` | passed |
+| Touched-file format | `black --check ...` | `5 files would be left unchanged` |
+| Package import smoke | `PYTHONPATH=web/backend python ...` | passed |
+| Exact scan | scripted text scan | getter=`0`, singleton=`0`, package re-export=`0`, direct getter calls=`0`, route dependency handlers=`6` |
+| GitNexus staged detect changes | `detect_changes(scope="staged")` | risk=`low`; changed count=`22`; changed files=`9`; affected count=`0`; affected processes=`0` |
+
+## Boundary Confirmation
+
+- No route/API files are edited.
+- No route path, response model, response shape, or OpenAPI exposure is changed.
+- No frontend, PM2, OpenSpec, issue-label, or runtime configuration file is changed.
+- `StockSearchService`, `install_stock_search_service`, and
+  `get_stock_search_service_dependency` remain present.
+- This does not authorize the next service lifecycle lane.
+
+## Next Gate
+
+Review and merge this implementation. If accepted, create G2.128
+StockSearchService getter-retirement closeout before selecting another service
+lifecycle getter lane.

--- a/governance/mainline/task-cards/pr-280.yaml
+++ b/governance/mainline/task-cards/pr-280.yaml
@@ -1,0 +1,132 @@
+version: "v0.2"
+
+task:
+  id: "pr-280"
+  title: "Retire StockSearchService module-level getter"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-stock-search-service-getter-retirement-implementation"
+  objective: "retire the StockSearchService module-level getter and singleton while preserving app-state dependency injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-stock-search-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-stock-search-service-getter-retirement-implementation"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow service getter retirement; no route, public API surface, OpenAPI exposure, frontend behavior, or OpenSpec capability is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/stock-search-service-getter-retirement-implementation-2026-05-26.json"
+    - "docs/reports/quality/backend-stock-search-service-getter-retirement-implementation-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-280.yaml"
+    - "web/backend/app/services/stock_search_service/stock_search_service.py"
+    - "web/backend/app/services/stock_search_service/__init__.py"
+    - "web/backend/tests/test_stock_search_service_lifecycle_di.py"
+    - "web/backend/tests/test_runtime_regressions_p0.py"
+    - "web/backend/tests/test_stock_search_service_getter_retirement.py"
+  forbidden_paths:
+    - "web/backend/app/api/**"
+    - "web/backend/app/main.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit stock search or market route handlers"
+  - "Do not modify route paths, response models, response shapes, or OpenAPI exposure"
+  - "Do not modify frontend code"
+  - "Do not modify PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not delete or rename StockSearchService"
+  - "Do not delete or alter install_stock_search_service"
+  - "Do not delete or alter get_stock_search_service_dependency"
+  - "Do not perform broader stock search service consolidation"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 279 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_getter_retirement.py -q --no-cov --tb=short"
+      required: true
+    - id: "focused-green-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_getter_retirement.py web/backend/tests/test_stock_search_service_lifecycle_di.py web/backend/tests/test_runtime_regressions_p0.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-files"
+      command: "ruff check web/backend/app/services/stock_search_service/stock_search_service.py web/backend/app/services/stock_search_service/__init__.py web/backend/tests/test_stock_search_service_lifecycle_di.py web/backend/tests/test_runtime_regressions_p0.py web/backend/tests/test_stock_search_service_getter_retirement.py"
+      required: true
+    - id: "black-touched-files"
+      command: "black --check web/backend/app/services/stock_search_service/stock_search_service.py web/backend/app/services/stock_search_service/__init__.py web/backend/tests/test_stock_search_service_lifecycle_di.py web/backend/tests/test_runtime_regressions_p0.py web/backend/tests/test_stock_search_service_getter_retirement.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-stock-search-service-getter-retirement-implementation-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/stock-search-service-getter-retirement-implementation-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-280.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-280.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "GitNexus classified the retired getter as CRITICAL because six route handlers are d=1 dependency consumers"
+    - "If route/API files are edited, stock search or market route contracts could drift outside the authorization"
+    - "If package re-export is not updated, app.services.stock_search_service imports can fail after getter removal"
+  rollback_plan: "revert this narrow implementation PR and keep G2.126 amendment as the latest accepted stock search getter gate"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "retire StockSearchService module-level getter and singleton"
+    modified_scope: "two stock search service package files, three focused tests, steward tree, implementation report, generated artifact, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "module-level getter and package re-export removed; app-state installer and dependency preserved"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, health route conflicts, touched-file lint/format, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T09:51:06+08:00"
+    approval_note: "Implementation packet after PR #279 amendment merge; CRITICAL GitNexus risk acknowledged and route/API files remain out of scope"
+    secondary_approved: false

--- a/web/backend/app/services/stock_search_service/__init__.py
+++ b/web/backend/app/services/stock_search_service/__init__.py
@@ -6,7 +6,6 @@ from .parse_datetime_to_timestamp import StockSearchError  # noqa: F401
 from .parse_datetime_to_timestamp import FinnhubAPIError  # noqa: F401
 from .stock_search_service import StockSearchService  # noqa: F401
 from .stock_search_service import STOCK_SEARCH_SERVICE_STATE_KEY  # noqa: F401
-from .stock_search_service import get_stock_search_service  # noqa: F401
 from .stock_search_service import get_stock_search_service_dependency  # noqa: F401
 from .stock_search_service import install_stock_search_service  # noqa: F401
 
@@ -17,7 +16,6 @@ __all__ = [
     "FinnhubAPIError",
     "StockSearchService",
     "STOCK_SEARCH_SERVICE_STATE_KEY",
-    "get_stock_search_service",
     "get_stock_search_service_dependency",
     "install_stock_search_service",
 ]

--- a/web/backend/app/services/stock_search_service/stock_search_service.py
+++ b/web/backend/app/services/stock_search_service/stock_search_service.py
@@ -71,7 +71,6 @@ if not AKSHARE_AVAILABLE:
     logger.warning("AKShare library not available, A/H share search features are disabled")
 
 
-_stock_search_service = None
 STOCK_SEARCH_SERVICE_STATE_KEY = "stock_search_service"
 
 
@@ -168,16 +167,8 @@ class StockSearchService:
         return results
 
 
-def get_stock_search_service() -> StockSearchService:
-    """获取股票搜索服务实例（单例模式）。"""
-    global _stock_search_service
-    if _stock_search_service is None:
-        _stock_search_service = StockSearchService()
-    return _stock_search_service
-
-
 def install_stock_search_service(app: Any, service: StockSearchService | None = None) -> StockSearchService:
-    selected_service = service if service is not None else get_stock_search_service()
+    selected_service = service if service is not None else StockSearchService()
     setattr(app.state, STOCK_SEARCH_SERVICE_STATE_KEY, selected_service)
     return selected_service
 

--- a/web/backend/tests/test_runtime_regressions_p0.py
+++ b/web/backend/tests/test_runtime_regressions_p0.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 import importlib
 import re
 import sys
+from types import SimpleNamespace
 
 import requests
 
 
-def test_stock_search_singleton_initialization(monkeypatch):
+def test_stock_search_app_state_install_initialization(monkeypatch):
     """
-    Regression: get_stock_search_service() must not crash with NameError.
+    Regression: stock search service app-state installation should initialize cleanly.
     """
     module = importlib.import_module("app.services.stock_search_service.stock_search_service")
 
@@ -21,14 +22,13 @@ def test_stock_search_singleton_initialization(monkeypatch):
         pass
 
     monkeypatch.setattr(module, "StockSearchService", DummyStockSearchService)
-    assert hasattr(module, "_stock_search_service")
-    monkeypatch.setattr(module, "_stock_search_service", None)
+    app = SimpleNamespace(state=SimpleNamespace())
 
-    first = module.get_stock_search_service()
-    second = module.get_stock_search_service()
+    service = module.install_stock_search_service(app)
 
-    assert isinstance(first, DummyStockSearchService)
-    assert second is first
+    assert isinstance(service, DummyStockSearchService)
+    assert getattr(app.state, module.STOCK_SEARCH_SERVICE_STATE_KEY) is service
+    assert module.get_stock_search_service_dependency(SimpleNamespace(app=app)) is service
 
 
 def test_watchlist_mock_data_keeps_success_shape():

--- a/web/backend/tests/test_stock_search_service_getter_retirement.py
+++ b/web/backend/tests/test_stock_search_service_getter_retirement.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import app.services.stock_search_service as stock_search_service_package
+from app.services.stock_search_service import stock_search_service as stock_search_service_module
+
+
+def test_legacy_getter_and_module_singleton_are_retired():
+    for target in (stock_search_service_package, stock_search_service_module):
+        assert hasattr(target, "StockSearchService")
+        assert hasattr(target, "install_stock_search_service")
+        assert hasattr(target, "get_stock_search_service_dependency")
+        assert not hasattr(target, "get_stock_search_service")
+
+    assert not hasattr(stock_search_service_module, "_stock_search_service")

--- a/web/backend/tests/test_stock_search_service_lifecycle_di.py
+++ b/web/backend/tests/test_stock_search_service_lifecycle_di.py
@@ -16,7 +16,7 @@ def test_stock_search_service_dependency_installs_app_state_when_missing(monkeyp
     fake_app = SimpleNamespace(state=SimpleNamespace())
     request = SimpleNamespace(app=fake_app)
 
-    monkeypatch.setattr(stock_search_service_module, "get_stock_search_service", lambda: fake_service)
+    monkeypatch.setattr(stock_search_service_module, "StockSearchService", lambda: fake_service)
 
     assert stock_search_service.get_stock_search_service_dependency(request) is fake_service
     assert getattr(fake_app.state, stock_search_service.STOCK_SEARCH_SERVICE_STATE_KEY) is fake_service


### PR DESCRIPTION
## Summary
- retire StockSearchService module-level _stock_search_service and get_stock_search_service
- remove get_stock_search_service from stock_search_service package re-export and __all__
- preserve StockSearchService, install_stock_search_service, get_stock_search_service_dependency, route paths, response contracts, and OpenAPI exposure
- update legacy tests and add focused getter-retirement regression coverage
- update steward tree, generated evidence, implementation report, and task card

## Risk
- GitNexus pre-edit impact for get_stock_search_service was CRITICAL: impacted_count=6, direct callers=6, affected_processes=11
- Route/API files were not edited; route dependency handlers remain 6

## Verification
- TDD red: 1 failed before implementation
- focused tests: 12 passed
- health route conflicts: 120 passed
- ruff check touched files: passed
- black --check touched files: passed
- package import smoke: passed
- exact scan: target getter definitions=0, singleton tokens=0, package re-export=0, app/API/test direct getter calls=0, route dependency handlers=6
- markdown governance: errors=0
- JSON/YAML parse: passed
- GitNexus staged detect_changes: low, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: completed