### PR TITLE
G2.138 Refresh service lifecycle candidates after facade retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2316,9 +2316,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                one focused test, report, generated artifact, task card,
 │   │                and steward-tree update
 │   ├── G2.137 Unused IntegratedServices service-facade getter retirement closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#290`
 │   │   ├── Evidence: `backend-unused-integrated-services-facade-getter-retirement-closeout-2026-05-26.md`
-│   │   ├── Current HEAD: `541a225b5cbc90807d8cc7af20d0ffd42b07fd2d`
+│   │   ├── Merge commit: `090c0c30a7ac64c75e30febce1b3f6e4d20eee1c`
 │   │   ├── Result: records PR `#289` as merged and closes the unused
 │   │   │          IntegratedServices service-facade getter retirement lane
 │   │   │          without changing runtime source, tests, route paths,
@@ -2330,9 +2330,36 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: closeout-only; no source/test edit, runtime behavior,
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                implementation, or issue-label change is made here
-│   └── Next gate: after G2.137 review and merge, refresh the remaining service
-│                  lifecycle candidate pool before selecting another
-│                  implementation lane
+│   ├── G2.138 Service lifecycle candidate refresh after IntegratedServices facade retirement
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-integrated-facade-retirement-2026-05-26.md`
+│   │   ├── Current HEAD: `090c0c30a7ac64c75e30febce1b3f6e4d20eee1c`
+│   │   ├── Result: refreshes the remaining service lifecycle DI candidate
+│   │   │          pool after G2.137 closeout and selects only a future
+│   │   │          authorization candidate, not an implementation lane
+│   │   ├── Verification: service files=`152`, backend app files=`575`,
+│   │   │          API files=`219`, tests=`205`, service getter
+│   │   │          definitions=`54`, root facade getters=`7`, FastAPI
+│   │   │          dependency/provider getters=`9`; retired IntegratedServices
+│   │   │          facade definitions remain `0` and locked facade definitions
+│   │   │          remain `1`
+│   │   ├── Candidate decision: select `get_backtest_engine` /
+│   │   │          `_backtest_engine` only for a future authorization package;
+│   │   │          GitNexus impact is LOW with impacted=`0`, direct=`0`,
+│   │   │          processes=`0`, and exact text scan finds no backend code
+│   │   │          caller outside the defining service file
+│   │   ├── Holds: `get_tdx_service` remains CRITICAL with impacted=`6`,
+│   │   │          direct=`2`, processes=`5`; `get_data_service`,
+│   │   │          `get_strategy_service`, `get_streaming_service`,
+│   │   │          root/risk facades, and active FastAPI dependency/provider
+│   │   │          seams remain out of scope
+│   │   └── Boundary: candidate-refresh-only; no backend source/test edit,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                getter deletion, implementation authorization, or
+│   │                issue-label change is made here
+│   └── Next gate: after G2.138 review and merge, prepare a BacktestEngine
+│                  singleton/getter retirement authorization package before
+│                  any source implementation work
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-integrated-facade-retirement-2026-05-26.json
+++ b/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-integrated-facade-retirement-2026-05-26.json
@@ -1,0 +1,137 @@
+{
+  "schema_version": "1.0",
+  "artifact": "service-lifecycle-candidate-refresh-after-integrated-facade-retirement",
+  "created_at": "2026-05-26T13:10:00+08:00",
+  "current_head": "090c0c30a7ac64c75e30febce1b3f6e4d20eee1c",
+  "parent_closeout": {
+    "lane": "G2.137",
+    "pull_request": 290,
+    "merge_commit": "090c0c30a7ac64c75e30febce1b3f6e4d20eee1c",
+    "meaning": "unused IntegratedServices service-facade getter retirement closeout accepted"
+  },
+  "scope": {
+    "mode": "governance-only candidate refresh",
+    "source_roots_scanned": [
+      "web/backend/app/services",
+      "web/backend/app",
+      "web/backend/tests"
+    ],
+    "runtime_code_changed": false,
+    "implementation_authorized": false
+  },
+  "file_counts": {
+    "service_py_files": 152,
+    "backend_app_py_files": 575,
+    "backend_api_py_files": 219,
+    "backend_test_py_files": 205
+  },
+  "getter_inventory": {
+    "service_getter_definitions": 54,
+    "root_facade_getters": 7,
+    "fastapi_dependency_getters": 9,
+    "zero_external_reference_getters": 9
+  },
+  "integrated_services_facade_state": {
+    "retired_definition_counts": {
+      "get_trading_data_service": 0,
+      "get_analysis_data_service": 0,
+      "get_data_api_service": 0,
+      "get_database_service": 0,
+      "get_websocket_service": 0,
+      "get_cache_service": 0
+    },
+    "locked_definition_counts": {
+      "get_integrated_services": 1,
+      "get_market_data_service": 1,
+      "get_risk_calculator": 1,
+      "get_risk_monitoring": 1,
+      "get_risk_alerts": 1,
+      "get_risk_settings": 1,
+      "get_risk_dashboard": 1
+    }
+  },
+  "selected_next_authorization_candidate": {
+    "symbol": "get_backtest_engine",
+    "file": "web/backend/app/services/backtest_engine.py",
+    "line": 275,
+    "singleton_state": "_backtest_engine",
+    "gitnexus_impact": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct": 0,
+      "processes_affected": 0
+    },
+    "text_reference_summary": {
+      "code_hits": 1,
+      "code_files": [
+        "web/backend/app/services/backtest_engine.py"
+      ]
+    },
+    "decision": "select as future authorization-candidate lane only"
+  },
+  "held_or_excluded_candidates": [
+    {
+      "symbol": "get_tdx_service",
+      "file": "web/backend/app/services/tdx_service.py",
+      "reason": "GitNexus CRITICAL risk; direct API callers and five affected flows",
+      "gitnexus_impact": {
+        "risk": "CRITICAL",
+        "impacted_count": 6,
+        "direct": 2,
+        "processes_affected": 5
+      }
+    },
+    {
+      "symbol": "get_data_service",
+      "file": "web/backend/app/services/data_service.py",
+      "reason": "existing high-risk design lane; not selected by this refresh"
+    },
+    {
+      "symbol": "get_strategy_service",
+      "file": "web/backend/app/services/strategy_service.py",
+      "reason": "existing high-risk design lane; not selected by this refresh"
+    },
+    {
+      "symbol": "get_streaming_service",
+      "file": "web/backend/app/services/realtime_streaming_service.py",
+      "reason": "existing high-risk design lane with broad caller surface; not selected by this refresh"
+    },
+    {
+      "symbol": "get_market_data_service",
+      "file": "web/backend/app/services/__init__.py",
+      "reason": "locked IntegratedServices composition/root facade; retained by G2.134/G2.137 boundary"
+    },
+    {
+      "symbol": "risk helper facades",
+      "file": "web/backend/app/services/__init__.py",
+      "reason": "locked compatibility facades; not part of this service getter retirement queue"
+    },
+    {
+      "symbol": "get_indicator_registry_dependency",
+      "file": "web/backend/app/services/indicator_registry.py",
+      "reason": "active FastAPI route provider seam; exact text references remain in API and tests"
+    },
+    {
+      "symbol": "get_tradingview_service_dependency",
+      "file": "web/backend/app/services/tradingview_widget_service.py",
+      "reason": "active FastAPI route provider seam; exact text references remain in API and tests"
+    },
+    {
+      "symbol": "get_company_news",
+      "file": "web/backend/app/services/stock_search_service/_stock_search_finnhub.py",
+      "reason": "stock-search helper callable, not a service singleton lifecycle getter"
+    }
+  ],
+  "next_gate": {
+    "lane": "G2.139",
+    "recommended_task": "BacktestEngine singleton/getter retirement authorization",
+    "allowed_mode": "authorization-only",
+    "implementation_allowed": false
+  },
+  "boundary": {
+    "no_source_or_test_edits": true,
+    "no_route_api_openapi_frontend_pm2_or_openspec_changes": true,
+    "no_issue_label_changes": true,
+    "no_getter_deletion": true
+  }
+}

--- a/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-integrated-facade-retirement-2026-05-26.md
+++ b/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-integrated-facade-retirement-2026-05-26.md
@@ -1,0 +1,118 @@
+# Backend Service Lifecycle Candidate Refresh After Integrated Facade Retirement
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Date: 2026-05-26
+
+Current HEAD: `090c0c30a7ac64c75e30febce1b3f6e4d20eee1c`
+
+Parent closeout: G2.137 / PR `#290`
+
+Boundary note: this is a governance-only candidate refresh. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, or GitHub issue labels. It does not authorize implementation.
+
+## Purpose
+
+Refresh the service lifecycle DI candidate pool after the unused IntegratedServices service-facade getter lane was closed.
+
+The parent lane retired these six unused facade getters from `web/backend/app/services/__init__.py`:
+
+- `get_trading_data_service`
+- `get_analysis_data_service`
+- `get_data_api_service`
+- `get_database_service`
+- `get_websocket_service`
+- `get_cache_service`
+
+This report confirms the post-closeout state and selects only the next authorization candidate. The actual source edit must be separately authorized.
+
+## Scan Snapshot
+
+| Metric | Value |
+|---|---:|
+| Service Python files | 152 |
+| Backend app Python files | 575 |
+| Backend API Python files | 219 |
+| Backend test Python files | 205 |
+| `def get_*` definitions under `web/backend/app/services` | 54 |
+| Root facade getters in `web/backend/app/services/__init__.py` | 7 |
+| FastAPI dependency/provider getters | 9 |
+| Zero-external-reference getter definitions | 9 |
+
+IntegratedServices facade verification:
+
+| Group | Expected | Current |
+|---|---:|---:|
+| Retired facade getter definitions | 0 each | 0 each |
+| Locked facade getter definitions | 1 each | 1 each |
+
+Locked facade getters remain:
+
+- `get_integrated_services`
+- `get_market_data_service`
+- `get_risk_calculator`
+- `get_risk_monitoring`
+- `get_risk_alerts`
+- `get_risk_settings`
+- `get_risk_dashboard`
+
+## Candidate Decision
+
+Selected next authorization candidate:
+
+| Candidate | File | Reason | Current gate |
+|---|---|---|---|
+| `get_backtest_engine` / `_backtest_engine` | `web/backend/app/services/backtest_engine.py` | GitNexus reports LOW risk, impacted `0`, direct `0`, processes `0`; exact text scan finds only the defining service file in backend code | Future authorization-only lane |
+
+This selection does not authorize deleting `get_backtest_engine` or `_backtest_engine`. It only identifies the next small authorization package to prepare.
+
+## Holds And Exclusions
+
+| Symbol or group | Disposition | Reason |
+|---|---|---|
+| `get_tdx_service` | Hold | GitNexus reports CRITICAL risk, impacted `6`, direct `2`, processes `5`; API dashboard flows still depend on it |
+| `get_data_service` | Hold | Existing high-risk design lane; not selected by this refresh |
+| `get_strategy_service` | Hold | Existing high-risk design lane; not selected by this refresh |
+| `get_streaming_service` | Hold | Broad caller surface; not selected by this refresh |
+| `get_market_data_service` root facade | Retain | Locked IntegratedServices composition/root facade |
+| Risk helper facades in `web/backend/app/services/__init__.py` | Retain | Locked compatibility facades from the IntegratedServices ownership decision |
+| `get_indicator_registry_dependency` | Exclude from service getter retirement queue | Active FastAPI route provider seam with API/test references |
+| `get_tradingview_service_dependency` | Exclude from service getter retirement queue | Active FastAPI route provider seam with API/test references |
+| `get_company_news` | Exclude | Stock-search helper callable, not a service singleton lifecycle getter |
+
+## Evidence
+
+Local evidence collected in this lane:
+
+- Current file-count scan at HEAD `090c0c30a7`.
+- Current `def get_*` scan under `web/backend/app/services`.
+- Current exact definition-count scan for retired and locked IntegratedServices facades.
+- GitNexus impact for `get_backtest_engine`: LOW, impacted `0`.
+- GitNexus impact for `get_tdx_service`: CRITICAL, impacted `6`, direct `2`, processes `5`.
+- Exact text reference checks for selected low-risk and excluded candidates.
+
+Generated artifact:
+
+- `.planning/codebase/generated/service-lifecycle-candidate-refresh-after-integrated-facade-retirement-2026-05-26.json`
+
+## Next Gate
+
+Recommended next lane:
+
+G2.139 BacktestEngine singleton/getter retirement authorization.
+
+Expected mode:
+
+- Authorization-only.
+- Define exact allowed paths, tests, rollback, and pre-edit GitNexus impact requirements.
+- Do not edit `web/backend/app/services/backtest_engine.py` until that authorization lane is accepted.
+
+## Non-Goals
+
+- No backend source or test edit.
+- No getter deletion.
+- No route/API behavior change.
+- No OpenAPI exposure change.
+- No frontend, PM2, OpenSpec, or issue-label change.
+- No authorization for `get_tdx_service`, `get_data_service`, `get_strategy_service`, `get_streaming_service`, route provider seams, or root/risk compatibility facades.

--- a/governance/mainline/task-cards/pr-291.yaml
+++ b/governance/mainline/task-cards/pr-291.yaml
@@ -1,0 +1,109 @@
+version: "v0.2"
+
+task:
+  id: "pr-291"
+  title: "Refresh service lifecycle candidates after IntegratedServices facade retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-service-lifecycle-candidate-refresh-after-integrated-facade-retirement"
+  objective: "refresh the remaining service lifecycle DI candidate pool after G2.137 closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-candidate-refresh"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-candidate-refresh-after-integrated-facade-retirement"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate-refresh-only packet; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-candidate-refresh-after-integrated-facade-retirement-2026-05-26.json"
+    - "docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-integrated-facade-retirement-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-291.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "current-head-file-counts"
+      command: "scripted file-count scan for service/app/api/test Python files"
+      required: true
+    - id: "getter-inventory"
+      command: "scripted def get_* scan under web/backend/app/services"
+      required: true
+    - id: "integrated-facade-state"
+      command: "scripted retired and locked IntegratedServices facade definition scan"
+      required: true
+    - id: "gitnexus-impact"
+      command: "GitNexus impact for get_backtest_engine and selected held candidates"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-integrated-facade-retirement-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-candidate-refresh-after-integrated-facade-retirement-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-291.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests."
+  - "Do not delete, rename, or alter any getter in this lane."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+  - "Do not authorize BacktestEngine implementation before a separate authorization package is accepted."
+
+risk_and_rollback:
+  risks:
+    - "If this refresh is treated as implementation authorization, a later worker could edit BacktestEngine without an accepted source lane"
+    - "If dependency provider seams are misclassified as unused service getters, route-level DI contracts could be damaged"
+  rollback_plan: "revert this candidate-refresh PR to remove only the refresh report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh remaining service lifecycle DI candidates after IntegratedServices facade retirement"
+    modified_scope: "steward tree, candidate-refresh report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; candidate refresh records scanner and GitNexus evidence only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON/YAML parsing, GitNexus staged scope, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T13:10:00+08:00"
+    approval_note: "Candidate-refresh-only lane after accepted G2.137 closeout"
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary
- refresh service lifecycle DI candidate pool after G2.137 / PR #290 closeout
- confirm retired IntegratedServices facade getter definitions remain at zero and locked facades remain defined
- select get_backtest_engine only as the next authorization candidate; no source implementation is authorized here

## Verification
- current scan: service files=152, backend app files=575, API files=219, backend tests=205
- service getter definitions=54, root facade getters=7, dependency/provider getters=9
- retired IntegratedServices facade definitions=0 each; locked facade definitions=1 each
- GitNexus impact get_backtest_engine: LOW, impacted=0, direct=0, processes=0
- GitNexus impact get_tdx_service: CRITICAL hold, impacted=6, direct=2, processes=5
- python -m json.tool .planning/codebase/generated/service-lifecycle-candidate-refresh-after-integrated-facade-retirement-2026-05-26.json
- python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-integrated-facade-retirement-2026-05-26.md
- gitnexus detect_changes scope=staged: low risk, 4 changed files, 0 affected symbols/processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: repository indexed successfully