### PR TITLE
G2.146 Close realtime socket injection lane

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2486,10 +2486,11 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                PM2, OpenSpec, implementation, or issue-label change is
 │   │                made here
 │   ├── G2.145 Realtime socket manager consumer-injection implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#298`
 │   │   ├── Evidence: `backend-realtime-socket-manager-consumer-injection-implementation-2026-05-26.md`
 │   │   ├── Parent: G2.144 accepted and merged by PR `#297`
 │   │   ├── Current HEAD: `3c27963c86bc095f7f28129d5b47d9257367a31f`
+│   │   ├── Merge commit: `fd04b30d6ff597209be0e923dd62d2cf1b38ee82`
 │   │   ├── Result: adds a manager-level `streaming_service` dependency to
 │   │   │          `MySocketIOManager`; Socket.IO namespace and manager
 │   │   │          streaming consumers use that injected dependency instead of
@@ -2512,7 +2513,31 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                `aggregation_streaming_bridge.py` edit, route/API,
 │   │                OpenAPI, frontend, PM2, OpenSpec, or issue-label change
 │   │                is made here
-│   └── Next gate: review G2.145; if accepted, perform closeout-only G2.146
+│   ├── G2.146 Realtime socket manager consumer-injection closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-realtime-socket-manager-consumer-injection-closeout-2026-05-26.md`
+│   │   ├── Parent: G2.145 accepted and merged by PR `#298`
+│   │   ├── Current HEAD: `fd04b30d6ff597209be0e923dd62d2cf1b38ee82`
+│   │   ├── Result: verifies the merged Socket.IO manager consumer-injection
+│   │   │          lane and closes it without opening another source edit
+│   │   ├── Verification: PR `#298` is merged; focused
+│   │   │          `test_realtime_socket_manager_streaming_dependency.py`
+│   │   │          reports `2 passed`; token scan reports
+│   │   │          `get_streaming_service` total refs=`2` and
+│   │   │          handler-level refs=`0`
+│   │   ├── Baseline blockers confirmed: `test_socketio_manager.py` still
+│   │   │          imports absent `get_socketio_manager`,
+│   │   │          `test_socketio_streaming_integration.py` still imports
+│   │   │          absent `reset_socketio_manager`, and
+│   │   │          `test_realtime_streaming_service.py` still has a
+│   │   │          naive/aware datetime comparison failure
+│   │   └── Boundary: closeout-only; no backend source/test edit,
+│   │                getter deletion, route/API, OpenAPI exposure, frontend,
+│   │                PM2, OpenSpec, issue-label change, or new
+│   │                implementation authorization is made here
+│   └── Next gate: route the baseline Socket.IO export and realtime datetime
+│                  blockers through a separate decision package, or pause the
+│                  realtime/socket track as closed
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/realtime-socket-manager-consumer-injection-closeout-2026-05-26.json
+++ b/.planning/codebase/generated/realtime-socket-manager-consumer-injection-closeout-2026-05-26.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "1.0",
+  "artifact": "realtime-socket-manager-consumer-injection-closeout",
+  "created_at": "2026-05-26T15:21:25+08:00",
+  "current_head": "fd04b30d6ff597209be0e923dd62d2cf1b38ee82",
+  "parent_implementation": {
+    "task": "G2.145 Realtime socket manager consumer-injection implementation",
+    "pull_request": 298,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T07:17:17Z",
+    "merge_commit": "fd04b30d6ff597209be0e923dd62d2cf1b38ee82",
+    "evidence": "docs/reports/quality/backend-realtime-socket-manager-consumer-injection-implementation-2026-05-26.md"
+  },
+  "scope": {
+    "workline": "G2.146 realtime socket manager consumer-injection closeout",
+    "mode": "closeout-only",
+    "source_edits_allowed": false,
+    "test_edits_allowed": false,
+    "route_api_openapi_change_allowed": false,
+    "frontend_pm2_openspec_issue_label_change_allowed": false
+  },
+  "closeout_result": {
+    "implementation_accepted_for_closeout": true,
+    "socketio_manager_streaming_dependency_confirmed": true,
+    "getter_retirement_done": false,
+    "getter_retirement_authorized_next": false,
+    "next_source_lane_selected": false
+  },
+  "verification": {
+    "pr_state": {
+      "number": 298,
+      "state": "MERGED",
+      "merged_at": "2026-05-26T07:17:17Z",
+      "merge_commit": "fd04b30d6ff597209be0e923dd62d2cf1b38ee82"
+    },
+    "focused_test": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short",
+      "result": "2 passed in 0.84s"
+    },
+    "token_scan": {
+      "socketio_manager_get_streaming_service_total_refs": 2,
+      "socketio_manager_handler_level_get_streaming_service_refs": 0,
+      "remaining_refs": [
+        {
+          "line": 38,
+          "text": "get_streaming_service,"
+        },
+        {
+          "line": 583,
+          "text": "self.streaming_service = streaming_service or get_streaming_service()"
+        }
+      ]
+    },
+    "baseline_blockers_confirmed": [
+      {
+        "check": "web/backend/tests/test_socketio_manager.py --collect-only",
+        "result": "collection error: cannot import get_socketio_manager",
+        "scope": "baseline blocker; not changed in G2.146"
+      },
+      {
+        "check": "web/backend/tests/test_socketio_streaming_integration.py --collect-only",
+        "result": "collection error: cannot import reset_socketio_manager",
+        "scope": "baseline blocker; not changed in G2.146"
+      },
+      {
+        "check": "web/backend/tests/test_realtime_streaming_service.py",
+        "result": "42 passed, 1 failed: TypeError comparing offset-naive and offset-aware datetimes",
+        "scope": "baseline blocker; realtime_streaming_service.py not edited in G2.145/G2.146"
+      }
+    ]
+  },
+  "decision": {
+    "g2_145_lane_closed": true,
+    "do_not_continue_source_work_from_closeout": true,
+    "recommended_next_gate": "baseline blocker routing decision",
+    "recommended_next_gate_reason": "The Socket.IO consumer-injection lane is closed; remaining failures are pre-existing export/test contract and datetime-test debt, not the G2.145 implementation scope."
+  },
+  "blocked_actions": [
+    "Do not delete get_streaming_service from this closeout.",
+    "Do not edit socketio_manager.py in G2.146.",
+    "Do not restore get_socketio_manager/reset_socketio_manager exports from this closeout without a separate decision package.",
+    "Do not fix realtime_streaming_service datetime tests from this closeout without a separate decision package.",
+    "Do not change route/API, OpenAPI, frontend, PM2, OpenSpec, or issue-label state."
+  ]
+}

--- a/docs/reports/quality/backend-realtime-socket-manager-consumer-injection-closeout-2026-05-26.md
+++ b/docs/reports/quality/backend-realtime-socket-manager-consumer-injection-closeout-2026-05-26.md
@@ -1,0 +1,113 @@
+# Backend Realtime Socket Manager Consumer-Injection Closeout
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Date: 2026-05-26
+
+Workline: G2.146 realtime socket manager consumer-injection closeout
+
+Boundary: this is a closeout-only package. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations.
+
+## Purpose
+
+G2.145 implemented the first realtime streaming/socket source lane by injecting a manager-level streaming service dependency into `MySocketIOManager`. This closeout verifies the merge state and post-merge behavior without opening any new source work.
+
+## Parent Implementation
+
+| Evidence | Value |
+|---|---|
+| Parent task | G2.145 Realtime socket manager consumer-injection implementation |
+| Parent PR | #298 |
+| Parent state | merged |
+| Parent merge commit | `fd04b30d6ff597209be0e923dd62d2cf1b38ee82` |
+| Parent evidence | `docs/reports/quality/backend-realtime-socket-manager-consumer-injection-implementation-2026-05-26.md` |
+| Current HEAD checked for closeout | `fd04b30d6ff597209be0e923dd62d2cf1b38ee82` |
+
+## Closeout Result
+
+G2.145 is accepted for closeout.
+
+Confirmed:
+
+- PR #298 is merged.
+- The focused G2.145 test still passes after merge.
+- `socketio_manager.py` has no handler-level `get_streaming_service` calls.
+- The realtime service getter remains present as constructor fallback.
+- No new source implementation is authorized from this closeout.
+
+Not done and not authorized here:
+
+- `get_streaming_service` retirement.
+- `reset_streaming_service` retirement.
+- `realtime_streaming_service.py` edits.
+- `aggregation_streaming_bridge.py` edits.
+- Socket.IO legacy export restoration.
+- Realtime streaming datetime test fix.
+
+## Verification
+
+PR state:
+
+| Check | Result |
+|---|---|
+| PR #298 | `MERGED` |
+| Merged at | `2026-05-26T07:17:17Z` |
+| Merge commit | `fd04b30d6ff597209be0e923dd62d2cf1b38ee82` |
+
+Focused test:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short
+```
+
+Result:
+
+- `2 passed in 0.84s`
+
+Token scan:
+
+| Metric | Value |
+|---|---:|
+| `socketio_manager.py` total `get_streaming_service` refs | 2 |
+| Handler-level `get_streaming_service` refs | 0 |
+
+Remaining refs:
+
+- line 38: import
+- line 583: constructor fallback
+
+## Baseline Blockers
+
+The same non-G2.145 blockers remain and should be routed separately.
+
+| Check | Current result | Closeout interpretation |
+|---|---|---|
+| `web/backend/tests/test_socketio_manager.py --collect-only` | collection error: cannot import `get_socketio_manager` | Baseline test/export mismatch; not introduced by G2.145 closeout |
+| `web/backend/tests/test_socketio_streaming_integration.py --collect-only` | collection error: cannot import `reset_socketio_manager` | Baseline test/export mismatch; not introduced by G2.145 closeout |
+| `web/backend/tests/test_realtime_streaming_service.py` | `42 passed, 1 failed`; naive/aware datetime comparison | Baseline realtime service test debt; realtime service source was not edited in G2.145/G2.146 |
+
+These should not block G2.145 closeout, but they should block using the broader Socket.IO/realtime test suite as a clean regression gate until a separate decision package assigns ownership.
+
+## Decision
+
+Close the G2.145 implementation lane.
+
+Do not continue directly into another source edit from G2.146.
+
+Recommended next gate:
+
+- Baseline blocker routing decision package for Socket.IO legacy export expectations and realtime streaming datetime test debt.
+
+## Rollback
+
+If this closeout is rejected, revert only this closeout package. The implementation rollback path remains the G2.145 PR revert, which restores prior direct getter usage and removes the focused dependency-injection test.
+
+## Next Gate
+
+Review G2.146.
+
+If accepted, either pause this realtime/socket track as closed or create a separate decision package for the baseline test blockers. Do not delete `get_streaming_service` from this closeout.

--- a/governance/mainline/task-cards/pr-299.yaml
+++ b/governance/mainline/task-cards/pr-299.yaml
@@ -1,0 +1,110 @@
+version: "v0.2"
+
+task:
+  id: "pr-299"
+  title: "Close out realtime socket manager consumer-injection lane"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-realtime-socket-manager-consumer-injection-closeout"
+  objective: "verify and close the G2.145 Socket.IO manager streaming dependency implementation after merge"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-closeout"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-realtime-socket-manager-consumer-injection-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/realtime-socket-manager-consumer-injection-closeout-2026-05-26.json"
+    - "docs/reports/quality/backend-realtime-socket-manager-consumer-injection-closeout-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-299.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 298 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "focused-test"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short"
+      required: true
+    - id: "token-scan"
+      command: "scripted socketio_manager.py get_streaming_service token scan"
+      required: true
+    - id: "baseline-blockers"
+      command: "collect-only checks for socketio legacy export tests and realtime streaming service test check"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-realtime-socket-manager-consumer-injection-closeout-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/realtime-socket-manager-consumer-injection-closeout-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-299.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this closeout."
+  - "Do not delete get_streaming_service, reset_streaming_service, or RealtimeStreamingService."
+  - "Do not restore get_socketio_manager/reset_socketio_manager exports in this closeout."
+  - "Do not fix realtime streaming service datetime test debt in this closeout."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is treated as source authorization, baseline Socket.IO export debt could be mixed into the completed G2.145 lane"
+    - "If baseline blockers are ignored, broader Socket.IO/realtime suites may be mistaken for clean regression gates"
+  rollback_plan: "revert this closeout PR to remove only the closeout report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out the G2.145 Socket.IO manager streaming dependency implementation"
+    modified_scope: "steward tree, closeout report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source edits remain unchanged from merged PR #298"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T15:21:25+08:00"
+    approval_note: "Closeout-only lane after accepted G2.145 implementation merge"
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary
- record PR #298 as merged and close the G2.145 Socket.IO manager consumer-injection implementation lane
- verify focused test and token scan after merge
- preserve source code untouched in this closeout and route remaining Socket.IO/realtime blockers as separate baseline decisions

## Verification
- PR #298 verified merged at fd04b30d6ff597209be0e923dd62d2cf1b38ee82
- focused test: web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -> 2 passed
- token scan: socketio_manager.py get_streaming_service refs total 2, handler-level 0
- baseline blockers confirmed: absent get_socketio_manager/reset_socketio_manager exports and realtime streaming naive/aware datetime test failure
- JSON/YAML parse passed
- markdown governance gate passed with 0 errors
- git diff --check passed
- GitNexus staged scope: low risk, 0 changed symbols, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore completed