### PR TITLE
G2.144 Authorize realtime streaming socket lane

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2460,9 +2460,31 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, route/API, OpenAPI exposure, frontend,
 │   │                PM2, OpenSpec, implementation authorization, or
 │   │                issue-label change is made here
-│   └── Next gate: review G2.143; if accepted, prepare a single-track
-│                  Realtime streaming/socket authorization package before any
-│                  source implementation lane
+│   ├── G2.144 Realtime streaming/socket authorization package
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-realtime-streaming-socket-authorization-package-2026-05-26.md`
+│   │   ├── Parent: G2.143 accepted and merged by PR `#296`
+│   │   ├── Current HEAD: `4b361b6c73972ad3b3d9b02bc0488946c5271882`
+│   │   ├── Result: defines the smallest first implementation candidate for
+│   │   │          the realtime streaming/socket track as Socket.IO manager
+│   │   │          consumer-injection only, with no getter deletion
+│   │   ├── Verification: GitNexus impact for `get_streaming_service` remains
+│   │   │          HIGH with impacted=`9`, direct=`9`, processes=`0`;
+│   │   │          source shape scan finds `socketio_manager.py` has `9`
+│   │   │          `get_streaming_service` tokens, while
+│   │   │          `aggregation_streaming_bridge.py` already accepts optional
+│   │   │          `streaming_service` and is not in the first source lane
+│   │   ├── Authorization if approved: G2.145 may edit only
+│   │   │          `web/backend/app/core/socketio_manager.py` plus focused
+│   │   │          socket manager tests and governance artifacts to replace
+│   │   │          repeated direct getter use with a manager-level injected
+│   │   │          streaming dependency
+│   │   └── Boundary: authorization-only; no backend source/test edit,
+│   │                getter deletion, route/API, OpenAPI exposure, frontend,
+│   │                PM2, OpenSpec, implementation, or issue-label change is
+│   │                made here
+│   └── Next gate: review G2.144; if accepted, start G2.145 as a narrow
+│                  Socket.IO manager consumer-injection implementation lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/realtime-streaming-socket-authorization-2026-05-26.json
+++ b/.planning/codebase/generated/realtime-streaming-socket-authorization-2026-05-26.json
@@ -1,0 +1,134 @@
+{
+  "schema_version": "1.0",
+  "artifact": "realtime-streaming-socket-authorization",
+  "created_at": "2026-05-26T14:15:00+08:00",
+  "current_head": "4b361b6c73972ad3b3d9b02bc0488946c5271882",
+  "parent_decision": {
+    "task": "G2.143 High-risk service getter strategy decision package",
+    "pull_request": 296,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T06:11:43Z",
+    "merge_commit": "4b361b6c73972ad3b3d9b02bc0488946c5271882",
+    "evidence": "docs/reports/quality/backend-high-risk-service-getter-strategy-decision-2026-05-26.md"
+  },
+  "scope": {
+    "workline": "G2.144 realtime streaming/socket authorization package",
+    "mode": "authorization-package-only",
+    "source_edits_in_this_package": false,
+    "test_edits_in_this_package": false,
+    "route_api_openapi_change_allowed": false,
+    "frontend_pm2_openspec_issue_label_change_allowed": false
+  },
+  "target_seam": {
+    "track_id": "realtime-streaming-socket",
+    "primary_getter": "get_streaming_service",
+    "service_file": "web/backend/app/services/realtime_streaming_service.py",
+    "service_class": "RealtimeStreamingService",
+    "risk": "HIGH",
+    "gitnexus_impact": {
+      "impacted": 9,
+      "direct": 9,
+      "processes": 0,
+      "modules": [
+        "Services",
+        "Cluster_1822",
+        "Models",
+        "Get_"
+      ]
+    },
+    "direct_callers": [
+      "web/backend/app/services/aggregation_streaming_bridge.py::__init__",
+      "web/backend/app/core/socketio_manager.py::get_stats",
+      "web/backend/app/core/socketio_manager.py::on_connect",
+      "web/backend/app/core/socketio_manager.py::on_disconnect",
+      "web/backend/app/core/socketio_manager.py::on_subscribe_market_stream",
+      "web/backend/app/core/socketio_manager.py::on_unsubscribe_market_stream",
+      "web/backend/app/core/socketio_manager.py::on_stream_filter_update",
+      "web/backend/app/core/socketio_manager.py::emit_stream_data",
+      "web/backend/app/core/socketio_manager.py::get_streaming_stats"
+    ]
+  },
+  "source_shape": {
+    "realtime_streaming_service.py": {
+      "lines": 436,
+      "contains": [
+        "RealtimeStreamingService",
+        "get_streaming_service",
+        "reset_streaming_service"
+      ],
+      "authorization_status": "do-not-edit-in-first-implementation-lane"
+    },
+    "aggregation_streaming_bridge.py": {
+      "lines": 207,
+      "get_streaming_service_tokens": 2,
+      "shape": "constructor already accepts optional streaming_service and falls back to get_streaming_service",
+      "authorization_status": "observe-only-for-first-implementation-lane"
+    },
+    "socketio_manager.py": {
+      "lines": 688,
+      "get_streaming_service_tokens": 9,
+      "shape": "Socket.IO event handlers call get_streaming_service directly",
+      "authorization_status": "candidate first source lane"
+    }
+  },
+  "authorization_decision": {
+    "this_package_authorizes_source_edits": false,
+    "if_this_package_is_approved": {
+      "next_task": "G2.145 realtime socket manager consumer-injection implementation",
+      "source_lane_may_start": true,
+      "authorized_goal": "Convert MySocketIOManager streaming consumers from repeated direct get_streaming_service calls to an explicit manager-level streaming_service dependency while preserving runtime behavior and the legacy service getter.",
+      "not_authorized_goal": "Do not remove get_streaming_service, _streaming_service, reset_streaming_service, RealtimeStreamingService, aggregation bridge fallback behavior, route/API contracts, OpenAPI exposure, frontend behavior, or PM2 workflows in the first implementation lane."
+    }
+  },
+  "g2_145_allowed_paths_if_approved": {
+    "source": [
+      "web/backend/app/core/socketio_manager.py"
+    ],
+    "tests": [
+      "web/backend/tests/test_socketio_manager.py",
+      "web/backend/tests/test_socketio_streaming_integration.py",
+      "web/backend/tests/test_realtime_socket_manager_streaming_dependency.py"
+    ],
+    "governance": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/realtime-socket-manager-consumer-injection-implementation-2026-05-26.json",
+      "docs/reports/quality/backend-realtime-socket-manager-consumer-injection-implementation-2026-05-26.md",
+      "governance/mainline/task-cards/pr-298.yaml"
+    ]
+  },
+  "g2_145_forbidden_paths_if_approved": [
+    "web/backend/app/services/realtime_streaming_service.py",
+    "web/backend/app/services/aggregation_streaming_bridge.py",
+    "web/backend/app/api/**",
+    "web/backend/app/schemas/**",
+    "web/frontend/**",
+    "src/**",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**"
+  ],
+  "g2_145_required_tdd_and_verification_if_approved": [
+    "Read architecture/STANDARDS.md before edits.",
+    "Run fresh GitNexus impact for get_streaming_service and MySocketIOManager before edits.",
+    "Write a failing focused test proving MySocketIOManager can use an injected streaming service without direct per-handler getter lookup.",
+    "Make the minimal socketio_manager.py change to satisfy the test.",
+    "Keep RealtimeStreamingService and get_streaming_service import compatibility intact.",
+    "Run focused socket manager and streaming tests.",
+    "Run ruff/black checks for touched backend files.",
+    "Run a scripted token scan proving socketio_manager.py no longer has handler-level get_streaming_service calls.",
+    "Run staged GitNexus detect_changes before commit.",
+    "Run mainline scope gate and gitnexus analyze after commit."
+  ],
+  "blocked_actions": [
+    "Do not edit source or tests in G2.144.",
+    "Do not delete get_streaming_service or reset_streaming_service in the first downstream implementation lane.",
+    "Do not edit aggregation_streaming_bridge.py in the first downstream implementation lane.",
+    "Do not change route/API, OpenAPI, frontend, PM2, OpenSpec, or issue-label state.",
+    "Do not touch Dashboard/TDX, Indicator/Data, Strategy adapter, root facade, or route dependency/provider tracks from this lane."
+  ],
+  "rollback_model": {
+    "g2_144": "revert only this authorization package if review rejects the lane split",
+    "future_g2_145": "revert one socketio_manager-focused implementation PR; runtime getter compatibility must remain available"
+  }
+}

--- a/docs/reports/quality/backend-realtime-streaming-socket-authorization-package-2026-05-26.md
+++ b/docs/reports/quality/backend-realtime-streaming-socket-authorization-package-2026-05-26.md
@@ -1,0 +1,174 @@
+# Backend Realtime Streaming/Socket Authorization Package
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Date: 2026-05-26
+
+Workline: G2.144 realtime streaming/socket authorization package
+
+Boundary: this is an authorization package only. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations.
+
+## Purpose
+
+G2.143 split the remaining HIGH/CRITICAL service getter work into explicit tracks and selected Realtime streaming/socket as the preferred first downstream design track. This package turns that decision into a narrow authorization candidate for the next implementation lane.
+
+The goal is to avoid jumping directly from a high-risk getter inventory to source edits. This package defines the smallest acceptable first implementation slice, the files it may touch, the files it must not touch, and the verification required before any future commit.
+
+## Parent State
+
+| Evidence | Value |
+|---|---|
+| Parent task | G2.143 High-risk service getter strategy decision package |
+| Parent PR | #296 |
+| Parent state | merged |
+| Parent merge commit | `4b361b6c73972ad3b3d9b02bc0488946c5271882` |
+| Parent evidence | `docs/reports/quality/backend-high-risk-service-getter-strategy-decision-2026-05-26.md` |
+| Current HEAD checked for this package | `4b361b6c73972ad3b3d9b02bc0488946c5271882` |
+
+## Target Seam
+
+Primary getter: `get_streaming_service`
+
+Service file: `web/backend/app/services/realtime_streaming_service.py`
+
+Service class: `RealtimeStreamingService`
+
+GitNexus impact:
+
+| Metric | Value |
+|---|---:|
+| Risk | HIGH |
+| Impacted symbols | 9 |
+| Direct callers | 9 |
+| Affected processes | 0 |
+| Affected modules | 4 |
+
+Direct callers:
+
+- `web/backend/app/services/aggregation_streaming_bridge.py::__init__`
+- `web/backend/app/core/socketio_manager.py::get_stats`
+- `web/backend/app/core/socketio_manager.py::on_connect`
+- `web/backend/app/core/socketio_manager.py::on_disconnect`
+- `web/backend/app/core/socketio_manager.py::on_subscribe_market_stream`
+- `web/backend/app/core/socketio_manager.py::on_unsubscribe_market_stream`
+- `web/backend/app/core/socketio_manager.py::on_stream_filter_update`
+- `web/backend/app/core/socketio_manager.py::emit_stream_data`
+- `web/backend/app/core/socketio_manager.py::get_streaming_stats`
+
+## Source Shape
+
+| File | Observed shape | G2.145 authorization status |
+|---|---|---|
+| `web/backend/app/services/realtime_streaming_service.py` | 436 lines; owns `RealtimeStreamingService`, `get_streaming_service`, and `reset_streaming_service` | Do not edit in first implementation lane |
+| `web/backend/app/services/aggregation_streaming_bridge.py` | 207 lines; constructor already accepts optional `streaming_service` and falls back to `get_streaming_service` | Observe only in first implementation lane |
+| `web/backend/app/core/socketio_manager.py` | 688 lines; Socket.IO handlers call `get_streaming_service` directly | Candidate first implementation lane |
+
+## Authorization Decision
+
+This G2.144 package itself does not authorize source edits.
+
+If this package is reviewed and approved, the next source lane may be:
+
+G2.145 realtime socket manager consumer-injection implementation.
+
+Authorized goal for G2.145:
+
+Convert `MySocketIOManager` streaming consumers from repeated direct `get_streaming_service` calls to an explicit manager-level `streaming_service` dependency while preserving runtime behavior and the legacy service getter.
+
+This is intentionally not a getter deletion lane. The first implementation should reduce direct consumer coupling inside `socketio_manager.py`, not retire the service singleton.
+
+## G2.145 Allowed Paths If Approved
+
+Source:
+
+- `web/backend/app/core/socketio_manager.py`
+
+Tests:
+
+- `web/backend/tests/test_socketio_manager.py`
+- `web/backend/tests/test_socketio_streaming_integration.py`
+- `web/backend/tests/test_realtime_socket_manager_streaming_dependency.py`
+
+Governance:
+
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/realtime-socket-manager-consumer-injection-implementation-2026-05-26.json`
+- `docs/reports/quality/backend-realtime-socket-manager-consumer-injection-implementation-2026-05-26.md`
+- `governance/mainline/task-cards/pr-298.yaml`
+
+## G2.145 Forbidden Paths If Approved
+
+- `web/backend/app/services/realtime_streaming_service.py`
+- `web/backend/app/services/aggregation_streaming_bridge.py`
+- `web/backend/app/api/**`
+- `web/backend/app/schemas/**`
+- `web/frontend/**`
+- `src/**`
+- `config/**`
+- `scripts/**`
+- `openspec/changes/**`
+- `openspec/specs/**`
+
+## Required G2.145 TDD And Verification If Approved
+
+Before source edits:
+
+- Read `architecture/STANDARDS.md`.
+- Run fresh GitNexus impact for `get_streaming_service`.
+- Run fresh GitNexus context or impact for `MySocketIOManager`.
+- Record current `get_streaming_service` token count in `socketio_manager.py`.
+
+TDD:
+
+- Write a focused failing test proving `MySocketIOManager` can use an injected streaming service without direct per-handler getter lookup.
+- Keep the failing red result in the implementation report.
+- Make the minimal `socketio_manager.py` change to satisfy the test.
+- Keep `RealtimeStreamingService`, `get_streaming_service`, and `reset_streaming_service` import compatibility intact.
+
+Verification:
+
+- Run the focused new test.
+- Run relevant existing socket manager and streaming integration tests when import-safe.
+- Run Ruff and Black checks for touched backend files.
+- Run a scripted token scan proving `socketio_manager.py` no longer has handler-level `get_streaming_service` calls.
+- Run staged GitNexus `detect_changes` before commit.
+- Run the mainline scope gate after commit.
+- Run `gitnexus analyze --with-gitignore` after commit.
+
+## Explicit Non-Authorization
+
+G2.144 does not authorize:
+
+- Editing source or tests in this PR.
+- Deleting `get_streaming_service`, `_streaming_service`, or `reset_streaming_service`.
+- Editing `web/backend/app/services/realtime_streaming_service.py`.
+- Editing `web/backend/app/services/aggregation_streaming_bridge.py`.
+- Changing route/API, OpenAPI, frontend, PM2, OpenSpec, or issue-label state.
+- Touching Dashboard/TDX, Indicator/Data, Strategy adapter, root facade, or route dependency/provider tracks.
+
+## Rollback Model
+
+If G2.144 is rejected, revert only this authorization package.
+
+If a future G2.145 implementation is rejected, revert one socket-manager-focused implementation PR. Runtime getter compatibility must remain available after that rollback.
+
+## Verification
+
+Fresh checks performed for this package:
+
+- PR #296 verified merged at `4b361b6c73972ad3b3d9b02bc0488946c5271882`.
+- Current worktree HEAD: `4b361b6c73972ad3b3d9b02bc0488946c5271882`.
+- GitNexus context found `get_streaming_service` in `web/backend/app/services/realtime_streaming_service.py`.
+- GitNexus context found `RealtimeStreamingService` in `web/backend/app/services/realtime_streaming_service.py`.
+- GitNexus impact for `get_streaming_service`: HIGH, impacted 9, direct 9, processes 0.
+- Source shape scan found `socketio_manager.py` has 9 `get_streaming_service` tokens and is the only authorized first implementation source file.
+
+## Next Gate
+
+Review G2.144.
+
+If approved, start G2.145 as a single-file `socketio_manager.py` consumer-injection implementation lane with focused tests and fresh GitNexus impact. Do not delete the realtime service getter in G2.145.

--- a/governance/mainline/task-cards/pr-297.yaml
+++ b/governance/mainline/task-cards/pr-297.yaml
@@ -1,0 +1,107 @@
+version: "v0.2"
+
+task:
+  id: "pr-297"
+  title: "Authorize realtime streaming/socket consumer-injection lane"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-realtime-streaming-socket-authorization"
+  objective: "authorize a narrow socket manager consumer-injection implementation lane after the high-risk service getter strategy split"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-authorization"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-realtime-streaming-socket-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/realtime-streaming-socket-authorization-2026-05-26.json"
+    - "docs/reports/quality/backend-realtime-streaming-socket-authorization-package-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-297.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 296 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "streaming-impact"
+      command: "GitNexus impact for get_streaming_service"
+      required: true
+    - id: "source-shape"
+      command: "scripted source shape scan for realtime_streaming_service.py, aggregation_streaming_bridge.py, and socketio_manager.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-realtime-streaming-socket-authorization-package-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/realtime-streaming-socket-authorization-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-297.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this authorization package."
+  - "Do not delete, rename, or alter get_streaming_service, reset_streaming_service, or RealtimeStreamingService in this package."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+  - "Do not authorize aggregation_streaming_bridge.py or realtime_streaming_service.py edits in the first downstream implementation lane."
+  - "Do not touch Dashboard/TDX, Indicator/Data, Strategy adapter, root facade, or route dependency/provider tracks from this lane."
+
+risk_and_rollback:
+  risks:
+    - "If this authorization is read too broadly, a later worker could delete the realtime service getter instead of first reducing Socket.IO consumer coupling"
+    - "If socket lifecycle tests are skipped in G2.145, subscription and unsubscribe behavior could regress without route/OpenAPI symptoms"
+  rollback_plan: "revert this authorization PR to remove only the authorization report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize a narrow future socket manager consumer-injection lane"
+    modified_scope: "steward tree, authorization report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source edits remain blocked until G2.144 review approval"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON/YAML parsing, GitNexus staged scope, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T14:15:00+08:00"
+    approval_note: "User approved merging G2.143 and starting G2.144 as realtime streaming/socket authorization only"
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary
- record PR #296 as merged and start G2.144 realtime streaming/socket authorization package
- authorize only a future G2.145 socketio_manager.py consumer-injection lane if this package is approved
- explicitly do not authorize source edits, getter deletion, aggregation bridge edits, route/API/OpenAPI/frontend/PM2/OpenSpec changes in this PR

## Verification
- PR #296 verified merged at 4b361b6c73972ad3b3d9b02bc0488946c5271882
- GitNexus context/impact for get_streaming_service refreshed: HIGH, impacted 9, direct 9, processes 0
- JSON/YAML parse passed
- markdown governance gate passed with 0 errors
- git diff --check passed
- GitNexus staged scope check: low risk, 0 changed symbols, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore completed