### PR TITLE
G2.129 Refresh service candidates after StockSearch

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2134,7 +2134,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                `StockSearchService` deletion, dependency deletion, or
 │   │                issue-label change is made here
 │   ├── G2.128 StockSearchService getter-retirement closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#281` merged at
+│   │   │          `dbef525d9b539674d69f75fde59b372d52298913`
 │   │   ├── Evidence: `backend-stock-search-service-getter-retirement-closeout-2026-05-26.md`
 │   │   ├── Current HEAD: `edf6c2673c6b38b614e43bb78b0ace8696990777`
 │   │   ├── Result: records PR `#280` as merged and verifies current-head
@@ -2148,9 +2149,33 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, getter deletion,
 │   │                implementation authorization, next-lane authorization, or
 │   │                issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.128; if accepted,
-│                  refresh the service lifecycle candidate pool before selecting
-│                  another getter-retirement lane
+│   ├── G2.129 Service lifecycle candidate refresh after StockSearchService
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.md`
+│   │   ├── Current HEAD: `dbef525d9b539674d69f75fde59b372d52298913`
+│   │   ├── Result: refreshes the remaining service getter pool after
+│   │   │          StockSearchService closeout; no direct implementation
+│   │   │          candidate is selected
+│   │   ├── Verification: service files=`152`, backend app files=`575`,
+│   │   │          API files=`219`, tests=`203`, getter definitions=`12`;
+│   │   │          Announcement/Email/StockSearch retired getter definitions
+│   │   │          and singleton tokens remain `0`
+│   │   ├── Candidate decision: `get_watchlist_service` is selected only as a
+│   │   │          future authorization-candidate lane because GitNexus reports
+│   │   │          MEDIUM risk / impacted=`15` / direct=`9` / processes=`0`,
+│   │   │          while adapter fallback seams and seven route dependency
+│   │   │          handlers still require explicit authorization scope
+│   │   ├── Holds: `get_market_data_service` remains held for graph/text symbol
+│   │   │          disambiguation; `get_tdx_service`, `get_data_service`,
+│   │   │          `get_strategy_service`, and `get_streaming_service` remain
+│   │   │          high-risk design lanes
+│   │   └── Boundary: candidate-refresh-only; no backend source/test edit,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                getter deletion, implementation authorization, or
+│   │                issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.129; if accepted,
+│                  prepare a separate G2.130 WatchlistService getter-retirement
+│                  authorization packet before any source branch is opened
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -2248,6 +2273,7 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-email-notification-getter-retirement-closeout-2026-05-26.md` | G | G2.109 closeout accepted in PR `#262` at `ae6d2f2`: records PR `#261` merge, confirms current-head `email_notification_service.py:get_email_service` refs=`0`, `_email_service` refs=`0`, route/API direct `email_notification_service` refs=`0`, preserves `EmailNotificationService` and route-backed `get_email_service_dependency`, and re-runs focused tests `5 passed`, health route conflicts `120 passed`, ruff, and black checks | Superseded by G2.110 service lifecycle candidate refresh after EmailNotificationService |
 | `backend-service-lifecycle-candidate-refresh-after-email-notification-2026-05-26.md` | G | G2.110 candidate refresh accepted in PR `#263` at `c4abd4e`: scans service files=`152`, backend app files=`575`, API files=`219`, backend test files=`199`, all test files=`1211`, getter definitions=`16`, candidate-like definitions=`9`; confirms retired `email_notification_service.py:get_email_service` is gone, records `get_market_data_service` as the only LOW / `0` next authorization candidate with route/API direct refs=`0`, and keeps streaming HIGH, TDX/data/strategy/stock search CRITICAL, and email/watchlist/announcement holds out of source scope | Superseded by G2.111 MarketDataService getter-retirement authorization |
 | `backend-market-data-service-getter-retirement-authorization-2026-05-26.md` | G | G2.111 authorization prepared at `c4abd4e`: authorizes only a future G2.112 implementation branch for the package-level `market_data_service/get_market_data_service.py` `_market_data_service` and `get_market_data_service` retirement; preserves `MarketDataService`, `install_market_data_service`, and `get_market_data_service_dependency`, records GitNexus impact LOW / `0`, direct API refs=`0`, and requires future adapter/package export cleanup because `market_data_adapter.py` and package `__init__.py` still reference the getter | Human review / PR merge decision; if accepted, create G2.112 MarketDataService getter-retirement implementation before any market-data service source edit |
+| `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.md` | G | G2.129 candidate refresh prepared at `dbef525d9`: confirms Announcement/Email/StockSearch retired getters remain `0`, scans service files=`152`, app files=`575`, API files=`219`, tests=`203`, getter definitions=`12`, selects no direct implementation lane, and identifies `get_watchlist_service` only as a future authorization candidate with GitNexus MEDIUM / impacted=`15` / direct=`9` / processes=`0` | Human review / PR merge decision; if accepted, prepare G2.130 WatchlistService getter-retirement authorization before any source branch |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.json
+++ b/.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.json
@@ -1,0 +1,218 @@
+{
+  "artifact": "service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26",
+  "recorded_at": "2026-05-26T10:29:38+08:00",
+  "workline": "G2.129 service lifecycle DI candidate refresh after StockSearchService getter retirement",
+  "status": "candidate-refresh-prepared-for-review",
+  "current_head": "dbef525d9b539674d69f75fde59b372d52298913",
+  "stale_if_head_mismatch": true,
+  "parent_pr": {
+    "number": 281,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T02:12:03Z",
+    "merge_commit": "dbef525d9b539674d69f75fde59b372d52298913",
+    "title": "G2.128 Close out StockSearchService getter retirement",
+    "url": "https://github.com/chengjon/mystocks/pull/281"
+  },
+  "scope_boundary": {
+    "source_edits_authorized": false,
+    "test_edits_authorized": false,
+    "openspec_change_required_now": false,
+    "issue_label_movement_authorized": false,
+    "implementation_authorized": false
+  },
+  "scan_summary": {
+    "service_files": 152,
+    "app_files": 575,
+    "api_files": 219,
+    "test_files": 203,
+    "service_getter_definitions": 12,
+    "retired_getter_confirmations": {
+      "get_announcement_service_definitions": 0,
+      "get_email_service_definitions": 0,
+      "get_stock_search_service_definitions": 0,
+      "_announcement_service_tokens": 0,
+      "_email_service_tokens": 0,
+      "_stock_search_service_tokens": 0
+    }
+  },
+  "candidate_inventory": [
+    {
+      "symbol": "get_watchlist_service",
+      "definition": {
+        "file": "web/backend/app/services/watchlist_service.py",
+        "line": 613
+      },
+      "disposition": "next-authorization-candidate-only",
+      "text_scan": {
+        "api_direct_calls": 0,
+        "app_direct_calls": 6,
+        "test_direct_calls": 2,
+        "dependency_refs": 18,
+        "route_dependency_handlers": 7,
+        "adapter_fallback_files": [
+          "web/backend/app/services/adapters/watchlist_adapter.py",
+          "web/backend/app/services/data_adapters/watchlist.py"
+        ]
+      },
+      "gitnexus": {
+        "risk": "MEDIUM",
+        "impacted_count": 15,
+        "direct": 9,
+        "processes_affected": 0,
+        "modules_affected": 2,
+        "direct_callers": [
+          "web/backend/app/services/data_adapters/watchlist.py:_get_watchlist_service",
+          "web/backend/app/services/adapters/watchlist_adapter.py:_get_watchlist_service",
+          "web/backend/app/api/watchlist.py:get_user_groups",
+          "web/backend/app/api/watchlist.py:create_group",
+          "web/backend/app/api/watchlist.py:update_group",
+          "web/backend/app/api/watchlist.py:delete_group",
+          "web/backend/app/api/watchlist.py:get_watchlist_by_group",
+          "web/backend/app/api/watchlist.py:move_stock_to_group",
+          "web/backend/app/api/watchlist.py:get_watchlist_with_groups"
+        ]
+      },
+      "required_next_gate": "Create a separate authorization packet before any source edit; include both adapter fallback seams, seven route dependency handlers, and focused route/test acceptance criteria."
+    },
+    {
+      "symbol": "get_market_data_service",
+      "definition": {
+        "file": "web/backend/app/services/__init__.py",
+        "line": 260
+      },
+      "disposition": "hold-graph-text-symbol-mismatch",
+      "text_scan": {
+        "api_direct_calls": 0,
+        "app_direct_calls": 2,
+        "test_direct_calls": 16,
+        "dependency_refs": 24
+      },
+      "gitnexus": {
+        "risk": "LOW",
+        "impacted_count": 0,
+        "direct": 0,
+        "processes_affected": 0,
+        "modules_affected": 0,
+        "resolved_symbol_file": "web/backend/app/services/market_data_service/get_market_data_service.py"
+      },
+      "required_next_gate": "Disambiguate package helper text evidence from GitNexus graph symbol before selecting this lane."
+    },
+    {
+      "symbol": "get_tdx_service",
+      "definition": {
+        "file": "web/backend/app/services/tdx_service.py",
+        "line": 275
+      },
+      "disposition": "hold-critical-dashboard-seam",
+      "text_scan": {
+        "api_direct_calls": 2,
+        "app_direct_calls": 4,
+        "test_direct_calls": 2,
+        "dependency_refs": 15,
+        "api_files": [
+          "web/backend/app/api/dashboard_data_source.py"
+        ]
+      },
+      "gitnexus": {
+        "risk": "CRITICAL",
+        "impacted_count": 6,
+        "direct": 2,
+        "processes_affected": 5,
+        "modules_affected": 1
+      },
+      "required_next_gate": "Keep on hold until dashboard live-market seam has a dedicated authorization and runtime acceptance plan."
+    },
+    {
+      "symbol": "get_data_service",
+      "definition": {
+        "file": "web/backend/app/services/data_service.py",
+        "line": 466
+      },
+      "disposition": "hold-critical-indicators-strategy-seam",
+      "text_scan": {
+        "api_direct_calls": 5,
+        "app_direct_calls": 6,
+        "test_direct_calls": 6,
+        "dependency_refs": 0,
+        "api_files": [
+          "web/backend/app/api/indicators/indicator_cache.py",
+          "web/backend/app/api/v1/strategy/indicators.py"
+        ]
+      },
+      "gitnexus": {
+        "risk": "CRITICAL",
+        "impacted_count": 5,
+        "direct": 3,
+        "processes_affected": 7,
+        "modules_affected": 2
+      },
+      "required_next_gate": "Keep on hold until indicator and strategy data-contract consumers are split into a design packet."
+    },
+    {
+      "symbol": "get_strategy_service",
+      "definition": {
+        "file": "web/backend/app/services/strategy_service.py",
+        "line": 455
+      },
+      "disposition": "hold-critical-strategy-adapter-task-seam",
+      "text_scan": {
+        "api_direct_calls": 4,
+        "app_direct_calls": 11,
+        "test_direct_calls": 1,
+        "dependency_refs": 0,
+        "api_files": [
+          "web/backend/app/api/strategy_management/_strategy_execution_router.py"
+        ]
+      },
+      "gitnexus": {
+        "risk": "CRITICAL",
+        "impacted_count": 13,
+        "direct": 6,
+        "processes_affected": 0,
+        "modules_affected": 5
+      },
+      "required_next_gate": "Keep on hold until strategy route, adapter, and task seams are triaged outside a narrow getter-retirement batch."
+    },
+    {
+      "symbol": "get_streaming_service",
+      "definition": {
+        "file": "web/backend/app/services/realtime_streaming_service.py",
+        "line": 424
+      },
+      "disposition": "hold-high-streaming-socketio-seam",
+      "text_scan": {
+        "api_direct_calls": 0,
+        "app_direct_calls": 12,
+        "test_direct_calls": 19,
+        "dependency_refs": 0
+      },
+      "gitnexus": {
+        "risk": "HIGH",
+        "impacted_count": 9,
+        "direct": 9,
+        "processes_affected": 0,
+        "modules_affected": 4
+      },
+      "required_next_gate": "Keep on hold; streaming and Socket.IO lifecycle behavior is not a narrow route-service getter retirement."
+    }
+  ],
+  "decision": {
+    "next_direct_implementation_candidate_selected": false,
+    "selected_authorization_candidate": "get_watchlist_service",
+    "selected_authorization_lane": "G2.130 WatchlistService getter-retirement authorization packet",
+    "rationale": "WatchlistService is the only non-HIGH/CRITICAL candidate sampled after StockSearchService closeout, but it still has adapter fallback seams and seven route dependency handlers; therefore this packet authorizes only a future authorization package, not source edits.",
+    "implementation_authorized_now": false
+  },
+  "verification": {
+    "parent_pr_state": "MERGED",
+    "candidate_scan": "fresh current-head scan at dbef525d9b539674d69f75fde59b372d52298913",
+    "gitnexus_impact_sampling": "fresh for watchlist, market_data, tdx, data, strategy, and streaming getters",
+    "staged_gitnexus_detect_changes": {
+      "risk_level": "low",
+      "changed_files": 4,
+      "changed_count": 0,
+      "affected_count": 0,
+      "affected_processes": 0
+    }
+  }
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.md
@@ -1,0 +1,127 @@
+# Backend Service Lifecycle DI Candidate Refresh After StockSearch - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: candidate-refresh-prepared-for-review
+- Workline: G2.129 service lifecycle DI candidate refresh after StockSearchService getter retirement
+- Current HEAD: `dbef525d9b539674d69f75fde59b372d52298913`
+- Parent PR: `#281` merged at `dbef525d9b539674d69f75fde59b372d52298913`
+- Generated artifact: `.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.json`
+
+This is a governance and evidence packet only. It does not edit backend source,
+tests, route handlers, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec
+changes, or GitHub issue labels.
+
+## Input State
+
+G2.128 closed the StockSearchService getter-retirement lane after PR `#280`
+merged and current-head closeout evidence confirmed:
+
+- `get_stock_search_service` definitions: `0`
+- `_stock_search_service` tokens: `0`
+- package re-export: absent
+- app/API/test direct getter calls: `0`
+- route dependency handlers: `6`
+
+This packet refreshes the remaining service getter pool before choosing any
+next lane.
+
+## Current-Head Scan
+
+| Metric | Count |
+|---|---:|
+| Service files scanned | 152 |
+| Backend app files scanned | 575 |
+| Backend API files scanned | 219 |
+| Backend test files scanned | 203 |
+| Service getter definitions found | 12 |
+| `get_announcement_service` definitions | 0 |
+| `get_email_service` definitions | 0 |
+| `get_stock_search_service` definitions | 0 |
+| `_announcement_service` tokens | 0 |
+| `_email_service` tokens | 0 |
+| `_stock_search_service` tokens | 0 |
+
+## Candidate Inventory
+
+| Candidate | Definition | Text-scan surface | GitNexus risk | Disposition |
+|---|---|---:|---|---|
+| `get_watchlist_service` | `web/backend/app/services/watchlist_service.py:613` | API direct `0`, app direct `6`, tests `2`, dependency refs `18`, route dependency handlers `7` | MEDIUM, impacted `15`, direct `9`, processes `0` | Next authorization candidate only |
+| `get_market_data_service` | `web/backend/app/services/__init__.py:260` | API direct `0`, app direct `2`, tests `16`, dependency refs `24` | LOW, impacted `0`, but graph resolves to `web/backend/app/services/market_data_service/get_market_data_service.py` | Hold for graph/text symbol disambiguation |
+| `get_tdx_service` | `web/backend/app/services/tdx_service.py:275` | API direct `2`, app direct `4`, tests `2`, dependency refs `15` | CRITICAL, impacted `6`, processes `5` | Hold: dashboard live-market seam |
+| `get_data_service` | `web/backend/app/services/data_service.py:466` | API direct `5`, app direct `6`, tests `6`, dependency refs `0` | CRITICAL, impacted `5`, processes `7` | Hold: indicators/strategy data seam |
+| `get_strategy_service` | `web/backend/app/services/strategy_service.py:455` | API direct `4`, app direct `11`, tests `1`, dependency refs `0` | CRITICAL, impacted `13`, modules `5` | Hold: strategy route/adapter/task seam |
+| `get_streaming_service` | `web/backend/app/services/realtime_streaming_service.py:424` | API direct `0`, app direct `12`, tests `19`, dependency refs `0` | HIGH, impacted `9`, direct `9` | Hold: streaming/Socket.IO lifecycle seam |
+
+## Watchlist Candidate Boundary
+
+`get_watchlist_service` is the only sampled candidate that is not HIGH or
+CRITICAL, and it has no affected execution processes in GitNexus. It is still
+not an implementation-ready change because direct d=1 callers include both
+adapter fallback helpers and route handlers:
+
+| Surface | Required future handling |
+|---|---|
+| `web/backend/app/services/data_adapters/watchlist.py:_get_watchlist_service` | Must be included in authorization scope or explicitly retained |
+| `web/backend/app/services/adapters/watchlist_adapter.py:_get_watchlist_service` | Must be included in authorization scope or explicitly retained |
+| `web/backend/app/api/watchlist.py:get_user_groups` | Route dependency acceptance required |
+| `web/backend/app/api/watchlist.py:create_group` | Route dependency acceptance required |
+| `web/backend/app/api/watchlist.py:update_group` | Route dependency acceptance required |
+| `web/backend/app/api/watchlist.py:delete_group` | Route dependency acceptance required |
+| `web/backend/app/api/watchlist.py:get_watchlist_by_group` | Route dependency acceptance required |
+| `web/backend/app/api/watchlist.py:move_stock_to_group` | Route dependency acceptance required |
+| `web/backend/app/api/watchlist.py:get_watchlist_with_groups` | Route dependency acceptance required |
+
+The next packet may prepare a WatchlistService getter-retirement authorization,
+but this report does not authorize source edits.
+
+## Decision
+
+No direct implementation candidate is selected by G2.129.
+
+Selected next gate:
+
+1. Create G2.130 WatchlistService getter-retirement authorization packet.
+2. Include adapter fallback seams, seven route dependency handlers, focused
+   tests, GitNexus d=1 acceptance, and rollback criteria.
+3. Keep `get_market_data_service` on hold until package-helper text evidence
+   and GitNexus graph symbol resolution are reconciled.
+4. Keep TDX, data, strategy, and streaming getters on their existing high-risk
+   design tracks.
+
+## Verification
+
+- Parent PR `#281`: `MERGED`, merge commit
+  `dbef525d9b539674d69f75fde59b372d52298913`
+- Candidate scan: fresh current-head scan at
+  `dbef525d9b539674d69f75fde59b372d52298913`
+- GitNexus impact sampling:
+  - `get_watchlist_service`: MEDIUM, impacted `15`, direct `9`, processes `0`
+  - `get_market_data_service`: LOW, impacted `0`, graph/text symbol mismatch
+  - `get_tdx_service`: CRITICAL, impacted `6`, processes `5`
+  - `get_data_service`: CRITICAL, impacted `5`, processes `7`
+  - `get_strategy_service`: CRITICAL, impacted `13`, modules `5`
+  - `get_streaming_service`: HIGH, impacted `9`, direct `9`
+- Staged GitNexus detect changes: low risk, changed files `4`, changed symbols
+  `0`, affected symbols `0`, affected processes `0`
+
+## Non-Goals
+
+- No backend source or test edits
+- No route handler edits
+- No service getter deletion or rewrite
+- No route path, response model, response shape, or OpenAPI exposure changes
+- No frontend, PM2, or runtime workflow changes
+- No OpenSpec change/spec creation or modification
+- No GitHub issue label or readiness change
+- No implementation authorization
+
+## Next Gate
+
+Human review / PR merge decision for G2.129. If accepted, prepare G2.130 as a
+separate WatchlistService getter-retirement authorization packet before any
+source branch is opened.

--- a/governance/mainline/task-cards/pr-282.yaml
+++ b/governance/mainline/task-cards/pr-282.yaml
@@ -1,0 +1,116 @@
+version: "v0.2"
+
+task:
+  id: "pr-282"
+  title: "Refresh service lifecycle candidates after StockSearchService"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-service-lifecycle-candidate-refresh-after-stock-search"
+  objective: "refresh the service getter candidate pool after StockSearchService retirement and select only the next authorization candidate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-candidate-refresh"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-candidate-refresh-after-stock-search"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate-refresh-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-282.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not edit route handlers"
+  - "Do not modify route paths, response models, response shapes, or OpenAPI exposure"
+  - "Do not modify frontend code"
+  - "Do not modify PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not authorize implementation"
+  - "Do not delete or alter any service getter"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 281 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "candidate-scan"
+      command: "scripted current-head text scan over service getter definitions, retired getter tokens, route dependency handlers, and direct getter calls"
+      required: true
+    - id: "gitnexus-impact-sampling"
+      command: "GitNexus impact sampling for watchlist, market_data, tdx, data, strategy, and streaming getters"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-282.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-282.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this refresh is mistaken for implementation authorization, WatchlistService getter edits could proceed without adapter fallback and route dependency acceptance criteria"
+    - "If stale pre-G2.128 counts are reused, the next service lifecycle lane could be selected from obsolete evidence"
+  rollback_plan: "revert this governance-only refresh PR and keep G2.128 as the latest accepted closeout gate"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh service lifecycle getter candidates after StockSearchService retirement"
+    modified_scope: "steward tree, candidate refresh report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; refresh-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent PR state, candidate scan, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T10:29:38+08:00"
+    approval_note: "Candidate-refresh-only packet after PR #281 merge; next implementation lane is not authorized here"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- refreshes service lifecycle getter candidates after PR #281 StockSearchService closeout
- records current-head scan evidence and GitNexus impact sampling
- selects no direct implementation lane; identifies WatchlistService only as a future authorization candidate

## Verification
- parent PR #281 verified merged at dbef525d9b539674d69f75fde59b372d52298913
- JSON/YAML parse passed
- markdown governance passed: 2 checked files, 0 errors
- git diff --cached --check passed
- GitNexus staged detect_changes: low risk, changed files 4, affected count 0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore completed

## Boundary
- governance-only; no backend source/test edits
- no route/API/OpenAPI/frontend/PM2/OpenSpec changes
- no implementation authorization or issue-label movement

Next gate after review: prepare a separate G2.130 WatchlistService getter-retirement authorization packet before any source branch.