### PR TITLE
G2.131 Retire WatchlistService getter singleton

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2175,7 +2175,8 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, implementation authorization, or
 │   │                issue-label change is made here
 │   ├── G2.130 WatchlistService getter-retirement authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted; PR `#283` merged at
+│   │   │          `35dcc90cd9a242e8906107a01abf1649d77737ea`
 │   │   ├── Evidence: `backend-watchlist-service-getter-retirement-authorization-2026-05-26.md`
 │   │   ├── Current HEAD: `cc32d0c2ba52cf7a9669ec1e9976740a84fd5be9`
 │   │   ├── Result: authorizes only a future implementation branch to retire
@@ -2197,9 +2198,33 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                getter deletion, implementation, or issue-label change is
 │   │                made here
-│   └── Next gate: human review / PR merge decision for G2.130; if accepted,
-│                  open G2.131 WatchlistService getter-retirement implementation
-│                  within the authorized source/test scope
+│   ├── G2.131 WatchlistService getter-retirement implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-watchlist-service-getter-retirement-implementation-2026-05-26.md`
+│   │   ├── Current HEAD: `35dcc90cd9a242e8906107a01abf1649d77737ea`
+│   │   ├── Result: removes `watchlist_service.py` `get_watchlist_service`
+│   │   │          and module-level `_watchlist_service`, removes both adapter
+│   │   │          fallback imports/calls, and preserves `WatchlistService`,
+│   │   │          `install_watchlist_service`,
+│   │   │          `get_watchlist_service_dependency`, route paths, response
+│   │   │          contracts, and OpenAPI exposure
+│   │   ├── Verification: TDD red `2 failed, 1 passed`, focused watchlist
+│   │   │          tests `28 passed`, health route conflicts `120 passed`,
+│   │   │          touched-file ruff passed, black check passed, import smoke
+│   │   │          passed; exact scan reports service getter definitions=`0`,
+│   │   │          service singleton assignments=`0`, adapter fallback
+│   │   │          imports=`0`, adapter public getter calls=`0`, app/API
+│   │   │          public getter calls=`0`, route dependency handlers=`7`
+│   │   └── Boundary: source-capable but limited to WatchlistService lifecycle
+│   │                module, two watchlist adapter fallback helpers, focused
+│   │                tests, governance report, generated artifact, task card,
+│   │                and steward-tree update; no route/API, OpenAPI exposure,
+│   │                frontend, PM2, OpenSpec, service class deletion, route
+│   │                dependency deletion, or issue-label change is made here
+│   └── Next gate: human review / PR merge decision for G2.131; if accepted,
+│                  close out the WatchlistService getter-retirement lane and
+│                  refresh the remaining service lifecycle candidate pool before
+│                  selecting another implementation lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -2298,7 +2323,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-candidate-refresh-after-email-notification-2026-05-26.md` | G | G2.110 candidate refresh accepted in PR `#263` at `c4abd4e`: scans service files=`152`, backend app files=`575`, API files=`219`, backend test files=`199`, all test files=`1211`, getter definitions=`16`, candidate-like definitions=`9`; confirms retired `email_notification_service.py:get_email_service` is gone, records `get_market_data_service` as the only LOW / `0` next authorization candidate with route/API direct refs=`0`, and keeps streaming HIGH, TDX/data/strategy/stock search CRITICAL, and email/watchlist/announcement holds out of source scope | Superseded by G2.111 MarketDataService getter-retirement authorization |
 | `backend-market-data-service-getter-retirement-authorization-2026-05-26.md` | G | G2.111 authorization prepared at `c4abd4e`: authorizes only a future G2.112 implementation branch for the package-level `market_data_service/get_market_data_service.py` `_market_data_service` and `get_market_data_service` retirement; preserves `MarketDataService`, `install_market_data_service`, and `get_market_data_service_dependency`, records GitNexus impact LOW / `0`, direct API refs=`0`, and requires future adapter/package export cleanup because `market_data_adapter.py` and package `__init__.py` still reference the getter | Human review / PR merge decision; if accepted, create G2.112 MarketDataService getter-retirement implementation before any market-data service source edit |
 | `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.md` | G | G2.129 candidate refresh accepted in PR `#282` at `cc32d0c2`: confirms Announcement/Email/StockSearch retired getters remain `0`, scans service files=`152`, app files=`575`, API files=`219`, tests=`203`, getter definitions=`12`, selects no direct implementation lane, and identifies `get_watchlist_service` only as a future authorization candidate with GitNexus MEDIUM / impacted=`15` / direct=`9` / processes=`0` | Superseded by G2.130 WatchlistService getter-retirement authorization |
-| `backend-watchlist-service-getter-retirement-authorization-2026-05-26.md` | G | G2.130 authorization prepared at `cc32d0c2`: authorizes only a future implementation branch to retire `watchlist_service.py` `get_watchlist_service` and `_watchlist_service`, while preserving `WatchlistService`, `install_watchlist_service`, `get_watchlist_service_dependency`, route paths, response contracts, and OpenAPI exposure; current scan shows getter definitions=`1`, singleton tokens=`74`, app/API direct getter calls=`0`, route dependency handlers=`7`, adapter fallback files=`2`, tests with getter refs=`4`; GitNexus impact MEDIUM / impacted=`15` / direct=`9` / processes=`0` | Human review / PR merge decision; if accepted, open G2.131 WatchlistService getter-retirement implementation within the authorized source/test scope |
+| `backend-watchlist-service-getter-retirement-authorization-2026-05-26.md` | G | G2.130 authorization accepted in PR `#283` at `35dcc90`: authorizes only a future implementation branch to retire `watchlist_service.py` `get_watchlist_service` and `_watchlist_service`, while preserving `WatchlistService`, `install_watchlist_service`, `get_watchlist_service_dependency`, route paths, response contracts, and OpenAPI exposure; current scan shows getter definitions=`1`, singleton tokens=`74`, app/API direct getter calls=`0`, route dependency handlers=`7`, adapter fallback files=`2`, tests with getter refs=`4`; GitNexus impact MEDIUM / impacted=`15` / direct=`9` / processes=`0` | Superseded by G2.131 WatchlistService getter-retirement implementation |
+| `backend-watchlist-service-getter-retirement-implementation-2026-05-26.md` | G | G2.131 implementation prepared at `35dcc90`: removes `watchlist_service.py` `get_watchlist_service` and module-level `_watchlist_service`, removes both adapter fallback imports/calls, preserves `WatchlistService`, `install_watchlist_service`, `get_watchlist_service_dependency`, route paths, response contracts, and OpenAPI exposure; TDD red `2 failed, 1 passed`, focused watchlist tests `28 passed`, health route conflicts `120 passed`, ruff/black/import smoke passed, exact scan reports service getter definitions=`0`, service singleton assignments=`0`, adapter fallback imports=`0`, adapter public getter calls=`0`, app/API public getter calls=`0`, route dependency handlers=`7` | Human review / PR merge decision; if accepted, close out WatchlistService getter retirement and refresh the remaining service lifecycle candidate pool |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/watchlist-service-getter-retirement-implementation-2026-05-26.json
+++ b/.planning/codebase/generated/watchlist-service-getter-retirement-implementation-2026-05-26.json
@@ -1,0 +1,94 @@
+{
+  "artifact": "watchlist-service-getter-retirement-implementation-2026-05-26",
+  "recorded_at": "2026-05-26T11:28:00+08:00",
+  "workline": "G2.131 WatchlistService getter-retirement implementation",
+  "status": "implementation-prepared-for-review",
+  "current_head": "35dcc90cd9a242e8906107a01abf1649d77737ea",
+  "stale_if_head_mismatch": true,
+  "parent_pr": {
+    "number": 283,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T03:02:11Z",
+    "merge_commit": "35dcc90cd9a242e8906107a01abf1649d77737ea",
+    "title": "G2.130 Authorize WatchlistService getter retirement",
+    "url": "https://github.com/chengjon/mystocks/pull/283"
+  },
+  "authorization_source": {
+    "report": "docs/reports/quality/backend-watchlist-service-getter-retirement-authorization-2026-05-26.md",
+    "generated_artifact": ".planning/codebase/generated/watchlist-service-getter-retirement-authorization-2026-05-26.json"
+  },
+  "changed_source_files": [
+    "web/backend/app/services/watchlist_service.py",
+    "web/backend/app/services/adapters/watchlist_adapter.py",
+    "web/backend/app/services/data_adapters/watchlist.py"
+  ],
+  "changed_test_files": [
+    "web/backend/tests/test_watchlist_service_lifecycle_di.py",
+    "web/backend/tests/test_watchlist_helper_lifecycle_di.py",
+    "web/backend/tests/test_watchlist_service_getter_retirement.py"
+  ],
+  "preserved_contracts": {
+    "WatchlistService": true,
+    "install_watchlist_service": true,
+    "get_watchlist_service_dependency": true,
+    "route_paths_changed": false,
+    "response_shapes_changed": false,
+    "openapi_exposure_changed": false
+  },
+  "removed_items": {
+    "public_get_watchlist_service_getter": true,
+    "module_level_watchlist_service_singleton": true,
+    "adapter_fallback_imports_of_get_watchlist_service": true
+  },
+  "gitnexus_pre_edit": {
+    "get_watchlist_service": {
+      "risk": "MEDIUM",
+      "impacted_count": 15,
+      "direct": 9,
+      "processes_affected": 0
+    },
+    "adapter_helper_context": {
+      "data_adapters_watchlist_direct_callers": [
+        "_fetch_watchlist_data",
+        "health_check"
+      ],
+      "legacy_adapter_direct_callers": [
+        "_fetch_watchlist_data",
+        "health_check"
+      ]
+    }
+  },
+  "tdd": {
+    "red": "web/backend/tests/test_watchlist_service_getter_retirement.py: 2 failed, 1 passed",
+    "green": "focused watchlist suite: 28 passed"
+  },
+  "verification": {
+    "focused_watchlist_tests": "28 passed in 3.54s",
+    "health_route_conflicts": "120 passed in 83.70s",
+    "ruff_touched": "All checks passed",
+    "black_check_touched": "8 files would be left unchanged",
+    "import_smoke": "watchlist-import-ok",
+    "exact_scan": {
+      "service_getter_definitions": 0,
+      "service_singleton_assignments": 0,
+      "adapter_fallback_imports": 0,
+      "adapter_public_getter_calls": 0,
+      "app_public_getter_calls": 0,
+      "route_dependency_refs": 8,
+      "route_dependency_handlers": 7,
+      "exports_preserved": {
+        "WatchlistService": true,
+        "install_watchlist_service": true,
+        "get_watchlist_service_dependency": true
+      }
+    },
+    "staged_gitnexus_detect_changes": {
+      "risk_level": "low",
+      "changed_files": 10,
+      "changed_count": 45,
+      "affected_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "rollback_plan": "Revert this implementation commit to restore get_watchlist_service, _watchlist_service, and the adapter fallback imports if focused tests, health route conflicts, exact scans, staged GitNexus, or mainline scope fail."
+}

--- a/docs/reports/quality/backend-watchlist-service-getter-retirement-implementation-2026-05-26.md
+++ b/docs/reports/quality/backend-watchlist-service-getter-retirement-implementation-2026-05-26.md
@@ -1,0 +1,134 @@
+# Backend WatchlistService Getter Retirement Implementation - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: implementation-prepared-for-review
+- Workline: G2.131 WatchlistService getter-retirement implementation
+- Current HEAD: `35dcc90cd9a242e8906107a01abf1649d77737ea`
+- Parent PR: `#283` merged at `35dcc90cd9a242e8906107a01abf1649d77737ea`
+- Generated artifact: `.planning/codebase/generated/watchlist-service-getter-retirement-implementation-2026-05-26.json`
+
+This is the source-capable implementation authorized by G2.130. The scope stays
+inside WatchlistService lifecycle code, two watchlist adapter fallback seams,
+focused tests, this report, the generated artifact, the task card, and the
+steward tree. It does not edit route handlers, route paths, response contracts,
+OpenAPI exposure, frontend code, PM2 workflows, OpenSpec changes, or GitHub
+issue labels.
+
+## Source Changes
+
+| File | Change |
+|---|---|
+| `web/backend/app/services/watchlist_service.py` | Removed module-level `_watchlist_service` and public `get_watchlist_service`; `install_watchlist_service()` now constructs `WatchlistService()` when no explicit service is supplied |
+| `web/backend/app/services/adapters/watchlist_adapter.py` | Removed fallback import/call of `get_watchlist_service`; live mode without `watchlist_service_provider` now fails explicitly |
+| `web/backend/app/services/data_adapters/watchlist.py` | Same fallback import/call retirement as the legacy adapter |
+| `web/backend/tests/test_watchlist_service_lifecycle_di.py` | Updated app-state dependency fallback test to patch `WatchlistService` construction instead of the retired getter |
+| `web/backend/tests/test_watchlist_helper_lifecycle_di.py` | Removed obsolete monkeypatch against the retired getter |
+| `web/backend/tests/test_watchlist_service_getter_retirement.py` | Added regression coverage for getter/singleton absence, dependency preservation, and adapter fallback import retirement |
+
+## Preserved Contracts
+
+- `WatchlistService` remains importable.
+- `install_watchlist_service` remains importable.
+- `get_watchlist_service_dependency` remains importable.
+- `web/backend/app/api/watchlist.py` was not edited.
+- Route dependency handlers remain `7`.
+- API direct `get_watchlist_service()` calls remain `0`.
+- Route paths, response shapes, response models, and OpenAPI exposure were not
+  changed.
+
+## Cleanup Decision
+
+Removed:
+
+- `web/backend/app/services/watchlist_service.py:get_watchlist_service`
+- module-level `_watchlist_service`
+- fallback imports/calls from both watchlist adapter helper files
+
+Retained:
+
+- adapter-local `_watchlist_service` cache attributes in both adapter classes
+- route dependency injection through `get_watchlist_service_dependency`
+- explicit provider-based adapter injection
+
+The adapter-local cache fields are retained because they cache injected
+providers, not the retired module singleton.
+
+## GitNexus Evidence
+
+Before source edits:
+
+- `get_watchlist_service`: MEDIUM, impacted `15`, direct `9`, processes `0`
+- data adapter `_get_watchlist_service`: LOW, direct callers
+  `_fetch_watchlist_data` and `health_check`
+- legacy adapter `_get_watchlist_service`: direct callers
+  `_fetch_watchlist_data` and `health_check`
+
+No HIGH or CRITICAL warning was returned for the edited adapter helper symbols.
+
+## TDD Evidence
+
+Red:
+
+- `web/backend/tests/test_watchlist_service_getter_retirement.py`:
+  `2 failed, 1 passed`
+- Failures proved the existing module still exposed `get_watchlist_service` and
+  adapter helper source still imported the public getter.
+
+Green:
+
+- Focused watchlist suite:
+  `web/backend/tests/test_watchlist_service_getter_retirement.py`
+  `web/backend/tests/test_watchlist_service_lifecycle_di.py`
+  `web/backend/tests/test_watchlist_helper_lifecycle_di.py`
+  `web/backend/tests/test_adapter_mock_fallback_controls.py`
+  `web/backend/tests/test_logging_noise_regressions.py`
+  -> `28 passed`
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Focused watchlist tests | `28 passed in 3.54s` |
+| Health route conflicts | `120 passed in 83.70s` |
+| Ruff touched files | `All checks passed` |
+| Black check touched files | `8 files would be left unchanged` |
+| Import smoke | `watchlist-import-ok` |
+| Staged GitNexus detect changes | low risk, changed files `10`, changed symbols `45`, affected symbols `0`, affected processes `0` |
+
+Exact scan:
+
+| Metric | Result |
+|---|---:|
+| `watchlist_service.py` `get_watchlist_service` definitions | 0 |
+| `watchlist_service.py` `_watchlist_service =` assignments | 0 |
+| Adapter fallback imports of `get_watchlist_service` | 0 |
+| Adapter public `get_watchlist_service()` calls | 0 |
+| App/API public `get_watchlist_service()` calls | 0 |
+| Route dependency refs | 8 |
+| Route dependency handlers | 7 |
+
+## Rollback
+
+Revert this implementation commit to restore `get_watchlist_service`,
+`_watchlist_service`, and both adapter fallback imports if focused tests, health
+route conflicts, exact scans, staged GitNexus, or mainline scope fail.
+
+## Non-Goals
+
+- No route handler edits
+- No route path, response model, response shape, or OpenAPI exposure changes
+- No frontend, PM2, runtime workflow, or OpenSpec changes
+- No GitHub issue label or readiness changes
+- No deletion of `WatchlistService`, `install_watchlist_service`, or
+  `get_watchlist_service_dependency`
+
+## Next Gate
+
+Human review / PR merge decision for G2.131. If accepted, close out the
+WatchlistService getter-retirement lane and refresh the remaining service
+lifecycle candidate pool before selecting another implementation lane.

--- a/governance/mainline/task-cards/pr-284.yaml
+++ b/governance/mainline/task-cards/pr-284.yaml
@@ -1,0 +1,132 @@
+version: "v0.2"
+
+task:
+  id: "pr-284"
+  title: "Retire WatchlistService compatibility getter"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-watchlist-service-getter-retirement-implementation"
+  objective: "retire the WatchlistService public compatibility getter and module singleton while preserving route dependency injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-watchlist-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-watchlist-service-getter-retirement-implementation"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow service getter retirement; no route, public API surface, OpenAPI exposure, frontend behavior, or OpenSpec capability is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/watchlist-service-getter-retirement-implementation-2026-05-26.json"
+    - "docs/reports/quality/backend-watchlist-service-getter-retirement-implementation-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-284.yaml"
+    - "web/backend/app/services/watchlist_service.py"
+    - "web/backend/app/services/adapters/watchlist_adapter.py"
+    - "web/backend/app/services/data_adapters/watchlist.py"
+    - "web/backend/tests/test_watchlist_service_lifecycle_di.py"
+    - "web/backend/tests/test_watchlist_helper_lifecycle_di.py"
+    - "web/backend/tests/test_watchlist_service_getter_retirement.py"
+  forbidden_paths:
+    - "web/backend/app/api/**"
+    - "web/backend/app/main.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "Do not edit route handlers"
+  - "Do not modify route paths, response models, response shapes, or OpenAPI exposure"
+  - "Do not modify frontend code"
+  - "Do not modify PM2 workflows"
+  - "Do not create or modify OpenSpec changes/specs"
+  - "Do not change GitHub issue labels or readiness state"
+  - "Do not delete WatchlistService, install_watchlist_service, or get_watchlist_service_dependency"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 283 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_getter_retirement.py -q --no-cov --tb=short before implementation"
+      required: true
+    - id: "focused-watchlist-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_getter_retirement.py web/backend/tests/test_watchlist_service_lifecycle_di.py web/backend/tests/test_watchlist_helper_lifecycle_di.py web/backend/tests/test_adapter_mock_fallback_controls.py web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/services/watchlist_service.py web/backend/app/services/adapters/watchlist_adapter.py web/backend/app/services/data_adapters/watchlist.py web/backend/tests/test_watchlist_service_lifecycle_di.py web/backend/tests/test_watchlist_helper_lifecycle_di.py web/backend/tests/test_watchlist_service_getter_retirement.py"
+      required: true
+    - id: "black-check-touched"
+      command: "black --check web/backend/app/services/watchlist_service.py web/backend/app/services/adapters/watchlist_adapter.py web/backend/app/services/data_adapters/watchlist.py web/backend/tests/test_watchlist_service_lifecycle_di.py web/backend/tests/test_watchlist_helper_lifecycle_di.py web/backend/tests/test_watchlist_service_getter_retirement.py"
+      required: true
+    - id: "exact-scan"
+      command: "scripted scan for service getter definitions, service singleton assignments, adapter fallback imports/calls, app/API public getter calls, and route dependency handler count"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-watchlist-service-getter-retirement-implementation-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/watchlist-service-getter-retirement-implementation-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('governance/mainline/task-cards/pr-284.yaml').read_text())\""
+      required: true
+    - id: "mainline-scope"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-284.yaml"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If adapter provider fallback is misread, live watchlist data adapters could attempt to use a retired public getter"
+    - "If route files are edited, the batch could exceed a getter-retirement scope"
+  rollback_plan: "revert this implementation PR to restore get_watchlist_service, _watchlist_service, and both adapter fallback imports"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "retire WatchlistService compatibility getter"
+    modified_scope: "WatchlistService lifecycle module, two watchlist adapter fallback helpers, focused tests, steward tree, report, artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "public compatibility getter and module singleton removed; route dependency injection preserved"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, health route conflicts, exact scans, GitNexus staged scope, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T11:28:00+08:00"
+    approval_note: "Implementation follows merged G2.130 authorization PR #283"
+    secondary_approved: false

--- a/web/backend/app/services/adapters/watchlist_adapter.py
+++ b/web/backend/app/services/adapters/watchlist_adapter.py
@@ -44,9 +44,7 @@ class WatchlistDataSourceAdapter(IDataSource):
                 if self._watchlist_service_provider is not None:
                     self._watchlist_service = self._watchlist_service_provider()
                 elif self.mode != "mock":
-                    from app.services.watchlist_service import get_watchlist_service
-
-                    self._watchlist_service = get_watchlist_service()
+                    raise RuntimeError("watchlist_service_provider is required for live watchlist adapter")
             except Exception as e:
                 self._watchlist_service = None
                 raise RuntimeError(f"Failed to initialize watchlist service: {e}")

--- a/web/backend/app/services/data_adapters/watchlist.py
+++ b/web/backend/app/services/data_adapters/watchlist.py
@@ -43,9 +43,7 @@ class WatchlistDataSourceAdapter(IDataSource):
                 if self._watchlist_service_provider is not None:
                     self._watchlist_service = self._watchlist_service_provider()
                 elif self.mode != "mock":
-                    from app.services.watchlist_service import get_watchlist_service
-
-                    self._watchlist_service = get_watchlist_service()
+                    raise RuntimeError("watchlist_service_provider is required for live watchlist adapter")
             except Exception as e:
                 self._watchlist_service = None
                 raise RuntimeError(f"Failed to initialize watchlist service: {e}")

--- a/web/backend/app/services/watchlist_service.py
+++ b/web/backend/app/services/watchlist_service.py
@@ -605,26 +605,11 @@ class WatchlistService(WatchlistGroupQueriesMixin):
             return False
 
 
-# 创建全局实例
-_watchlist_service = None
 WATCHLIST_SERVICE_STATE_KEY = "watchlist_service"
 
 
-def get_watchlist_service() -> WatchlistService:
-    """
-    获取自选股服务实例（单例模式）
-
-    Returns:
-        WatchlistService: 自选股服务实例
-    """
-    global _watchlist_service
-    if _watchlist_service is None:
-        _watchlist_service = WatchlistService()
-    return _watchlist_service
-
-
 def install_watchlist_service(app: Any, service: WatchlistService | None = None) -> WatchlistService:
-    selected_service = service if service is not None else get_watchlist_service()
+    selected_service = service if service is not None else WatchlistService()
     setattr(app.state, WATCHLIST_SERVICE_STATE_KEY, selected_service)
     return selected_service
 

--- a/web/backend/tests/test_watchlist_helper_lifecycle_di.py
+++ b/web/backend/tests/test_watchlist_helper_lifecycle_di.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pytest
 
-from app.services import watchlist_service
 from app.services.adapters.watchlist_adapter import (
     WatchlistDataSourceAdapter as LegacyWatchlistDataSourceAdapter,
 )
@@ -18,19 +17,14 @@ from app.services.data_adapters.watchlist import (
         LegacyWatchlistDataSourceAdapter,
     ],
 )
-def test_watchlist_adapters_use_injected_provider_in_live_mode(monkeypatch, adapter_cls):
+def test_watchlist_adapters_use_injected_provider_in_live_mode(adapter_cls):
     fake_service = object()
     provider_calls = 0
-
-    def fail_global_getter():
-        raise AssertionError("global watchlist getter should not be called")
 
     def provider():
         nonlocal provider_calls
         provider_calls += 1
         return fake_service
-
-    monkeypatch.setattr(watchlist_service, "get_watchlist_service", fail_global_getter)
 
     adapter = adapter_cls(
         {

--- a/web/backend/tests/test_watchlist_service_getter_retirement.py
+++ b/web/backend/tests/test_watchlist_service_getter_retirement.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+from app.services import watchlist_service
+from app.services.adapters.watchlist_adapter import (
+    WatchlistDataSourceAdapter as LegacyWatchlistDataSourceAdapter,
+)
+from app.services.data_adapters.watchlist import (
+    WatchlistDataSourceAdapter as DataWatchlistDataSourceAdapter,
+)
+
+
+def test_watchlist_service_module_getter_and_singleton_are_retired():
+    assert not hasattr(watchlist_service, "get_watchlist_service")
+    assert not hasattr(watchlist_service, "_watchlist_service")
+    assert hasattr(watchlist_service, "WatchlistService")
+    assert hasattr(watchlist_service, "install_watchlist_service")
+    assert hasattr(watchlist_service, "get_watchlist_service_dependency")
+
+
+def test_watchlist_service_dependency_installs_constructed_service(monkeypatch):
+    fake_service = object()
+    fake_app = SimpleNamespace(state=SimpleNamespace())
+    request = SimpleNamespace(app=fake_app)
+
+    monkeypatch.setattr(watchlist_service, "WatchlistService", lambda: fake_service)
+
+    assert watchlist_service.get_watchlist_service_dependency(request) is fake_service
+    assert getattr(fake_app.state, watchlist_service.WATCHLIST_SERVICE_STATE_KEY) is fake_service
+
+
+def test_watchlist_adapters_do_not_import_retired_getter():
+    for adapter_cls in [DataWatchlistDataSourceAdapter, LegacyWatchlistDataSourceAdapter]:
+        source = inspect.getsource(adapter_cls._get_watchlist_service)
+        assert "import get_watchlist_service" not in source
+        assert "get_watchlist_service()" not in source

--- a/web/backend/tests/test_watchlist_service_lifecycle_di.py
+++ b/web/backend/tests/test_watchlist_service_lifecycle_di.py
@@ -14,7 +14,7 @@ def test_watchlist_service_dependency_installs_app_state_when_missing(monkeypatc
     fake_app = SimpleNamespace(state=SimpleNamespace())
     request = SimpleNamespace(app=fake_app)
 
-    monkeypatch.setattr(watchlist_service, "get_watchlist_service", lambda: fake_service)
+    monkeypatch.setattr(watchlist_service, "WatchlistService", lambda: fake_service)
 
     assert watchlist_service.get_watchlist_service_dependency(request) is fake_service
     assert getattr(fake_app.state, watchlist_service.WATCHLIST_SERVICE_STATE_KEY) is fake_service


### PR DESCRIPTION
## Summary
- retires WatchlistService public compatibility getter and module singleton
- removes fallback imports/calls from both watchlist adapter helper files
- preserves WatchlistService, install_watchlist_service, get_watchlist_service_dependency, route paths, response contracts, and OpenAPI exposure

## Verification
- parent PR #283 verified merged at 35dcc90cd9a242e8906107a01abf1649d77737ea
- GitNexus pre-edit: get_watchlist_service MEDIUM, impacted 15, direct 9, processes 0; adapter helper contexts reviewed
- TDD red: new retirement test 2 failed, 1 passed before implementation
- focused watchlist suite: 28 passed
- health route conflicts: 120 passed
- ruff touched files: passed
- black --check touched files: passed
- import smoke: watchlist-import-ok
- exact scan: service getter definitions 0, service singleton assignments 0, adapter fallback imports 0, adapter public getter calls 0, app/API public getter calls 0, route dependency handlers 7
- staged GitNexus detect_changes: low risk, changed files 10, changed symbols 45, affected count 0
- post-commit mainline scope gate: pass=True
- gitnexus analyze --with-gitignore completed

## Boundary
- no route/API/OpenAPI/frontend/PM2/OpenSpec changes
- no issue-label movement
- no deletion of WatchlistService, install_watchlist_service, or get_watchlist_service_dependency

Next gate after review: close out WatchlistService getter retirement and refresh the remaining service lifecycle candidate pool.