### PR TITLE
G2.140 Retire BacktestEngine getter

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2358,9 +2358,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, implementation authorization, or
 │   │                issue-label change is made here
 │   ├── G2.139 BacktestEngine singleton/getter retirement authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#292`
 │   │   ├── Evidence: `backend-backtest-engine-getter-retirement-authorization-2026-05-26.md`
-│   │   ├── Current HEAD: `2d51cbd52bc37dae2ae5f59855bcdb70d41f169c`
+│   │   ├── Merge commit: `0f78609e25898181ea5653edc7350efc03a3bb9b`
 │   │   ├── Result: authorizes only a future narrow implementation lane to
 │   │   │          retire `_backtest_engine` and `get_backtest_engine` from
 │   │   │          `web/backend/app/services/backtest_engine.py`
@@ -2379,10 +2379,30 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                getter deletion, implementation, or issue-label change is
 │   │                made here
-│   └── Next gate: after G2.139 review and merge, execute the BacktestEngine
-│                  singleton/getter retirement implementation lane with TDD,
-│                  fresh GitNexus impact, staged detect_changes, and mainline
-│                  scope gate
+│   ├── G2.140 BacktestEngine singleton/getter retirement implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-backtest-engine-getter-retirement-implementation-2026-05-26.md`
+│   │   ├── Current HEAD: `0f78609e25898181ea5653edc7350efc03a3bb9b`
+│   │   ├── Result: removes only `_backtest_engine` and
+│   │   │          `get_backtest_engine` from
+│   │   │          `web/backend/app/services/backtest_engine.py` and adds a
+│   │   │          focused regression test
+│   │   ├── Preserved scope: `BacktestConfig`, `BacktestResult`,
+│   │   │          `BacktestEngine`, existing BacktestEngine methods,
+│   │   │          route/API, OpenAPI exposure, frontend, PM2, OpenSpec, issue
+│   │   │          labels, and unrelated service lifecycle candidates remain
+│   │   │          unchanged
+│   │   ├── Verification: pre-edit GitNexus impact LOW / impacted=`0`;
+│   │   │          TDD red `1 failed, 1 passed`; focused green `2 passed`;
+│   │   │          exact scan reports getter definition=`0` and singleton
+│   │   │          token count=`0`; import smoke confirms preserved types and
+│   │   │          removed legacy surfaces; Ruff and Black passed
+│   │   └── Boundary: source-capable but limited to one backend service file,
+│   │                one focused test, report, generated artifact, task card,
+│   │                and steward-tree update
+│   └── Next gate: after G2.140 review and merge, prepare a closeout packet
+│                  before refreshing the remaining service lifecycle candidate
+│                  pool again
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/backtest-engine-getter-retirement-implementation-2026-05-26.json
+++ b/.planning/codebase/generated/backtest-engine-getter-retirement-implementation-2026-05-26.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "1.0",
+  "artifact": "backtest-engine-getter-retirement-implementation",
+  "created_at": "2026-05-26T13:37:00+08:00",
+  "base_head": "0f78609e25898181ea5653edc7350efc03a3bb9b",
+  "authorization": {
+    "lane": "G2.139",
+    "pull_request": 292,
+    "merge_commit": "0f78609e25898181ea5653edc7350efc03a3bb9b",
+    "report": "docs/reports/quality/backend-backtest-engine-getter-retirement-authorization-2026-05-26.md"
+  },
+  "scope": {
+    "mode": "source implementation",
+    "target_service_file": "web/backend/app/services/backtest_engine.py",
+    "focused_test_file": "web/backend/tests/test_backtest_engine_getter_retirement.py",
+    "retired_symbols": [
+      "_backtest_engine",
+      "get_backtest_engine"
+    ],
+    "preserved_symbols": [
+      "BacktestConfig",
+      "BacktestResult",
+      "BacktestEngine"
+    ]
+  },
+  "pre_edit_gate": {
+    "gitnexus_impact": {
+      "symbol": "get_backtest_engine",
+      "direction": "upstream",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct": 0,
+      "processes_affected": 0,
+      "modules_affected": 0
+    }
+  },
+  "tdd": {
+    "red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_engine_getter_retirement.py -q --no-cov --tb=short",
+      "result": "1 failed, 1 passed",
+      "failing_assertion": "hasattr(backtest_engine, '_backtest_engine') was True"
+    },
+    "green": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_engine_getter_retirement.py -q --no-cov --tb=short",
+      "result": "2 passed in 0.77s"
+    }
+  },
+  "post_edit_evidence": {
+    "exact_scan": {
+      "BacktestEngine_definition_count": 1,
+      "get_backtest_engine_definition_count": 0,
+      "_backtest_engine_token_count": 0,
+      "remaining_get_backtest_engine_references": [
+        {
+          "file": "web/backend/tests/test_backtest_engine_getter_retirement.py",
+          "count": 1
+        }
+      ]
+    },
+    "import_smoke": {
+      "import_ok": true,
+      "has_getter": false,
+      "has_singleton": false,
+      "BacktestEngine": true,
+      "BacktestConfig": true,
+      "BacktestResult": true
+    },
+    "ruff": "All checks passed",
+    "black_check": "2 files would be left unchanged"
+  },
+  "boundary": {
+    "route_api_changed": false,
+    "openapi_changed": false,
+    "frontend_changed": false,
+    "pm2_changed": false,
+    "openspec_changed": false,
+    "issue_labels_changed": false,
+    "unrelated_service_candidates_changed": false
+  }
+}

--- a/docs/reports/quality/backend-backtest-engine-getter-retirement-implementation-2026-05-26.md
+++ b/docs/reports/quality/backend-backtest-engine-getter-retirement-implementation-2026-05-26.md
@@ -1,0 +1,111 @@
+# Backend BacktestEngine Getter Retirement Implementation
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Date: 2026-05-26
+
+Base HEAD: `0f78609e25898181ea5653edc7350efc03a3bb9b`
+
+Authorization: G2.139 / PR `#292`
+
+Boundary note: this implementation is limited to the authorized BacktestEngine legacy singleton/getter retirement. It does not change route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or unrelated service lifecycle candidates.
+
+## Scope
+
+Changed runtime file:
+
+- `web/backend/app/services/backtest_engine.py`
+
+Added focused test:
+
+- `web/backend/tests/test_backtest_engine_getter_retirement.py`
+
+Retired symbols:
+
+- `_backtest_engine`
+- `get_backtest_engine`
+
+Preserved symbols:
+
+- `BacktestConfig`
+- `BacktestResult`
+- `BacktestEngine`
+- Existing `BacktestEngine` methods
+
+## Pre-Edit Gate
+
+GitNexus upstream impact for `get_backtest_engine`:
+
+| Risk | Impacted | Direct | Processes | Modules |
+|---|---:|---:|---:|---:|
+| LOW | 0 | 0 | 0 | 0 |
+
+## TDD Evidence
+
+Red run:
+
+```text
+1 failed, 1 passed
+```
+
+The failing assertion proved `_backtest_engine` was still present before the implementation.
+
+Green run:
+
+```text
+2 passed in 0.77s
+```
+
+Command:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_engine_getter_retirement.py -q --no-cov --tb=short
+```
+
+## Post-Edit Evidence
+
+Exact scan after edit:
+
+| Item | Count |
+|---|---:|
+| `BacktestEngine` definition | 1 |
+| `get_backtest_engine` definition | 0 |
+| `_backtest_engine` token count | 0 |
+
+Remaining `get_backtest_engine` text reference:
+
+- `web/backend/tests/test_backtest_engine_getter_retirement.py`
+
+Import smoke after edit:
+
+| Check | Result |
+|---|---|
+| `BacktestConfig` importable | yes |
+| `BacktestResult` importable | yes |
+| `BacktestEngine` importable | yes |
+| module has `get_backtest_engine` | no |
+| module has `_backtest_engine` | no |
+
+Lint/format checks:
+
+- Ruff touched files: passed.
+- Black check touched files: passed.
+
+## Non-Goals
+
+- No route/API behavior change.
+- No OpenAPI exposure change.
+- No frontend or PM2 workflow change.
+- No OpenSpec or GitHub issue-label change.
+- No implementation for `get_tdx_service`, `get_data_service`, `get_strategy_service`, `get_streaming_service`, route provider seams, root/risk compatibility facades, or other service lifecycle candidates.
+
+## Next Gate
+
+After this implementation is reviewed and merged, prepare a closeout packet that verifies:
+
+- PR state and merge commit.
+- Focused test still passes.
+- Exact scan still reports `get_backtest_engine` definition `0` and `_backtest_engine` token count `0`.
+- `BacktestEngine`, `BacktestConfig`, and `BacktestResult` remain importable.

--- a/governance/mainline/task-cards/pr-293.yaml
+++ b/governance/mainline/task-cards/pr-293.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-293"
+  title: "Retire BacktestEngine getter"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-backtest-engine-getter-retirement-implementation"
+  objective: "retire the unused BacktestEngine module singleton/getter within the authorized scope"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-backtest-engine-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-backtest-engine-getter-retirement-implementation"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorized service-internal cleanup; no runtime entrypoint, route, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/services/backtest_engine.py"
+    - "web/backend/tests/test_backtest_engine_getter_retirement.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/backtest-engine-getter-retirement-implementation-2026-05-26.json"
+    - "docs/reports/quality/backend-backtest-engine-getter-retirement-implementation-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-293.yaml"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "pre-edit-gitnexus-impact"
+      command: "GitNexus impact get_backtest_engine direction=upstream"
+      required: true
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_engine_getter_retirement.py -q --no-cov --tb=short"
+      required: true
+    - id: "tdd-green"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_engine_getter_retirement.py -q --no-cov --tb=short"
+      required: true
+    - id: "exact-scan"
+      command: "scripted exact scan for BacktestEngine, get_backtest_engine, and _backtest_engine"
+      required: true
+    - id: "import-smoke"
+      command: "PYTHONPATH=web/backend python - <<'PY'\nfrom app.services.backtest_engine import BacktestConfig, BacktestEngine, BacktestResult\nprint(BacktestConfig.__name__, BacktestEngine.__name__, BacktestResult.__name__)\nPY"
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/services/backtest_engine.py web/backend/tests/test_backtest_engine_getter_retirement.py"
+      required: true
+    - id: "black"
+      command: "black --check web/backend/app/services/backtest_engine.py web/backend/tests/test_backtest_engine_getter_retirement.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-backtest-engine-getter-retirement-implementation-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/backtest-engine-getter-retirement-implementation-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-293.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not change route/API behavior or OpenAPI exposure."
+  - "Do not touch frontend, PM2, OpenSpec, docs/api, docs/guides, config, or scripts."
+  - "Do not modify unrelated service lifecycle candidates."
+  - "Do not remove BacktestConfig, BacktestResult, BacktestEngine, or existing BacktestEngine methods."
+
+risk_and_rollback:
+  risks:
+    - "Hidden runtime consumers could import the legacy getter despite current exact scan and GitNexus evidence"
+    - "Over-broad cleanup could remove BacktestEngine behavior rather than only the unused singleton/getter"
+  rollback_plan: "restore _backtest_engine and get_backtest_engine in web/backend/app/services/backtest_engine.py and remove the focused regression test/report/artifact/task-card/tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "retire unused BacktestEngine module singleton/getter"
+    modified_scope: "one backend service file, one focused test, steward tree, implementation report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "removes only unused legacy singleton/getter; BacktestEngine class and methods remain"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "restore _backtest_engine/get_backtest_engine if focused tests, exact scan, imports, Ruff, Black, staged GitNexus, or mainline scope checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T13:37:00+08:00"
+    approval_note: "Implementation follows accepted G2.139 authorization PR #292"
+    secondary_approved: false
+

--- a/web/backend/app/services/backtest_engine.py
+++ b/web/backend/app/services/backtest_engine.py
@@ -266,15 +266,3 @@ class BacktestEngine:
             equity_curve=pd.DataFrame(),
             trade_history=pd.DataFrame(),
         )
-
-
-# 全局单例
-_backtest_engine = None
-
-
-def get_backtest_engine() -> BacktestEngine:
-    """获取回测引擎单例"""
-    global _backtest_engine
-    if _backtest_engine is None:
-        _backtest_engine = BacktestEngine()
-    return _backtest_engine

--- a/web/backend/tests/test_backtest_engine_getter_retirement.py
+++ b/web/backend/tests/test_backtest_engine_getter_retirement.py
@@ -1,0 +1,13 @@
+from app.services import backtest_engine
+from app.services.backtest_engine import BacktestConfig, BacktestEngine, BacktestResult
+
+
+def test_backtest_engine_public_surface_excludes_legacy_singleton_getter() -> None:
+    assert not hasattr(backtest_engine, "_backtest_engine")
+    assert not hasattr(backtest_engine, "get_backtest_engine")
+
+
+def test_backtest_engine_core_types_remain_importable() -> None:
+    assert BacktestConfig.__name__ == "BacktestConfig"
+    assert BacktestResult.__name__ == "BacktestResult"
+    assert BacktestEngine.__name__ == "BacktestEngine"


### PR DESCRIPTION
## Summary
- retire only _backtest_engine and get_backtest_engine from web/backend/app/services/backtest_engine.py
- preserve BacktestConfig, BacktestResult, BacktestEngine, and existing BacktestEngine methods
- add focused regression coverage and update steward tree/report/artifact/task card

## Verification
- pre-edit GitNexus impact get_backtest_engine: LOW, impacted=0, direct=0, processes=0
- TDD red: 1 failed, 1 passed
- focused green: PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_engine_getter_retirement.py -q --no-cov --tb=short -> 2 passed
- exact scan: get_backtest_engine definition=0, _backtest_engine token count=0, BacktestEngine definition=1
- import smoke: BacktestConfig, BacktestResult, BacktestEngine importable; legacy getter/singleton absent
- ruff check touched files: passed
- black --check touched files: passed
- markdown governance: 2 checked, 0 errors
- git diff --check over intended paths: passed
- GitNexus staged detect_changes: low risk, affected processes=0
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: repository indexed successfully