### PR TITLE
G2.130 Authorize WatchlistService getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2150,7 +2150,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                implementation authorization, next-lane authorization, or
 │   │                issue-label change is made here
 │   ├── G2.129 Service lifecycle candidate refresh after StockSearchService
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#282` merged at
+│   │   │          `cc32d0c2ba52cf7a9669ec1e9976740a84fd5be9`
 │   │   ├── Evidence: `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.md`
 │   │   ├── Current HEAD: `dbef525d9b539674d69f75fde59b372d52298913`
 │   │   ├── Result: refreshes the remaining service getter pool after
@@ -2173,9 +2174,32 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                getter deletion, implementation authorization, or
 │   │                issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.129; if accepted,
-│                  prepare a separate G2.130 WatchlistService getter-retirement
-│                  authorization packet before any source branch is opened
+│   ├── G2.130 WatchlistService getter-retirement authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-watchlist-service-getter-retirement-authorization-2026-05-26.md`
+│   │   ├── Current HEAD: `cc32d0c2ba52cf7a9669ec1e9976740a84fd5be9`
+│   │   ├── Result: authorizes only a future implementation branch to retire
+│   │   │          `watchlist_service.py` `get_watchlist_service` and
+│   │   │          `_watchlist_service`, while preserving `WatchlistService`,
+│   │   │          `install_watchlist_service`,
+│   │   │          `get_watchlist_service_dependency`, route paths, response
+│   │   │          contracts, and OpenAPI exposure
+│   │   ├── Verification: baseline focused watchlist tests `9 passed`;
+│   │   │          current scan shows getter definitions=`1`, singleton
+│   │   │          tokens=`74`, app/API direct getter calls=`0`, route
+│   │   │          dependency handlers=`7`, adapter fallback files=`2`,
+│   │   │          tests with getter refs=`4`
+│   │   ├── Risk note: GitNexus impact is MEDIUM with impacted=`15`,
+│   │   │          direct=`9`, processes=`0`; future implementation must cover
+│   │   │          two adapter fallback helpers and seven route dependency
+│   │   │          handlers in acceptance criteria
+│   │   └── Boundary: authorization-only; no backend source/test edit,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                getter deletion, implementation, or issue-label change is
+│   │                made here
+│   └── Next gate: human review / PR merge decision for G2.130; if accepted,
+│                  open G2.131 WatchlistService getter-retirement implementation
+│                  within the authorized source/test scope
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -2273,7 +2297,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-email-notification-getter-retirement-closeout-2026-05-26.md` | G | G2.109 closeout accepted in PR `#262` at `ae6d2f2`: records PR `#261` merge, confirms current-head `email_notification_service.py:get_email_service` refs=`0`, `_email_service` refs=`0`, route/API direct `email_notification_service` refs=`0`, preserves `EmailNotificationService` and route-backed `get_email_service_dependency`, and re-runs focused tests `5 passed`, health route conflicts `120 passed`, ruff, and black checks | Superseded by G2.110 service lifecycle candidate refresh after EmailNotificationService |
 | `backend-service-lifecycle-candidate-refresh-after-email-notification-2026-05-26.md` | G | G2.110 candidate refresh accepted in PR `#263` at `c4abd4e`: scans service files=`152`, backend app files=`575`, API files=`219`, backend test files=`199`, all test files=`1211`, getter definitions=`16`, candidate-like definitions=`9`; confirms retired `email_notification_service.py:get_email_service` is gone, records `get_market_data_service` as the only LOW / `0` next authorization candidate with route/API direct refs=`0`, and keeps streaming HIGH, TDX/data/strategy/stock search CRITICAL, and email/watchlist/announcement holds out of source scope | Superseded by G2.111 MarketDataService getter-retirement authorization |
 | `backend-market-data-service-getter-retirement-authorization-2026-05-26.md` | G | G2.111 authorization prepared at `c4abd4e`: authorizes only a future G2.112 implementation branch for the package-level `market_data_service/get_market_data_service.py` `_market_data_service` and `get_market_data_service` retirement; preserves `MarketDataService`, `install_market_data_service`, and `get_market_data_service_dependency`, records GitNexus impact LOW / `0`, direct API refs=`0`, and requires future adapter/package export cleanup because `market_data_adapter.py` and package `__init__.py` still reference the getter | Human review / PR merge decision; if accepted, create G2.112 MarketDataService getter-retirement implementation before any market-data service source edit |
-| `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.md` | G | G2.129 candidate refresh prepared at `dbef525d9`: confirms Announcement/Email/StockSearch retired getters remain `0`, scans service files=`152`, app files=`575`, API files=`219`, tests=`203`, getter definitions=`12`, selects no direct implementation lane, and identifies `get_watchlist_service` only as a future authorization candidate with GitNexus MEDIUM / impacted=`15` / direct=`9` / processes=`0` | Human review / PR merge decision; if accepted, prepare G2.130 WatchlistService getter-retirement authorization before any source branch |
+| `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.md` | G | G2.129 candidate refresh accepted in PR `#282` at `cc32d0c2`: confirms Announcement/Email/StockSearch retired getters remain `0`, scans service files=`152`, app files=`575`, API files=`219`, tests=`203`, getter definitions=`12`, selects no direct implementation lane, and identifies `get_watchlist_service` only as a future authorization candidate with GitNexus MEDIUM / impacted=`15` / direct=`9` / processes=`0` | Superseded by G2.130 WatchlistService getter-retirement authorization |
+| `backend-watchlist-service-getter-retirement-authorization-2026-05-26.md` | G | G2.130 authorization prepared at `cc32d0c2`: authorizes only a future implementation branch to retire `watchlist_service.py` `get_watchlist_service` and `_watchlist_service`, while preserving `WatchlistService`, `install_watchlist_service`, `get_watchlist_service_dependency`, route paths, response contracts, and OpenAPI exposure; current scan shows getter definitions=`1`, singleton tokens=`74`, app/API direct getter calls=`0`, route dependency handlers=`7`, adapter fallback files=`2`, tests with getter refs=`4`; GitNexus impact MEDIUM / impacted=`15` / direct=`9` / processes=`0` | Human review / PR merge decision; if accepted, open G2.131 WatchlistService getter-retirement implementation within the authorized source/test scope |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/watchlist-service-getter-retirement-authorization-2026-05-26.json
+++ b/.planning/codebase/generated/watchlist-service-getter-retirement-authorization-2026-05-26.json
@@ -1,0 +1,114 @@
+{
+  "artifact": "watchlist-service-getter-retirement-authorization-2026-05-26",
+  "recorded_at": "2026-05-26T10:52:00+08:00",
+  "workline": "G2.130 WatchlistService getter-retirement authorization",
+  "status": "authorization-prepared-for-review",
+  "current_head": "cc32d0c2ba52cf7a9669ec1e9976740a84fd5be9",
+  "stale_if_head_mismatch": true,
+  "parent_pr": {
+    "number": 282,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T02:46:37Z",
+    "merge_commit": "cc32d0c2ba52cf7a9669ec1e9976740a84fd5be9",
+    "title": "G2.129 Refresh service candidates after StockSearch",
+    "url": "https://github.com/chengjon/mystocks/pull/282"
+  },
+  "authorization_boundary": {
+    "source_edits_authorized_by_this_packet": false,
+    "future_source_edits_authorized_after_review": true,
+    "openspec_change_required_now": false,
+    "issue_label_movement_authorized": false,
+    "route_contract_change_authorized": false,
+    "openapi_exposure_change_authorized": false,
+    "frontend_change_authorized": false,
+    "pm2_change_authorized": false
+  },
+  "current_evidence": {
+    "getter_definitions": 1,
+    "singleton_tokens": 74,
+    "app_api_direct_getter_calls": 0,
+    "route_dependency_refs": 8,
+    "route_dependency_handlers": 7,
+    "adapter_fallback_files": [
+      "web/backend/app/services/adapters/watchlist_adapter.py",
+      "web/backend/app/services/data_adapters/watchlist.py"
+    ],
+    "tests_with_getter_refs": [
+      "web/backend/tests/test_adapter_mock_fallback_controls.py",
+      "web/backend/tests/test_logging_noise_regressions.py",
+      "web/backend/tests/test_watchlist_helper_lifecycle_di.py",
+      "web/backend/tests/test_watchlist_service_lifecycle_di.py"
+    ],
+    "focused_baseline_tests": "9 passed in 2.72s"
+  },
+  "gitnexus_impact": {
+    "target": "get_watchlist_service",
+    "risk": "MEDIUM",
+    "impacted_count": 15,
+    "direct": 9,
+    "processes_affected": 0,
+    "modules_affected": 2,
+    "direct_callers": [
+      "web/backend/app/services/data_adapters/watchlist.py:_get_watchlist_service",
+      "web/backend/app/services/adapters/watchlist_adapter.py:_get_watchlist_service",
+      "web/backend/app/api/watchlist.py:get_user_groups",
+      "web/backend/app/api/watchlist.py:create_group",
+      "web/backend/app/api/watchlist.py:update_group",
+      "web/backend/app/api/watchlist.py:delete_group",
+      "web/backend/app/api/watchlist.py:get_watchlist_by_group",
+      "web/backend/app/api/watchlist.py:move_stock_to_group",
+      "web/backend/app/api/watchlist.py:get_watchlist_with_groups"
+    ]
+  },
+  "future_implementation_allowed_paths": [
+    "web/backend/app/services/watchlist_service.py",
+    "web/backend/app/services/adapters/watchlist_adapter.py",
+    "web/backend/app/services/data_adapters/watchlist.py",
+    "web/backend/tests/test_watchlist_service_lifecycle_di.py",
+    "web/backend/tests/test_watchlist_helper_lifecycle_di.py",
+    "web/backend/tests/test_adapter_mock_fallback_controls.py",
+    "web/backend/tests/test_logging_noise_regressions.py",
+    "web/backend/tests/test_watchlist_service_getter_retirement.py",
+    ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+    ".planning/codebase/generated/watchlist-service-getter-retirement-implementation-2026-05-26.json",
+    "docs/reports/quality/backend-watchlist-service-getter-retirement-implementation-2026-05-26.md",
+    "governance/mainline/task-cards/pr-284.yaml"
+  ],
+  "future_implementation_locked_paths": [
+    "web/backend/app/api/watchlist.py",
+    "web/backend/app/api/**",
+    "web/frontend/**",
+    "src/**",
+    "docs/api/**",
+    "docs/guides/**",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**"
+  ],
+  "required_future_acceptance": [
+    "Run GitNexus impact for get_watchlist_service and context/impact for any adapter helper symbol before source edits.",
+    "Add a TDD red test proving get_watchlist_service and _watchlist_service are retired while WatchlistService, install_watchlist_service, and get_watchlist_service_dependency remain available.",
+    "Remove adapter fallback imports of get_watchlist_service or explicitly replace them with an authorized provider/app-state fallback.",
+    "Keep web/backend/app/api/watchlist.py route paths, response shapes, and dependency handler count unchanged unless a separate amendment authorizes route edits.",
+    "Focused tests must include watchlist service lifecycle, watchlist helper lifecycle, adapter mock fallback controls, logging noise regressions, and the new retirement regression.",
+    "Run health route conflicts and touched-file ruff/black checks.",
+    "Run exact post-change scans for getter definitions, singleton tokens, adapter fallback imports, app/API direct getter calls, and route dependency handler count.",
+    "Run staged GitNexus detect_changes and post-commit mainline scope gate."
+  ],
+  "decision": {
+    "future_implementation_lane": "G2.131 WatchlistService getter-retirement implementation",
+    "authorized_after_human_review": true,
+    "implementation_authorized_now_by_this_commit": false,
+    "rollback_plan": "Revert the future implementation commit and restore get_watchlist_service plus adapter fallback imports if focused route/helper tests or exact scans fail."
+  },
+  "authorization_packet_verification": {
+    "staged_gitnexus_detect_changes": {
+      "risk_level": "low",
+      "changed_files": 4,
+      "changed_count": 0,
+      "affected_count": 0,
+      "affected_processes": 0
+    }
+  }
+}

--- a/docs/reports/quality/backend-watchlist-service-getter-retirement-authorization-2026-05-26.md
+++ b/docs/reports/quality/backend-watchlist-service-getter-retirement-authorization-2026-05-26.md
@@ -1,0 +1,160 @@
+# Backend WatchlistService Getter Retirement Authorization - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: authorization-prepared-for-review
+- Workline: G2.130 WatchlistService getter-retirement authorization
+- Current HEAD: `cc32d0c2ba52cf7a9669ec1e9976740a84fd5be9`
+- Parent PR: `#282` merged at `cc32d0c2ba52cf7a9669ec1e9976740a84fd5be9`
+- Generated artifact: `.planning/codebase/generated/watchlist-service-getter-retirement-authorization-2026-05-26.json`
+
+This packet authorizes only a future implementation branch after human review.
+It does not change backend source, tests, route handlers, OpenAPI exposure,
+frontend code, PM2 workflows, OpenSpec changes, or GitHub issue labels.
+
+## Parent Decision
+
+G2.129 selected `get_watchlist_service` only as a future authorization candidate.
+It did not select a direct implementation lane because the WatchlistService getter
+still crosses adapter fallback seams and seven route dependency handlers.
+
+## Current Evidence
+
+| Evidence | Current value |
+|---|---:|
+| `get_watchlist_service` definitions | 1 |
+| `_watchlist_service` tokens | 74 |
+| App/API direct `get_watchlist_service()` calls | 0 |
+| API `get_watchlist_service_dependency` refs | 8 |
+| Route dependency handlers | 7 |
+| Adapter fallback files importing `get_watchlist_service` | 2 |
+| Tests with getter refs | 4 |
+| Focused watchlist baseline tests | 9 passed |
+
+Adapter fallback files:
+
+- `web/backend/app/services/adapters/watchlist_adapter.py`
+- `web/backend/app/services/data_adapters/watchlist.py`
+
+Tests with current getter references:
+
+- `web/backend/tests/test_adapter_mock_fallback_controls.py`
+- `web/backend/tests/test_logging_noise_regressions.py`
+- `web/backend/tests/test_watchlist_helper_lifecycle_di.py`
+- `web/backend/tests/test_watchlist_service_lifecycle_di.py`
+
+## GitNexus Impact
+
+| Target | Risk | Impacted | Direct | Processes | Modules |
+|---|---:|---:|---:|---:|---:|
+| `get_watchlist_service` | MEDIUM | 15 | 9 | 0 | 2 |
+
+Direct d=1 callers that future work must account for:
+
+- `web/backend/app/services/data_adapters/watchlist.py:_get_watchlist_service`
+- `web/backend/app/services/adapters/watchlist_adapter.py:_get_watchlist_service`
+- `web/backend/app/api/watchlist.py:get_user_groups`
+- `web/backend/app/api/watchlist.py:create_group`
+- `web/backend/app/api/watchlist.py:update_group`
+- `web/backend/app/api/watchlist.py:delete_group`
+- `web/backend/app/api/watchlist.py:get_watchlist_by_group`
+- `web/backend/app/api/watchlist.py:move_stock_to_group`
+- `web/backend/app/api/watchlist.py:get_watchlist_with_groups`
+
+## Future Write Scope
+
+If this authorization is accepted, the future implementation branch may edit
+only these source/test files:
+
+- `web/backend/app/services/watchlist_service.py`
+- `web/backend/app/services/adapters/watchlist_adapter.py`
+- `web/backend/app/services/data_adapters/watchlist.py`
+- `web/backend/tests/test_watchlist_service_lifecycle_di.py`
+- `web/backend/tests/test_watchlist_helper_lifecycle_di.py`
+- `web/backend/tests/test_adapter_mock_fallback_controls.py`
+- `web/backend/tests/test_logging_noise_regressions.py`
+- `web/backend/tests/test_watchlist_service_getter_retirement.py`
+
+The future implementation may also update its own report, generated artifact,
+task card, and steward-tree record.
+
+## Locked Scope
+
+The future implementation must not edit:
+
+- `web/backend/app/api/watchlist.py`
+- other `web/backend/app/api/**` files
+- frontend code
+- `src/**`
+- API docs or guides
+- PM2, Docker, or runtime workflow files
+- OpenSpec changes/specs
+- GitHub issue labels or readiness state
+
+Route paths, response shapes, response models, dependency handler count, and
+OpenAPI exposure are locked unless a separate amendment authorizes route edits.
+
+## Required Future Acceptance
+
+The future implementation must:
+
+1. Run GitNexus impact for `get_watchlist_service` before source edits.
+2. Run GitNexus context/impact for any adapter helper symbol that will be
+   changed.
+3. Add a TDD red test proving `get_watchlist_service` and `_watchlist_service`
+   are retired while `WatchlistService`, `install_watchlist_service`, and
+   `get_watchlist_service_dependency` remain available.
+4. Remove adapter fallback imports of `get_watchlist_service` or replace them
+   with an explicitly authorized provider/app-state fallback.
+5. Keep `web/backend/app/api/watchlist.py` route paths, response shapes, and
+   dependency handlers unchanged.
+6. Run focused tests:
+   - `web/backend/tests/test_watchlist_service_getter_retirement.py`
+   - `web/backend/tests/test_watchlist_service_lifecycle_di.py`
+   - `web/backend/tests/test_watchlist_helper_lifecycle_di.py`
+   - `web/backend/tests/test_adapter_mock_fallback_controls.py`
+   - `web/backend/tests/test_logging_noise_regressions.py`
+7. Run `web/backend/tests/test_health_route_conflicts.py`.
+8. Run touched-file ruff and black checks.
+9. Run exact scans for getter definitions, singleton tokens, adapter fallback
+   imports, app/API direct getter calls, and route dependency handler count.
+10. Run staged GitNexus detect changes and post-commit mainline scope gate.
+
+## Rollback
+
+If the future implementation fails route/helper tests, exact scans, GitNexus
+staged scope, or mainline scope, revert the implementation commit and restore
+`get_watchlist_service` plus adapter fallback imports.
+
+## Authorization Packet Verification
+
+- Parent PR `#282`: `MERGED`, merge commit
+  `cc32d0c2ba52cf7a9669ec1e9976740a84fd5be9`
+- Focused watchlist baseline:
+  `web/backend/tests/test_watchlist_helper_lifecycle_di.py`
+  and `web/backend/tests/test_watchlist_service_lifecycle_di.py`:
+  `9 passed`
+- GitNexus impact for `get_watchlist_service`: MEDIUM, impacted `15`,
+  direct `9`, processes `0`
+- Staged GitNexus detect changes for this authorization packet: low risk,
+  changed files `4`, changed symbols `0`, affected symbols `0`, affected
+  processes `0`
+
+## Non-Goals
+
+- No source or test edits in this authorization packet
+- No direct implementation in this packet
+- No route handler edits
+- No route path, response model, response shape, or OpenAPI exposure changes
+- No frontend, PM2, runtime workflow, or OpenSpec changes
+- No GitHub issue label or readiness change
+
+## Next Gate
+
+Human review / PR merge decision for G2.130. If accepted, open G2.131 as the
+source-capable WatchlistService getter-retirement implementation branch within
+the scope above.

--- a/governance/mainline/task-cards/pr-283.yaml
+++ b/governance/mainline/task-cards/pr-283.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-283"
+  title: "Authorize WatchlistService getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-watchlist-service-getter-retirement-authorization"
+  objective: "authorize the future WatchlistService getter-retirement implementation scope without editing source code"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-watchlist-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-watchlist-service-getter-retirement-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only packet; no runtime entrypoint, route, service symbol, public API surface, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/watchlist-service-getter-retirement-authorization-2026-05-26.json"
+    - "docs/reports/quality/backend-watchlist-service-getter-retirement-authorization-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-283.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit backend source or tests"
+  - "Do not edit route handlers"
+  - "Do not modify route paths, response models, response shapes, or OpenAPI exposure"
+  - "Do not modify frontend code"
+  - "Do not modify PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not implement the WatchlistService getter retirement in this packet"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 282 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "watchlist-current-scan"
+      command: "scripted current-head scan for get_watchlist_service definitions, _watchlist_service tokens, route dependency handlers, adapter fallback imports, and tests with getter refs"
+      required: true
+    - id: "watchlist-focused-baseline"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_helper_lifecycle_di.py web/backend/tests/test_watchlist_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "gitnexus-impact"
+      command: "GitNexus impact for get_watchlist_service"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-watchlist-service-getter-retirement-authorization-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/watchlist-service-getter-retirement-authorization-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-283.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-283.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If the future implementation edits route handlers, it could turn a getter retirement into a route-contract change"
+    - "If adapter fallback seams are omitted, retiring the getter could break non-route watchlist data adapters"
+  rollback_plan: "revert this authorization packet and keep G2.129 as the latest accepted candidate refresh"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize future WatchlistService getter retirement"
+    modified_scope: "steward tree, authorization report, generated artifact, and this task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; authorization-only, no source or test edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent PR state, current scan, focused baseline, governance validation, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T10:52:00+08:00"
+    approval_note: "Authorization-only packet after PR #282 merge; source implementation must wait for this packet to be accepted"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- authorizes a future WatchlistService getter-retirement implementation lane
- locks route/API/OpenAPI/frontend/PM2/OpenSpec scope out of this lane
- records current scan, focused baseline, GitNexus impact, rollback, and acceptance criteria

## Evidence
- parent PR #282 verified merged at cc32d0c2ba52cf7a9669ec1e9976740a84fd5be9
- focused watchlist baseline: 9 passed
- current scan: getter definitions 1, singleton tokens 74, app/API direct getter calls 0, route dependency handlers 7, adapter fallback files 2, tests with getter refs 4
- GitNexus impact for get_watchlist_service: MEDIUM, impacted 15, direct 9, processes 0
- staged GitNexus detect_changes: low risk, changed files 4, affected count 0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore completed

## Boundary
- authorization-only; no backend source/test edits
- no route/API/OpenAPI/frontend/PM2/OpenSpec changes
- no issue-label movement

Next gate after review: G2.131 WatchlistService getter-retirement implementation within the authorized source/test scope.