### PR TITLE
G2.133 Refresh service lifecycle candidates after WatchlistService

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2222,9 +2222,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                frontend, PM2, OpenSpec, service class deletion, route
 │   │                dependency deletion, or issue-label change is made here
 │   ├── G2.132 WatchlistService getter-retirement closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#285`
 │   │   ├── Evidence: `backend-watchlist-service-getter-retirement-closeout-2026-05-26.md`
-│   │   ├── Current HEAD: `ccadd5e0560c4fa1fab7fae130a8b64e624352bc`
+│   │   ├── Merge commit: `f0e0e37726140499b2e6b25cdad96739fc8f5462`
 │   │   ├── Result: records PR `#284` as merged and closes the
 │   │   │          WatchlistService getter-retirement lane without changing
 │   │   │          runtime source, tests, route paths, response contracts, or
@@ -2239,9 +2239,28 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                service symbol deletion, route dependency deletion, or
 │   │                issue-label change is made here
-│   └── Next gate: after G2.132 review and merge, refresh the remaining service
-│                  lifecycle candidate pool before selecting another
-│                  implementation lane
+│   ├── G2.133 Service lifecycle candidate refresh after WatchlistService
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.md`
+│   │   ├── Current HEAD: `f0e0e37726140499b2e6b25cdad96739fc8f5462`
+│   │   ├── Result: confirms Announcement/Email/StockSearch/Watchlist retired
+│   │   │          public getter definitions remain `0`, scans service files
+│   │   │          `152`, app files `575`, API files `219`, tests `204`,
+│   │   │          and remaining service getter definitions `11`
+│   │   ├── Candidate decision: no direct implementation lane selected;
+│   │   │          six LOW graph-risk candidates are shared
+│   │   │          `IntegratedServices` facade getters in
+│   │   │          `web/backend/app/services/__init__.py`; `get_market_data_service`
+│   │   │          remains held for graph/text symbol disambiguation; `get_tdx_service`,
+│   │   │          `get_data_service`, `get_strategy_service`, and
+│   │   │          `get_streaming_service` remain held at HIGH/CRITICAL risk
+│   │   └── Boundary: refresh-only; no source/test edit, IntegratedServices
+│   │                facade deletion, route/API, OpenAPI exposure, frontend,
+│   │                PM2, OpenSpec, implementation authorization, or issue-label
+│   │                change is made here
+│   └── Next gate: prepare an IntegratedServices facade getter ownership
+│                  decision packet before authorizing any `services/__init__.py`
+│                  facade getter retirement or migration
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -2342,7 +2361,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-di-candidate-refresh-after-stock-search-2026-05-26.md` | G | G2.129 candidate refresh accepted in PR `#282` at `cc32d0c2`: confirms Announcement/Email/StockSearch retired getters remain `0`, scans service files=`152`, app files=`575`, API files=`219`, tests=`203`, getter definitions=`12`, selects no direct implementation lane, and identifies `get_watchlist_service` only as a future authorization candidate with GitNexus MEDIUM / impacted=`15` / direct=`9` / processes=`0` | Superseded by G2.130 WatchlistService getter-retirement authorization |
 | `backend-watchlist-service-getter-retirement-authorization-2026-05-26.md` | G | G2.130 authorization accepted in PR `#283` at `35dcc90`: authorizes only a future implementation branch to retire `watchlist_service.py` `get_watchlist_service` and `_watchlist_service`, while preserving `WatchlistService`, `install_watchlist_service`, `get_watchlist_service_dependency`, route paths, response contracts, and OpenAPI exposure; current scan shows getter definitions=`1`, singleton tokens=`74`, app/API direct getter calls=`0`, route dependency handlers=`7`, adapter fallback files=`2`, tests with getter refs=`4`; GitNexus impact MEDIUM / impacted=`15` / direct=`9` / processes=`0` | Superseded by G2.131 WatchlistService getter-retirement implementation |
 | `backend-watchlist-service-getter-retirement-implementation-2026-05-26.md` | G | G2.131 implementation accepted in PR `#284` at `ccadd5e`: removes `watchlist_service.py` `get_watchlist_service` and module-level `_watchlist_service`, removes both adapter fallback imports/calls, preserves `WatchlistService`, `install_watchlist_service`, `get_watchlist_service_dependency`, route paths, response contracts, and OpenAPI exposure; TDD red `2 failed, 1 passed`, focused watchlist tests `28 passed`, health route conflicts `120 passed`, ruff/black/import smoke passed, exact scan reports service getter definitions=`0`, service singleton assignments=`0`, adapter fallback imports=`0`, adapter public getter calls=`0`, app/API public getter calls=`0`, route dependency handlers=`7` | Superseded by G2.132 WatchlistService getter-retirement closeout |
-| `backend-watchlist-service-getter-retirement-closeout-2026-05-26.md` | G | G2.132 closeout prepared at `ccadd5e`: records PR `#284` merged at `2026-05-26T03:30:49Z`, confirms current-head scan still has service getter definitions=`0`, service singleton assignments=`0`, adapter fallback imports=`0`, adapter public getter calls=`0`, app/API public getter calls=`0`, route dependency handlers=`7`, focused watchlist tests `28 passed`, and health route conflicts `120 passed`; no runtime source, tests, route paths, response contracts, OpenAPI exposure, PM2 workflow, OpenSpec change, or issue-label change is modified | Human review / PR merge decision; if accepted, refresh the remaining service lifecycle candidate pool |
+| `backend-watchlist-service-getter-retirement-closeout-2026-05-26.md` | G | G2.132 closeout accepted in PR `#285` at `f0e0e37`: records PR `#284` merged at `2026-05-26T03:30:49Z`, confirms current-head scan still has service getter definitions=`0`, service singleton assignments=`0`, adapter fallback imports=`0`, adapter public getter calls=`0`, app/API public getter calls=`0`, route dependency handlers=`7`, focused watchlist tests `28 passed`, and health route conflicts `120 passed`; no runtime source, tests, route paths, response contracts, OpenAPI exposure, PM2 workflow, OpenSpec change, or issue-label change is modified | Superseded by G2.133 service lifecycle candidate refresh after WatchlistService |
+| `backend-service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.md` | G | G2.133 candidate refresh prepared at `f0e0e37`: service files=`152`, app files=`575`, API files=`219`, tests=`204`, remaining service getter definitions=`11`, Announcement/Email/StockSearch/Watchlist retired public getter definitions remain `0`; no direct implementation lane is selected; six LOW graph-risk remaining candidates are shared `IntegratedServices` facade getters, `get_market_data_service` is held for graph/text disambiguation, and `get_tdx_service`, `get_data_service`, `get_strategy_service`, `get_streaming_service` remain HIGH/CRITICAL holds | Human review / PR merge decision; if accepted, prepare IntegratedServices facade getter ownership decision packet |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.json
+++ b/.planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.json
@@ -1,0 +1,272 @@
+{
+  "artifact": "service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26",
+  "recorded_at": "2026-05-26T11:54:19+08:00",
+  "workline": "G2.133 service lifecycle DI candidate refresh after WatchlistService getter retirement",
+  "status": "candidate-refresh-prepared-for-review",
+  "current_head": "f0e0e37726140499b2e6b25cdad96739fc8f5462",
+  "stale_if_head_mismatch": true,
+  "parent_pr": {
+    "number": 285,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T03:50:09Z",
+    "merge_commit": "f0e0e37726140499b2e6b25cdad96739fc8f5462",
+    "title": "G2.132 Close out WatchlistService getter retirement",
+    "url": "https://github.com/chengjon/mystocks/pull/285"
+  },
+  "scope_boundary": {
+    "source_edits_authorized": false,
+    "test_edits_authorized": false,
+    "openspec_change_required_now": false,
+    "issue_label_movement_authorized": false,
+    "implementation_authorized": false
+  },
+  "scan_summary": {
+    "service_files": 152,
+    "app_files": 575,
+    "api_files": 219,
+    "test_files": 204,
+    "service_getter_definitions": 11,
+    "retired_getter_confirmations": {
+      "get_announcement_service_definitions": 0,
+      "get_email_service_definitions": 0,
+      "get_stock_search_service_definitions": 0,
+      "get_watchlist_service_definitions": 0,
+      "_announcement_service_tokens": 0,
+      "_email_service_tokens": 0,
+      "_stock_search_service_tokens": 0,
+      "_watchlist_service_singleton_assignments": 0,
+      "_watchlist_service_residual_private_helper_tokens": 10,
+      "_watchlist_service_residual_classification": "adapter private provider/helper names and locals; not a module-level singleton or public getter"
+    }
+  },
+  "candidate_inventory": [
+    {
+      "symbol": "get_analysis_data_service",
+      "definition": {
+        "file": "web/backend/app/services/__init__.py",
+        "line": 272
+      },
+      "text_scan": {
+        "api_direct_calls": 0,
+        "app_direct_calls": 1,
+        "test_direct_calls": 0,
+        "dependency_refs": 0
+      },
+      "gitnexus": {
+        "risk": "LOW",
+        "impacted": 0,
+        "direct": 0,
+        "processes": 0
+      },
+      "disposition": "integrated-services-facade-hold"
+    },
+    {
+      "symbol": "get_cache_service",
+      "definition": {
+        "file": "web/backend/app/services/__init__.py",
+        "line": 296
+      },
+      "text_scan": {
+        "api_direct_calls": 0,
+        "app_direct_calls": 1,
+        "test_direct_calls": 0,
+        "dependency_refs": 0
+      },
+      "gitnexus": {
+        "risk": "LOW",
+        "impacted": 0,
+        "direct": 0,
+        "processes": 0
+      },
+      "disposition": "integrated-services-facade-hold"
+    },
+    {
+      "symbol": "get_data_api_service",
+      "definition": {
+        "file": "web/backend/app/services/__init__.py",
+        "line": 278
+      },
+      "text_scan": {
+        "api_direct_calls": 0,
+        "app_direct_calls": 1,
+        "test_direct_calls": 0,
+        "dependency_refs": 0
+      },
+      "gitnexus": {
+        "risk": "LOW",
+        "impacted": 0,
+        "direct": 0,
+        "processes": 0
+      },
+      "disposition": "integrated-services-facade-hold"
+    },
+    {
+      "symbol": "get_database_service",
+      "definition": {
+        "file": "web/backend/app/services/__init__.py",
+        "line": 284
+      },
+      "text_scan": {
+        "api_direct_calls": 0,
+        "app_direct_calls": 1,
+        "test_direct_calls": 0,
+        "dependency_refs": 0
+      },
+      "gitnexus": {
+        "risk": "LOW",
+        "impacted": 0,
+        "direct": 0,
+        "processes": 0
+      },
+      "disposition": "integrated-services-facade-hold"
+    },
+    {
+      "symbol": "get_trading_data_service",
+      "definition": {
+        "file": "web/backend/app/services/__init__.py",
+        "line": 266
+      },
+      "text_scan": {
+        "api_direct_calls": 0,
+        "app_direct_calls": 1,
+        "test_direct_calls": 0,
+        "dependency_refs": 0
+      },
+      "gitnexus": {
+        "risk": "LOW",
+        "impacted": 0,
+        "direct": 0,
+        "processes": 0
+      },
+      "disposition": "integrated-services-facade-hold"
+    },
+    {
+      "symbol": "get_websocket_service",
+      "definition": {
+        "file": "web/backend/app/services/__init__.py",
+        "line": 290
+      },
+      "text_scan": {
+        "api_direct_calls": 0,
+        "app_direct_calls": 1,
+        "test_direct_calls": 0,
+        "dependency_refs": 0
+      },
+      "gitnexus": {
+        "risk": "LOW",
+        "impacted": 0,
+        "direct": 0,
+        "processes": 0
+      },
+      "disposition": "integrated-services-facade-hold"
+    },
+    {
+      "symbol": "get_market_data_service",
+      "definition": {
+        "file": "web/backend/app/services/__init__.py",
+        "line": 260
+      },
+      "text_scan": {
+        "api_direct_calls": 0,
+        "app_direct_calls": 1,
+        "test_direct_calls": 1,
+        "dependency_refs": 11
+      },
+      "gitnexus": {
+        "risk": "LOW",
+        "impacted": 0,
+        "direct": 0,
+        "processes": 0,
+        "resolved_file": "web/backend/app/services/market_data_service/get_market_data_service.py"
+      },
+      "disposition": "hold-for-graph-text-symbol-disambiguation"
+    },
+    {
+      "symbol": "get_data_service",
+      "definition": {
+        "file": "web/backend/app/services/data_service.py",
+        "line": 466
+      },
+      "text_scan": {
+        "api_direct_calls": 3,
+        "app_direct_calls": 4,
+        "test_direct_calls": 2,
+        "dependency_refs": 0
+      },
+      "gitnexus": {
+        "risk": "CRITICAL",
+        "impacted": 4,
+        "direct": 3,
+        "processes": 7
+      },
+      "disposition": "hold-indicators-strategy-data-seam"
+    },
+    {
+      "symbol": "get_strategy_service",
+      "definition": {
+        "file": "web/backend/app/services/strategy_service.py",
+        "line": 455
+      },
+      "text_scan": {
+        "api_direct_calls": 3,
+        "app_direct_calls": 7,
+        "test_direct_calls": 0,
+        "dependency_refs": 0
+      },
+      "gitnexus": {
+        "risk": "CRITICAL",
+        "impacted": 11,
+        "direct": 6,
+        "processes": 0,
+        "modules": 5
+      },
+      "disposition": "hold-strategy-route-adapter-task-seam"
+    },
+    {
+      "symbol": "get_streaming_service",
+      "definition": {
+        "file": "web/backend/app/services/realtime_streaming_service.py",
+        "line": 424
+      },
+      "text_scan": {
+        "api_direct_calls": 0,
+        "app_direct_calls": 10,
+        "test_direct_calls": 16,
+        "dependency_refs": 0
+      },
+      "gitnexus": {
+        "risk": "HIGH",
+        "impacted": 9,
+        "direct": 9,
+        "processes": 0,
+        "modules": 4
+      },
+      "disposition": "hold-socketio-streaming-seam"
+    },
+    {
+      "symbol": "get_tdx_service",
+      "definition": {
+        "file": "web/backend/app/services/tdx_service.py",
+        "line": 275
+      },
+      "text_scan": {
+        "api_direct_calls": 0,
+        "app_direct_calls": 2,
+        "test_direct_calls": 0,
+        "dependency_refs": 7
+      },
+      "gitnexus": {
+        "risk": "CRITICAL",
+        "impacted": 4,
+        "direct": 2,
+        "processes": 5
+      },
+      "disposition": "hold-dashboard-live-market-seam"
+    }
+  ],
+  "recommendation": {
+    "direct_implementation_lane": "none",
+    "next_gate": "Prepare an IntegratedServices facade getter ownership decision packet before authorizing any __init__.py facade getter retirement or migration.",
+    "reason": "The only LOW graph-risk remaining candidates are shared IntegratedServices facade getters in web/backend/app/services/__init__.py. They should be handled as an ownership/design decision, not as isolated source edits."
+  }
+}

--- a/docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.md
@@ -1,0 +1,86 @@
+# Backend Service Lifecycle DI Candidate Refresh After Watchlist - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Candidate refresh prepared for review.
+
+This packet refreshes the remaining service lifecycle getter candidate pool after the WatchlistService getter-retirement closeout. It is governance-only and does not authorize source edits, tests edits, OpenSpec changes, PM2 execution, route changes, OpenAPI exposure changes, or issue-label movement.
+
+## Parent State
+
+| Field | Value |
+|---|---|
+| Parent PR | `#285` |
+| Parent state | `MERGED` |
+| Parent merged at | `2026-05-26T03:50:09Z` |
+| Parent merge commit | `f0e0e37726140499b2e6b25cdad96739fc8f5462` |
+| Parent title | `G2.132 Close out WatchlistService getter retirement` |
+| Parent URL | `https://github.com/chengjon/mystocks/pull/285` |
+
+## Current-Head Scan
+
+Current HEAD: `f0e0e37726140499b2e6b25cdad96739fc8f5462`.
+
+| Metric | Value |
+|---|---:|
+| Service Python files | `152` |
+| Backend app Python files | `575` |
+| Backend API Python files | `219` |
+| Backend test Python files | `204` |
+| Remaining service getter definitions | `11` |
+| `get_announcement_service` definitions | `0` |
+| `get_email_service` definitions | `0` |
+| `get_stock_search_service` definitions | `0` |
+| `get_watchlist_service` definitions | `0` |
+| `_announcement_service` tokens | `0` |
+| `_email_service` tokens | `0` |
+| `_stock_search_service` tokens | `0` |
+| `_watchlist_service` singleton assignments | `0` |
+| `_watchlist_service` residual private helper tokens | `10` |
+
+The residual `_watchlist_service` tokens are adapter private provider/helper names and local variables. They are not a module-level singleton and do not reintroduce the public `get_watchlist_service` compatibility getter.
+
+## Candidate Inventory
+
+| Candidate | Definition | Text-scan surface | GitNexus risk | Disposition |
+|---|---|---:|---|---|
+| `get_analysis_data_service` | `web/backend/app/services/__init__.py:272` | API direct `0`, app direct `1`, tests `0`, dependency refs `0` | LOW, impacted `0`, direct `0`, processes `0` | IntegratedServices facade hold |
+| `get_cache_service` | `web/backend/app/services/__init__.py:296` | API direct `0`, app direct `1`, tests `0`, dependency refs `0` | LOW, impacted `0`, direct `0`, processes `0` | IntegratedServices facade hold |
+| `get_data_api_service` | `web/backend/app/services/__init__.py:278` | API direct `0`, app direct `1`, tests `0`, dependency refs `0` | LOW, impacted `0`, direct `0`, processes `0` | IntegratedServices facade hold |
+| `get_database_service` | `web/backend/app/services/__init__.py:284` | API direct `0`, app direct `1`, tests `0`, dependency refs `0` | LOW, impacted `0`, direct `0`, processes `0` | IntegratedServices facade hold |
+| `get_trading_data_service` | `web/backend/app/services/__init__.py:266` | API direct `0`, app direct `1`, tests `0`, dependency refs `0` | LOW, impacted `0`, direct `0`, processes `0` | IntegratedServices facade hold |
+| `get_websocket_service` | `web/backend/app/services/__init__.py:290` | API direct `0`, app direct `1`, tests `0`, dependency refs `0` | LOW, impacted `0`, direct `0`, processes `0` | IntegratedServices facade hold |
+| `get_market_data_service` | `web/backend/app/services/__init__.py:260` | API direct `0`, app direct `1`, tests `1`, dependency refs `11` | LOW, impacted `0`; graph resolves to `web/backend/app/services/market_data_service/get_market_data_service.py` | Hold for graph/text symbol disambiguation |
+| `get_data_service` | `web/backend/app/services/data_service.py:466` | API direct `3`, app direct `4`, tests `2`, dependency refs `0` | CRITICAL, impacted `4`, direct `3`, processes `7` | Hold: indicators/strategy data seam |
+| `get_strategy_service` | `web/backend/app/services/strategy_service.py:455` | API direct `3`, app direct `7`, tests `0`, dependency refs `0` | CRITICAL, impacted `11`, direct `6`, modules `5` | Hold: strategy route/adapter/task seam |
+| `get_streaming_service` | `web/backend/app/services/realtime_streaming_service.py:424` | API direct `0`, app direct `10`, tests `16`, dependency refs `0` | HIGH, impacted `9`, direct `9`, modules `4` | Hold: Socket.IO streaming seam |
+| `get_tdx_service` | `web/backend/app/services/tdx_service.py:275` | API direct `0`, app direct `2`, tests `0`, dependency refs `7` | CRITICAL, impacted `4`, direct `2`, processes `5` | Hold: dashboard live-market seam |
+
+## Recommendation
+
+No direct implementation lane is selected by this refresh.
+
+The only LOW graph-risk remaining candidates are shared IntegratedServices facade getters in `web/backend/app/services/__init__.py`. They are not equivalent to the already completed route-surface getter retirements because each delegates through `get_integrated_services()` and represents a shared composition-root ownership question.
+
+Recommended next gate:
+
+- Prepare an IntegratedServices facade getter ownership decision packet.
+- Do not authorize deletion or migration of any `services/__init__.py` facade getter until that decision packet classifies whether the facade should be retained, wrapped, split, or retired as a group.
+- Keep `get_market_data_service` on hold until graph/text symbol disambiguation is resolved.
+- Keep `get_tdx_service`, `get_data_service`, `get_strategy_service`, and `get_streaming_service` on hold because their GitNexus risk is HIGH or CRITICAL.
+
+## Verification
+
+| Gate | Result |
+|---|---|
+| Parent PR state | `#285` is `MERGED` at `f0e0e37726140499b2e6b25cdad96739fc8f5462` |
+| Current-head scan | Service getter definitions `11`; retired public getter definitions for Announcement, Email, StockSearch, and Watchlist remain `0` |
+| GitNexus impact sampling | Six IntegratedServices facade getters LOW; `get_market_data_service` graph/text mismatch; `get_data_service`, `get_strategy_service`, `get_tdx_service` CRITICAL; `get_streaming_service` HIGH |
+
+## Boundary
+
+This refresh is not an implementation authorization. Future source work requires a separate authorization packet, explicit allowed paths, pre-edit GitNexus impact for edited symbols, TDD red/green proof, staged GitNexus scope check, mainline scope gate, and PR review.

--- a/governance/mainline/task-cards/pr-286.yaml
+++ b/governance/mainline/task-cards/pr-286.yaml
@@ -1,0 +1,104 @@
+version: "v0.2"
+
+task:
+  id: "pr-286"
+  title: "Refresh service lifecycle DI candidates after WatchlistService"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-service-lifecycle-di-candidate-refresh-after-watchlist"
+  objective: "record the G2.133 current-head service lifecycle DI candidate refresh after PR #285"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-di-candidate-refresh-after-watchlist"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-di-candidate-refresh-after-watchlist"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate refresh records current-head evidence only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.json"
+    - "docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-286.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 285 --json number,state,mergedAt,mergeCommit,title,url"
+      required: true
+    - id: "candidate-scan"
+      command: "scripted current-head text scan over service getter definitions, retired getter confirmations, text-scan surfaces, and residual Watchlist private-helper token classification"
+      required: true
+    - id: "gitnexus-impact-sampling"
+      command: "GitNexus impact sampling for IntegratedServices facade getters, market_data, data, strategy, streaming, and tdx getters"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-286.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests."
+  - "Do not authorize or perform IntegratedServices facade getter deletion or migration."
+  - "Do not move issue labels, change OpenSpec content, run PM2, or change route/OpenAPI behavior."
+
+risk_and_rollback:
+  risks:
+    - "If LOW graph-risk IntegratedServices facade getters are treated as isolated implementation candidates, the shared composition-root ownership question could be skipped"
+    - "If HIGH/CRITICAL getters are selected without a separate authorization packet, route, adapter, task, dashboard, or streaming seams could regress"
+  rollback_plan: "revert this candidate-refresh PR to remove only the refresh report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh service lifecycle DI candidates after WatchlistService getter retirement"
+    modified_scope: "steward tree, candidate refresh report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON/YAML parsing, GitNexus staged scope, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T11:54:19+08:00"
+    approval_note: "Candidate refresh follows merged G2.132 closeout PR #285"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Refresh the service lifecycle DI candidate pool after PR #285 closed WatchlistService getter retirement
- Record current-head scan: service getter definitions 11, retired public getter definitions for Announcement/Email/StockSearch/Watchlist remain 0
- Recommend no direct implementation lane; next gate is an IntegratedServices facade getter ownership decision packet

## Verification
- Parent PR #285 state: MERGED at f0e0e37726140499b2e6b25cdad96739fc8f5462
- Candidate scan regenerated at current HEAD
- GitNexus impact sampling: IntegratedServices facade getters LOW; market_data graph/text mismatch; data/strategy/tdx CRITICAL; streaming HIGH
- Markdown governance: 2 checked files, 0 errors
- JSON/YAML parse: passed
- GitNexus staged scope: low risk, affected processes 0
- Mainline scope gate: pass=True

## Boundary
Governance refresh only. No backend source, tests, route paths, OpenAPI exposure, PM2 workflow, OpenSpec changes, or issue-label changes.