### PR TITLE
G2.136 Retire unused IntegratedServices facade getters

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2278,9 +2278,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                implementation authorization, or issue-label change is
 │   │                made here
 │   ├── G2.135 Unused IntegratedServices service-facade getter retirement authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#288`
 │   │   ├── Evidence: `backend-unused-integrated-services-facade-getter-retirement-authorization-2026-05-26.md`
-│   │   ├── Current HEAD: `65498c4565db877ee187f9ceb6dd140b7e4db7fd`
+│   │   ├── Merge commit: `4aaa5a88eafa6d43df383a083c15642e88205e4d`
 │   │   ├── Authorization: future source lane may remove only
 │   │   │          `get_trading_data_service`, `get_analysis_data_service`,
 │   │   │          `get_data_api_service`, `get_database_service`,
@@ -2294,8 +2294,29 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: authorization-only; no source/test edit, facade deletion,
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                implementation, or issue-label change is made here
-│   └── Next gate: if G2.135 is accepted, run G2.136 source implementation
-│                  under the exact authorized paths and TDD/GitNexus gates
+│   ├── G2.136 Unused IntegratedServices service-facade getter retirement implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.md`
+│   │   ├── Current HEAD: `4aaa5a88eafa6d43df383a083c15642e88205e4d`
+│   │   ├── Result: removes only `get_trading_data_service`,
+│   │   │          `get_analysis_data_service`, `get_data_api_service`,
+│   │   │          `get_database_service`, `get_websocket_service`, and
+│   │   │          `get_cache_service` from `web/backend/app/services/__init__.py`
+│   │   │          and adds focused regression coverage
+│   │   ├── Preserved scope: `get_integrated_services`,
+│   │   │          `get_market_data_service`, all risk helper facades, route/API,
+│   │   │          OpenAPI, PM2, frontend, OpenSpec, and issue labels remain
+│   │   │          unchanged
+│   │   ├── Verification: pre-edit GitNexus impact LOW / impacted `0` for all
+│   │   │          six removed symbols; TDD red `1 failed, 1 passed`; focused
+│   │   │          test `2 passed`; import smoke reports removed absent and
+│   │   │          locked callable; exact scan reports removed definitions=`0`
+│   │   │          and locked definitions=`1`; Ruff and Black passed
+│   │   └── Boundary: source-capable but limited to one service facade module,
+│   │                one focused test, report, generated artifact, task card,
+│   │                and steward-tree update
+│   └── Next gate: human review / PR merge decision for G2.136; if accepted,
+│                  close out the unused IntegratedServices facade getter lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -2399,7 +2420,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-watchlist-service-getter-retirement-closeout-2026-05-26.md` | G | G2.132 closeout accepted in PR `#285` at `f0e0e37`: records PR `#284` merged at `2026-05-26T03:30:49Z`, confirms current-head scan still has service getter definitions=`0`, service singleton assignments=`0`, adapter fallback imports=`0`, adapter public getter calls=`0`, app/API public getter calls=`0`, route dependency handlers=`7`, focused watchlist tests `28 passed`, and health route conflicts `120 passed`; no runtime source, tests, route paths, response contracts, OpenAPI exposure, PM2 workflow, OpenSpec change, or issue-label change is modified | Superseded by G2.133 service lifecycle candidate refresh after WatchlistService |
 | `backend-service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.md` | G | G2.133 candidate refresh accepted in PR `#286` at `bc2d2a8`: service files=`152`, app files=`575`, API files=`219`, tests=`204`, remaining service getter definitions=`11`, Announcement/Email/StockSearch/Watchlist retired public getter definitions remain `0`; no direct implementation lane is selected; six LOW graph-risk remaining candidates are shared `IntegratedServices` facade getters, `get_market_data_service` is held for graph/text disambiguation, and `get_tdx_service`, `get_data_service`, `get_strategy_service`, `get_streaming_service` remain HIGH/CRITICAL holds | Superseded by G2.134 IntegratedServices facade getter ownership decision |
 | `backend-integrated-services-facade-getter-ownership-decision-2026-05-26.md` | G | G2.134 decision accepted in PR `#287` at `65498c4`: classifies `web/backend/app/services/__init__.py` getters as a shared IntegratedServices compatibility facade owned by the composition root; retains `get_integrated_services` and `get_market_data_service`; marks only `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, and `get_cache_service` as eligible for a future unused-facade retirement authorization packet; risk helper facades are out of the current service-getter queue | Superseded by G2.135 unused IntegratedServices service-facade getter retirement authorization |
-| `backend-unused-integrated-services-facade-getter-retirement-authorization-2026-05-26.md` | G | G2.135 authorization prepared at `65498c4`: future source lane may remove only `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, and `get_cache_service` from `web/backend/app/services/__init__.py`, with one focused test file and implementation evidence; `get_integrated_services`, `get_market_data_service`, risk helper facades, HIGH/CRITICAL service getters, route/API, OpenAPI, PM2, frontend, OpenSpec, and issue labels remain locked | Human review / PR merge decision; if accepted, run G2.136 source implementation under exact authorized paths |
+| `backend-unused-integrated-services-facade-getter-retirement-authorization-2026-05-26.md` | G | G2.135 authorization accepted in PR `#288` at `4aaa5a8`: future source lane may remove only `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, and `get_cache_service` from `web/backend/app/services/__init__.py`, with one focused test file and implementation evidence; `get_integrated_services`, `get_market_data_service`, risk helper facades, HIGH/CRITICAL service getters, route/API, OpenAPI, PM2, frontend, OpenSpec, and issue labels remain locked | Superseded by G2.136 unused IntegratedServices service-facade getter retirement implementation |
+| `backend-unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.md` | G | G2.136 implementation prepared at `4aaa5a8`: removes only `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, and `get_cache_service` from `web/backend/app/services/__init__.py`; preserves `get_integrated_services`, `get_market_data_service`, all risk helper facades, route/API, OpenAPI, PM2, frontend, OpenSpec, and issue labels; pre-edit GitNexus impact was LOW / impacted `0` for all six symbols; TDD red `1 failed, 1 passed`, focused test `2 passed`, import smoke, exact scan, Ruff, and Black passed | Human review / PR merge decision; if accepted, close out unused IntegratedServices facade getter lane |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.json
+++ b/.planning/codebase/generated/unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.json
@@ -1,0 +1,140 @@
+{
+  "artifact": "unused-integrated-services-facade-getter-retirement-implementation-2026-05-26",
+  "recorded_at": "2026-05-26T12:42:07+08:00",
+  "workline": "G2.136 unused IntegratedServices service-facade getter retirement implementation",
+  "status": "implementation-prepared-for-review",
+  "current_head": "4aaa5a88eafa6d43df383a083c15642e88205e4d",
+  "stale_if_head_mismatch": true,
+  "parent_pr": {
+    "number": 288,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T04:24:06Z",
+    "merge_commit": "4aaa5a88eafa6d43df383a083c15642e88205e4d",
+    "title": "G2.135 Authorize unused IntegratedServices facade getter retirement",
+    "url": "https://github.com/chengjon/mystocks/pull/288"
+  },
+  "source_changes": {
+    "modified_files": [
+      "web/backend/app/services/__init__.py",
+      "web/backend/tests/test_integrated_services_facade_getter_retirement.py",
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.json",
+      "docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.md",
+      "governance/mainline/task-cards/pr-289.yaml"
+    ],
+    "removed_symbols": [
+      "get_trading_data_service",
+      "get_analysis_data_service",
+      "get_data_api_service",
+      "get_database_service",
+      "get_websocket_service",
+      "get_cache_service"
+    ],
+    "locked_symbols_preserved": [
+      "get_integrated_services",
+      "get_market_data_service",
+      "get_risk_calculator",
+      "get_risk_monitoring",
+      "get_risk_alerts",
+      "get_risk_settings",
+      "get_risk_dashboard"
+    ],
+    "type_annotation_support": "Added TYPE_CHECKING-only imports for retained annotations and removed the runtime RiskProfile import from IntegratedServices.__init__."
+  },
+  "pre_edit_gitnexus_impact": {
+    "get_trading_data_service": {
+      "risk": "LOW",
+      "impacted": 0,
+      "direct": 0,
+      "processes": 0
+    },
+    "get_analysis_data_service": {
+      "risk": "LOW",
+      "impacted": 0,
+      "direct": 0,
+      "processes": 0
+    },
+    "get_data_api_service": {
+      "risk": "LOW",
+      "impacted": 0,
+      "direct": 0,
+      "processes": 0
+    },
+    "get_database_service": {
+      "risk": "LOW",
+      "impacted": 0,
+      "direct": 0,
+      "processes": 0
+    },
+    "get_websocket_service": {
+      "risk": "LOW",
+      "impacted": 0,
+      "direct": 0,
+      "processes": 0
+    },
+    "get_cache_service": {
+      "risk": "LOW",
+      "impacted": 0,
+      "direct": 0,
+      "processes": 0
+    }
+  },
+  "tdd": {
+    "red": "1 failed, 1 passed; failure confirmed get_trading_data_service still existed on app.services",
+    "green": "2 passed in 0.28s"
+  },
+  "exact_scan": {
+    "removed_definitions": {
+      "get_trading_data_service": 0,
+      "get_analysis_data_service": 0,
+      "get_data_api_service": 0,
+      "get_database_service": 0,
+      "get_websocket_service": 0,
+      "get_cache_service": 0
+    },
+    "locked_definitions": {
+      "get_integrated_services": 1,
+      "get_market_data_service": 1,
+      "get_risk_calculator": 1,
+      "get_risk_monitoring": 1,
+      "get_risk_alerts": 1,
+      "get_risk_settings": 1,
+      "get_risk_dashboard": 1
+    }
+  },
+  "verification": [
+    {
+      "id": "focused-test",
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_integrated_services_facade_getter_retirement.py -q --no-cov --tb=short",
+      "result": "2 passed in 0.28s"
+    },
+    {
+      "id": "import-smoke",
+      "command": "PYTHONPATH=web/backend python -c \"import app.services ...\"",
+      "result": "{'removed_absent': True, 'locked_callable': True}"
+    },
+    {
+      "id": "ruff",
+      "command": "ruff check web/backend/app/services/__init__.py web/backend/tests/test_integrated_services_facade_getter_retirement.py",
+      "result": "All checks passed"
+    },
+    {
+      "id": "black",
+      "command": "black --check web/backend/app/services/__init__.py web/backend/tests/test_integrated_services_facade_getter_retirement.py",
+      "result": "2 files would be left unchanged"
+    },
+    {
+      "id": "staged-gitnexus",
+      "command": "gitnexus detect_changes scope=staged",
+      "result": "risk=low, changed_files=6, changed_count=20, affected_count=0, affected_processes=0"
+    }
+  ],
+  "scope_boundary": {
+    "route_api_changed": false,
+    "openapi_changed": false,
+    "pm2_changed": false,
+    "frontend_changed": false,
+    "openspec_changed": false,
+    "issue_label_changed": false
+  }
+}

--- a/docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.md
+++ b/docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.md
@@ -1,0 +1,106 @@
+# Backend Unused IntegratedServices Facade Getter Retirement Implementation - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Implementation prepared for review.
+
+This implementation follows the accepted G2.135 authorization boundary. It removes only six unused IntegratedServices service-facade getters from `web/backend/app/services/__init__.py` and adds one focused regression test file.
+
+## Parent Authorization
+
+| Field | Value |
+|---|---|
+| Parent PR | `#288` |
+| Parent state | `MERGED` |
+| Parent merged at | `2026-05-26T04:24:06Z` |
+| Parent merge commit | `4aaa5a88eafa6d43df383a083c15642e88205e4d` |
+| Parent title | `G2.135 Authorize unused IntegratedServices facade getter retirement` |
+| Parent URL | `https://github.com/chengjon/mystocks/pull/288` |
+
+## Source Changes
+
+Changed runtime file:
+
+- `web/backend/app/services/__init__.py`
+
+Added focused test:
+
+- `web/backend/tests/test_integrated_services_facade_getter_retirement.py`
+
+Removed only these authorized facade getters:
+
+- `get_trading_data_service`
+- `get_analysis_data_service`
+- `get_data_api_service`
+- `get_database_service`
+- `get_websocket_service`
+- `get_cache_service`
+
+Preserved locked facade getters:
+
+- `get_integrated_services`
+- `get_market_data_service`
+- `get_risk_calculator`
+- `get_risk_monitoring`
+- `get_risk_alerts`
+- `get_risk_settings`
+- `get_risk_dashboard`
+
+The implementation also adds `TYPE_CHECKING`-only imports for retained annotations and removes the runtime `RiskProfile` import from `IntegratedServices.__init__`, which keeps Ruff F821/F401 checks clean without changing runtime construction.
+
+## Pre-Edit GitNexus Impact
+
+| Symbol | Risk | Impacted | Direct | Processes |
+|---|---|---:|---:|---:|
+| `get_trading_data_service` | LOW | `0` | `0` | `0` |
+| `get_analysis_data_service` | LOW | `0` | `0` | `0` |
+| `get_data_api_service` | LOW | `0` | `0` | `0` |
+| `get_database_service` | LOW | `0` | `0` | `0` |
+| `get_websocket_service` | LOW | `0` | `0` | `0` |
+| `get_cache_service` | LOW | `0` | `0` | `0` |
+
+## TDD Evidence
+
+| Phase | Result |
+|---|---|
+| Red | `1 failed, 1 passed`; failure confirmed `get_trading_data_service` still existed on `app.services` |
+| Green | `2 passed in 0.28s` |
+
+## Exact Scan
+
+| Removed symbol | Definition count |
+|---|---:|
+| `get_trading_data_service` | `0` |
+| `get_analysis_data_service` | `0` |
+| `get_data_api_service` | `0` |
+| `get_database_service` | `0` |
+| `get_websocket_service` | `0` |
+| `get_cache_service` | `0` |
+
+| Locked symbol | Definition count |
+|---|---:|
+| `get_integrated_services` | `1` |
+| `get_market_data_service` | `1` |
+| `get_risk_calculator` | `1` |
+| `get_risk_monitoring` | `1` |
+| `get_risk_alerts` | `1` |
+| `get_risk_settings` | `1` |
+| `get_risk_dashboard` | `1` |
+
+## Verification
+
+| Gate | Result |
+|---|---|
+| Focused tests | `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_integrated_services_facade_getter_retirement.py -q --no-cov --tb=short` -> `2 passed in 0.28s` |
+| Import smoke | `{'removed_absent': True, 'locked_callable': True}` |
+| Ruff | `All checks passed` |
+| Black | `2 files would be left unchanged` |
+| Staged GitNexus | Risk `low`, changed files `6`, changed symbols `20`, affected count `0`, affected processes `0` |
+
+## Boundary
+
+No route/API files, OpenAPI exposure, PM2 workflow, frontend files, OpenSpec changes, GitHub issue labels, `get_integrated_services`, `get_market_data_service`, risk helper facades, or HIGH/CRITICAL service getters were changed.

--- a/governance/mainline/task-cards/pr-289.yaml
+++ b/governance/mainline/task-cards/pr-289.yaml
@@ -1,0 +1,119 @@
+version: "v0.2"
+
+task:
+  id: "pr-289"
+  title: "Retire unused IntegratedServices facade getters"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-unused-integrated-services-facade-getter-retirement-implementation"
+  objective: "remove six unused IntegratedServices service-facade getters under the accepted G2.135 authorization boundary"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-unused-integrated-services-facade-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-unused-integrated-services-facade-getter-retirement-implementation"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow backend service facade cleanup; no route, OpenAPI, frontend, runtime endpoint, or product surface changes are introduced"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/services/__init__.py"
+    - "web/backend/tests/test_integrated_services_facade_getter_retirement.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.json"
+    - "docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-289.yaml"
+  forbidden_paths:
+    - "web/backend/app/api/**"
+    - "web/backend/app/services/market_data_service/**"
+    - "web/backend/app/services/tdx_service.py"
+    - "web/backend/app/services/data_service.py"
+    - "web/backend/app/services/strategy_service.py"
+    - "web/backend/app/services/realtime_streaming_service.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "pre-edit-gitnexus-impact"
+      command: "GitNexus impact for get_trading_data_service, get_analysis_data_service, get_data_api_service, get_database_service, get_websocket_service, and get_cache_service"
+      required: true
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_integrated_services_facade_getter_retirement.py -q --no-cov --tb=short before implementation"
+      required: true
+    - id: "focused-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_integrated_services_facade_getter_retirement.py -q --no-cov --tb=short"
+      required: true
+    - id: "import-smoke"
+      command: "PYTHONPATH=web/backend python -c \"import app.services ...\""
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/services/__init__.py web/backend/tests/test_integrated_services_facade_getter_retirement.py"
+      required: true
+    - id: "black"
+      command: "black --check web/backend/app/services/__init__.py web/backend/tests/test_integrated_services_facade_getter_retirement.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-289.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not change route/API files, OpenAPI exposure, PM2 workflow, frontend files, OpenSpec content, or issue labels."
+  - "Do not remove get_integrated_services, get_market_data_service, risk helper facades, or HIGH/CRITICAL service getters."
+  - "Do not edit files outside the accepted G2.135 implementation boundary."
+
+risk_and_rollback:
+  risks:
+    - "If locked facade getters are removed, downstream compatibility can break despite the narrow source change"
+    - "If services/__init__.py annotations are not kept lint-clean, repository F821/F401 quality gates can regress"
+  rollback_plan: "revert this implementation PR to restore the six unused facade getter definitions and remove the focused test/report/artifact/task-card updates"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "retire six unused IntegratedServices service-facade getters"
+    modified_scope: "services/__init__.py, one focused test, steward tree, implementation report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "six unused facade accessors removed; composition root and locked compatibility facades preserved"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, import smoke, exact scan, Ruff, Black, staged GitNexus scope, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T12:42:07+08:00"
+    approval_note: "Implementation follows merged G2.135 authorization PR #288"
+    secondary_approved: false

--- a/web/backend/app/services/__init__.py
+++ b/web/backend/app/services/__init__.py
@@ -8,9 +8,18 @@ from __future__ import annotations
 
 from datetime import datetime
 import logging
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 logger = __import__("logging").getLogger(__name__)
+
+if TYPE_CHECKING:
+    from .market_api import MarketDataService
+    from .risk_management.risk_alerts import AlertManager
+    from .risk_management.risk_base import RiskProfile
+    from .risk_management.risk_calculator import RiskCalculator
+    from .risk_management.risk_dashboard import RiskDashboard
+    from .risk_management.risk_monitoring import RiskMonitoring
+    from .risk_management.risk_settings import RiskSettingsManager
 
 
 class IntegratedServices:
@@ -25,7 +34,7 @@ class IntegratedServices:
         from .data_api_new import DataApiService
         from .market_api import MarketDataService
         from .risk_management.risk_alerts import AlertManager
-        from .risk_management.risk_base import RiskBase, RiskProfile
+        from .risk_management.risk_base import RiskBase
         from .risk_management.risk_calculator import RiskCalculator
         from .risk_management.risk_dashboard import RiskDashboard
         from .risk_management.risk_monitoring import RiskMonitoring
@@ -146,12 +155,12 @@ class IntegratedServices:
                 "trading_data_status": await self._get_trading_data_status(),
                 "analysis_data_status": await self._get_analysis_data_status(),
                 "service_health": {
-                    "database_service": self.database_service.check_health()
-                    if self.database_service
-                    else "unavailable",
-                    "websocket_service": self.websocket_service.check_health()
-                    if self.websocket_service
-                    else "unavailable",
+                    "database_service": (
+                        self.database_service.check_health() if self.database_service else "unavailable"
+                    ),
+                    "websocket_service": (
+                        self.websocket_service.check_health() if self.websocket_service else "unavailable"
+                    ),
                     "cache_service": self.cache_service.get_health() if self.cache_service else "unavailable",
                 },
                 "generated_at": datetime.now().isoformat(),
@@ -261,42 +270,6 @@ def get_market_data_service() -> MarketDataService:
     """获取市场数据服务实例"""
     integrated_services = get_integrated_services()
     return integrated_services.market_data_service
-
-
-def get_trading_data_service() -> TradingDataService:
-    """获取交易数据服务实例"""
-    integrated_services = get_integrated_services()
-    return integrated_services.trading_data_service
-
-
-def get_analysis_data_service() -> AnalysisDataService:
-    """获取分析数据服务实例"""
-    integrated_services = get_integrated_services()
-    return integrated_services.analysis_data_service
-
-
-def get_data_api_service() -> DataApiService:
-    """获取数据API服务实例"""
-    integrated_services = get_integrated_services()
-    return integrated_services.data_api_service
-
-
-def get_database_service() -> DatabaseService:
-    """获取数据库服务实例"""
-    integrated_services = get_integrated_services()
-    return integrated_services.database_service
-
-
-def get_websocket_service() -> WebSocketService:
-    """获取WebSocket服务实例"""
-    integrated_services = get_integrated_services()
-    return integrated_services.websocket_service
-
-
-def get_cache_service() -> CacheService:
-    """获取缓存服务实例"""
-    integrated_services = get_integrated_services()
-    return integrated_services.cache_service
 
 
 def get_risk_monitoring() -> RiskMonitoring:

--- a/web/backend/tests/test_integrated_services_facade_getter_retirement.py
+++ b/web/backend/tests/test_integrated_services_facade_getter_retirement.py
@@ -1,0 +1,39 @@
+"""Regression tests for retiring unused IntegratedServices facade getters."""
+
+from __future__ import annotations
+
+import importlib
+
+
+REMOVED_SERVICE_FACADE_GETTERS = (
+    "get_trading_data_service",
+    "get_analysis_data_service",
+    "get_data_api_service",
+    "get_database_service",
+    "get_websocket_service",
+    "get_cache_service",
+)
+
+LOCKED_FACADE_GETTERS = (
+    "get_integrated_services",
+    "get_market_data_service",
+    "get_risk_calculator",
+    "get_risk_monitoring",
+    "get_risk_alerts",
+    "get_risk_settings",
+    "get_risk_dashboard",
+)
+
+
+def test_unused_integrated_services_facade_getters_are_retired() -> None:
+    services = importlib.import_module("app.services")
+
+    for getter_name in REMOVED_SERVICE_FACADE_GETTERS:
+        assert not hasattr(services, getter_name), f"{getter_name} should not remain on app.services"
+
+
+def test_locked_integrated_services_facade_getters_remain_available() -> None:
+    services = importlib.import_module("app.services")
+
+    for getter_name in LOCKED_FACADE_GETTERS:
+        assert callable(getattr(services, getter_name, None)), f"{getter_name} should remain callable"


### PR DESCRIPTION
## Summary
- Remove six authorized unused IntegratedServices service-facade getters from app.services
- Preserve get_integrated_services, get_market_data_service, risk helper facades, route/API, OpenAPI, PM2, frontend, OpenSpec, and issue labels
- Add focused regression tests and implementation evidence

## Verification
- Pre-edit GitNexus impact for all six removed symbols: LOW / impacted 0 / direct 0 / processes 0
- TDD red: 1 failed, 1 passed before implementation
- Focused test: 2 passed
- Import smoke: removed_absent=True, locked_callable=True
- Exact scan: removed definitions 0, locked definitions 1
- Ruff: All checks passed
- Black: 2 files would be left unchanged
- Markdown governance: 2 checked files, 0 errors
- JSON/YAML parse: passed
- Staged GitNexus: low risk, changed_files 6, affected_count 0
- Mainline scope gate: pass=True
- GitNexus analyze: repository indexed successfully

## Boundary
Source-capable but limited to G2.135 authorized paths. No route/API files, OpenAPI exposure, PM2 workflow, frontend files, OpenSpec content, issue labels, get_integrated_services, get_market_data_service, risk helper facades, or HIGH/CRITICAL service getters changed.