### PR TITLE
G2.134 Decide IntegratedServices facade getter ownership

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2240,9 +2240,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                service symbol deletion, route dependency deletion, or
 │   │                issue-label change is made here
 │   ├── G2.133 Service lifecycle candidate refresh after WatchlistService
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#286`
 │   │   ├── Evidence: `backend-service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.md`
-│   │   ├── Current HEAD: `f0e0e37726140499b2e6b25cdad96739fc8f5462`
+│   │   ├── Merge commit: `bc2d2a891787484b7fc65dd8fec61e19d66345bf`
 │   │   ├── Result: confirms Announcement/Email/StockSearch/Watchlist retired
 │   │   │          public getter definitions remain `0`, scans service files
 │   │   │          `152`, app files `575`, API files `219`, tests `204`,
@@ -2258,9 +2258,29 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                facade deletion, route/API, OpenAPI exposure, frontend,
 │   │                PM2, OpenSpec, implementation authorization, or issue-label
 │   │                change is made here
-│   └── Next gate: prepare an IntegratedServices facade getter ownership
-│                  decision packet before authorizing any `services/__init__.py`
-│                  facade getter retirement or migration
+│   ├── G2.134 IntegratedServices facade getter ownership decision
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-integrated-services-facade-getter-ownership-decision-2026-05-26.md`
+│   │   ├── Current HEAD: `bc2d2a891787484b7fc65dd8fec61e19d66345bf`
+│   │   ├── Decision: treat `web/backend/app/services/__init__.py` getters
+│   │   │          as a shared IntegratedServices compatibility facade owned
+│   │   │          by the composition root, not as independent route-surface
+│   │   │          singleton getters
+│   │   ├── Result: retain `get_integrated_services` and
+│   │   │          `get_market_data_service`; mark only
+│   │   │          `get_trading_data_service`, `get_analysis_data_service`,
+│   │   │          `get_data_api_service`, `get_database_service`,
+│   │   │          `get_websocket_service`, and `get_cache_service` as eligible
+│   │   │          for a future unused-facade retirement authorization packet;
+│   │   │          risk helper facades are out of the current service-getter queue
+│   │   └── Boundary: decision-only; no source/test edit, facade deletion,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                implementation authorization, or issue-label change is
+│   │                made here
+│   └── Next gate: prepare a narrow unused IntegratedServices service-facade
+│                  getter retirement authorization packet, excluding
+│                  `get_integrated_services`, `get_market_data_service`, risk
+│                  helper facades, and HIGH/CRITICAL service getters
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -2362,7 +2382,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-watchlist-service-getter-retirement-authorization-2026-05-26.md` | G | G2.130 authorization accepted in PR `#283` at `35dcc90`: authorizes only a future implementation branch to retire `watchlist_service.py` `get_watchlist_service` and `_watchlist_service`, while preserving `WatchlistService`, `install_watchlist_service`, `get_watchlist_service_dependency`, route paths, response contracts, and OpenAPI exposure; current scan shows getter definitions=`1`, singleton tokens=`74`, app/API direct getter calls=`0`, route dependency handlers=`7`, adapter fallback files=`2`, tests with getter refs=`4`; GitNexus impact MEDIUM / impacted=`15` / direct=`9` / processes=`0` | Superseded by G2.131 WatchlistService getter-retirement implementation |
 | `backend-watchlist-service-getter-retirement-implementation-2026-05-26.md` | G | G2.131 implementation accepted in PR `#284` at `ccadd5e`: removes `watchlist_service.py` `get_watchlist_service` and module-level `_watchlist_service`, removes both adapter fallback imports/calls, preserves `WatchlistService`, `install_watchlist_service`, `get_watchlist_service_dependency`, route paths, response contracts, and OpenAPI exposure; TDD red `2 failed, 1 passed`, focused watchlist tests `28 passed`, health route conflicts `120 passed`, ruff/black/import smoke passed, exact scan reports service getter definitions=`0`, service singleton assignments=`0`, adapter fallback imports=`0`, adapter public getter calls=`0`, app/API public getter calls=`0`, route dependency handlers=`7` | Superseded by G2.132 WatchlistService getter-retirement closeout |
 | `backend-watchlist-service-getter-retirement-closeout-2026-05-26.md` | G | G2.132 closeout accepted in PR `#285` at `f0e0e37`: records PR `#284` merged at `2026-05-26T03:30:49Z`, confirms current-head scan still has service getter definitions=`0`, service singleton assignments=`0`, adapter fallback imports=`0`, adapter public getter calls=`0`, app/API public getter calls=`0`, route dependency handlers=`7`, focused watchlist tests `28 passed`, and health route conflicts `120 passed`; no runtime source, tests, route paths, response contracts, OpenAPI exposure, PM2 workflow, OpenSpec change, or issue-label change is modified | Superseded by G2.133 service lifecycle candidate refresh after WatchlistService |
-| `backend-service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.md` | G | G2.133 candidate refresh prepared at `f0e0e37`: service files=`152`, app files=`575`, API files=`219`, tests=`204`, remaining service getter definitions=`11`, Announcement/Email/StockSearch/Watchlist retired public getter definitions remain `0`; no direct implementation lane is selected; six LOW graph-risk remaining candidates are shared `IntegratedServices` facade getters, `get_market_data_service` is held for graph/text disambiguation, and `get_tdx_service`, `get_data_service`, `get_strategy_service`, `get_streaming_service` remain HIGH/CRITICAL holds | Human review / PR merge decision; if accepted, prepare IntegratedServices facade getter ownership decision packet |
+| `backend-service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.md` | G | G2.133 candidate refresh accepted in PR `#286` at `bc2d2a8`: service files=`152`, app files=`575`, API files=`219`, tests=`204`, remaining service getter definitions=`11`, Announcement/Email/StockSearch/Watchlist retired public getter definitions remain `0`; no direct implementation lane is selected; six LOW graph-risk remaining candidates are shared `IntegratedServices` facade getters, `get_market_data_service` is held for graph/text disambiguation, and `get_tdx_service`, `get_data_service`, `get_strategy_service`, `get_streaming_service` remain HIGH/CRITICAL holds | Superseded by G2.134 IntegratedServices facade getter ownership decision |
+| `backend-integrated-services-facade-getter-ownership-decision-2026-05-26.md` | G | G2.134 decision prepared at `bc2d2a8`: classifies `web/backend/app/services/__init__.py` getters as a shared IntegratedServices compatibility facade owned by the composition root; retains `get_integrated_services` and `get_market_data_service`; marks only `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, and `get_cache_service` as eligible for a future unused-facade retirement authorization packet; risk helper facades are out of the current service-getter queue | Human review / PR merge decision; if accepted, prepare unused IntegratedServices service-facade getter retirement authorization packet |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/integrated-services-facade-getter-ownership-decision-2026-05-26.json
+++ b/.planning/codebase/generated/integrated-services-facade-getter-ownership-decision-2026-05-26.json
@@ -1,0 +1,135 @@
+{
+  "artifact": "integrated-services-facade-getter-ownership-decision-2026-05-26",
+  "recorded_at": "2026-05-26T12:06:42+08:00",
+  "workline": "G2.134 IntegratedServices facade getter ownership decision",
+  "status": "decision-prepared-for-review",
+  "current_head": "bc2d2a891787484b7fc65dd8fec61e19d66345bf",
+  "stale_if_head_mismatch": true,
+  "parent_pr": {
+    "number": 286,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T04:02:08Z",
+    "merge_commit": "bc2d2a891787484b7fc65dd8fec61e19d66345bf",
+    "title": "G2.133 Refresh service lifecycle candidates after WatchlistService",
+    "url": "https://github.com/chengjon/mystocks/pull/286"
+  },
+  "scope_boundary": {
+    "source_edits_authorized": false,
+    "test_edits_authorized": false,
+    "implementation_authorized": false,
+    "openspec_change_required_now": false,
+    "issue_label_movement_authorized": false
+  },
+  "ownership_decision": {
+    "owner_group": "IntegratedServices facade getters in web/backend/app/services/__init__.py",
+    "decision": "Treat these functions as a shared compatibility facade owned by the IntegratedServices composition root, not as independent route-surface singleton getters.",
+    "retain_now": [
+      "get_integrated_services",
+      "get_market_data_service"
+    ],
+    "eligible_for_future_authorization_packet": [
+      "get_trading_data_service",
+      "get_analysis_data_service",
+      "get_data_api_service",
+      "get_database_service",
+      "get_websocket_service",
+      "get_cache_service"
+    ],
+    "out_of_current_service_getter_queue": [
+      "get_risk_calculator",
+      "get_risk_monitoring",
+      "get_risk_alerts",
+      "get_risk_settings",
+      "get_risk_dashboard"
+    ],
+    "next_gate": "Prepare a narrow authorization packet for unused IntegratedServices service-facade getter retirement, excluding get_integrated_services, get_market_data_service, and risk helper facades."
+  },
+  "facade_scan": {
+    "service_init_path": "web/backend/app/services/__init__.py",
+    "get_integrated_services": {
+      "definition_line": 227,
+      "gitnexus": {
+        "risk": "MEDIUM",
+        "impacted": 13,
+        "direct": 13,
+        "processes": 0
+      },
+      "decision": "retain as composition root accessor"
+    },
+    "service_facade_getters": [
+      {
+        "symbol": "get_market_data_service",
+        "definition_line": 260,
+        "returns": "integrated_services.market_data_service",
+        "active_app_calls_excluding_definition": 0,
+        "test_calls": 1,
+        "app_token_files": [
+          "web/backend/app/services/market_data_service/__init__.py"
+        ],
+        "decision": "retain for now; package-level symbol collision and test consumers require separate disambiguation"
+      },
+      {
+        "symbol": "get_trading_data_service",
+        "definition_line": 266,
+        "returns": "integrated_services.trading_data_service",
+        "active_app_calls_excluding_definition": 0,
+        "test_calls": 0,
+        "decision": "eligible for future unused-facade retirement authorization"
+      },
+      {
+        "symbol": "get_analysis_data_service",
+        "definition_line": 272,
+        "returns": "integrated_services.analysis_data_service",
+        "active_app_calls_excluding_definition": 0,
+        "test_calls": 0,
+        "decision": "eligible for future unused-facade retirement authorization"
+      },
+      {
+        "symbol": "get_data_api_service",
+        "definition_line": 278,
+        "returns": "integrated_services.data_api_service",
+        "active_app_calls_excluding_definition": 0,
+        "test_calls": 0,
+        "decision": "eligible for future unused-facade retirement authorization"
+      },
+      {
+        "symbol": "get_database_service",
+        "definition_line": 284,
+        "returns": "integrated_services.database_service",
+        "active_app_calls_excluding_definition": 0,
+        "test_calls": 0,
+        "decision": "eligible for future unused-facade retirement authorization"
+      },
+      {
+        "symbol": "get_websocket_service",
+        "definition_line": 290,
+        "returns": "integrated_services.websocket_service",
+        "active_app_calls_excluding_definition": 0,
+        "test_calls": 0,
+        "decision": "eligible for future unused-facade retirement authorization"
+      },
+      {
+        "symbol": "get_cache_service",
+        "definition_line": 296,
+        "returns": "integrated_services.cache_service",
+        "active_app_calls_excluding_definition": 0,
+        "test_calls": 0,
+        "decision": "eligible for future unused-facade retirement authorization"
+      }
+    ],
+    "risk_helper_facades": [
+      "get_risk_calculator",
+      "get_risk_monitoring",
+      "get_risk_alerts",
+      "get_risk_settings",
+      "get_risk_dashboard"
+    ]
+  },
+  "future_authorization_requirements": [
+    "Do not edit web/backend/app/services/__init__.py under this decision packet.",
+    "Future source authorization must list exact removable facade getter names.",
+    "Future source authorization must exclude get_integrated_services and get_market_data_service.",
+    "Future implementation must run pre-edit GitNexus impact for every edited symbol.",
+    "Future implementation must include import smoke for app.services and focused tests covering the removed names."
+  ]
+}

--- a/docs/reports/quality/backend-integrated-services-facade-getter-ownership-decision-2026-05-26.md
+++ b/docs/reports/quality/backend-integrated-services-facade-getter-ownership-decision-2026-05-26.md
@@ -1,0 +1,99 @@
+# Backend IntegratedServices Facade Getter Ownership Decision - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Decision prepared for review.
+
+This packet resolves the G2.133 question about LOW graph-risk getters in `web/backend/app/services/__init__.py`. It is decision-only and does not authorize source edits, tests edits, OpenSpec changes, PM2 execution, route changes, OpenAPI exposure changes, or issue-label movement.
+
+## Decision
+
+Treat the `web/backend/app/services/__init__.py` getter group as a shared IntegratedServices compatibility facade owned by the IntegratedServices composition root.
+
+These functions are not equivalent to the already completed route-surface singleton getter retirements. Each delegates through `get_integrated_services()` and belongs to the same composition-root facade. The group must be handled as an ownership decision and future narrow authorization, not as isolated opportunistic deletion.
+
+## Parent State
+
+| Field | Value |
+|---|---|
+| Parent PR | `#286` |
+| Parent state | `MERGED` |
+| Parent merged at | `2026-05-26T04:02:08Z` |
+| Parent merge commit | `bc2d2a891787484b7fc65dd8fec61e19d66345bf` |
+| Parent title | `G2.133 Refresh service lifecycle candidates after WatchlistService` |
+| Parent URL | `https://github.com/chengjon/mystocks/pull/286` |
+
+## Facade Ownership
+
+| Symbol | Definition | Ownership decision |
+|---|---|---|
+| `get_integrated_services` | `web/backend/app/services/__init__.py:227` | Retain as the composition-root accessor |
+| `get_market_data_service` | `web/backend/app/services/__init__.py:260` | Retain for now; same-name package provider and test consumers require separate disambiguation |
+| `get_trading_data_service` | `web/backend/app/services/__init__.py:266` | Eligible for a future unused-facade retirement authorization packet |
+| `get_analysis_data_service` | `web/backend/app/services/__init__.py:272` | Eligible for a future unused-facade retirement authorization packet |
+| `get_data_api_service` | `web/backend/app/services/__init__.py:278` | Eligible for a future unused-facade retirement authorization packet |
+| `get_database_service` | `web/backend/app/services/__init__.py:284` | Eligible for a future unused-facade retirement authorization packet |
+| `get_websocket_service` | `web/backend/app/services/__init__.py:290` | Eligible for a future unused-facade retirement authorization packet |
+| `get_cache_service` | `web/backend/app/services/__init__.py:296` | Eligible for a future unused-facade retirement authorization packet |
+
+The risk helper facade functions in the same file are out of this service-getter queue:
+
+- `get_risk_calculator`
+- `get_risk_monitoring`
+- `get_risk_alerts`
+- `get_risk_settings`
+- `get_risk_dashboard`
+
+## Evidence
+
+| Evidence | Result |
+|---|---|
+| Current HEAD | `bc2d2a891787484b7fc65dd8fec61e19d66345bf` |
+| `get_integrated_services` impact | GitNexus MEDIUM, impacted `13`, direct `13`, processes `0` |
+| Six eligible service facades | Active app calls excluding definitions `0`; test calls `0`; prior GitNexus impact LOW / impacted `0` |
+| `get_market_data_service` | Active app calls excluding definition `0`, but package token exists in `web/backend/app/services/market_data_service/__init__.py` and tests still reference market-data getter/provider names |
+| G2.133 source queue | `get_tdx_service`, `get_data_service`, `get_strategy_service`, and `get_streaming_service` remain HIGH/CRITICAL holds |
+
+## Next Gate
+
+Prepare a narrow unused IntegratedServices service-facade getter retirement authorization packet.
+
+The future authorization packet may consider only:
+
+- `get_trading_data_service`
+- `get_analysis_data_service`
+- `get_data_api_service`
+- `get_database_service`
+- `get_websocket_service`
+- `get_cache_service`
+
+The future authorization packet must explicitly exclude:
+
+- `get_integrated_services`
+- `get_market_data_service`
+- Risk helper facades
+- `get_tdx_service`
+- `get_data_service`
+- `get_strategy_service`
+- `get_streaming_service`
+
+## Future Implementation Requirements
+
+Future source work is not authorized by this packet. If a later authorization packet is accepted, implementation must include:
+
+- Exact allowed path list before edits.
+- Pre-edit GitNexus impact for every edited symbol.
+- TDD red proof for the selected removable facade names.
+- Import smoke for `app.services`.
+- Focused tests covering the selected facade names and excluded names.
+- Staged GitNexus scope check.
+- Mainline scope gate.
+- PR review.
+
+## Boundary
+
+No runtime source, tests, route paths, response contracts, OpenAPI exposure, PM2 workflow, OpenSpec changes, GitHub issue labels, or product behavior are changed by this decision packet.

--- a/governance/mainline/task-cards/pr-287.yaml
+++ b/governance/mainline/task-cards/pr-287.yaml
@@ -1,0 +1,104 @@
+version: "v0.2"
+
+task:
+  id: "pr-287"
+  title: "Decide IntegratedServices facade getter ownership"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-integrated-services-facade-getter-ownership-decision"
+  objective: "record the G2.134 ownership decision for IntegratedServices facade getters after PR #286"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-integrated-services-facade-getter-ownership"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-integrated-services-facade-getter-ownership-decision"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision packet records facade getter ownership only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/integrated-services-facade-getter-ownership-decision-2026-05-26.json"
+    - "docs/reports/quality/backend-integrated-services-facade-getter-ownership-decision-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-287.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 286 --json number,state,mergedAt,mergeCommit,title,url"
+      required: true
+    - id: "facade-scan"
+      command: "scripted current-head scan over web/backend/app/services/__init__.py facade getter definitions, consumer tokens, and IntegratedServices ownership evidence"
+      required: true
+    - id: "gitnexus-impact-sampling"
+      command: "GitNexus impact for get_integrated_services plus prior G2.133 LOW/HIGH/CRITICAL getter risk evidence"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-integrated-services-facade-getter-ownership-decision-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/integrated-services-facade-getter-ownership-decision-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-287.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests."
+  - "Do not authorize source implementation in this decision packet."
+  - "Do not include get_integrated_services, get_market_data_service, risk helper facades, or HIGH/CRITICAL service getters in a future cleanup list without a separate authorization packet."
+
+risk_and_rollback:
+  risks:
+    - "If IntegratedServices facade getters are treated as independent route-surface getters, future implementation could skip the composition-root ownership boundary"
+    - "If get_market_data_service is grouped with unused facades, the package-level provider symbol collision could be misclassified"
+  rollback_plan: "revert this decision PR to remove only the decision report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "decide IntegratedServices facade getter ownership"
+    modified_scope: "steward tree, ownership decision report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON/YAML parsing, GitNexus staged scope, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T12:06:42+08:00"
+    approval_note: "Decision packet follows merged G2.133 candidate refresh PR #286"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Classify services/__init__.py getter group as an IntegratedServices compatibility facade owned by the composition root
- Retain get_integrated_services and get_market_data_service for now
- Mark only six unused service facades as eligible for a future narrow authorization packet

## Verification
- Parent PR #286 state: MERGED at bc2d2a891787484b7fc65dd8fec61e19d66345bf
- Facade scan completed at current HEAD
- GitNexus impact: get_integrated_services MEDIUM / impacted 13 / direct 13; six eligible facades inherit prior LOW graph risk
- Markdown governance: 2 checked files, 0 errors
- JSON/YAML parse: passed
- GitNexus staged scope: low risk, affected processes 0
- Mainline scope gate: pass=True

## Boundary
Decision-only governance packet. No backend source, tests, route paths, OpenAPI exposure, PM2 workflow, OpenSpec changes, or issue-label changes.