### PR TITLE
G2.145 Inject Socket.IO streaming service dependency

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2439,9 +2439,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, implementation authorization, or
 │   │                issue-label change is made here
 │   ├── G2.143 High-risk service getter strategy decision package
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#296`
 │   │   ├── Evidence: `backend-high-risk-service-getter-strategy-decision-2026-05-26.md`
 │   │   ├── Current HEAD: `c11dfb858200aaed46beee50c15e022c86408b54`
+│   │   ├── Merge commit: `4b361b6c73972ad3b3d9b02bc0488946c5271882`
 │   │   ├── Result: splits the exhausted low-risk service getter queue into
 │   │   │          six explicit tracks: Dashboard/TDX, Indicator/Data,
 │   │   │          Strategy adapter, Realtime streaming/socket, root facade
@@ -2461,10 +2462,11 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                PM2, OpenSpec, implementation authorization, or
 │   │                issue-label change is made here
 │   ├── G2.144 Realtime streaming/socket authorization package
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#297`
 │   │   ├── Evidence: `backend-realtime-streaming-socket-authorization-package-2026-05-26.md`
 │   │   ├── Parent: G2.143 accepted and merged by PR `#296`
 │   │   ├── Current HEAD: `4b361b6c73972ad3b3d9b02bc0488946c5271882`
+│   │   ├── Merge commit: `3c27963c86bc095f7f28129d5b47d9257367a31f`
 │   │   ├── Result: defines the smallest first implementation candidate for
 │   │   │          the realtime streaming/socket track as Socket.IO manager
 │   │   │          consumer-injection only, with no getter deletion
@@ -2483,8 +2485,34 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, route/API, OpenAPI exposure, frontend,
 │   │                PM2, OpenSpec, implementation, or issue-label change is
 │   │                made here
-│   └── Next gate: review G2.144; if accepted, start G2.145 as a narrow
-│                  Socket.IO manager consumer-injection implementation lane
+│   ├── G2.145 Realtime socket manager consumer-injection implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-realtime-socket-manager-consumer-injection-implementation-2026-05-26.md`
+│   │   ├── Parent: G2.144 accepted and merged by PR `#297`
+│   │   ├── Current HEAD: `3c27963c86bc095f7f28129d5b47d9257367a31f`
+│   │   ├── Result: adds a manager-level `streaming_service` dependency to
+│   │   │          `MySocketIOManager`; Socket.IO namespace and manager
+│   │   │          streaming consumers use that injected dependency instead of
+│   │   │          repeated direct handler-level `get_streaming_service` calls
+│   │   ├── Verification: pre-edit GitNexus impact records
+│   │   │          `get_streaming_service` HIGH impacted=`9`, direct=`9`,
+│   │   │          processes=`0`, and `MySocketIOManager` LOW impacted=`0`;
+│   │   │          TDD red `2 failed`, focused green `2 passed`; Ruff and
+│   │   │          Black passed; token scan reports `get_streaming_service`
+│   │   │          total refs=`2` and handler-level refs=`0`
+│   │   ├── Baseline blockers: existing `test_socketio_manager.py` and
+│   │   │          `test_socketio_streaming_integration.py` still import
+│   │   │          absent `get_socketio_manager` / `reset_socketio_manager`;
+│   │   │          `test_realtime_streaming_service.py` has a pre-existing
+│   │   │          naive/aware datetime assertion failure outside this lane
+│   │   └── Boundary: source-capable but limited to `socketio_manager.py`,
+│   │                one focused test, report, generated artifact, task card,
+│   │                and steward-tree update; no getter deletion,
+│   │                `realtime_streaming_service.py` edit,
+│   │                `aggregation_streaming_bridge.py` edit, route/API,
+│   │                OpenAPI, frontend, PM2, OpenSpec, or issue-label change
+│   │                is made here
+│   └── Next gate: review G2.145; if accepted, perform closeout-only G2.146
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/realtime-socket-manager-consumer-injection-implementation-2026-05-26.json
+++ b/.planning/codebase/generated/realtime-socket-manager-consumer-injection-implementation-2026-05-26.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": "1.0",
+  "artifact": "realtime-socket-manager-consumer-injection-implementation",
+  "created_at": "2026-05-26T15:05:00+08:00",
+  "current_head": "3c27963c86bc095f7f28129d5b47d9257367a31f",
+  "parent_authorization": {
+    "task": "G2.144 Realtime streaming/socket authorization package",
+    "pull_request": 297,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T06:49:59Z",
+    "merge_commit": "3c27963c86bc095f7f28129d5b47d9257367a31f",
+    "evidence": "docs/reports/quality/backend-realtime-streaming-socket-authorization-package-2026-05-26.md"
+  },
+  "scope": {
+    "workline": "G2.145 realtime socket manager consumer-injection implementation",
+    "mode": "approved-source-implementation",
+    "source_files_modified": [
+      "web/backend/app/core/socketio_manager.py"
+    ],
+    "test_files_added": [
+      "web/backend/tests/test_realtime_socket_manager_streaming_dependency.py"
+    ],
+    "governance_files_modified": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/realtime-socket-manager-consumer-injection-implementation-2026-05-26.json",
+      "docs/reports/quality/backend-realtime-socket-manager-consumer-injection-implementation-2026-05-26.md",
+      "governance/mainline/task-cards/pr-298.yaml"
+    ],
+    "forbidden_paths_touched": false,
+    "route_api_openapi_change": false,
+    "frontend_pm2_openspec_issue_label_change": false
+  },
+  "pre_edit_gates": {
+    "standards_read": "architecture/STANDARDS.md",
+    "gitnexus": {
+      "get_streaming_service": {
+        "risk": "HIGH",
+        "impacted": 9,
+        "direct": 9,
+        "processes": 0
+      },
+      "MySocketIOManager": {
+        "risk": "LOW",
+        "impacted": 0,
+        "direct": 0,
+        "processes": 0
+      }
+    }
+  },
+  "implementation": {
+    "summary": "MySocketIOManager now accepts an optional streaming_service dependency, stores it as manager-level state, and Socket.IO namespace/manager streaming consumers use that injected dependency instead of direct handler-level get_streaming_service calls.",
+    "preserved": [
+      "RealtimeStreamingService",
+      "get_streaming_service",
+      "reset_streaming_service",
+      "realtime_streaming_service.py",
+      "aggregation_streaming_bridge.py",
+      "route/API behavior",
+      "OpenAPI exposure",
+      "frontend behavior",
+      "PM2 workflows",
+      "OpenSpec state",
+      "issue labels"
+    ],
+    "token_scan_after": {
+      "socketio_manager_get_streaming_service_total_refs": 2,
+      "socketio_manager_handler_level_get_streaming_service_refs": 0,
+      "remaining_refs": [
+        {
+          "line": 38,
+          "text": "get_streaming_service,"
+        },
+        {
+          "line": 583,
+          "text": "self.streaming_service = streaming_service or get_streaming_service()"
+        }
+      ]
+    }
+  },
+  "tdd": {
+    "red": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short",
+      "result": "2 failed",
+      "failure": "MySocketIOManager.__init__() got an unexpected keyword argument 'streaming_service'"
+    },
+    "green": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short",
+      "result": "2 passed in 0.83s"
+    }
+  },
+  "verification": {
+    "passed": [
+      {
+        "name": "focused new test",
+        "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short",
+        "result": "2 passed in 0.83s"
+      },
+      {
+        "name": "ruff touched files",
+        "command": "ruff check web/backend/app/core/socketio_manager.py web/backend/tests/test_realtime_socket_manager_streaming_dependency.py",
+        "result": "All checks passed"
+      },
+      {
+        "name": "black check touched files",
+        "command": "black --check web/backend/app/core/socketio_manager.py web/backend/tests/test_realtime_socket_manager_streaming_dependency.py",
+        "result": "2 files would be left unchanged"
+      },
+      {
+        "name": "token scan",
+        "command": "scripted socketio_manager.py get_streaming_service token scan",
+        "result": "total refs 2, handler-level refs 0"
+      }
+    ],
+    "blocked_or_baseline": [
+      {
+        "name": "existing socketio manager tests",
+        "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_manager.py -q --no-cov --tb=short",
+        "result": "collection error: cannot import get_socketio_manager",
+        "baseline_evidence": "parent and current socketio_manager.py both contain zero get_socketio_manager tokens"
+      },
+      {
+        "name": "existing socketio streaming integration tests",
+        "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py -q --no-cov --tb=short",
+        "result": "collection error: cannot import reset_socketio_manager",
+        "baseline_evidence": "parent and current socketio_manager.py both contain zero reset_socketio_manager tokens"
+      },
+      {
+        "name": "existing realtime streaming service tests",
+        "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py -q --no-cov --tb=short",
+        "result": "42 passed, 1 failed",
+        "baseline_evidence": "failure is naive/aware datetime comparison in test_realtime_streaming_service.py; realtime_streaming_service.py was not edited in G2.145"
+      }
+    ]
+  },
+  "next_gate": {
+    "task": "G2.146 realtime socket manager consumer-injection closeout",
+    "mode": "closeout-only",
+    "source_allowed": false
+  }
+}

--- a/docs/reports/quality/backend-realtime-socket-manager-consumer-injection-implementation-2026-05-26.md
+++ b/docs/reports/quality/backend-realtime-socket-manager-consumer-injection-implementation-2026-05-26.md
@@ -1,0 +1,146 @@
+# Backend Realtime Socket Manager Consumer-Injection Implementation
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Date: 2026-05-26
+
+Workline: G2.145 realtime socket manager consumer-injection implementation
+
+Boundary: this is the narrow source lane authorized by G2.144. It edits only `web/backend/app/core/socketio_manager.py`, adds one focused test file, and updates governance artifacts. It does not delete `get_streaming_service`, does not edit `realtime_streaming_service.py`, does not edit `aggregation_streaming_bridge.py`, and does not change route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, or GitHub issue labels.
+
+## Purpose
+
+G2.144 authorized the first implementation slice for the realtime streaming/socket track: reduce direct Socket.IO consumer coupling to `get_streaming_service` without retiring the realtime streaming service getter.
+
+This implementation gives `MySocketIOManager` a manager-level streaming service dependency and routes namespace/manager streaming operations through that dependency.
+
+## Parent Authorization
+
+| Evidence | Value |
+|---|---|
+| Parent task | G2.144 Realtime streaming/socket authorization package |
+| Parent PR | #297 |
+| Parent state | merged |
+| Parent merge commit | `3c27963c86bc095f7f28129d5b47d9257367a31f` |
+| Parent evidence | `docs/reports/quality/backend-realtime-streaming-socket-authorization-package-2026-05-26.md` |
+| Current HEAD before implementation | `3c27963c86bc095f7f28129d5b47d9257367a31f` |
+
+## Pre-Edit Gates
+
+`architecture/STANDARDS.md` was read before source edits.
+
+GitNexus impact before edits:
+
+| Symbol | Risk | Impacted | Direct | Processes |
+|---|---:|---:|---:|---:|
+| `get_streaming_service` | HIGH | 9 | 9 | 0 |
+| `MySocketIOManager` | LOW | 0 | 0 | 0 |
+
+The HIGH risk was accepted only because G2.144 explicitly authorized the first Socket.IO manager consumer-injection slice. The implementation stayed inside that authorized slice.
+
+## Implementation
+
+Modified source:
+
+- `web/backend/app/core/socketio_manager.py`
+
+Added focused test:
+
+- `web/backend/tests/test_realtime_socket_manager_streaming_dependency.py`
+
+Behavioral change:
+
+- `MySocketIOManager` now accepts an optional `streaming_service` dependency.
+- If no dependency is provided, it still falls back to `get_streaming_service()`.
+- Socket.IO namespace streaming event handlers use `self.sio.streaming_service`.
+- Socket.IO manager streaming stats and stream data emission use `self.streaming_service`.
+
+Preserved behavior and compatibility:
+
+- `RealtimeStreamingService` remains unchanged.
+- `get_streaming_service` remains unchanged.
+- `reset_streaming_service` remains unchanged.
+- `web/backend/app/services/realtime_streaming_service.py` was not edited.
+- `web/backend/app/services/aggregation_streaming_bridge.py` was not edited.
+- No route/API, OpenAPI, frontend, PM2, OpenSpec, or issue-label state changed.
+
+## TDD Evidence
+
+Red:
+
+Command:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short
+```
+
+Result:
+
+- `2 failed`
+- Failure reason: `MySocketIOManager.__init__() got an unexpected keyword argument 'streaming_service'`
+
+Green:
+
+Command:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short
+```
+
+Result:
+
+- `2 passed in 0.83s`
+
+## Token Scan
+
+After implementation, `socketio_manager.py` contains only two `get_streaming_service` references:
+
+| Line | Reference |
+|---:|---|
+| 38 | import |
+| 583 | constructor fallback |
+
+Handler-level `get_streaming_service` references: 0.
+
+This satisfies the G2.144 target: remove repeated direct handler-level getter lookup while keeping compatibility fallback intact.
+
+## Verification
+
+Passed:
+
+| Check | Result |
+|---|---|
+| Focused new test | `2 passed in 0.83s` |
+| Ruff touched files | `All checks passed` |
+| Black check touched files | `2 files would be left unchanged` |
+| Token scan | total refs 2, handler-level refs 0 |
+
+Blocked or baseline failures observed:
+
+| Check | Result | Interpretation |
+|---|---|---|
+| `web/backend/tests/test_socketio_manager.py` | collection error: cannot import `get_socketio_manager` | Baseline mismatch. Parent and current `socketio_manager.py` both contain zero `get_socketio_manager` tokens. |
+| `web/backend/tests/test_socketio_streaming_integration.py` | collection error: cannot import `reset_socketio_manager` | Baseline mismatch. Parent and current `socketio_manager.py` both contain zero `reset_socketio_manager` tokens. |
+| `web/backend/tests/test_realtime_streaming_service.py` | `42 passed, 1 failed` | Baseline datetime issue: naive/aware datetime comparison in `test_subscriber_update_activity`; realtime service source was not edited in G2.145. |
+
+These baseline failures were not fixed here because G2.144 explicitly forbids expanding this lane into realtime service getter deletion, aggregation bridge edits, or unrelated Socket.IO export restoration.
+
+## Rollback
+
+Revert the G2.145 PR to restore prior `socketio_manager.py` direct getter usage and remove the focused test and governance artifacts.
+
+Because `get_streaming_service`, `reset_streaming_service`, and `RealtimeStreamingService` were preserved, rollback does not require route/API, OpenAPI, frontend, PM2, or OpenSpec changes.
+
+## Next Gate
+
+G2.146 should be closeout-only:
+
+- Verify the G2.145 PR merge state.
+- Re-run the focused test.
+- Re-run the token scan.
+- Record the persistent baseline test blockers separately from this implementation lane.
+- Do not delete `get_streaming_service`.

--- a/governance/mainline/task-cards/pr-298.yaml
+++ b/governance/mainline/task-cards/pr-298.yaml
@@ -1,0 +1,121 @@
+version: "v0.2"
+
+task:
+  id: "pr-298"
+  title: "Inject streaming dependency into Socket.IO manager"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-realtime-socket-manager-consumer-injection"
+  objective: "replace direct Socket.IO handler-level get_streaming_service lookup with a manager-level streaming service dependency"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-implementation"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-realtime-socket-manager-consumer-injection"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow authorized implementation; no public runtime entrypoint, route, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/core/socketio_manager.py"
+    - "web/backend/tests/test_realtime_socket_manager_streaming_dependency.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/realtime-socket-manager-consumer-injection-implementation-2026-05-26.json"
+    - "docs/reports/quality/backend-realtime-socket-manager-consumer-injection-implementation-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-298.yaml"
+  forbidden_paths:
+    - "web/backend/app/services/realtime_streaming_service.py"
+    - "web/backend/app/services/aggregation_streaming_bridge.py"
+    - "web/backend/app/api/**"
+    - "web/backend/app/schemas/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "pre-edit-impact"
+      command: "GitNexus impact for get_streaming_service and MySocketIOManager before edits"
+      required: true
+    - id: "tdd-red"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short"
+      required: true
+    - id: "tdd-green"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short"
+      required: true
+    - id: "token-scan"
+      command: "scripted socketio_manager.py get_streaming_service token scan"
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/core/socketio_manager.py web/backend/tests/test_realtime_socket_manager_streaming_dependency.py"
+      required: true
+    - id: "black-check"
+      command: "black --check web/backend/app/core/socketio_manager.py web/backend/tests/test_realtime_socket_manager_streaming_dependency.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-realtime-socket-manager-consumer-injection-implementation-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/realtime-socket-manager-consumer-injection-implementation-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-298.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit realtime_streaming_service.py."
+  - "Do not edit aggregation_streaming_bridge.py."
+  - "Do not delete get_streaming_service, reset_streaming_service, or RealtimeStreamingService."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+  - "Do not restore unrelated get_socketio_manager/reset_socketio_manager exports in this lane."
+  - "Do not fix unrelated realtime streaming service datetime test debt in this lane."
+
+risk_and_rollback:
+  risks:
+    - "Socket.IO streaming subscription behavior could regress if manager-level dependency wiring misses namespace paths"
+    - "Baseline Socket.IO tests remain partially non-import-safe because get_socketio_manager/reset_socketio_manager exports are absent in the parent state"
+  rollback_plan: "revert this implementation PR to restore prior socketio_manager.py direct getter usage and remove the focused test and governance artifacts"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "inject a manager-level streaming dependency into the Socket.IO manager"
+    modified_scope: "one backend core file, one focused backend test, steward tree, generated artifact, report, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "legacy realtime streaming service getter remains available as the default constructor fallback"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused TDD, token scan, lint/format, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-26T15:05:00+08:00"
+    approval_note: "G2.144 authorization package merged by PR #297; user requested continue into G2.145"
+    secondary_approved: false
+

--- a/web/backend/app/core/socketio_manager.py
+++ b/web/backend/app/core/socketio_manager.py
@@ -34,6 +34,7 @@ from app.models.websocket_message import (
     create_response_message,
 )
 from app.services.realtime_streaming_service import (
+    RealtimeStreamingService,
     get_streaming_service,
 )
 
@@ -208,7 +209,7 @@ class MySocketIONamespace(AsyncNamespace):
         reconnection_manager.mark_reconnected(sid)
 
         # Initialize streaming state for this connection
-        get_streaming_service()
+        self.sio.streaming_service
         # Note: Streaming subscriptions are explicitly managed via on_subscribe_market_stream
         logger.info(
             "🎬 Streaming support initialized for connection",
@@ -227,10 +228,9 @@ class MySocketIONamespace(AsyncNamespace):
         reconnection_manager.mark_disconnected(sid)
 
         # Clean up streaming subscriptions for this connection
-        streaming_service = get_streaming_service()
-        active_symbols = streaming_service.get_active_symbols()
+        active_symbols = self.sio.streaming_service.get_active_symbols()
         for symbol in active_symbols:
-            streaming_service.unsubscribe(sid, symbol)
+            self.sio.streaming_service.unsubscribe(sid, symbol)
 
         logger.info(
             "🎬 Streaming subscriptions cleaned up on disconnect",
@@ -392,11 +392,10 @@ class MySocketIONamespace(AsyncNamespace):
                 fields = None
 
             # Subscribe to streaming service
-            streaming_service = get_streaming_service()
             connection = self.sio.connection_manager.get_connection(sid)
             user_id = connection.get("user_id") if connection else None
 
-            success = streaming_service.subscribe(sid, symbol, user_id, fields)
+            success = self.sio.streaming_service.subscribe(sid, symbol, user_id, fields)
 
             if success:
                 logger.info(
@@ -454,8 +453,7 @@ class MySocketIONamespace(AsyncNamespace):
                 return
 
             # Unsubscribe from streaming service
-            streaming_service = get_streaming_service()
-            success = streaming_service.unsubscribe(sid, symbol)
+            success = self.sio.streaming_service.unsubscribe(sid, symbol)
 
             if success:
                 logger.info("✅ Market stream unsubscription", sid=sid, symbol=symbol)
@@ -510,8 +508,7 @@ class MySocketIONamespace(AsyncNamespace):
                 return
 
             # Get streaming service and update subscriber fields
-            streaming_service = get_streaming_service()
-            stream = streaming_service.get_stream(symbol)
+            stream = self.sio.streaming_service.get_stream(symbol)
 
             if not stream:
                 await self.emit(
@@ -568,7 +565,11 @@ class MySocketIONamespace(AsyncNamespace):
 class MySocketIOManager:
     """MyStocks Socket.IO服务器管理器"""
 
-    def __init__(self, async_mode: str = "asgi"):
+    def __init__(
+        self,
+        async_mode: str = "asgi",
+        streaming_service: Optional[RealtimeStreamingService] = None,
+    ):
         """初始化Socket.IO管理器"""
         self.sio = AsyncServer(
             async_mode=async_mode,
@@ -579,6 +580,7 @@ class MySocketIOManager:
 
         self.connection_manager = ConnectionManager()
         self.request_handlers: Dict[str, Callable] = {}
+        self.streaming_service = streaming_service or get_streaming_service()
 
         # 注册命名空间
         self.sio.register_namespace(MySocketIONamespace("/", self))
@@ -636,8 +638,7 @@ class MySocketIOManager:
         stats["reconnection"] = reconnection_stats
 
         # 添加流服务统计
-        streaming_service = get_streaming_service()
-        streaming_stats = streaming_service.get_stats()
+        streaming_stats = self.streaming_service.get_stats()
         stats["streaming"] = streaming_stats
 
         return stats
@@ -649,8 +650,7 @@ class MySocketIOManager:
     ) -> None:
         """Emit market data to stream subscribers (room-based broadcast)"""
         try:
-            streaming_service = get_streaming_service()
-            stream = streaming_service.get_stream(symbol)
+            stream = self.streaming_service.get_stream(symbol)
 
             if not stream:
                 logger.warning(
@@ -672,7 +672,7 @@ class MySocketIOManager:
             )
 
             # Also record the broadcast in the stream
-            streaming_service.broadcast_data(symbol, data)
+            self.streaming_service.broadcast_data(symbol, data)
 
         except Exception as e:
             logger.error(
@@ -683,5 +683,4 @@ class MySocketIOManager:
 
     def get_streaming_stats(self) -> Dict[str, Any]:
         """Get real-time streaming service statistics"""
-        streaming_service = get_streaming_service()
-        return streaming_service.get_stats()
+        return self.streaming_service.get_stats()

--- a/web/backend/tests/test_realtime_socket_manager_streaming_dependency.py
+++ b/web/backend/tests/test_realtime_socket_manager_streaming_dependency.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core import socketio_manager
+from app.core.socketio_manager import MySocketIOManager, MySocketIONamespace
+
+
+class FakeStreamingService:
+    def __init__(self) -> None:
+        self.stats_calls = 0
+        self.stream_lookups: list[str] = []
+        self.broadcasts: list[tuple[str, dict]] = []
+        self.subscriptions: list[tuple[str, str, str | None, set[str] | None]] = []
+        self.unsubscriptions: list[tuple[str, str]] = []
+
+    def get_stats(self) -> dict:
+        self.stats_calls += 1
+        return {"source": "fake-streaming-service"}
+
+    def get_stream(self, symbol: str) -> object:
+        self.stream_lookups.append(symbol)
+        return object()
+
+    def broadcast_data(self, symbol: str, data: dict) -> None:
+        self.broadcasts.append((symbol, data))
+
+    def subscribe(
+        self,
+        sid: str,
+        symbol: str,
+        user_id: str | None = None,
+        fields: set[str] | None = None,
+    ) -> bool:
+        self.subscriptions.append((sid, symbol, user_id, fields))
+        return True
+
+    def unsubscribe(self, sid: str, symbol: str) -> bool:
+        self.unsubscriptions.append((sid, symbol))
+        return True
+
+
+def _reject_global_streaming_getter():
+    raise AssertionError("Socket.IO manager should use its injected streaming service")
+
+
+@pytest.mark.asyncio
+async def test_manager_uses_injected_streaming_service(monkeypatch):
+    fake = FakeStreamingService()
+    monkeypatch.setattr(socketio_manager, "get_streaming_service", _reject_global_streaming_getter)
+
+    manager = MySocketIOManager(streaming_service=fake)
+    manager.sio.emit = AsyncMock()
+
+    assert manager.get_streaming_stats() == {"source": "fake-streaming-service"}
+
+    await manager.emit_stream_data("600000", {"price": 12.34})
+
+    assert fake.stats_calls == 1
+    assert fake.stream_lookups == ["600000"]
+    assert fake.broadcasts == [("600000", {"price": 12.34})]
+    manager.sio.emit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_namespace_stream_events_use_manager_injected_streaming_service(monkeypatch):
+    fake = FakeStreamingService()
+    monkeypatch.setattr(socketio_manager, "get_streaming_service", _reject_global_streaming_getter)
+
+    manager = MySocketIOManager(streaming_service=fake)
+    manager.connection_manager.add_connection("sid-1", user_id="user-1")
+    namespace = MySocketIONamespace("/", manager)
+    namespace.emit = AsyncMock()
+
+    await namespace.on_subscribe_market_stream(
+        "sid-1",
+        {
+            "symbol": "600000",
+            "fields": ["price", "volume"],
+        },
+    )
+    await namespace.on_unsubscribe_market_stream("sid-1", {"symbol": "600000"})
+
+    assert fake.subscriptions == [("sid-1", "600000", "user-1", {"price", "volume"})]
+    assert fake.unsubscriptions == [("sid-1", "600000")]
+    assert namespace.emit.await_count == 2


### PR DESCRIPTION
## Summary
- merge G2.144 authorization and implement the narrow G2.145 Socket.IO manager consumer-injection lane
- add optional streaming_service dependency to MySocketIOManager and route namespace/manager streaming consumers through it
- preserve get_streaming_service/reset_streaming_service and do not touch realtime_streaming_service.py or aggregation_streaming_bridge.py

## Verification
- pre-edit GitNexus impact: get_streaming_service HIGH impacted 9/direct 9/processes 0; MySocketIOManager LOW impacted 0
- TDD red: new focused test failed with unexpected keyword argument streaming_service
- TDD green: web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -> 2 passed
- ruff touched files: passed
- black --check touched files: passed
- token scan: socketio_manager.py get_streaming_service refs total 2, handler-level 0
- markdown governance: 0 errors
- JSON/YAML parse passed
- GitNexus staged scope: low risk, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore completed

## Baseline blockers observed
- web/backend/tests/test_socketio_manager.py collection still imports absent get_socketio_manager; parent/current socketio_manager.py both contain 0 get_socketio_manager tokens
- web/backend/tests/test_socketio_streaming_integration.py collection still imports absent reset_socketio_manager; parent/current socketio_manager.py both contain 0 reset_socketio_manager tokens
- web/backend/tests/test_realtime_streaming_service.py: 42 passed, 1 failed on pre-existing naive/aware datetime assertion; realtime_streaming_service.py was not edited