### PR TITLE
G2.128 Close out StockSearchService getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2113,7 +2113,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                implementation, or issue-label change is made here
 │   ├── G2.127 StockSearchService getter-retirement implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#280` merged at
+│   │   │          `edf6c2673c6b38b614e43bb78b0ace8696990777`
 │   │   ├── Evidence: `backend-stock-search-service-getter-retirement-implementation-2026-05-26.md`
 │   │   ├── Current HEAD: `d23a4cf1de28972f3880495cce659540064b2576`
 │   │   ├── Result: removes `stock_search_service.py` `_stock_search_service`
@@ -2132,9 +2133,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                `StockSearchService` deletion, dependency deletion, or
 │   │                issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.127; if accepted,
-│                  create G2.128 StockSearchService getter-retirement closeout
-│                  before selecting another service lifecycle getter lane
+│   ├── G2.128 StockSearchService getter-retirement closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-stock-search-service-getter-retirement-closeout-2026-05-26.md`
+│   │   ├── Current HEAD: `edf6c2673c6b38b614e43bb78b0ace8696990777`
+│   │   ├── Result: records PR `#280` as merged and verifies current-head
+│   │   │          StockSearchService getter-retirement state
+│   │   ├── Verification: parent PR `#280` state=`MERGED`, focused tests
+│   │   │          `12 passed`, health route conflicts `120 passed`, exact scan
+│   │   │          reports getter=`0`, singleton=`0`, package re-export=`0`,
+│   │   │          app/API/test direct getter calls=`0`, route dependency
+│   │   │          handlers=`6`
+│   │   └── Boundary: closeout-only; no backend source/test edit, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
+│   │                implementation authorization, next-lane authorization, or
+│   │                issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.128; if accepted,
+│                  refresh the service lifecycle candidate pool before selecting
+│                  another getter-retirement lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/stock-search-service-getter-retirement-closeout-2026-05-26.json
+++ b/.planning/codebase/generated/stock-search-service-getter-retirement-closeout-2026-05-26.json
@@ -1,0 +1,68 @@
+{
+  "artifact": "stock-search-service-getter-retirement-closeout-2026-05-26",
+  "status": "ready_for_review",
+  "created_at": "2026-05-26T10:04:52+08:00",
+  "branch": "g2-128-stock-search-service-getter-retirement-closeout",
+  "current_head": "edf6c2673c6b38b614e43bb78b0ace8696990777",
+  "current_head_checked_at_review": "2026-05-26T10:04:52+08:00",
+  "parent_implementation": {
+    "node": "G2.127 StockSearchService getter-retirement implementation",
+    "pr": 280,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T02:00:56Z",
+    "merge_commit": "edf6c2673c6b38b614e43bb78b0ace8696990777",
+    "url": "https://github.com/chengjon/mystocks/pull/280"
+  },
+  "current_head_scan": {
+    "backend_app_and_test_python_files_scanned": 778,
+    "target_getter_definitions": 0,
+    "target_singleton_variable_tokens": 0,
+    "package_getter_import_exact": false,
+    "package_getter_all_exact": false,
+    "api_direct_getter_calls": 0,
+    "app_direct_getter_calls": 0,
+    "test_direct_getter_calls": 0,
+    "dependency_refs": 14,
+    "route_dependency_handlers": 6,
+    "installer_refs": 7
+  },
+  "verification": {
+    "parent_pr_state": {
+      "command": "gh pr view 280 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title",
+      "result": "MERGED"
+    },
+    "focused_tests": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_getter_retirement.py web/backend/tests/test_stock_search_service_lifecycle_di.py web/backend/tests/test_runtime_regressions_p0.py -q --no-cov --tb=short",
+      "result": "12 passed"
+    },
+    "health_route_conflicts": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "120 passed"
+    },
+    "exact_scan": {
+      "result": "target_getter_definitions=0; target_singleton_variable_tokens=0; package_getter_import_exact=false; package_getter_all_exact=false; direct_getter_calls=0; route_dependency_handlers=6"
+    },
+    "gitnexus_staged_detect_changes": {
+      "scope": "staged",
+      "risk_level": "low",
+      "changed_count": 0,
+      "changed_files": 4,
+      "affected_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "boundary": {
+    "closeout_only": true,
+    "source_edits": false,
+    "test_edits": false,
+    "route_or_api_edits": false,
+    "openapi_edits": false,
+    "frontend_edits": false,
+    "pm2_edits": false,
+    "openspec_edits": false,
+    "issue_label_changes": false,
+    "next_lane_authorization": false
+  },
+  "closeout_decision": "StockSearchService getter retirement implementation is merged and current-head verified. This packet closes the lane for review but does not authorize the next implementation lane.",
+  "next_gate": "Review and merge this closeout. After acceptance, refresh the service lifecycle candidate pool before selecting another getter-retirement lane."
+}

--- a/docs/reports/quality/backend-stock-search-service-getter-retirement-closeout-2026-05-26.md
+++ b/docs/reports/quality/backend-stock-search-service-getter-retirement-closeout-2026-05-26.md
@@ -1,0 +1,90 @@
+# Backend StockSearchService Getter Retirement Closeout - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Ready for review.
+
+This is a closeout-only governance packet for the merged G2.127
+StockSearchService getter retirement implementation. It records the parent
+merge, verifies current-head state, and preserves the next-gate boundary.
+
+## Parent Merge
+
+| Field | Value |
+|---|---|
+| Parent node | G2.127 StockSearchService getter-retirement implementation |
+| Parent PR | `#280` |
+| Parent state | `MERGED` |
+| Parent merge commit | `edf6c2673c6b38b614e43bb78b0ace8696990777` |
+| Parent merged at | `2026-05-26T02:00:56Z` |
+| Parent URL | `https://github.com/chengjon/mystocks/pull/280` |
+| Closeout branch | `g2-128-stock-search-service-getter-retirement-closeout` |
+| Current HEAD | `edf6c2673c6b38b614e43bb78b0ace8696990777` |
+
+## Closeout Decision
+
+G2.127 is accepted as the implementation-complete parent for the
+StockSearchService getter retirement lane.
+
+The current checkout verifies that `web/backend/app/services/stock_search_service`
+no longer exposes the legacy module-level `get_stock_search_service` getter,
+standalone `_stock_search_service` singleton, or package re-export of the getter.
+
+The preserved service boundary remains:
+
+- `StockSearchService`
+- `STOCK_SEARCH_SERVICE_STATE_KEY`
+- `install_stock_search_service`
+- `get_stock_search_service_dependency`
+- stock search route paths
+- market kline route path
+- response contracts
+- OpenAPI exposure
+
+This packet does not authorize the next implementation lane. After this closeout
+is reviewed and merged, the service lifecycle candidate pool should be refreshed
+before selecting another getter-retirement lane.
+
+## Current-Head Evidence
+
+| Check | Result |
+|---|---:|
+| Backend app/test Python files scanned | `778` |
+| Target getter definitions | `0` |
+| Target singleton variable tokens | `0` |
+| Exact package getter import | `false` |
+| Exact package `__all__` getter entry | `false` |
+| API direct getter calls | `0` |
+| App direct getter calls | `0` |
+| Test direct getter calls | `0` |
+| Dependency refs | `14` |
+| Route dependency handlers | `6` |
+| Installer refs | `7` |
+
+## Verification
+
+| Check | Command | Result |
+|---|---|---|
+| Parent PR state | `gh pr view 280 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title` | `MERGED`, merge commit `edf6c2673c6b38b614e43bb78b0ace8696990777` |
+| Focused tests | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_getter_retirement.py web/backend/tests/test_stock_search_service_lifecycle_di.py web/backend/tests/test_runtime_regressions_p0.py -q --no-cov --tb=short` | `12 passed` |
+| Health route conflicts | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `120 passed` |
+| Current-head scan | scripted text scan | getter=`0`, singleton=`0`, package re-export=`0`, direct getter calls=`0`, route dependency handlers=`6` |
+| GitNexus staged detect changes | `detect_changes(scope="staged")` | risk=`low`; changed count=`0`; changed files=`4`; affected count=`0`; affected processes=`0` |
+
+## Boundary Confirmation
+
+- No backend source or test files are edited in this closeout.
+- No route path, response model, response shape, or OpenAPI exposure is changed.
+- No frontend, PM2, OpenSpec, issue-label, or runtime configuration file is changed.
+- No next service lifecycle getter lane is authorized here.
+- No `StockSearchService`, `install_stock_search_service`, or
+  `get_stock_search_service_dependency` deletion is authorized here.
+
+## Next Gate
+
+Review and merge this closeout. After acceptance, refresh the service lifecycle
+candidate pool before selecting another getter-retirement lane.

--- a/governance/mainline/task-cards/pr-281.yaml
+++ b/governance/mainline/task-cards/pr-281.yaml
@@ -1,0 +1,115 @@
+version: "v0.2"
+
+task:
+  id: "pr-281"
+  title: "Close out StockSearchService getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-stock-search-service-getter-retirement-closeout"
+  objective: "record the merged StockSearchService getter retirement and verify current-head closeout evidence"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-stock-search-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-stock-search-service-getter-retirement-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/stock-search-service-getter-retirement-closeout-2026-05-26.json"
+    - "docs/reports/quality/backend-stock-search-service-getter-retirement-closeout-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-281.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not edit stock search or market route handlers"
+  - "Do not modify route paths, response models, response shapes, or OpenAPI exposure"
+  - "Do not modify frontend code"
+  - "Do not modify PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not authorize the next implementation lane"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 280 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "focused-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stock_search_service_getter_retirement.py web/backend/tests/test_stock_search_service_lifecycle_di.py web/backend/tests/test_runtime_regressions_p0.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-stock-search-service-getter-retirement-closeout-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/stock-search-service-getter-retirement-closeout-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-281.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-281.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If closeout is mistaken for implementation authorization, a next source lane could skip candidate refresh"
+    - "If parent PR state is not verified, the steward tree could record an unmerged implementation as closed"
+  rollback_plan: "revert this governance-only closeout PR and keep G2.127 as the latest implementation gate"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out merged StockSearchService getter retirement"
+    modified_scope: "steward tree, closeout report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; closeout-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent PR state, current-head scan, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T10:04:52+08:00"
+    approval_note: "Closeout-only packet after PR #280 merge; next implementation lane is not authorized here"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record PR #280 as merged for G2.127 StockSearchService getter retirement
- verify current-head StockSearchService getter retirement state
- add G2.128 closeout report, generated evidence, task card, and steward tree update
- preserve the boundary that no next implementation lane is authorized here

## Verification
- parent PR #280: MERGED at edf6c2673c6b38b614e43bb78b0ace8696990777
- focused tests: 12 passed
- health route conflicts: 120 passed
- exact scan: target getter definitions=0, singleton tokens=0, package re-export=0, app/API/test direct getter calls=0, route dependency handlers=6
- markdown governance: errors=0
- JSON/YAML parse: passed
- GitNexus staged detect_changes: low, affected_count=0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: completed