### PR TITLE
G2.147 Route realtime socket baseline blockers

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2514,10 +2514,11 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI, frontend, PM2, OpenSpec, or issue-label change
 │   │                is made here
 │   ├── G2.146 Realtime socket manager consumer-injection closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#299`
 │   │   ├── Evidence: `backend-realtime-socket-manager-consumer-injection-closeout-2026-05-26.md`
 │   │   ├── Parent: G2.145 accepted and merged by PR `#298`
 │   │   ├── Current HEAD: `fd04b30d6ff597209be0e923dd62d2cf1b38ee82`
+│   │   ├── Merge commit: `e42f4b11524da98cbf22f45807459f8984c9ebed`
 │   │   ├── Result: verifies the merged Socket.IO manager consumer-injection
 │   │   │          lane and closes it without opening another source edit
 │   │   ├── Verification: PR `#298` is merged; focused
@@ -2535,9 +2536,30 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                getter deletion, route/API, OpenAPI exposure, frontend,
 │   │                PM2, OpenSpec, issue-label change, or new
 │   │                implementation authorization is made here
-│   └── Next gate: route the baseline Socket.IO export and realtime datetime
-│                  blockers through a separate decision package, or pause the
-│                  realtime/socket track as closed
+│   ├── G2.147 Realtime socket baseline blocker routing decision
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-realtime-socket-baseline-blocker-routing-decision-2026-05-26.md`
+│   │   ├── Parent: G2.146 accepted and merged by PR `#299`
+│   │   ├── Current HEAD: `e42f4b11524da98cbf22f45807459f8984c9ebed`
+│   │   ├── Result: routes remaining realtime/socket blockers into two
+│   │   │          independent future decision tracks instead of reopening
+│   │   │          G2.145 or expanding G2.146 closeout
+│   │   ├── Verification: focused
+│   │   │          `test_realtime_socket_manager_streaming_dependency.py`
+│   │   │          still reports `2 passed`; source scan finds
+│   │   │          `socketio_manager.py` has `0` `get_socketio_manager` and
+│   │   │          `0` `reset_socketio_manager` tokens, while legacy tests
+│   │   │          still reference those names; realtime streaming service
+│   │   │          test still reports `42 passed, 1 failed`
+│   │   ├── Decision: split next work into G2.148 Socket.IO legacy export
+│   │   │          contract authorization and G2.149 realtime datetime test
+│   │   │          debt authorization; no source/test edit is authorized here
+│   │   └── Boundary: decision-only; no backend source/test edit, getter
+│   │                deletion, route/API, OpenAPI exposure, frontend, PM2,
+│   │                OpenSpec, issue-label change, or implementation
+│   │                authorization is made here
+│   └── Next gate: review G2.147; if accepted, prepare G2.148 Socket.IO
+│                  legacy export contract authorization package
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/realtime-socket-baseline-blocker-routing-decision-2026-05-26.json
+++ b/.planning/codebase/generated/realtime-socket-baseline-blocker-routing-decision-2026-05-26.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": "1.0",
+  "artifact": "realtime-socket-baseline-blocker-routing-decision",
+  "created_at": "2026-05-26T17:05:22+08:00",
+  "current_head": "e42f4b11524da98cbf22f45807459f8984c9ebed",
+  "parent_closeout": {
+    "task": "G2.146 Realtime socket manager consumer-injection closeout",
+    "pull_request": 299,
+    "state": "MERGED",
+    "merged_at": "2026-05-26T09:01:34Z",
+    "merge_commit": "e42f4b11524da98cbf22f45807459f8984c9ebed",
+    "evidence": "docs/reports/quality/backend-realtime-socket-manager-consumer-injection-closeout-2026-05-26.md"
+  },
+  "scope": {
+    "workline": "G2.147 realtime socket baseline blocker routing decision",
+    "mode": "decision-only",
+    "source_edits_allowed": false,
+    "test_edits_allowed": false,
+    "route_api_openapi_change_allowed": false,
+    "frontend_pm2_openspec_issue_label_change_allowed": false
+  },
+  "current_evidence": {
+    "focused_g2_145_test": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short",
+      "result": "2 passed in 0.83s"
+    },
+    "socketio_export_gap": {
+      "source_file": "web/backend/app/core/socketio_manager.py",
+      "source_export_tokens": {
+        "get_socketio_manager": 0,
+        "reset_socketio_manager": 0
+      },
+      "test_import_tokens": {
+        "web/backend/tests/test_socketio_manager.py": {
+          "get_socketio_manager": 8,
+          "reset_socketio_manager": 5
+        },
+        "web/backend/tests/test_socketio_streaming_integration.py": {
+          "get_socketio_manager": 0,
+          "reset_socketio_manager": 18
+        }
+      },
+      "collect_only_results": [
+        "test_socketio_manager.py cannot import get_socketio_manager",
+        "test_socketio_streaming_integration.py cannot import reset_socketio_manager"
+      ]
+    },
+    "realtime_datetime_test_debt": {
+      "test_file": "web/backend/tests/test_realtime_streaming_service.py",
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py -q --no-cov --tb=short",
+      "result": "42 passed, 1 failed",
+      "failure": "TypeError comparing offset-naive and offset-aware datetimes",
+      "relevant_lines": [
+        {
+          "line": 46,
+          "text": "old_time = subscriber.subscribed_at"
+        },
+        {
+          "line": 50,
+          "text": "assert subscriber.subscribed_at >= old_time"
+        }
+      ]
+    }
+  },
+  "routing_decision": {
+    "g2_145_track_status": "closed",
+    "do_not_reopen_g2_145": true,
+    "do_not_delete_get_streaming_service": true,
+    "tracks": [
+      {
+        "track_id": "socketio-legacy-export-contract",
+        "name": "Socket.IO legacy export contract alignment",
+        "classification": "test/source contract alignment decision",
+        "problem": "Existing Socket.IO tests import get_socketio_manager/reset_socketio_manager, but socketio_manager.py exposes neither token at current HEAD.",
+        "candidate_next_gate": "G2.148 Socket.IO legacy export contract authorization package",
+        "source_allowed_from_g2_147": false,
+        "decision_options_for_next_gate": [
+          "restore thin get_socketio_manager/reset_socketio_manager compatibility exports and keep tests",
+          "update legacy tests to instantiate MySocketIOManager directly and drop obsolete export expectations",
+          "split test-only modernization from source compatibility if both are needed"
+        ],
+        "required_evidence_before_source": [
+          "GitNexus impact for socketio_manager.py and MySocketIOManager",
+          "import consumer matrix for get_socketio_manager/reset_socketio_manager",
+          "decision on whether these symbols are public compatibility surface or obsolete test-only helpers",
+          "TDD plan and rollback for whichever option is approved"
+        ]
+      },
+      {
+        "track_id": "realtime-streaming-datetime-test-debt",
+        "name": "Realtime streaming datetime test debt",
+        "classification": "test contract debt decision",
+        "problem": "test_realtime_streaming_service.py compares subscriber timestamps across timezone awareness boundaries.",
+        "candidate_next_gate": "G2.149 Realtime streaming datetime test authorization package",
+        "source_allowed_from_g2_147": false,
+        "decision_options_for_next_gate": [
+          "fix the test to compare timezone-aware timestamps consistently",
+          "adjust the source timestamp contract only if a separate source impact review proves the current contract is wrong",
+          "mark as separate test debt if broader realtime source semantics are intentionally unchanged"
+        ],
+        "required_evidence_before_source": [
+          "current RealtimeStreamingService timestamp contract review",
+          "focused failing test or current failing test capture",
+          "decision whether the fix is test-only or source+test",
+          "TDD plan and rollback for the selected scope"
+        ]
+      }
+    ]
+  },
+  "blocked_actions": [
+    "Do not edit source or tests in G2.147.",
+    "Do not restore get_socketio_manager/reset_socketio_manager exports from this decision package.",
+    "Do not change realtime streaming datetime behavior from this decision package.",
+    "Do not delete get_streaming_service/reset_streaming_service/RealtimeStreamingService.",
+    "Do not change route/API, OpenAPI, frontend, PM2, OpenSpec, or issue-label state."
+  ],
+  "recommended_next": {
+    "first": "G2.148 Socket.IO legacy export contract authorization package",
+    "second": "G2.149 Realtime streaming datetime test authorization package",
+    "reason": "Socket.IO collect-only blockers prevent using broader Socket.IO suites as regression gates; datetime debt is separate and should not be mixed with export contract alignment."
+  }
+}

--- a/docs/reports/quality/backend-realtime-socket-baseline-blocker-routing-decision-2026-05-26.md
+++ b/docs/reports/quality/backend-realtime-socket-baseline-blocker-routing-decision-2026-05-26.md
@@ -1,0 +1,162 @@
+# Backend Realtime Socket Baseline Blocker Routing Decision
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: ready for review
+
+Date: 2026-05-26
+
+Workline: G2.147 realtime socket baseline blocker routing decision
+
+Boundary: this is a decision-only routing package. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations.
+
+## Purpose
+
+G2.146 closed the G2.145 Socket.IO manager consumer-injection lane. The remaining failures are not part of that implementation. They are baseline blocker candidates that need separate ownership before broader Socket.IO/realtime suites can be used as clean regression gates.
+
+This package routes those blockers into separate decision tracks.
+
+## Parent Closeout
+
+| Evidence | Value |
+|---|---|
+| Parent task | G2.146 Realtime socket manager consumer-injection closeout |
+| Parent PR | #299 |
+| Parent state | merged |
+| Parent merge commit | `e42f4b11524da98cbf22f45807459f8984c9ebed` |
+| Parent evidence | `docs/reports/quality/backend-realtime-socket-manager-consumer-injection-closeout-2026-05-26.md` |
+| Current HEAD checked for this package | `e42f4b11524da98cbf22f45807459f8984c9ebed` |
+
+## Current Positive Gate
+
+The G2.145 focused regression test remains green:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short
+```
+
+Result:
+
+- `2 passed in 0.83s`
+
+This confirms the consumer-injection lane remains intact after PR #299.
+
+## Blocker Evidence
+
+### Socket.IO Legacy Export Contract
+
+Current source scan:
+
+| Symbol | Count in `socketio_manager.py` |
+|---|---:|
+| `get_socketio_manager` | 0 |
+| `reset_socketio_manager` | 0 |
+
+Current test import scan:
+
+| Test file | `get_socketio_manager` tokens | `reset_socketio_manager` tokens |
+|---|---:|---:|
+| `web/backend/tests/test_socketio_manager.py` | 8 | 5 |
+| `web/backend/tests/test_socketio_streaming_integration.py` | 0 | 18 |
+
+Collect-only results:
+
+- `web/backend/tests/test_socketio_manager.py`: cannot import `get_socketio_manager`
+- `web/backend/tests/test_socketio_streaming_integration.py`: cannot import `reset_socketio_manager`
+
+Interpretation:
+
+The source/test contract is inconsistent. This should not be fixed inside G2.147 because doing so would require either source compatibility exports, test modernization, or both.
+
+### Realtime Streaming Datetime Test Debt
+
+Current command:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py -q --no-cov --tb=short
+```
+
+Result:
+
+- `42 passed, 1 failed`
+- Failure: `TypeError` comparing offset-naive and offset-aware datetimes
+
+Relevant test lines:
+
+| Line | Text |
+|---:|---|
+| 46 | `old_time = subscriber.subscribed_at` |
+| 50 | `assert subscriber.subscribed_at >= old_time` |
+
+Interpretation:
+
+This is a realtime streaming timestamp/test-contract issue. It should not be mixed with Socket.IO legacy export alignment or G2.145 closeout.
+
+## Routing Decision
+
+G2.145 remains closed.
+
+Do not reopen G2.145 to repair these blockers.
+
+Split the remaining work into two independent downstream decision packages:
+
+| Track | Candidate gate | Scope |
+|---|---|---|
+| Socket.IO legacy export contract alignment | G2.148 | Decide whether to restore thin compatibility exports, modernize legacy tests, or split source/test work |
+| Realtime streaming datetime test debt | G2.149 | Decide whether this is test-only timezone consistency work or requires source timestamp contract review |
+
+## G2.148 Candidate: Socket.IO Legacy Export Contract
+
+Problem:
+
+Existing tests expect `get_socketio_manager` and `reset_socketio_manager`, but current source does not expose them.
+
+Decision options for the next gate:
+
+- Restore thin `get_socketio_manager` / `reset_socketio_manager` compatibility exports and keep existing tests.
+- Update legacy tests to instantiate `MySocketIOManager` directly and drop obsolete export expectations.
+- Split test-only modernization from source compatibility if both are needed.
+
+Required evidence before any source or test edit:
+
+- GitNexus impact for `socketio_manager.py` and `MySocketIOManager`.
+- Import consumer matrix for `get_socketio_manager` / `reset_socketio_manager`.
+- Explicit decision on whether these symbols are public compatibility surface or obsolete test-only helpers.
+- TDD plan and rollback for the approved option.
+
+## G2.149 Candidate: Realtime Streaming Datetime Test Debt
+
+Problem:
+
+`test_realtime_streaming_service.py` compares timestamps across timezone awareness boundaries.
+
+Decision options for the next gate:
+
+- Fix the test to compare timezone-aware timestamps consistently.
+- Adjust the source timestamp contract only if a separate source impact review proves the current contract is wrong.
+- Mark as separate test debt if broader realtime source semantics are intentionally unchanged.
+
+Required evidence before any source or test edit:
+
+- Current `RealtimeStreamingService` timestamp contract review.
+- Focused failing test or current failing test capture.
+- Decision whether the fix is test-only or source+test.
+- TDD plan and rollback for the selected scope.
+
+## Explicit Non-Authorization
+
+G2.147 does not authorize:
+
+- Editing backend source or tests.
+- Restoring `get_socketio_manager` or `reset_socketio_manager`.
+- Changing realtime streaming timestamp behavior.
+- Deleting `get_streaming_service`, `reset_streaming_service`, or `RealtimeStreamingService`.
+- Changing route/API, OpenAPI, frontend, PM2, OpenSpec, or issue-label state.
+
+## Recommended Next Step
+
+Review G2.147.
+
+If accepted, start G2.148 as a Socket.IO legacy export contract authorization package. Treat G2.149 as a separate later lane so datetime test debt does not contaminate the Socket.IO export contract decision.

--- a/governance/mainline/task-cards/pr-300.yaml
+++ b/governance/mainline/task-cards/pr-300.yaml
@@ -1,0 +1,110 @@
+version: "v0.2"
+
+task:
+  id: "pr-300"
+  title: "Route realtime socket baseline blockers"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-realtime-socket-baseline-blocker-routing"
+  objective: "route Socket.IO legacy export and realtime datetime baseline blockers after closing the consumer-injection lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-realtime-socket-baseline-blocker-routing"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision-only routing package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/realtime-socket-baseline-blocker-routing-decision-2026-05-26.json"
+    - "docs/reports/quality/backend-realtime-socket-baseline-blocker-routing-decision-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-300.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 299 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "focused-test"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short"
+      required: true
+    - id: "blocker-evidence"
+      command: "collect-only checks for Socket.IO legacy export tests and realtime streaming service test check"
+      required: true
+    - id: "source-test-scan"
+      command: "scripted source/test token scan for get_socketio_manager/reset_socketio_manager and datetime comparison lines"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-realtime-socket-baseline-blocker-routing-decision-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/realtime-socket-baseline-blocker-routing-decision-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-300.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this routing package."
+  - "Do not restore get_socketio_manager/reset_socketio_manager exports in this routing package."
+  - "Do not fix realtime streaming datetime test debt in this routing package."
+  - "Do not delete get_streaming_service, reset_streaming_service, or RealtimeStreamingService."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this routing package is treated as implementation authorization, legacy export work and datetime test debt could be mixed into a single unsafe lane"
+    - "If Socket.IO collect-only blockers remain untracked, broader Socket.IO suites may be reported as clean when they are not import-safe"
+  rollback_plan: "revert this routing PR to remove only the routing report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "route baseline Socket.IO export and realtime datetime blockers after G2.146"
+    modified_scope: "steward tree, routing report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T17:05:22+08:00"
+    approval_note: "Decision-only baseline blocker routing after accepted G2.146 closeout merge"
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary
- record PR #299 as merged and route remaining realtime/socket baseline blockers
- split follow-up into G2.148 Socket.IO legacy export contract authorization and G2.149 realtime datetime test authorization
- keep this lane decision-only: no source/test edits, no export restoration, no datetime fix, no getter deletion

## Verification
- PR #299 verified merged at e42f4b11524da98cbf22f45807459f8984c9ebed
- focused G2.145 test remains green: web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -> 2 passed
- source/test scan confirms socketio_manager.py has 0 get_socketio_manager/reset_socketio_manager tokens while legacy tests still reference those names
- collect-only blockers confirmed for test_socketio_manager.py and test_socketio_streaming_integration.py
- realtime streaming service baseline remains 42 passed, 1 failed on naive/aware datetime comparison
- JSON/YAML parse passed
- markdown governance gate passed with 0 errors
- git diff --check passed
- GitNexus staged scope: low risk, 0 changed symbols, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore completed
