### PR TITLE
G2.135 Authorize unused IntegratedServices facade getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2259,9 +2259,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                PM2, OpenSpec, implementation authorization, or issue-label
 │   │                change is made here
 │   ├── G2.134 IntegratedServices facade getter ownership decision
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#287`
 │   │   ├── Evidence: `backend-integrated-services-facade-getter-ownership-decision-2026-05-26.md`
-│   │   ├── Current HEAD: `bc2d2a891787484b7fc65dd8fec61e19d66345bf`
+│   │   ├── Merge commit: `65498c4565db877ee187f9ceb6dd140b7e4db7fd`
 │   │   ├── Decision: treat `web/backend/app/services/__init__.py` getters
 │   │   │          as a shared IntegratedServices compatibility facade owned
 │   │   │          by the composition root, not as independent route-surface
@@ -2277,10 +2277,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                implementation authorization, or issue-label change is
 │   │                made here
-│   └── Next gate: prepare a narrow unused IntegratedServices service-facade
-│                  getter retirement authorization packet, excluding
-│                  `get_integrated_services`, `get_market_data_service`, risk
-│                  helper facades, and HIGH/CRITICAL service getters
+│   ├── G2.135 Unused IntegratedServices service-facade getter retirement authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-unused-integrated-services-facade-getter-retirement-authorization-2026-05-26.md`
+│   │   ├── Current HEAD: `65498c4565db877ee187f9ceb6dd140b7e4db7fd`
+│   │   ├── Authorization: future source lane may remove only
+│   │   │          `get_trading_data_service`, `get_analysis_data_service`,
+│   │   │          `get_data_api_service`, `get_database_service`,
+│   │   │          `get_websocket_service`, and `get_cache_service` from
+│   │   │          `web/backend/app/services/__init__.py`, with one focused
+│   │   │          test file and standard implementation evidence
+│   │   ├── Locked scope: `get_integrated_services`, `get_market_data_service`,
+│   │   │          risk helper facades, route/API, OpenAPI, PM2, frontend,
+│   │   │          OpenSpec, issue labels, and HIGH/CRITICAL service getters
+│   │   │          remain out of scope
+│   │   └── Boundary: authorization-only; no source/test edit, facade deletion,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                implementation, or issue-label change is made here
+│   └── Next gate: if G2.135 is accepted, run G2.136 source implementation
+│                  under the exact authorized paths and TDD/GitNexus gates
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -2383,7 +2398,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-watchlist-service-getter-retirement-implementation-2026-05-26.md` | G | G2.131 implementation accepted in PR `#284` at `ccadd5e`: removes `watchlist_service.py` `get_watchlist_service` and module-level `_watchlist_service`, removes both adapter fallback imports/calls, preserves `WatchlistService`, `install_watchlist_service`, `get_watchlist_service_dependency`, route paths, response contracts, and OpenAPI exposure; TDD red `2 failed, 1 passed`, focused watchlist tests `28 passed`, health route conflicts `120 passed`, ruff/black/import smoke passed, exact scan reports service getter definitions=`0`, service singleton assignments=`0`, adapter fallback imports=`0`, adapter public getter calls=`0`, app/API public getter calls=`0`, route dependency handlers=`7` | Superseded by G2.132 WatchlistService getter-retirement closeout |
 | `backend-watchlist-service-getter-retirement-closeout-2026-05-26.md` | G | G2.132 closeout accepted in PR `#285` at `f0e0e37`: records PR `#284` merged at `2026-05-26T03:30:49Z`, confirms current-head scan still has service getter definitions=`0`, service singleton assignments=`0`, adapter fallback imports=`0`, adapter public getter calls=`0`, app/API public getter calls=`0`, route dependency handlers=`7`, focused watchlist tests `28 passed`, and health route conflicts `120 passed`; no runtime source, tests, route paths, response contracts, OpenAPI exposure, PM2 workflow, OpenSpec change, or issue-label change is modified | Superseded by G2.133 service lifecycle candidate refresh after WatchlistService |
 | `backend-service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.md` | G | G2.133 candidate refresh accepted in PR `#286` at `bc2d2a8`: service files=`152`, app files=`575`, API files=`219`, tests=`204`, remaining service getter definitions=`11`, Announcement/Email/StockSearch/Watchlist retired public getter definitions remain `0`; no direct implementation lane is selected; six LOW graph-risk remaining candidates are shared `IntegratedServices` facade getters, `get_market_data_service` is held for graph/text disambiguation, and `get_tdx_service`, `get_data_service`, `get_strategy_service`, `get_streaming_service` remain HIGH/CRITICAL holds | Superseded by G2.134 IntegratedServices facade getter ownership decision |
-| `backend-integrated-services-facade-getter-ownership-decision-2026-05-26.md` | G | G2.134 decision prepared at `bc2d2a8`: classifies `web/backend/app/services/__init__.py` getters as a shared IntegratedServices compatibility facade owned by the composition root; retains `get_integrated_services` and `get_market_data_service`; marks only `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, and `get_cache_service` as eligible for a future unused-facade retirement authorization packet; risk helper facades are out of the current service-getter queue | Human review / PR merge decision; if accepted, prepare unused IntegratedServices service-facade getter retirement authorization packet |
+| `backend-integrated-services-facade-getter-ownership-decision-2026-05-26.md` | G | G2.134 decision accepted in PR `#287` at `65498c4`: classifies `web/backend/app/services/__init__.py` getters as a shared IntegratedServices compatibility facade owned by the composition root; retains `get_integrated_services` and `get_market_data_service`; marks only `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, and `get_cache_service` as eligible for a future unused-facade retirement authorization packet; risk helper facades are out of the current service-getter queue | Superseded by G2.135 unused IntegratedServices service-facade getter retirement authorization |
+| `backend-unused-integrated-services-facade-getter-retirement-authorization-2026-05-26.md` | G | G2.135 authorization prepared at `65498c4`: future source lane may remove only `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, and `get_cache_service` from `web/backend/app/services/__init__.py`, with one focused test file and implementation evidence; `get_integrated_services`, `get_market_data_service`, risk helper facades, HIGH/CRITICAL service getters, route/API, OpenAPI, PM2, frontend, OpenSpec, and issue labels remain locked | Human review / PR merge decision; if accepted, run G2.136 source implementation under exact authorized paths |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/unused-integrated-services-facade-getter-retirement-authorization-2026-05-26.json
+++ b/.planning/codebase/generated/unused-integrated-services-facade-getter-retirement-authorization-2026-05-26.json
@@ -1,0 +1,80 @@
+{
+  "artifact": "unused-integrated-services-facade-getter-retirement-authorization-2026-05-26",
+  "recorded_at": "2026-05-26T12:16:32+08:00",
+  "workline": "G2.135 unused IntegratedServices service-facade getter retirement authorization",
+  "status": "authorization-prepared-for-review",
+  "current_head": "65498c4565db877ee187f9ceb6dd140b7e4db7fd",
+  "stale_if_head_mismatch": true,
+  "parent_pr": {
+    "number": 287,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T04:14:13Z",
+    "merge_commit": "65498c4565db877ee187f9ceb6dd140b7e4db7fd",
+    "title": "G2.134 Decide IntegratedServices facade getter ownership",
+    "url": "https://github.com/chengjon/mystocks/pull/287"
+  },
+  "future_implementation_authorization": {
+    "source_edits_authorized_by_this_packet": false,
+    "future_source_lane": "G2.136 unused IntegratedServices service-facade getter retirement implementation",
+    "future_allowed_paths": [
+      "web/backend/app/services/__init__.py",
+      "web/backend/tests/test_integrated_services_facade_getter_retirement.py",
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.json",
+      "docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.md",
+      "governance/mainline/task-cards/pr-288.yaml"
+    ],
+    "future_removable_symbols": [
+      "get_trading_data_service",
+      "get_analysis_data_service",
+      "get_data_api_service",
+      "get_database_service",
+      "get_websocket_service",
+      "get_cache_service"
+    ],
+    "future_locked_symbols": [
+      "get_integrated_services",
+      "get_market_data_service",
+      "get_risk_calculator",
+      "get_risk_monitoring",
+      "get_risk_alerts",
+      "get_risk_settings",
+      "get_risk_dashboard",
+      "get_tdx_service",
+      "get_data_service",
+      "get_strategy_service",
+      "get_streaming_service"
+    ],
+    "future_forbidden_paths": [
+      "web/backend/app/api/**",
+      "web/backend/app/services/market_data_service/**",
+      "web/backend/app/services/tdx_service.py",
+      "web/backend/app/services/data_service.py",
+      "web/backend/app/services/strategy_service.py",
+      "web/backend/app/services/realtime_streaming_service.py",
+      "web/frontend/**",
+      "src/**",
+      "docs/api/**",
+      "docs/guides/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ]
+  },
+  "acceptance_requirements_for_future_source_lane": [
+    "Run pre-edit GitNexus impact for each future removable symbol.",
+    "Use TDD: first add/adjust a focused test that fails because the removable facade symbols still exist.",
+    "Remove only the six future_removable_symbols from web/backend/app/services/__init__.py.",
+    "Do not modify IntegratedServices construction, get_integrated_services, get_market_data_service, risk helper facades, route files, OpenAPI output, PM2 workflow, or issue labels.",
+    "Focused tests must assert removed symbols are absent and locked symbols remain present/callable as appropriate.",
+    "Run app.services import smoke.",
+    "Run Ruff and Black checks on touched files.",
+    "Run staged GitNexus detect_changes and mainline scope gate before PR."
+  ],
+  "risk_notes": [
+    "This authorization does not open a source edit in G2.135 itself.",
+    "The future implementation is intentionally narrow because the selected symbols have no active app consumers excluding their definitions and no direct test calls in the current scan.",
+    "get_market_data_service remains locked because same-name package provider and tests require separate disambiguation."
+  ]
+}

--- a/docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-authorization-2026-05-26.md
+++ b/docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-authorization-2026-05-26.md
@@ -1,0 +1,107 @@
+# Backend Unused IntegratedServices Facade Getter Retirement Authorization - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Authorization prepared for review.
+
+This packet authorizes the shape of a future source lane only. It does not edit source code, tests, OpenSpec content, route paths, OpenAPI exposure, PM2 workflow, GitHub issue labels, or product behavior.
+
+## Parent Decision
+
+| Field | Value |
+|---|---|
+| Parent PR | `#287` |
+| Parent state | `MERGED` |
+| Parent merged at | `2026-05-26T04:14:13Z` |
+| Parent merge commit | `65498c4565db877ee187f9ceb6dd140b7e4db7fd` |
+| Parent title | `G2.134 Decide IntegratedServices facade getter ownership` |
+| Parent URL | `https://github.com/chengjon/mystocks/pull/287` |
+
+## Future Source Lane
+
+Future lane name:
+
+`G2.136 unused IntegratedServices service-facade getter retirement implementation`
+
+Future source work is not performed by this packet. If this authorization is accepted, a separate implementation branch may edit only:
+
+- `web/backend/app/services/__init__.py`
+- `web/backend/tests/test_integrated_services_facade_getter_retirement.py`
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.json`
+- `docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.md`
+- `governance/mainline/task-cards/pr-288.yaml`
+
+## Authorized Removable Symbols
+
+Only the following `web/backend/app/services/__init__.py` facade symbols are eligible for future removal:
+
+- `get_trading_data_service`
+- `get_analysis_data_service`
+- `get_data_api_service`
+- `get_database_service`
+- `get_websocket_service`
+- `get_cache_service`
+
+These were selected because G2.134 classified them as unused service-facade getters with no active app calls excluding their own definitions and no direct test calls in the current scan.
+
+## Locked Symbols
+
+The future implementation must not remove, rename, alter, or migrate:
+
+- `get_integrated_services`
+- `get_market_data_service`
+- `get_risk_calculator`
+- `get_risk_monitoring`
+- `get_risk_alerts`
+- `get_risk_settings`
+- `get_risk_dashboard`
+- `get_tdx_service`
+- `get_data_service`
+- `get_strategy_service`
+- `get_streaming_service`
+
+`get_market_data_service` remains locked because same-name package provider and tests require a separate graph/text disambiguation decision.
+
+## Future Forbidden Paths
+
+The future implementation must not edit:
+
+- `web/backend/app/api/**`
+- `web/backend/app/services/market_data_service/**`
+- `web/backend/app/services/tdx_service.py`
+- `web/backend/app/services/data_service.py`
+- `web/backend/app/services/strategy_service.py`
+- `web/backend/app/services/realtime_streaming_service.py`
+- `web/frontend/**`
+- `src/**`
+- `docs/api/**`
+- `docs/guides/**`
+- `config/**`
+- `scripts/**`
+- `openspec/changes/**`
+- `openspec/specs/**`
+
+## Future Acceptance Criteria
+
+The future source lane must:
+
+- Run pre-edit GitNexus impact for each removable symbol.
+- Use TDD: first add or adjust a focused test that fails because the removable facade symbols still exist.
+- Remove only the six authorized removable symbols from `web/backend/app/services/__init__.py`.
+- Keep `IntegratedServices` construction unchanged.
+- Keep `get_integrated_services`, `get_market_data_service`, and risk helper facades present.
+- Keep routes, OpenAPI exposure, PM2 workflow, OpenSpec changes, frontend, issue labels, and high-risk service getters untouched.
+- Run an `app.services` import smoke.
+- Run Ruff and Black checks on touched files.
+- Run focused tests for removed and locked symbols.
+- Run staged GitNexus `detect_changes`.
+- Run mainline scope gate before PR.
+
+## Boundary
+
+This is an authorization packet only. It defines the future allowed scope and acceptance criteria but does not itself authorize or perform runtime source edits.

--- a/governance/mainline/task-cards/pr-288.yaml
+++ b/governance/mainline/task-cards/pr-288.yaml
@@ -1,0 +1,101 @@
+version: "v0.2"
+
+task:
+  id: "pr-288"
+  title: "Authorize unused IntegratedServices facade getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-unused-integrated-services-facade-getter-retirement-authorization"
+  objective: "record the G2.135 authorization boundaries for a future unused IntegratedServices service-facade getter retirement source lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-unused-integrated-services-facade-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-unused-integrated-services-facade-getter-retirement-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization packet records future source boundaries only and does not change runtime code, route paths, OpenAPI behavior, or product surface"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/unused-integrated-services-facade-getter-retirement-authorization-2026-05-26.json"
+    - "docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-authorization-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-288.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 287 --json number,state,mergedAt,mergeCommit,title,url"
+      required: true
+    - id: "authorization-scope"
+      command: "manual review of allowed future source paths, removable symbols, locked symbols, forbidden paths, and acceptance criteria"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-authorization-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/unused-integrated-services-facade-getter-retirement-authorization-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-288.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this authorization packet."
+  - "Do not authorize changes to get_integrated_services, get_market_data_service, risk helper facades, or HIGH/CRITICAL service getters."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If the future implementation expands beyond six unused facade getters, it could accidentally touch composition-root behavior"
+    - "If get_market_data_service is included, the known graph/text symbol ambiguity could be mishandled"
+  rollback_plan: "revert this authorization PR to remove only the authorization report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize future unused IntegratedServices service-facade getter retirement"
+    modified_scope: "steward tree, authorization report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON/YAML parsing, GitNexus staged scope, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T12:16:32+08:00"
+    approval_note: "Authorization follows merged G2.134 ownership decision PR #287"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Authorize the future G2.136 source lane boundaries for six unused IntegratedServices service-facade getters
- Lock get_integrated_services, get_market_data_service, risk helper facades, high-risk service getters, route/API, OpenAPI, PM2, frontend, OpenSpec, and issue labels
- Define TDD, GitNexus, import smoke, lint/format, staged scope, and mainline gate requirements for the future source lane

## Verification
- Parent PR #287 state: MERGED at 65498c4565db877ee187f9ceb6dd140b7e4db7fd
- Authorization scope reviewed and recorded
- Markdown governance: 2 checked files, 0 errors
- JSON/YAML parse: passed
- GitNexus staged scope: low risk, affected processes 0
- Mainline scope gate: pass=True

## Boundary
Authorization-only governance packet. No backend source, tests, route paths, OpenAPI exposure, PM2 workflow, OpenSpec changes, or issue-label changes.