### PR TITLE
G2.132 Close out WatchlistService getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2199,9 +2199,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, implementation, or issue-label change is
 │   │                made here
 │   ├── G2.131 WatchlistService getter-retirement implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#284`
 │   │   ├── Evidence: `backend-watchlist-service-getter-retirement-implementation-2026-05-26.md`
-│   │   ├── Current HEAD: `35dcc90cd9a242e8906107a01abf1649d77737ea`
+│   │   ├── Merge commit: `ccadd5e0560c4fa1fab7fae130a8b64e624352bc`
 │   │   ├── Result: removes `watchlist_service.py` `get_watchlist_service`
 │   │   │          and module-level `_watchlist_service`, removes both adapter
 │   │   │          fallback imports/calls, and preserves `WatchlistService`,
@@ -2221,10 +2221,27 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                and steward-tree update; no route/API, OpenAPI exposure,
 │   │                frontend, PM2, OpenSpec, service class deletion, route
 │   │                dependency deletion, or issue-label change is made here
-│   └── Next gate: human review / PR merge decision for G2.131; if accepted,
-│                  close out the WatchlistService getter-retirement lane and
-│                  refresh the remaining service lifecycle candidate pool before
-│                  selecting another implementation lane
+│   ├── G2.132 WatchlistService getter-retirement closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-watchlist-service-getter-retirement-closeout-2026-05-26.md`
+│   │   ├── Current HEAD: `ccadd5e0560c4fa1fab7fae130a8b64e624352bc`
+│   │   ├── Result: records PR `#284` as merged and closes the
+│   │   │          WatchlistService getter-retirement lane without changing
+│   │   │          runtime source, tests, route paths, response contracts, or
+│   │   │          OpenAPI exposure
+│   │   ├── Verification: parent PR state `MERGED`; focused watchlist tests
+│   │   │          `28 passed`; health route conflicts `120 passed`; exact
+│   │   │          scan reports service getter definitions=`0`, service
+│   │   │          singleton assignments=`0`, adapter fallback imports=`0`,
+│   │   │          adapter public getter calls=`0`, app/API public getter
+│   │   │          calls=`0`, route dependency handlers=`7`
+│   │   └── Boundary: closeout-only; no source/test edit, runtime behavior,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                service symbol deletion, route dependency deletion, or
+│   │                issue-label change is made here
+│   └── Next gate: after G2.132 review and merge, refresh the remaining service
+│                  lifecycle candidate pool before selecting another
+│                  implementation lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -2324,7 +2341,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-market-data-service-getter-retirement-authorization-2026-05-26.md` | G | G2.111 authorization prepared at `c4abd4e`: authorizes only a future G2.112 implementation branch for the package-level `market_data_service/get_market_data_service.py` `_market_data_service` and `get_market_data_service` retirement; preserves `MarketDataService`, `install_market_data_service`, and `get_market_data_service_dependency`, records GitNexus impact LOW / `0`, direct API refs=`0`, and requires future adapter/package export cleanup because `market_data_adapter.py` and package `__init__.py` still reference the getter | Human review / PR merge decision; if accepted, create G2.112 MarketDataService getter-retirement implementation before any market-data service source edit |
 | `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.md` | G | G2.129 candidate refresh accepted in PR `#282` at `cc32d0c2`: confirms Announcement/Email/StockSearch retired getters remain `0`, scans service files=`152`, app files=`575`, API files=`219`, tests=`203`, getter definitions=`12`, selects no direct implementation lane, and identifies `get_watchlist_service` only as a future authorization candidate with GitNexus MEDIUM / impacted=`15` / direct=`9` / processes=`0` | Superseded by G2.130 WatchlistService getter-retirement authorization |
 | `backend-watchlist-service-getter-retirement-authorization-2026-05-26.md` | G | G2.130 authorization accepted in PR `#283` at `35dcc90`: authorizes only a future implementation branch to retire `watchlist_service.py` `get_watchlist_service` and `_watchlist_service`, while preserving `WatchlistService`, `install_watchlist_service`, `get_watchlist_service_dependency`, route paths, response contracts, and OpenAPI exposure; current scan shows getter definitions=`1`, singleton tokens=`74`, app/API direct getter calls=`0`, route dependency handlers=`7`, adapter fallback files=`2`, tests with getter refs=`4`; GitNexus impact MEDIUM / impacted=`15` / direct=`9` / processes=`0` | Superseded by G2.131 WatchlistService getter-retirement implementation |
-| `backend-watchlist-service-getter-retirement-implementation-2026-05-26.md` | G | G2.131 implementation prepared at `35dcc90`: removes `watchlist_service.py` `get_watchlist_service` and module-level `_watchlist_service`, removes both adapter fallback imports/calls, preserves `WatchlistService`, `install_watchlist_service`, `get_watchlist_service_dependency`, route paths, response contracts, and OpenAPI exposure; TDD red `2 failed, 1 passed`, focused watchlist tests `28 passed`, health route conflicts `120 passed`, ruff/black/import smoke passed, exact scan reports service getter definitions=`0`, service singleton assignments=`0`, adapter fallback imports=`0`, adapter public getter calls=`0`, app/API public getter calls=`0`, route dependency handlers=`7` | Human review / PR merge decision; if accepted, close out WatchlistService getter retirement and refresh the remaining service lifecycle candidate pool |
+| `backend-watchlist-service-getter-retirement-implementation-2026-05-26.md` | G | G2.131 implementation accepted in PR `#284` at `ccadd5e`: removes `watchlist_service.py` `get_watchlist_service` and module-level `_watchlist_service`, removes both adapter fallback imports/calls, preserves `WatchlistService`, `install_watchlist_service`, `get_watchlist_service_dependency`, route paths, response contracts, and OpenAPI exposure; TDD red `2 failed, 1 passed`, focused watchlist tests `28 passed`, health route conflicts `120 passed`, ruff/black/import smoke passed, exact scan reports service getter definitions=`0`, service singleton assignments=`0`, adapter fallback imports=`0`, adapter public getter calls=`0`, app/API public getter calls=`0`, route dependency handlers=`7` | Superseded by G2.132 WatchlistService getter-retirement closeout |
+| `backend-watchlist-service-getter-retirement-closeout-2026-05-26.md` | G | G2.132 closeout prepared at `ccadd5e`: records PR `#284` merged at `2026-05-26T03:30:49Z`, confirms current-head scan still has service getter definitions=`0`, service singleton assignments=`0`, adapter fallback imports=`0`, adapter public getter calls=`0`, app/API public getter calls=`0`, route dependency handlers=`7`, focused watchlist tests `28 passed`, and health route conflicts `120 passed`; no runtime source, tests, route paths, response contracts, OpenAPI exposure, PM2 workflow, OpenSpec change, or issue-label change is modified | Human review / PR merge decision; if accepted, refresh the remaining service lifecycle candidate pool |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/watchlist-service-getter-retirement-closeout-2026-05-26.json
+++ b/.planning/codebase/generated/watchlist-service-getter-retirement-closeout-2026-05-26.json
@@ -1,0 +1,85 @@
+{
+  "artifact": "watchlist-service-getter-retirement-closeout-2026-05-26",
+  "generated_at": "2026-05-26T11:40:28+08:00",
+  "task": {
+    "id": "G2.132",
+    "title": "WatchlistService getter-retirement closeout",
+    "track": "G",
+    "type": "governance-closeout"
+  },
+  "current_head": {
+    "sha": "ccadd5e0560c4fa1fab7fae130a8b64e624352bc",
+    "short": "ccadd5e05",
+    "subject": "refactor(services): retire watchlist getter singleton (#284)"
+  },
+  "parent_pr": {
+    "number": 284,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T03:30:49Z",
+    "merge_commit": "ccadd5e0560c4fa1fab7fae130a8b64e624352bc",
+    "title": "G2.131 Retire WatchlistService getter singleton",
+    "url": "https://github.com/chengjon/mystocks/pull/284"
+  },
+  "closeout_decision": {
+    "state": "ready-for-review",
+    "decision": "Record G2.131 as merged and close the WatchlistService getter-retirement lane.",
+    "implementation_scope": "No runtime code, tests, API routes, OpenAPI exposure, PM2 workflow, OpenSpec change, or issue-label change is modified by this closeout.",
+    "next_gate": "After this closeout is reviewed and merged, refresh the remaining service lifecycle candidate pool before selecting another implementation lane."
+  },
+  "current_head_scan": {
+    "service_getter_definitions": 0,
+    "service_singleton_assignments": 0,
+    "service_symbols_preserved": {
+      "WatchlistService": true,
+      "install_watchlist_service": true,
+      "get_watchlist_service_dependency": true
+    },
+    "adapter_fallback_imports": 0,
+    "adapter_public_getter_calls": 0,
+    "app_api_public_getter_calls": 0,
+    "route_dependency_refs": 8,
+    "route_dependency_handlers": 7
+  },
+  "verification": [
+    {
+      "id": "parent-pr-state",
+      "command": "gh pr view 284 --json number,state,mergedAt,mergeCommit,title,url",
+      "result": "MERGED at 2026-05-26T03:30:49Z with merge commit ccadd5e0560c4fa1fab7fae130a8b64e624352bc"
+    },
+    {
+      "id": "current-head-scan",
+      "command": "scripted current-head text scan over watchlist_service.py, watchlist adapters, and watchlist route dependency wiring",
+      "result": "getter definitions=0, singleton assignments=0, adapter fallback imports=0, adapter public getter calls=0, app/API public getter calls=0, route dependency handlers=7"
+    },
+    {
+      "id": "focused-watchlist-tests",
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_getter_retirement.py web/backend/tests/test_watchlist_service_lifecycle_di.py web/backend/tests/test_watchlist_helper_lifecycle_di.py web/backend/tests/test_adapter_mock_fallback_controls.py web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short",
+      "result": "28 passed in 3.29s"
+    },
+    {
+      "id": "health-route-conflicts",
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short",
+      "result": "120 passed in 73.83s"
+    }
+  ],
+  "scope": {
+    "allowed_paths": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/watchlist-service-getter-retirement-closeout-2026-05-26.json",
+      "docs/reports/quality/backend-watchlist-service-getter-retirement-closeout-2026-05-26.md",
+      "governance/mainline/task-cards/pr-285.yaml"
+    ],
+    "forbidden_paths": [
+      "web/backend/**",
+      "web/frontend/**",
+      "src/**",
+      "tests/**",
+      "docs/api/**",
+      "docs/guides/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ]
+  }
+}

--- a/docs/reports/quality/backend-watchlist-service-getter-retirement-closeout-2026-05-26.md
+++ b/docs/reports/quality/backend-watchlist-service-getter-retirement-closeout-2026-05-26.md
@@ -1,0 +1,78 @@
+# Backend WatchlistService Getter Retirement Closeout - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Decision
+
+G2.132 records the G2.131 WatchlistService getter-retirement implementation as merged and closes the WatchlistService getter-retirement lane.
+
+This closeout is governance-only. It does not modify runtime code, tests, API routes, OpenAPI exposure, PM2 workflow, OpenSpec changes, GitHub issue labels, or product behavior.
+
+## Parent Merge
+
+| Field | Value |
+|---|---|
+| Parent PR | `#284` |
+| State | `MERGED` |
+| Merged at | `2026-05-26T03:30:49Z` |
+| Merge commit | `ccadd5e0560c4fa1fab7fae130a8b64e624352bc` |
+| Title | `G2.131 Retire WatchlistService getter singleton` |
+| URL | `https://github.com/chengjon/mystocks/pull/284` |
+
+Current branch HEAD for this closeout is `ccadd5e0560c4fa1fab7fae130a8b64e624352bc`.
+
+## Current-Head Scan
+
+The current-head scan confirms the intended retired symbols remain absent and the app-state dependency seam remains present.
+
+| Check | Result |
+|---|---:|
+| `watchlist_service.py` `get_watchlist_service` definitions | `0` |
+| `watchlist_service.py` `_watchlist_service` assignments | `0` |
+| `WatchlistService` class preserved | `true` |
+| `install_watchlist_service` preserved | `true` |
+| `get_watchlist_service_dependency` preserved | `true` |
+| Adapter fallback imports | `0` |
+| Adapter public getter calls | `0` |
+| App/API public getter calls | `0` |
+| Watchlist route dependency references | `8` |
+| Watchlist route dependency handlers | `7` |
+
+## Verification
+
+| Gate | Command | Result |
+|---|---|---|
+| Parent PR state | `gh pr view 284 --json number,state,mergedAt,mergeCommit,title,url` | `MERGED` at `2026-05-26T03:30:49Z` |
+| Current-head scan | Scripted scan over `watchlist_service.py`, watchlist adapters, and `app/api/watchlist.py` | Getter definitions `0`, singleton assignments `0`, adapter fallback imports `0`, route dependency handlers `7` |
+| Focused watchlist tests | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_getter_retirement.py web/backend/tests/test_watchlist_service_lifecycle_di.py web/backend/tests/test_watchlist_helper_lifecycle_di.py web/backend/tests/test_adapter_mock_fallback_controls.py web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short` | `28 passed in 3.29s` |
+| Health route conflicts | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short` | `120 passed in 73.83s` |
+
+## Scope Boundary
+
+Allowed closeout paths:
+
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/watchlist-service-getter-retirement-closeout-2026-05-26.json`
+- `docs/reports/quality/backend-watchlist-service-getter-retirement-closeout-2026-05-26.md`
+- `governance/mainline/task-cards/pr-285.yaml`
+
+Forbidden paths remain locked for this closeout:
+
+- `web/backend/**`
+- `web/frontend/**`
+- `src/**`
+- `tests/**`
+- `docs/api/**`
+- `docs/guides/**`
+- `config/**`
+- `scripts/**`
+- `openspec/changes/**`
+- `openspec/specs/**`
+
+## Closeout Result
+
+The WatchlistService getter-retirement lane is ready to close after this governance PR is reviewed and merged.
+
+The next steward-tree gate is a fresh remaining-candidate scan before selecting another service lifecycle implementation lane. The next scan must treat `WatchlistService` as a completed retired-getter case and must not reopen the already accepted route dependency seam unless a current-head contradiction appears.

--- a/governance/mainline/task-cards/pr-285.yaml
+++ b/governance/mainline/task-cards/pr-285.yaml
@@ -1,0 +1,107 @@
+version: "v0.2"
+
+task:
+  id: "pr-285"
+  title: "Close out WatchlistService getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-watchlist-service-getter-retirement-closeout"
+  objective: "record PR #284 merge evidence and close the WatchlistService getter-retirement lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-watchlist-service-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-watchlist-service-getter-retirement-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only packet; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/watchlist-service-getter-retirement-closeout-2026-05-26.json"
+    - "docs/reports/quality/backend-watchlist-service-getter-retirement-closeout-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-285.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 284 --json number,state,mergedAt,mergeCommit,title,url"
+      required: true
+    - id: "current-head-scan"
+      command: "scripted current-head text scan over WatchlistService getter definitions, singleton assignments, adapter fallback imports/calls, app/API getter calls, and route dependency handlers"
+      required: true
+    - id: "focused-watchlist-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_watchlist_service_getter_retirement.py web/backend/tests/test_watchlist_service_lifecycle_di.py web/backend/tests/test_watchlist_helper_lifecycle_di.py web/backend/tests/test_adapter_mock_fallback_controls.py web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-conflicts"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-watchlist-service-getter-retirement-closeout-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/watchlist-service-getter-retirement-closeout-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-285.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests."
+  - "Do not change watchlist route paths, response contracts, OpenAPI exposure, PM2 workflow, OpenSpec changes, or GitHub issue labels."
+  - "Do not select the next implementation candidate before a fresh post-closeout candidate refresh."
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is treated as source authorization, a later worker could reopen an already merged WatchlistService getter-retirement implementation lane"
+    - "If the next candidate pool is selected without a fresh scan, completed getter-retirement evidence could be stale"
+  rollback_plan: "revert this closeout PR to remove only the closeout report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out WatchlistService getter retirement"
+    modified_scope: "steward tree, closeout report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; closeout records the merged parent implementation and does not change runtime code"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON/YAML parsing, GitNexus staged scope, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T11:40:28+08:00"
+    approval_note: "Closeout follows merged G2.131 implementation PR #284"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Record PR #284 as merged and close the WatchlistService getter-retirement lane
- Add current-head closeout artifact and quality report
- Update steward tree and mainline task card for the next candidate-refresh gate

## Verification
- Parent PR #284 state: MERGED at ccadd5e0560c4fa1fab7fae130a8b64e624352bc
- Focused watchlist tests: 28 passed
- Health route conflicts: 120 passed
- Markdown governance: 2 checked files, 0 errors
- JSON/YAML parse: passed
- GitNexus staged scope: low risk, affected processes 0
- Mainline scope gate: pass=True

## Boundary
Governance closeout only. No backend source, tests, route paths, response contracts, OpenAPI exposure, PM2 workflow, OpenSpec changes, or issue-label changes.