### PR TITLE
G2.139 Authorize BacktestEngine getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2331,9 +2331,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                implementation, or issue-label change is made here
 │   ├── G2.138 Service lifecycle candidate refresh after IntegratedServices facade retirement
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#291`
 │   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-integrated-facade-retirement-2026-05-26.md`
-│   │   ├── Current HEAD: `090c0c30a7ac64c75e30febce1b3f6e4d20eee1c`
+│   │   ├── Merge commit: `2d51cbd52bc37dae2ae5f59855bcdb70d41f169c`
 │   │   ├── Result: refreshes the remaining service lifecycle DI candidate
 │   │   │          pool after G2.137 closeout and selects only a future
 │   │   │          authorization candidate, not an implementation lane
@@ -2357,9 +2357,32 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                getter deletion, implementation authorization, or
 │   │                issue-label change is made here
-│   └── Next gate: after G2.138 review and merge, prepare a BacktestEngine
-│                  singleton/getter retirement authorization package before
-│                  any source implementation work
+│   ├── G2.139 BacktestEngine singleton/getter retirement authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-backtest-engine-getter-retirement-authorization-2026-05-26.md`
+│   │   ├── Current HEAD: `2d51cbd52bc37dae2ae5f59855bcdb70d41f169c`
+│   │   ├── Result: authorizes only a future narrow implementation lane to
+│   │   │          retire `_backtest_engine` and `get_backtest_engine` from
+│   │   │          `web/backend/app/services/backtest_engine.py`
+│   │   ├── Preserved scope: `BacktestConfig`, `BacktestResult`,
+│   │   │          `BacktestEngine`, all BacktestEngine methods, route/API,
+│   │   │          OpenAPI exposure, frontend, PM2, OpenSpec, issue labels,
+│   │   │          and unrelated service lifecycle candidates remain out of
+│   │   │          scope
+│   │   ├── Verification: GitNexus impact for `get_backtest_engine` is LOW
+│   │   │          with impacted=`0`, direct=`0`, processes=`0`; exact scan
+│   │   │          shows `BacktestEngine` definition=`1`, getter definition=`1`,
+│   │   │          `_backtest_engine` token count=`5`, and backend code
+│   │   │          references only in the defining service file; import smoke
+│   │   │          confirms class/config/result/getter importability
+│   │   └── Boundary: authorization-only; no backend source/test edit,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                getter deletion, implementation, or issue-label change is
+│   │                made here
+│   └── Next gate: after G2.139 review and merge, execute the BacktestEngine
+│                  singleton/getter retirement implementation lane with TDD,
+│                  fresh GitNexus impact, staged detect_changes, and mainline
+│                  scope gate
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/backtest-engine-getter-retirement-authorization-2026-05-26.json
+++ b/.planning/codebase/generated/backtest-engine-getter-retirement-authorization-2026-05-26.json
@@ -1,0 +1,106 @@
+{
+  "schema_version": "1.0",
+  "artifact": "backtest-engine-getter-retirement-authorization",
+  "created_at": "2026-05-26T13:23:00+08:00",
+  "current_head": "2d51cbd52bc37dae2ae5f59855bcdb70d41f169c",
+  "parent_refresh": {
+    "lane": "G2.138",
+    "pull_request": 291,
+    "merge_commit": "2d51cbd52bc37dae2ae5f59855bcdb70d41f169c",
+    "selected_candidate": "get_backtest_engine"
+  },
+  "authorization_mode": {
+    "this_lane": "authorization-only",
+    "source_implementation_allowed_in_this_lane": false,
+    "future_implementation_required": true
+  },
+  "target": {
+    "service_file": "web/backend/app/services/backtest_engine.py",
+    "class_to_preserve": "BacktestEngine",
+    "config_to_preserve": "BacktestConfig",
+    "result_to_preserve": "BacktestResult",
+    "singleton_to_retire": "_backtest_engine",
+    "getter_to_retire": "get_backtest_engine"
+  },
+  "current_head_evidence": {
+    "class_definitions": {
+      "BacktestEngine": 1
+    },
+    "getter_definitions": {
+      "get_backtest_engine": 1
+    },
+    "singleton_token_count": {
+      "_backtest_engine": 5
+    },
+    "backend_code_references": [
+      {
+        "file": "web/backend/app/services/backtest_engine.py",
+        "count": 1
+      }
+    ],
+    "import_smoke": {
+      "BacktestConfig": true,
+      "BacktestEngine": true,
+      "BacktestResult": true,
+      "get_backtest_engine": true
+    }
+  },
+  "gitnexus_impact": {
+    "symbol": "get_backtest_engine",
+    "direction": "upstream",
+    "risk": "LOW",
+    "impacted_count": 0,
+    "direct": 0,
+    "processes_affected": 0,
+    "modules_affected": 0
+  },
+  "future_implementation_scope": {
+    "allowed_paths": [
+      "web/backend/app/services/backtest_engine.py",
+      "web/backend/tests/test_backtest_engine_getter_retirement.py",
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/backtest-engine-getter-retirement-implementation-2026-05-26.json",
+      "docs/reports/quality/backend-backtest-engine-getter-retirement-implementation-2026-05-26.md",
+      "governance/mainline/task-cards/pr-293.yaml"
+    ],
+    "must_preserve": [
+      "BacktestConfig",
+      "BacktestResult",
+      "BacktestEngine",
+      "BacktestEngine.run_backtest",
+      "BacktestEngine._simulate_trades",
+      "BacktestEngine._calculate_metrics",
+      "BacktestEngine._calculate_equity_curve",
+      "BacktestEngine._calculate_max_drawdown",
+      "BacktestEngine._empty_result"
+    ],
+    "must_not_change": [
+      "route/API behavior",
+      "OpenAPI exposure",
+      "frontend code",
+      "PM2 workflow",
+      "OpenSpec state",
+      "GitHub issue labels",
+      "unrelated service lifecycle candidates"
+    ]
+  },
+  "future_implementation_requirements": [
+    "Run fresh GitNexus impact for get_backtest_engine before editing.",
+    "Run exact text scan for get_backtest_engine and _backtest_engine before editing.",
+    "Use TDD: add a focused failing test that proves the legacy getter surface is absent while BacktestEngine remains importable.",
+    "Remove only _backtest_engine and get_backtest_engine from web/backend/app/services/backtest_engine.py if the current-head evidence still matches this packet.",
+    "Run focused test web/backend/tests/test_backtest_engine_getter_retirement.py.",
+    "Run Ruff and Black checks over touched backend files.",
+    "Run GitNexus detect_changes on staged scope before committing.",
+    "Run mainline scope gate after commit."
+  ],
+  "rollback": {
+    "strategy": "restore _backtest_engine and get_backtest_engine in web/backend/app/services/backtest_engine.py and remove the focused regression test/report/artifact/task-card updates from the implementation PR",
+    "expected_blast_radius": "low if implementation remains within the authorized paths"
+  },
+  "boundary": {
+    "no_source_or_test_edits_in_this_authorization_pr": true,
+    "no_getter_deletion_in_this_authorization_pr": true,
+    "no_runtime_behavior_change_in_this_authorization_pr": true
+  }
+}

--- a/docs/reports/quality/backend-backtest-engine-getter-retirement-authorization-2026-05-26.md
+++ b/docs/reports/quality/backend-backtest-engine-getter-retirement-authorization-2026-05-26.md
@@ -1,0 +1,90 @@
+# Backend BacktestEngine Getter Retirement Authorization
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Date: 2026-05-26
+
+Current HEAD: `2d51cbd52bc37dae2ae5f59855bcdb70d41f169c`
+
+Parent refresh: G2.138 / PR `#291`
+
+Boundary note: this is an authorization-only package. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, or GitHub issue labels. It does not remove `get_backtest_engine` or `_backtest_engine`.
+
+## Purpose
+
+Authorize a future narrow implementation lane to retire the unused BacktestEngine module singleton and compatibility getter.
+
+The candidate was selected by G2.138 because the current evidence shows low blast radius and no backend code references outside the defining service file.
+
+## Target
+
+| Item | Value |
+|---|---|
+| Service file | `web/backend/app/services/backtest_engine.py` |
+| Class to preserve | `BacktestEngine` |
+| Config/result models to preserve | `BacktestConfig`, `BacktestResult` |
+| Singleton to retire in future implementation | `_backtest_engine` |
+| Getter to retire in future implementation | `get_backtest_engine` |
+
+## Current Evidence
+
+| Check | Result |
+|---|---|
+| `BacktestEngine` class definition count | `1` |
+| `get_backtest_engine` definition count | `1` |
+| `_backtest_engine` token count in target file | `5` |
+| Backend code references to `get_backtest_engine` | `web/backend/app/services/backtest_engine.py:1` only |
+| Import smoke | `BacktestConfig`, `BacktestEngine`, `BacktestResult`, `get_backtest_engine` importable |
+| GitNexus upstream impact for `get_backtest_engine` | LOW, impacted `0`, direct `0`, processes `0`, modules `0` |
+
+## Future Implementation Scope
+
+Allowed paths for the future implementation lane:
+
+- `web/backend/app/services/backtest_engine.py`
+- `web/backend/tests/test_backtest_engine_getter_retirement.py`
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/backtest-engine-getter-retirement-implementation-2026-05-26.json`
+- `docs/reports/quality/backend-backtest-engine-getter-retirement-implementation-2026-05-26.md`
+- `governance/mainline/task-cards/pr-293.yaml`
+
+Future implementation must preserve:
+
+- `BacktestConfig`
+- `BacktestResult`
+- `BacktestEngine`
+- `BacktestEngine.run_backtest`
+- `BacktestEngine._simulate_trades`
+- `BacktestEngine._calculate_metrics`
+- `BacktestEngine._calculate_equity_curve`
+- `BacktestEngine._calculate_max_drawdown`
+- `BacktestEngine._empty_result`
+
+## Required Future Gates
+
+Before editing source in the future implementation lane:
+
+- Run fresh GitNexus impact for `get_backtest_engine`.
+- Run an exact text scan for `get_backtest_engine` and `_backtest_engine`.
+- Stop if any external backend code caller appears outside `web/backend/app/services/backtest_engine.py`.
+- Use TDD: add a focused failing test that proves the legacy getter surface is absent while `BacktestEngine` remains importable.
+
+After source edit in the future implementation lane:
+
+- Run the focused BacktestEngine getter-retirement test.
+- Run Ruff and Black checks over touched backend files.
+- Run GitNexus `detect_changes` on staged scope.
+- Run the mainline scope gate after commit.
+
+## Non-Goals
+
+- No source or test edit in this authorization PR.
+- No direct deletion of `get_backtest_engine` or `_backtest_engine` in this authorization PR.
+- No route/API, OpenAPI, frontend, PM2, OpenSpec, or issue-label change.
+- No authorization for `get_tdx_service`, `get_data_service`, `get_strategy_service`, `get_streaming_service`, route provider seams, root/risk compatibility facades, or other service lifecycle candidates.
+
+## Rollback
+
+If the future implementation causes an unexpected regression, restore `_backtest_engine` and `get_backtest_engine` in `web/backend/app/services/backtest_engine.py`, remove the focused regression test, and revert the implementation report/artifact/task-card/tree update.

--- a/governance/mainline/task-cards/pr-292.yaml
+++ b/governance/mainline/task-cards/pr-292.yaml
@@ -1,0 +1,106 @@
+version: "v0.2"
+
+task:
+  id: "pr-292"
+  title: "Authorize BacktestEngine getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-backtest-engine-getter-retirement-authorization"
+  objective: "authorize a future narrow implementation lane to retire BacktestEngine module singleton/getter"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-backtest-engine-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-backtest-engine-getter-retirement-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only packet; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/backtest-engine-getter-retirement-authorization-2026-05-26.json"
+    - "docs/reports/quality/backend-backtest-engine-getter-retirement-authorization-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-292.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "gitnexus-impact"
+      command: "GitNexus impact get_backtest_engine direction=upstream"
+      required: true
+    - id: "current-head-scan"
+      command: "scripted exact scan for BacktestEngine, get_backtest_engine, _backtest_engine, and backend code references"
+      required: true
+    - id: "import-smoke"
+      command: "PYTHONPATH=web/backend python - <<'PY'\nfrom app.services.backtest_engine import BacktestConfig, BacktestEngine, BacktestResult, get_backtest_engine\nprint(callable(get_backtest_engine), BacktestEngine.__name__, BacktestConfig.__name__, BacktestResult.__name__)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-backtest-engine-getter-retirement-authorization-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/backtest-engine-getter-retirement-authorization-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-292.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this authorization lane."
+  - "Do not delete get_backtest_engine or _backtest_engine in this authorization lane."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+  - "Do not authorize any other service lifecycle candidate."
+
+risk_and_rollback:
+  risks:
+    - "If this authorization is mistaken for implementation, the source getter could be deleted before TDD and staged GitNexus checks"
+    - "If future implementation proceeds after external callers appear, it could break hidden runtime consumers"
+  rollback_plan: "revert this authorization PR to remove only the authorization report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize a future BacktestEngine singleton/getter retirement implementation lane"
+    modified_scope: "steward tree, authorization report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; this lane records authorization constraints only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON/YAML parsing, GitNexus staged scope, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T13:23:00+08:00"
+    approval_note: "Authorization follows G2.138 candidate-refresh selection"
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary
- authorize a future narrow implementation lane to retire BacktestEngine module singleton/getter
- preserve BacktestConfig, BacktestResult, BacktestEngine, all BacktestEngine methods, route/API, OpenAPI, frontend, PM2, OpenSpec, and issue labels
- update steward tree with G2.138 accepted state and G2.139 ready-for-review authorization state

## Verification
- GitNexus impact get_backtest_engine: LOW, impacted=0, direct=0, processes=0
- exact scan: BacktestEngine definition=1, get_backtest_engine definition=1, _backtest_engine token count=5, backend code refs only in defining service file
- import smoke: BacktestConfig, BacktestEngine, BacktestResult, get_backtest_engine importable
- python -m json.tool .planning/codebase/generated/backtest-engine-getter-retirement-authorization-2026-05-26.json
- python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-backtest-engine-getter-retirement-authorization-2026-05-26.md
- git diff --check over intended paths
- gitnexus detect_changes scope=staged: low risk, 4 changed files, 0 affected symbols/processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: repository indexed successfully