### PR TITLE
G2.141 Close out BacktestEngine getter retirement

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2380,9 +2380,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, implementation, or issue-label change is
 │   │                made here
 │   ├── G2.140 BacktestEngine singleton/getter retirement implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#293`
 │   │   ├── Evidence: `backend-backtest-engine-getter-retirement-implementation-2026-05-26.md`
-│   │   ├── Current HEAD: `0f78609e25898181ea5653edc7350efc03a3bb9b`
+│   │   ├── Merge commit: `62cf56cc8736c3784f8b7cc9ac5cc21a52d39423`
 │   │   ├── Result: removes only `_backtest_engine` and
 │   │   │          `get_backtest_engine` from
 │   │   │          `web/backend/app/services/backtest_engine.py` and adds a
@@ -2400,9 +2400,25 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: source-capable but limited to one backend service file,
 │   │                one focused test, report, generated artifact, task card,
 │   │                and steward-tree update
-│   └── Next gate: after G2.140 review and merge, prepare a closeout packet
-│                  before refreshing the remaining service lifecycle candidate
-│                  pool again
+│   ├── G2.141 BacktestEngine singleton/getter retirement closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-backtest-engine-getter-retirement-closeout-2026-05-26.md`
+│   │   ├── Current HEAD: `62cf56cc8736c3784f8b7cc9ac5cc21a52d39423`
+│   │   ├── Result: records PR `#293` as merged and closes the
+│   │   │          BacktestEngine singleton/getter retirement lane without
+│   │   │          changing runtime source, tests, route paths, response
+│   │   │          contracts, or OpenAPI exposure
+│   │   ├── Verification: parent PR state `MERGED`; focused closeout test
+│   │   │          `2 passed`; exact scan reports getter definition=`0`,
+│   │   │          singleton token count=`0`, and `BacktestEngine`
+│   │   │          definition=`1`; import smoke confirms preserved types and
+│   │   │          removed legacy surfaces
+│   │   └── Boundary: closeout-only; no source/test edit, runtime behavior,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                implementation, or issue-label change is made here
+│   └── Next gate: after G2.141 review and merge, refresh the remaining service
+│                  lifecycle candidate pool before selecting another
+│                  implementation lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/backtest-engine-getter-retirement-closeout-2026-05-26.json
+++ b/.planning/codebase/generated/backtest-engine-getter-retirement-closeout-2026-05-26.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "1.0",
+  "artifact": "backtest-engine-getter-retirement-closeout",
+  "created_at": "2026-05-26T13:48:00+08:00",
+  "current_head": "62cf56cc8736c3784f8b7cc9ac5cc21a52d39423",
+  "parent_implementation": {
+    "lane": "G2.140",
+    "pull_request": 293,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T05:32:51Z",
+    "merge_commit": "62cf56cc8736c3784f8b7cc9ac5cc21a52d39423",
+    "title": "G2.140 Retire BacktestEngine getter",
+    "url": "https://github.com/chengjon/mystocks/pull/293"
+  },
+  "closeout_scope": {
+    "mode": "closeout-only",
+    "runtime_code_changed": false,
+    "tests_changed": false,
+    "implementation_authorized": false
+  },
+  "verification": {
+    "focused_test": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_engine_getter_retirement.py -q --no-cov --tb=short",
+      "result": "2 passed in 0.57s"
+    },
+    "exact_scan": {
+      "BacktestEngine_definition_count": 1,
+      "get_backtest_engine_definition_count": 0,
+      "_backtest_engine_token_count": 0,
+      "remaining_get_backtest_engine_references": [
+        {
+          "file": "web/backend/tests/test_backtest_engine_getter_retirement.py",
+          "count": 1
+        }
+      ]
+    },
+    "import_smoke": {
+      "import_ok": true,
+      "has_getter": false,
+      "has_singleton": false,
+      "BacktestConfig": true,
+      "BacktestResult": true,
+      "BacktestEngine": true
+    }
+  },
+  "closed_lane": {
+    "retired_symbols": [
+      "_backtest_engine",
+      "get_backtest_engine"
+    ],
+    "preserved_symbols": [
+      "BacktestConfig",
+      "BacktestResult",
+      "BacktestEngine"
+    ],
+    "next_gate": "refresh remaining service lifecycle candidate pool"
+  },
+  "boundary": {
+    "no_source_or_test_edits": true,
+    "no_route_api_openapi_frontend_pm2_or_openspec_changes": true,
+    "no_issue_label_changes": true,
+    "no_next_implementation_authorization": true
+  }
+}

--- a/docs/reports/quality/backend-backtest-engine-getter-retirement-closeout-2026-05-26.md
+++ b/docs/reports/quality/backend-backtest-engine-getter-retirement-closeout-2026-05-26.md
@@ -1,0 +1,86 @@
+# Backend BacktestEngine Getter Retirement Closeout
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Date: 2026-05-26
+
+Current HEAD: `62cf56cc8736c3784f8b7cc9ac5cc21a52d39423`
+
+Parent implementation: G2.140 / PR `#293`
+
+Boundary note: this is a closeout-only package. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or other service lifecycle candidates.
+
+## Parent Merge
+
+| Field | Value |
+|---|---|
+| Parent PR | `#293` |
+| Parent state | `MERGED` |
+| Parent merged at | `2026-05-26T05:32:51Z` |
+| Parent merge commit | `62cf56cc8736c3784f8b7cc9ac5cc21a52d39423` |
+| Parent title | `G2.140 Retire BacktestEngine getter` |
+| Parent URL | `https://github.com/chengjon/mystocks/pull/293` |
+
+## Verification
+
+Focused closeout test:
+
+```text
+2 passed in 0.57s
+```
+
+Command:
+
+```bash
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_engine_getter_retirement.py -q --no-cov --tb=short
+```
+
+Exact scan:
+
+| Item | Count |
+|---|---:|
+| `BacktestEngine` definition | 1 |
+| `get_backtest_engine` definition | 0 |
+| `_backtest_engine` token count | 0 |
+
+Remaining `get_backtest_engine` text reference:
+
+- `web/backend/tests/test_backtest_engine_getter_retirement.py`
+
+Import smoke:
+
+| Check | Result |
+|---|---|
+| `BacktestConfig` importable | yes |
+| `BacktestResult` importable | yes |
+| `BacktestEngine` importable | yes |
+| module has `get_backtest_engine` | no |
+| module has `_backtest_engine` | no |
+
+## Closeout Result
+
+The BacktestEngine legacy singleton/getter retirement lane is closed as implemented and verified.
+
+Retired:
+
+- `_backtest_engine`
+- `get_backtest_engine`
+
+Preserved:
+
+- `BacktestConfig`
+- `BacktestResult`
+- `BacktestEngine`
+- Existing `BacktestEngine` methods
+
+## Next Gate
+
+Refresh the remaining service lifecycle candidate pool before selecting another implementation lane.
+
+## Non-Goals
+
+- No backend source or test edit in this closeout PR.
+- No route/API, OpenAPI, frontend, PM2, OpenSpec, or issue-label change.
+- No authorization for another service lifecycle implementation lane.

--- a/governance/mainline/task-cards/pr-294.yaml
+++ b/governance/mainline/task-cards/pr-294.yaml
@@ -1,0 +1,108 @@
+version: "v0.2"
+
+task:
+  id: "pr-294"
+  title: "Close out BacktestEngine getter retirement"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-backtest-engine-getter-retirement-closeout"
+  objective: "record PR #293 merge evidence and close the BacktestEngine singleton/getter retirement lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-backtest-engine-getter-retirement"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-backtest-engine-getter-retirement-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only packet; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/backtest-engine-getter-retirement-closeout-2026-05-26.json"
+    - "docs/reports/quality/backend-backtest-engine-getter-retirement-closeout-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-294.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 293 --json number,state,mergedAt,mergeCommit,title,url"
+      required: true
+    - id: "focused-closeout-test"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_engine_getter_retirement.py -q --no-cov --tb=short"
+      required: true
+    - id: "exact-scan"
+      command: "scripted exact scan for BacktestEngine, get_backtest_engine, and _backtest_engine"
+      required: true
+    - id: "import-smoke"
+      command: "PYTHONPATH=web/backend python - <<'PY'\nfrom app.services.backtest_engine import BacktestConfig, BacktestEngine, BacktestResult\nprint(BacktestConfig.__name__, BacktestEngine.__name__, BacktestResult.__name__)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-backtest-engine-getter-retirement-closeout-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/backtest-engine-getter-retirement-closeout-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-294.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+  - "Do not select the next implementation lane before a fresh candidate refresh."
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is treated as source authorization, a later worker could edit another service without a fresh candidate refresh"
+    - "If closeout evidence is stale, the steward tree could overstate the merged implementation state"
+  rollback_plan: "revert this closeout PR to remove only the closeout report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out BacktestEngine singleton/getter retirement"
+    modified_scope: "steward tree, closeout report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; closeout records the merged parent implementation and does not change runtime code"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON/YAML parsing, GitNexus staged scope, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T13:48:00+08:00"
+    approval_note: "Closeout follows merged G2.140 implementation PR #293"
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary
- close out PR #293 BacktestEngine singleton/getter retirement
- record current-head evidence for retired get_backtest_engine and _backtest_engine
- update steward tree and task card for the closeout lane

## Verification
- parent PR #293 state: MERGED, merge commit 62cf56cc8736c3784f8b7cc9ac5cc21a52d39423
- focused closeout test: PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_engine_getter_retirement.py -q --no-cov --tb=short -> 2 passed
- exact scan: get_backtest_engine definition=0, _backtest_engine token count=0, BacktestEngine definition=1
- import smoke: BacktestConfig, BacktestResult, BacktestEngine importable; legacy getter/singleton absent
- python -m json.tool .planning/codebase/generated/backtest-engine-getter-retirement-closeout-2026-05-26.json
- markdown governance: 2 checked, 0 errors
- git diff --check over intended paths: passed
- GitNexus staged detect_changes: low risk, 4 changed files, 0 affected symbols/processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: repository indexed successfully