### PR TITLE
G2.148 Authorize Socket.IO legacy export contract routing

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2558,8 +2558,32 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                deletion, route/API, OpenAPI exposure, frontend, PM2,
 │   │                OpenSpec, issue-label change, or implementation
 │   │                authorization is made here
-│   └── Next gate: review G2.147; if accepted, prepare G2.148 Socket.IO
-│                  legacy export contract authorization package
+│   ├── G2.148 Socket.IO legacy export contract authorization
+│   │   ├── State: reviewable decision package
+│   │   ├── Evidence: `backend-socketio-legacy-export-contract-authorization-2026-05-26.md`
+│   │   ├── Parent: G2.147 accepted and merged by PR `#300`
+│   │   ├── Current HEAD: `3b1d67ceb52a5c3ccbbbafb534895c6a70aa6d2e`
+│   │   ├── Result: routes the legacy Socket.IO export collection blocker to
+│   │   │          a future test-only import-alignment lane instead of
+│   │   │          restoring exports from `socketio_manager.py`
+│   │   ├── Verification: focused
+│   │   │          `test_realtime_socket_manager_streaming_dependency.py`
+│   │   │          reports `2 passed`; collect-only still fails for
+│   │   │          `test_socketio_manager.py` on missing
+│   │   │          `get_socketio_manager` and for
+│   │   │          `test_socketio_streaming_integration.py` on missing
+│   │   │          `reset_socketio_manager`
+│   │   ├── Decision: canonical helper path is
+│   │   │          `app.core._socketio_manager_singleton`; runtime composition
+│   │   │          already imports from that helper, so the next lane should
+│   │   │          align stale test imports rather than widen
+│   │   │          `app.core.socketio_manager`
+│   │   └── Boundary: decision-only; no backend source/test edit, helper
+│   │                alias restoration, realtime datetime fix, route/API,
+│   │                OpenAPI exposure, frontend, PM2, OpenSpec, issue-label
+│   │                change, or implementation work is performed here
+│   └── Next gate: review G2.148; if accepted, start G2.150 Socket.IO
+│                  test import alignment as a separate test-only lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/socketio-legacy-export-contract-authorization-2026-05-26.json
+++ b/.planning/codebase/generated/socketio-legacy-export-contract-authorization-2026-05-26.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "governance-decision-v1",
+  "id": "g2-148-socketio-legacy-export-contract-authorization",
+  "title": "Socket.IO legacy export contract authorization",
+  "created_at": "2026-05-26T17:34:00+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "3b1d67ceb52a5c3ccbbbafb534895c6a70aa6d2e",
+  "parent": {
+    "id": "g2-147-realtime-socket-baseline-blocker-routing",
+    "pr": 300,
+    "state": "merged",
+    "merge_commit": "3b1d67ceb52a5c3ccbbbafb534895c6a70aa6d2e"
+  },
+  "scope": {
+    "mode": "decision-only",
+    "runtime_source_edits": false,
+    "test_edits": false,
+    "openspec_edits": false,
+    "route_api_openapi_frontend_pm2_edits": false
+  },
+  "fresh_evidence": {
+    "focused_consumer_injection_regression": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short",
+      "exit_code": 0,
+      "result": "2 passed in 1.04s"
+    },
+    "legacy_socketio_manager_collection": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_manager.py --collect-only -q --no-cov --tb=short",
+      "exit_code": 2,
+      "failure": "ImportError: cannot import name 'get_socketio_manager' from 'app.core.socketio_manager'"
+    },
+    "legacy_socketio_streaming_integration_collection": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py --collect-only -q --no-cov --tb=short",
+      "exit_code": 2,
+      "failure": "ImportError: cannot import name 'reset_socketio_manager' from 'app.core.socketio_manager'"
+    },
+    "runtime_singleton_contract": {
+      "canonical_helper_module": "web/backend/app/core/_socketio_manager_singleton.py",
+      "canonical_exports": [
+        "get_socketio_manager",
+        "reset_socketio_manager"
+      ],
+      "runtime_consumers": [
+        "web/backend/app/main.py",
+        "web/backend/app/app_factory.py"
+      ],
+      "runtime_consumer_import_path": "app.core._socketio_manager_singleton"
+    },
+    "stale_test_imports": {
+      "web/backend/tests/test_socketio_manager.py": {
+        "get_socketio_manager_tokens": 8,
+        "reset_socketio_manager_tokens": 5,
+        "current_import_path": "app.core.socketio_manager"
+      },
+      "web/backend/tests/test_socketio_streaming_integration.py": {
+        "get_socketio_manager_tokens": 0,
+        "reset_socketio_manager_tokens": 18,
+        "current_import_path": "app.core.socketio_manager"
+      }
+    }
+  },
+  "decision": {
+    "selected_path": "test-import-alignment-to-canonical-singleton-helper",
+    "rationale": [
+      "The runtime singleton helper contract already exists in app.core._socketio_manager_singleton.",
+      "Production composition roots import get_socketio_manager from the canonical helper module.",
+      "The failing tests import legacy helper names from app.core.socketio_manager, while socketio_manager.py no longer exposes those names.",
+      "Restoring public aliases in socketio_manager.py would re-expand the manager facade and weaken the getter-reduction direction from the service lifecycle workline."
+    ],
+    "authorize_next_lane": {
+      "id": "g2-150-socketio-test-import-alignment",
+      "scope": "test-only import alignment plus focused verification",
+      "allowed_paths": [
+        "web/backend/tests/test_socketio_manager.py",
+        "web/backend/tests/test_socketio_streaming_integration.py",
+        "docs/reports/quality/**",
+        ".planning/codebase/**",
+        "governance/mainline/task-cards/**"
+      ],
+      "forbidden_paths": [
+        "web/backend/app/core/socketio_manager.py",
+        "web/backend/app/core/_socketio_manager_singleton.py",
+        "web/backend/app/services/realtime_streaming_service.py",
+        "web/backend/app/core/aggregation_streaming_bridge.py",
+        "web/backend/app/api/**",
+        "web/frontend/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ]
+    }
+  },
+  "required_next_lane_gates": [
+    "Run GitNexus context or impact before editing test imports if repository policy requires it for test symbols.",
+    "Use TDD-style red evidence from the current collection failures.",
+    "Change only stale test imports to consume get_socketio_manager/reset_socketio_manager from app.core._socketio_manager_singleton.",
+    "Keep MySocketIOManager imported from app.core.socketio_manager.",
+    "Run collect-only for both legacy Socket.IO suites after the import alignment.",
+    "Run the focused G2.145 regression test after the import alignment.",
+    "If collection exposes unrelated behavioral failures, record them as separate baseline debt instead of expanding the lane.",
+    "Run ruff on touched test files.",
+    "Run staged GitNexus detect_changes before commit.",
+    "Run mainline scope gate after commit."
+  ],
+  "non_goals": [
+    "Do not restore get_socketio_manager or reset_socketio_manager exports from app.core.socketio_manager in this authorization package.",
+    "Do not edit runtime source in this authorization package.",
+    "Do not delete socket singleton helpers.",
+    "Do not fix realtime streaming datetime debt in this package.",
+    "Do not change route/API, OpenAPI, frontend, PM2, OpenSpec, issue labels, or GitHub issue state."
+  ],
+  "next_gate": "Review and merge this G2.148 authorization package before starting G2.150 test import alignment."
+}

--- a/docs/reports/quality/backend-socketio-legacy-export-contract-authorization-2026-05-26.md
+++ b/docs/reports/quality/backend-socketio-legacy-export-contract-authorization-2026-05-26.md
@@ -1,0 +1,132 @@
+# Backend Socket.IO Legacy Export Contract Authorization
+
+Date: 2026-05-26
+
+Branch: `g2-148-socketio-legacy-export-contract-authorization`
+
+Base: `wip/root-dirty-20260403` at `3b1d67ceb52a5c3ccbbbafb534895c6a70aa6d2e`
+
+Status: reviewable decision package
+
+> **历史决策说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary: this is a decision-only authorization package. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations.
+
+## Purpose
+
+G2.147 split the remaining realtime/socket baseline blockers into two tracks:
+
+- G2.148: Socket.IO legacy export contract authorization.
+- G2.149: realtime streaming datetime test authorization.
+
+This document covers only G2.148. It decides how the missing
+`get_socketio_manager` / `reset_socketio_manager` imports should be routed. It
+does not edit backend source or tests.
+
+## Fresh Evidence
+
+Focused consumer-injection regression remains clean:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short
+2 passed in 1.04s
+```
+
+The legacy Socket.IO manager suite still fails at collection:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_manager.py --collect-only -q --no-cov --tb=short
+ImportError: cannot import name 'get_socketio_manager' from 'app.core.socketio_manager'
+```
+
+The legacy Socket.IO streaming integration suite still fails at collection:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py --collect-only -q --no-cov --tb=short
+ImportError: cannot import name 'reset_socketio_manager' from 'app.core.socketio_manager'
+```
+
+## Current Contract Shape
+
+The missing helper names are not absent from the repository. They live in the
+canonical helper module:
+
+- `web/backend/app/core/_socketio_manager_singleton.py`
+  - `get_socketio_manager()`
+  - `reset_socketio_manager()`
+
+Runtime composition already consumes that canonical module:
+
+- `web/backend/app/main.py`
+- `web/backend/app/app_factory.py`
+
+The failing tests still import the helper names from
+`app.core.socketio_manager`, while runtime composition imports them from
+`app.core._socketio_manager_singleton`.
+
+## Decision
+
+Selected path: authorize a follow-up test-only import-alignment lane.
+
+Do not restore `get_socketio_manager` or `reset_socketio_manager` as exports
+from `app.core.socketio_manager` unless a later review proves they are a real
+public compatibility contract rather than stale test imports.
+
+Reasoning:
+
+- The canonical helper module already exists and is used by runtime composition
+  roots.
+- The baseline blocker is a stale test import path, not a missing runtime
+  provider.
+- Re-exporting the helpers from `socketio_manager.py` would make the manager
+  facade wider again and weaken the getter-reduction direction from the service
+  lifecycle workline.
+- A test-only import alignment is narrower and keeps the runtime contract as-is.
+
+## Authorized Next Lane
+
+Next lane: G2.150 Socket.IO test import alignment.
+
+Allowed implementation scope:
+
+- `web/backend/tests/test_socketio_manager.py`
+- `web/backend/tests/test_socketio_streaming_integration.py`
+- focused reports, generated governance artifacts, task card, and steward-tree
+  update
+
+Expected implementation shape:
+
+- Keep `MySocketIOManager` imported from `app.core.socketio_manager`.
+- Import `get_socketio_manager` and `reset_socketio_manager` from
+  `app.core._socketio_manager_singleton`.
+- Do not edit runtime source.
+- Do not restore helper aliases in `socketio_manager.py`.
+
+Required verification for G2.150:
+
+- Current red evidence from the two collect-only failures.
+- Post-change collect-only for both legacy Socket.IO suites.
+- Focused G2.145 regression test:
+  `web/backend/tests/test_realtime_socket_manager_streaming_dependency.py`.
+- Ruff check for touched test files.
+- Staged GitNexus detect_changes.
+- Mainline scope gate after commit.
+
+If either legacy suite collects successfully but exposes unrelated behavioral
+failures, G2.150 must record those as separate baseline debt instead of
+expanding the lane.
+
+## Non-Goals
+
+- No backend source edit is authorized by this package.
+- No test edit is performed by this package.
+- No realtime streaming datetime fix is included here.
+- No route/API, OpenAPI, frontend, PM2, OpenSpec, issue-label, or GitHub issue
+  state change is included here.
+- No deletion of Socket.IO singleton helpers is included here.
+
+## Next Gate
+
+Review and merge this G2.148 authorization package. After acceptance, start
+G2.150 as a separate test-only implementation lane.

--- a/governance/mainline/task-cards/pr-301.yaml
+++ b/governance/mainline/task-cards/pr-301.yaml
@@ -1,0 +1,110 @@
+version: "v0.2"
+
+task:
+  id: "pr-301"
+  title: "Authorize Socket.IO legacy export contract routing"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-socketio-legacy-export-contract-authorization"
+  objective: "decide how to route Socket.IO legacy singleton helper import blockers after G2.147"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-socketio-legacy-export-contract-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision-only authorization package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/socketio-legacy-export-contract-authorization-2026-05-26.json"
+    - "docs/reports/quality/backend-socketio-legacy-export-contract-authorization-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-301.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 300 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "focused-test"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short"
+      required: true
+    - id: "legacy-collect-only-evidence"
+      command: "collect-only checks for test_socketio_manager.py and test_socketio_streaming_integration.py"
+      required: true
+    - id: "canonical-helper-evidence"
+      command: "scripted scan of _socketio_manager_singleton.py, main.py, app_factory.py, and stale legacy test imports"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-socketio-legacy-export-contract-authorization-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/socketio-legacy-export-contract-authorization-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-301.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this authorization package."
+  - "Do not restore get_socketio_manager/reset_socketio_manager exports in app.core.socketio_manager in this authorization package."
+  - "Do not fix realtime streaming datetime test debt in this authorization package."
+  - "Do not delete Socket.IO singleton helpers."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this package is treated as implementation authorization, stale test-import alignment may be mixed with runtime source alias restoration."
+    - "If the canonical helper module is ignored, future work could widen socketio_manager.py against the getter-reduction direction."
+  rollback_plan: "revert this authorization PR to remove only the decision report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize the safe route for Socket.IO legacy singleton helper import blockers"
+    modified_scope: "steward tree, authorization report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T17:34:00+08:00"
+    approval_note: "Decision-only Socket.IO legacy export contract authorization after accepted G2.147 merge"
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary
- record PR #300 as merged and prepare G2.148 as the Socket.IO legacy export contract authorization package
- decide that the current blocker is stale test imports, not a missing runtime provider
- authorize a future G2.150 test-only import alignment lane to consume get_socketio_manager/reset_socketio_manager from app.core._socketio_manager_singleton
- keep this lane decision-only: no source/test edits, no alias restoration, no datetime fix, no route/API/OpenAPI/frontend/PM2/OpenSpec changes

## Verification
- PR #300 verified merged at 3b1d67ceb52a5c3ccbbbafb534895c6a70aa6d2e
- focused G2.145 regression remains green: web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -> 2 passed
- legacy collect-only blocker confirmed: test_socketio_manager.py cannot import get_socketio_manager from app.core.socketio_manager
- legacy collect-only blocker confirmed: test_socketio_streaming_integration.py cannot import reset_socketio_manager from app.core.socketio_manager
- canonical helper evidence: _socketio_manager_singleton.py exports get_socketio_manager/reset_socketio_manager; main.py and app_factory.py already import from that helper
- JSON/YAML parse passed
- markdown governance gate passed with 0 errors
- git diff --check passed
- GitNexus staged scope: low risk, 0 changed symbols, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore completed
