### PR TITLE
G2.142 Refresh service lifecycle candidates after BacktestEngine

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2401,9 +2401,9 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                one focused test, report, generated artifact, task card,
 │   │                and steward-tree update
 │   ├── G2.141 BacktestEngine singleton/getter retirement closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#294`
 │   │   ├── Evidence: `backend-backtest-engine-getter-retirement-closeout-2026-05-26.md`
-│   │   ├── Current HEAD: `62cf56cc8736c3784f8b7cc9ac5cc21a52d39423`
+│   │   ├── Merge commit: `32d0cfb1e02d1207301e632b44a94e74efdddf69`
 │   │   ├── Result: records PR `#293` as merged and closes the
 │   │   │          BacktestEngine singleton/getter retirement lane without
 │   │   │          changing runtime source, tests, route paths, response
@@ -2416,9 +2416,29 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: closeout-only; no source/test edit, runtime behavior,
 │   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │                implementation, or issue-label change is made here
-│   └── Next gate: after G2.141 review and merge, refresh the remaining service
-│                  lifecycle candidate pool before selecting another
-│                  implementation lane
+│   ├── G2.142 Service lifecycle candidate refresh after BacktestEngine
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-service-lifecycle-candidate-refresh-after-backtest-2026-05-26.md`
+│   │   ├── Current HEAD: `32d0cfb1e02d1207301e632b44a94e74efdddf69`
+│   │   ├── Result: refreshes the remaining service lifecycle DI candidate
+│   │   │          pool after BacktestEngine closeout and selects no direct
+│   │   │          implementation candidate
+│   │   ├── Verification: service files=`152`, backend app files=`575`,
+│   │   │          API files=`219`, tests=`206`, service getter
+│   │   │          definitions=`53`, root facade getters=`7`, FastAPI
+│   │   │          dependency/provider getters=`9`, zero-external-reference
+│   │   │          getters=`0`; BacktestEngine retired tokens remain `0`
+│   │   ├── High-risk holds: `get_tdx_service` CRITICAL impacted=`6`,
+│   │   │          `get_data_service` CRITICAL impacted=`5`,
+│   │   │          `get_strategy_service` CRITICAL impacted=`13`, and
+│   │   │          `get_streaming_service` HIGH impacted=`9`; these require
+│   │   │          design decomposition before implementation authorization
+│   │   └── Boundary: candidate-refresh-only; no backend source/test edit,
+│   │                route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │                getter deletion, implementation authorization, or
+│   │                issue-label change is made here
+│   └── Next gate: prepare a high-risk service getter strategy decision package
+│                  before selecting another source implementation lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-backtest-2026-05-26.json
+++ b/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-backtest-2026-05-26.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": "1.0",
+  "artifact": "service-lifecycle-candidate-refresh-after-backtest",
+  "created_at": "2026-05-26T13:58:00+08:00",
+  "current_head": "32d0cfb1e02d1207301e632b44a94e74efdddf69",
+  "parent_closeout": {
+    "lane": "G2.141",
+    "pull_request": 294,
+    "merge_commit": "32d0cfb1e02d1207301e632b44a94e74efdddf69",
+    "meaning": "BacktestEngine singleton/getter retirement closeout accepted"
+  },
+  "scope": {
+    "mode": "governance-only candidate refresh",
+    "runtime_code_changed": false,
+    "implementation_authorized": false
+  },
+  "inventory": {
+    "service_py_files": 152,
+    "backend_app_py_files": 575,
+    "backend_api_py_files": 219,
+    "backend_test_py_files": 206,
+    "service_getter_definitions": 53,
+    "root_facade_getters": 7,
+    "fastapi_dependency_getters": 9,
+    "zero_external_reference_getters": 0
+  },
+  "retired_backtest_state": {
+    "get_backtest_engine_tokens_under_services": 0,
+    "_backtest_engine_tokens_under_services": 0
+  },
+  "root_facade_current_refs": {
+    "get_integrated_services": 1,
+    "get_risk_calculator": 1,
+    "get_market_data_service": 18,
+    "get_risk_monitoring": 1,
+    "get_risk_alerts": 1,
+    "get_risk_settings": 2,
+    "get_risk_dashboard": 2
+  },
+  "dependency_provider_current_refs": {
+    "get_market_data_service_v2_dependency": 17,
+    "get_market_data_service_dependency": 15,
+    "get_indicator_registry_dependency": 4,
+    "get_tdx_service_dependency": 8,
+    "get_announcement_service_dependency": 14,
+    "get_email_service_dependency": 11,
+    "get_watchlist_service_dependency": 11,
+    "get_stock_search_service_dependency": 13,
+    "get_tradingview_service_dependency": 10
+  },
+  "high_risk_holds": {
+    "get_tdx_service": {
+      "risk": "CRITICAL",
+      "impacted_count": 6,
+      "direct": 2,
+      "processes_affected": 5
+    },
+    "get_data_service": {
+      "risk": "CRITICAL",
+      "impacted_count": 5,
+      "direct": 3,
+      "processes_affected": 7
+    },
+    "get_strategy_service": {
+      "risk": "CRITICAL",
+      "impacted_count": 13,
+      "direct": 6,
+      "processes_affected": 0,
+      "modules_affected": 5
+    },
+    "get_streaming_service": {
+      "risk": "HIGH",
+      "impacted_count": 9,
+      "direct": 9,
+      "processes_affected": 0,
+      "modules_affected": 4
+    }
+  },
+  "decision": {
+    "direct_next_implementation_candidate": null,
+    "reason": "zero-external-reference service getter candidates are exhausted; remaining candidates are active facades, route dependency/provider seams, or HIGH/CRITICAL service getters",
+    "recommended_next_gate": "G2.143 high-risk service getter strategy decision package",
+    "implementation_allowed": false
+  },
+  "boundary": {
+    "no_source_or_test_edits": true,
+    "no_getter_deletion": true,
+    "no_route_api_openapi_frontend_pm2_or_openspec_changes": true,
+    "no_issue_label_changes": true
+  }
+}

--- a/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-backtest-2026-05-26.md
+++ b/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-backtest-2026-05-26.md
@@ -1,0 +1,115 @@
+# Backend Service Lifecycle Candidate Refresh After BacktestEngine
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Date: 2026-05-26
+
+Current HEAD: `32d0cfb1e02d1207301e632b44a94e74efdddf69`
+
+Parent closeout: G2.141 / PR `#294`
+
+Boundary note: this is a governance-only candidate refresh. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or other service lifecycle candidates. It does not authorize implementation.
+
+## Purpose
+
+Refresh the remaining service lifecycle DI candidate pool after the BacktestEngine singleton/getter retirement lane closed.
+
+## Scan Snapshot
+
+| Metric | Value |
+|---|---:|
+| Service Python files | 152 |
+| Backend app Python files | 575 |
+| Backend API Python files | 219 |
+| Backend test Python files | 206 |
+| `def get_*` definitions under `web/backend/app/services` | 53 |
+| Root facade getters in `web/backend/app/services/__init__.py` | 7 |
+| FastAPI dependency/provider getters | 9 |
+| Zero-external-reference getter definitions | 0 |
+
+BacktestEngine retired state:
+
+| Token | Count under `web/backend/app/services` |
+|---|---:|
+| `get_backtest_engine` | 0 |
+| `_backtest_engine` | 0 |
+
+## Current Interpretation
+
+The prior low-risk queue is exhausted. There is no remaining `def get_*` service getter with zero external references.
+
+Remaining service lifecycle surfaces now fall into three categories:
+
+- Active root/composition compatibility facades.
+- Active FastAPI dependency/provider seams.
+- HIGH/CRITICAL service getters that need design decomposition before any implementation.
+
+## Held High-Risk Getters
+
+| Getter | Risk | Impacted | Direct | Processes | Disposition |
+|---|---:|---:|---:|---:|---|
+| `get_tdx_service` | CRITICAL | 6 | 2 | 5 | Hold for design package |
+| `get_data_service` | CRITICAL | 5 | 3 | 7 | Hold for design package |
+| `get_strategy_service` | CRITICAL | 13 | 6 | 0 | Hold for design package |
+| `get_streaming_service` | HIGH | 9 | 9 | 0 | Hold for design package |
+
+Root facade current references:
+
+| Facade | Reference count |
+|---|---:|
+| `get_integrated_services` | 1 |
+| `get_risk_calculator` | 1 |
+| `get_market_data_service` | 18 |
+| `get_risk_monitoring` | 1 |
+| `get_risk_alerts` | 1 |
+| `get_risk_settings` | 2 |
+| `get_risk_dashboard` | 2 |
+
+FastAPI dependency/provider current references:
+
+| Provider | Reference count |
+|---|---:|
+| `get_market_data_service_v2_dependency` | 17 |
+| `get_market_data_service_dependency` | 15 |
+| `get_indicator_registry_dependency` | 4 |
+| `get_tdx_service_dependency` | 8 |
+| `get_announcement_service_dependency` | 14 |
+| `get_email_service_dependency` | 11 |
+| `get_watchlist_service_dependency` | 11 |
+| `get_stock_search_service_dependency` | 13 |
+| `get_tradingview_service_dependency` | 10 |
+
+## Decision
+
+No direct implementation candidate is selected by this refresh.
+
+The next step should be a design decision package for the remaining high-risk service getter cluster. That package should decide whether to split work by:
+
+- Dashboard/TDX runtime seam.
+- Indicator/data service seam.
+- Strategy service adapter seam.
+- Realtime streaming/socket seam.
+- Root facade compatibility seam.
+- Route dependency/provider governance seam.
+
+## Next Gate
+
+Recommended next lane:
+
+G2.143 high-risk service getter strategy decision package.
+
+Expected mode:
+
+- Decision-only.
+- No backend source/test edit.
+- No getter deletion.
+- No route/API or OpenAPI change.
+
+## Non-Goals
+
+- No source or test edit.
+- No implementation authorization.
+- No selection of a concrete source implementation lane.
+- No route/API, OpenAPI, frontend, PM2, OpenSpec, or issue-label change.

--- a/governance/mainline/task-cards/pr-295.yaml
+++ b/governance/mainline/task-cards/pr-295.yaml
@@ -1,0 +1,103 @@
+version: "v0.2"
+
+task:
+  id: "pr-295"
+  title: "Refresh service lifecycle candidates after BacktestEngine"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-service-lifecycle-candidate-refresh-after-backtest"
+  objective: "refresh the remaining service lifecycle DI candidate pool after BacktestEngine closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-candidate-refresh"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-lifecycle-candidate-refresh-after-backtest"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Candidate-refresh-only packet; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-candidate-refresh-after-backtest-2026-05-26.json"
+    - "docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-backtest-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-295.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "current-head-inventory"
+      command: "scripted def get_* inventory and current reference counts under web/backend/app/services"
+      required: true
+    - id: "high-risk-impacts"
+      command: "GitNexus impact for get_tdx_service, get_data_service, get_strategy_service, and get_streaming_service"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-backtest-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-candidate-refresh-after-backtest-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-295.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests."
+  - "Do not delete, rename, or alter any getter in this lane."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+  - "Do not select a concrete source implementation lane without a separate design decision package."
+
+risk_and_rollback:
+  risks:
+    - "If this refresh is treated as implementation authorization, a later worker could edit a HIGH/CRITICAL service seam without design decomposition"
+    - "If active dependency providers are misclassified as unused getters, route contracts could be damaged"
+  rollback_plan: "revert this candidate-refresh PR to remove only the refresh report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh remaining service lifecycle DI candidates after BacktestEngine closeout"
+    modified_scope: "steward tree, candidate-refresh report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; candidate refresh records scanner and GitNexus evidence only"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON/YAML parsing, GitNexus staged scope, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T13:58:00+08:00"
+    approval_note: "Candidate-refresh-only lane after accepted G2.141 closeout"
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary
- refresh service lifecycle candidate pool after G2.141 / PR #294 closeout
- confirm BacktestEngine retired tokens remain zero
- record that zero-external-reference getter candidates are exhausted and no direct implementation lane is selected

## Verification
- current scan: service files=152, app files=575, API files=219, tests=206
- service getter definitions=53, root facade getters=7, dependency/provider getters=9, zero-external-reference getters=0
- BacktestEngine retired tokens under services: get_backtest_engine=0, _backtest_engine=0
- GitNexus impacts: get_tdx_service CRITICAL impacted=6, get_data_service CRITICAL impacted=5, get_strategy_service CRITICAL impacted=13, get_streaming_service HIGH impacted=9
- python -m json.tool .planning/codebase/generated/service-lifecycle-candidate-refresh-after-backtest-2026-05-26.json
- markdown governance: 2 checked, 0 errors
- git diff --check over intended paths: passed
- GitNexus staged detect_changes: low risk, 4 changed files, 0 affected symbols/processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: repository indexed successfully