### PR TITLE
G2.137 Close out unused IntegratedServices facade getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2295,9 +2295,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                implementation, or issue-label change is made here
 │   ├── G2.136 Unused IntegratedServices service-facade getter retirement implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#289`
 │   │   ├── Evidence: `backend-unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.md`
-│   │   ├── Current HEAD: `4aaa5a88eafa6d43df383a083c15642e88205e4d`
+│   │   ├── Merge commit: `541a225b5cbc90807d8cc7af20d0ffd42b07fd2d`
 │   │   ├── Result: removes only `get_trading_data_service`,
 │   │   │          `get_analysis_data_service`, `get_data_api_service`,
 │   │   │          `get_database_service`, `get_websocket_service`, and
@@ -2315,8 +2315,24 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: source-capable but limited to one service facade module,
 │   │                one focused test, report, generated artifact, task card,
 │   │                and steward-tree update
-│   └── Next gate: human review / PR merge decision for G2.136; if accepted,
-│                  close out the unused IntegratedServices facade getter lane
+│   ├── G2.137 Unused IntegratedServices service-facade getter retirement closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.md`
+│   │   ├── Current HEAD: `541a225b5cbc90807d8cc7af20d0ffd42b07fd2d`
+│   │   ├── Result: records PR `#289` as merged and closes the unused
+│   │   │          IntegratedServices service-facade getter retirement lane
+│   │   │          without changing runtime source, tests, route paths,
+│   │   │          response contracts, or OpenAPI exposure
+│   │   ├── Verification: parent PR state `MERGED`; focused closeout test
+│   │   │          `2 passed`; import smoke reports removed absent and locked
+│   │   │          callable; exact scan reports retired definitions=`0` and
+│   │   │          locked definitions=`1`
+│   │   └── Boundary: closeout-only; no source/test edit, runtime behavior,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                implementation, or issue-label change is made here
+│   └── Next gate: after G2.137 review and merge, refresh the remaining service
+│                  lifecycle candidate pool before selecting another
+│                  implementation lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -2421,7 +2437,8 @@ CODEBASE-MAP Architecture Remediation Program
 | `backend-service-lifecycle-di-candidate-refresh-after-watchlist-2026-05-26.md` | G | G2.133 candidate refresh accepted in PR `#286` at `bc2d2a8`: service files=`152`, app files=`575`, API files=`219`, tests=`204`, remaining service getter definitions=`11`, Announcement/Email/StockSearch/Watchlist retired public getter definitions remain `0`; no direct implementation lane is selected; six LOW graph-risk remaining candidates are shared `IntegratedServices` facade getters, `get_market_data_service` is held for graph/text disambiguation, and `get_tdx_service`, `get_data_service`, `get_strategy_service`, `get_streaming_service` remain HIGH/CRITICAL holds | Superseded by G2.134 IntegratedServices facade getter ownership decision |
 | `backend-integrated-services-facade-getter-ownership-decision-2026-05-26.md` | G | G2.134 decision accepted in PR `#287` at `65498c4`: classifies `web/backend/app/services/__init__.py` getters as a shared IntegratedServices compatibility facade owned by the composition root; retains `get_integrated_services` and `get_market_data_service`; marks only `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, and `get_cache_service` as eligible for a future unused-facade retirement authorization packet; risk helper facades are out of the current service-getter queue | Superseded by G2.135 unused IntegratedServices service-facade getter retirement authorization |
 | `backend-unused-integrated-services-facade-getter-retirement-authorization-2026-05-26.md` | G | G2.135 authorization accepted in PR `#288` at `4aaa5a8`: future source lane may remove only `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, and `get_cache_service` from `web/backend/app/services/__init__.py`, with one focused test file and implementation evidence; `get_integrated_services`, `get_market_data_service`, risk helper facades, HIGH/CRITICAL service getters, route/API, OpenAPI, PM2, frontend, OpenSpec, and issue labels remain locked | Superseded by G2.136 unused IntegratedServices service-facade getter retirement implementation |
-| `backend-unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.md` | G | G2.136 implementation prepared at `4aaa5a8`: removes only `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, and `get_cache_service` from `web/backend/app/services/__init__.py`; preserves `get_integrated_services`, `get_market_data_service`, all risk helper facades, route/API, OpenAPI, PM2, frontend, OpenSpec, and issue labels; pre-edit GitNexus impact was LOW / impacted `0` for all six symbols; TDD red `1 failed, 1 passed`, focused test `2 passed`, import smoke, exact scan, Ruff, and Black passed | Human review / PR merge decision; if accepted, close out unused IntegratedServices facade getter lane |
+| `backend-unused-integrated-services-facade-getter-retirement-implementation-2026-05-26.md` | G | G2.136 implementation accepted in PR `#289` at `541a225`: removes only `get_trading_data_service`, `get_analysis_data_service`, `get_data_api_service`, `get_database_service`, `get_websocket_service`, and `get_cache_service` from `web/backend/app/services/__init__.py`; preserves `get_integrated_services`, `get_market_data_service`, all risk helper facades, route/API, OpenAPI, PM2, frontend, OpenSpec, and issue labels; pre-edit GitNexus impact was LOW / impacted `0` for all six symbols; TDD red `1 failed, 1 passed`, focused test `2 passed`, import smoke, exact scan, Ruff, and Black passed | Superseded by G2.137 unused IntegratedServices service-facade getter retirement closeout |
+| `backend-unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.md` | G | G2.137 closeout prepared at `541a225`: records PR `#289` merged at `2026-05-26T04:51:23Z`, confirms current-head scan has retired facade definitions=`0` and locked facade definitions=`1`, focused closeout test `2 passed`, and import smoke `removed_absent=True` / `locked_callable=True`; no runtime source, tests, route paths, response contracts, OpenAPI exposure, PM2 workflow, OpenSpec change, or issue-label change is modified | Human review / PR merge decision; if accepted, refresh the remaining service lifecycle candidate pool |
 
 | G2.1-G2.11 service lifecycle DI early lanes | G | Folded evidence mapping for the first service lifecycle sequence: G2.1 candidate classification, G2.2 email authorization, G2.3 email implementation, G2.4 steward-tree retrospective, G2.5 announcement authorization, G2.6 announcement implementation, G2.7 announcement closeout, G2.8 watchlist selection, G2.9 watchlist authorization, G2.10 watchlist implementation, and G2.11 watchlist closeout. Detailed per-step records remain in the Completed And Reviewed Ledger and G branch source-evidence list. | Superseded by G2.12 adapter-aware watchlist helper cleanup decision packet |
 | `backend-watchlist-helper-cleanup-next-lane-decision-2026-05-23.md` | G | G2.12 decision packet merged: adapter-aware watchlist helper cleanup selected as the next authorization candidate; no source edits or OpenSpec changes were authorized | Superseded by G2.13 authorization packet for future implementation scope |

--- a/.planning/codebase/generated/unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.json
+++ b/.planning/codebase/generated/unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.json
@@ -1,0 +1,83 @@
+{
+  "artifact": "unused-integrated-services-facade-getter-retirement-closeout-2026-05-26",
+  "recorded_at": "2026-05-26T12:54:24+08:00",
+  "workline": "G2.137 unused IntegratedServices service-facade getter retirement closeout",
+  "status": "closeout-prepared-for-review",
+  "current_head": "541a225b5cbc90807d8cc7af20d0ffd42b07fd2d",
+  "stale_if_head_mismatch": true,
+  "parent_pr": {
+    "number": 289,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T04:51:23Z",
+    "merge_commit": "541a225b5cbc90807d8cc7af20d0ffd42b07fd2d",
+    "title": "G2.136 Retire unused IntegratedServices facade getters",
+    "url": "https://github.com/chengjon/mystocks/pull/289"
+  },
+  "closeout_decision": {
+    "state": "ready-for-review",
+    "decision": "Record G2.136 as merged and close the unused IntegratedServices service-facade getter retirement lane.",
+    "implementation_scope": "No runtime code, tests, API routes, OpenAPI exposure, PM2 workflow, OpenSpec change, or issue-label change is modified by this closeout.",
+    "next_gate": "Refresh the remaining service lifecycle candidate pool before selecting another implementation lane."
+  },
+  "current_head_scan": {
+    "removed_definitions": {
+      "get_trading_data_service": 0,
+      "get_analysis_data_service": 0,
+      "get_data_api_service": 0,
+      "get_database_service": 0,
+      "get_websocket_service": 0,
+      "get_cache_service": 0
+    },
+    "locked_definitions": {
+      "get_integrated_services": 1,
+      "get_market_data_service": 1,
+      "get_risk_calculator": 1,
+      "get_risk_monitoring": 1,
+      "get_risk_alerts": 1,
+      "get_risk_settings": 1,
+      "get_risk_dashboard": 1
+    }
+  },
+  "verification": [
+    {
+      "id": "parent-pr-state",
+      "command": "gh pr view 289 --json number,state,mergedAt,mergeCommit,title,url",
+      "result": "MERGED at 2026-05-26T04:51:23Z with merge commit 541a225b5cbc90807d8cc7af20d0ffd42b07fd2d"
+    },
+    {
+      "id": "focused-closeout-test",
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_integrated_services_facade_getter_retirement.py -q --no-cov --tb=short",
+      "result": "2 passed in 0.28s"
+    },
+    {
+      "id": "import-smoke",
+      "command": "PYTHONPATH=web/backend python -c \"import app.services ...\"",
+      "result": "{'removed_absent': True, 'locked_callable': True}"
+    },
+    {
+      "id": "exact-current-head-scan",
+      "command": "scripted current-head scan over app.services facade getter definitions",
+      "result": "removed definitions=0 for six retired facades; locked definitions=1 for seven locked facades"
+    }
+  ],
+  "scope": {
+    "allowed_paths": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.json",
+      "docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.md",
+      "governance/mainline/task-cards/pr-290.yaml"
+    ],
+    "forbidden_paths": [
+      "web/backend/**",
+      "web/frontend/**",
+      "src/**",
+      "tests/**",
+      "docs/api/**",
+      "docs/guides/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ]
+  }
+}

--- a/docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.md
+++ b/docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.md
@@ -1,0 +1,64 @@
+# Backend Unused IntegratedServices Facade Getter Retirement Closeout - 2026-05-26
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+Closeout prepared for review.
+
+This packet records the G2.136 source implementation as merged and closes the unused IntegratedServices service-facade getter retirement lane. It is governance-only and does not modify runtime code, tests, API routes, OpenAPI exposure, PM2 workflow, OpenSpec changes, GitHub issue labels, or product behavior.
+
+## Parent Merge
+
+| Field | Value |
+|---|---|
+| Parent PR | `#289` |
+| Parent state | `MERGED` |
+| Parent merged at | `2026-05-26T04:51:23Z` |
+| Parent merge commit | `541a225b5cbc90807d8cc7af20d0ffd42b07fd2d` |
+| Parent title | `G2.136 Retire unused IntegratedServices facade getters` |
+| Parent URL | `https://github.com/chengjon/mystocks/pull/289` |
+
+## Current-Head Scan
+
+Current HEAD: `541a225b5cbc90807d8cc7af20d0ffd42b07fd2d`.
+
+| Retired facade getter | Definition count |
+|---|---:|
+| `get_trading_data_service` | `0` |
+| `get_analysis_data_service` | `0` |
+| `get_data_api_service` | `0` |
+| `get_database_service` | `0` |
+| `get_websocket_service` | `0` |
+| `get_cache_service` | `0` |
+
+| Locked facade getter | Definition count |
+|---|---:|
+| `get_integrated_services` | `1` |
+| `get_market_data_service` | `1` |
+| `get_risk_calculator` | `1` |
+| `get_risk_monitoring` | `1` |
+| `get_risk_alerts` | `1` |
+| `get_risk_settings` | `1` |
+| `get_risk_dashboard` | `1` |
+
+## Verification
+
+| Gate | Result |
+|---|---|
+| Parent PR state | `#289` is `MERGED` at `541a225b5cbc90807d8cc7af20d0ffd42b07fd2d` |
+| Focused closeout test | `2 passed in 0.28s` |
+| Import smoke | `{'removed_absent': True, 'locked_callable': True}` |
+| Exact current-head scan | Retired definitions `0`; locked definitions `1` |
+
+## Closeout Result
+
+The unused IntegratedServices service-facade getter retirement lane is ready to close after this governance PR is reviewed and merged.
+
+The next steward-tree gate is a fresh remaining service lifecycle candidate refresh before selecting another implementation lane.
+
+## Boundary
+
+This closeout does not change runtime source, tests, route paths, response contracts, OpenAPI exposure, PM2 workflow, frontend files, OpenSpec changes, GitHub issue labels, or product behavior.

--- a/governance/mainline/task-cards/pr-290.yaml
+++ b/governance/mainline/task-cards/pr-290.yaml
@@ -1,0 +1,107 @@
+version: "v0.2"
+
+task:
+  id: "pr-290"
+  title: "Close out unused IntegratedServices facade getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-unused-integrated-services-facade-getter-retirement-closeout"
+  objective: "record PR #289 merge evidence and close the unused IntegratedServices service-facade getter retirement lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-unused-integrated-services-facade-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-unused-integrated-services-facade-getter-retirement-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only packet; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.json"
+    - "docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-290.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 289 --json number,state,mergedAt,mergeCommit,title,url"
+      required: true
+    - id: "current-head-scan"
+      command: "scripted current-head scan over retired and locked app.services facade getter definitions"
+      required: true
+    - id: "focused-closeout-test"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_integrated_services_facade_getter_retirement.py -q --no-cov --tb=short"
+      required: true
+    - id: "import-smoke"
+      command: "PYTHONPATH=web/backend python -c \"import app.services ...\""
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-290.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+  - "Do not select the next implementation lane before a fresh candidate refresh."
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is treated as source authorization, a later worker could reopen an already merged implementation lane"
+    - "If the next service candidate is selected without a fresh scan, remaining-candidate evidence could be stale"
+  rollback_plan: "revert this closeout PR to remove only the closeout report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out unused IntegratedServices facade getter retirement"
+    modified_scope: "steward tree, closeout report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; closeout records the merged parent implementation and does not change runtime code"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON/YAML parsing, GitNexus staged scope, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T12:54:24+08:00"
+    approval_note: "Closeout follows merged G2.136 implementation PR #289"
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- close out PR #289 unused IntegratedServices facade getter retirement
- record current-head verification evidence for removed and locked facade getters
- update steward tree and mainline task card for the closeout lane

## Verification
- python -m json.tool .planning/codebase/generated/unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.json
- python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.md
- git diff --check -- .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md .planning/codebase/generated/unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.json docs/reports/quality/backend-unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.md governance/mainline/task-cards/pr-290.yaml
- gitnexus detect_changes scope=staged: low risk, 4 changed files, 0 affected symbols/processes
- python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-290.yaml: pass=True
- gitnexus analyze --with-gitignore: repository indexed successfully