### PR TITLE
G2.150 Align Socket.IO legacy test imports

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2537,7 +2537,7 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                PM2, OpenSpec, issue-label change, or new
 │   │                implementation authorization is made here
 │   ├── G2.147 Realtime socket baseline blocker routing decision
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#300`
 │   │   ├── Evidence: `backend-realtime-socket-baseline-blocker-routing-decision-2026-05-26.md`
 │   │   ├── Parent: G2.146 accepted and merged by PR `#299`
 │   │   ├── Current HEAD: `e42f4b11524da98cbf22f45807459f8984c9ebed`
@@ -2559,7 +2559,7 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenSpec, issue-label change, or implementation
 │   │                authorization is made here
 │   ├── G2.148 Socket.IO legacy export contract authorization
-│   │   ├── State: reviewable decision package
+│   │   ├── State: accepted and merged by PR `#301`
 │   │   ├── Evidence: `backend-socketio-legacy-export-contract-authorization-2026-05-26.md`
 │   │   ├── Parent: G2.147 accepted and merged by PR `#300`
 │   │   ├── Current HEAD: `3b1d67ceb52a5c3ccbbbafb534895c6a70aa6d2e`
@@ -2582,8 +2582,35 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                alias restoration, realtime datetime fix, route/API,
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, issue-label
 │   │                change, or implementation work is performed here
-│   └── Next gate: review G2.148; if accepted, start G2.150 Socket.IO
-│                  test import alignment as a separate test-only lane
+│   ├── G2.150 Socket.IO test import alignment
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-socketio-test-import-alignment-2026-05-26.md`
+│   │   ├── Parent: G2.148 accepted and merged by PR `#301`
+│   │   ├── Current HEAD: `deb182e7f3ba7e50d0cc982c51248826e522dacd`
+│   │   ├── Result: aligns stale Socket.IO test imports to
+│   │   │          `app.core._socketio_manager_singleton` without widening
+│   │   │          `app.core.socketio_manager`
+│   │   ├── Verification: red collect-only failures reproduced for missing
+│   │   │          `get_socketio_manager` and `reset_socketio_manager`; after
+│   │   │          alignment, `test_socketio_manager.py` collects `26` tests,
+│   │   │          `test_socketio_streaming_integration.py` collects `20`
+│   │   │          tests, focused consumer-injection regression reports
+│   │   │          `2 passed`, ruff touched tests reports
+│   │   │          `All checks passed`, and `test_socketio_manager.py`
+│   │   │          reports `26 passed`
+│   │   ├── Newly exposed debt:
+│   │   │          `test_socketio_streaming_integration.py` full suite now
+│   │   │          reaches behavior assertions and reports `1 failed, 19
+│   │   │          passed` for `test_exception_during_subscription`; this is
+│   │   │          routed outside G2.150
+│   │   └── Boundary: test-only; no backend runtime source edit, helper alias
+│   │              restoration, realtime datetime fix, route/API, OpenAPI
+│   │              exposure, frontend, PM2, OpenSpec, issue-label change, or
+│   │              GitHub issue state change is performed here
+│   └── Next gate: review G2.150; if accepted, route the exposed Socket.IO
+│                  streaming error-emission behavior debt as G2.151 or
+│                  continue with the already split G2.149 realtime datetime
+│                  test authorization
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/socketio-test-import-alignment-2026-05-26.json
+++ b/.planning/codebase/generated/socketio-test-import-alignment-2026-05-26.json
@@ -1,0 +1,99 @@
+{
+  "schema_version": "implementation-evidence-v1",
+  "id": "g2-150-socketio-test-import-alignment",
+  "title": "Socket.IO test import alignment",
+  "created_at": "2026-05-26T17:56:00+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "deb182e7f3ba7e50d0cc982c51248826e522dacd",
+  "parent": {
+    "id": "g2-148-socketio-legacy-export-contract-authorization",
+    "pr": 301,
+    "state": "merged",
+    "merge_commit": "deb182e7f3ba7e50d0cc982c51248826e522dacd"
+  },
+  "scope": {
+    "mode": "test-only implementation",
+    "runtime_source_edits": false,
+    "test_edits": true,
+    "openspec_edits": false,
+    "route_api_openapi_frontend_pm2_edits": false
+  },
+  "edited_files": [
+    "web/backend/tests/test_socketio_manager.py",
+    "web/backend/tests/test_socketio_streaming_integration.py"
+  ],
+  "implementation": {
+    "test_socketio_manager.py": [
+      "Kept ConnectionManager imported from app.core.socketio_manager.",
+      "Moved get_socketio_manager and reset_socketio_manager imports to app.core._socketio_manager_singleton."
+    ],
+    "test_socketio_streaming_integration.py": [
+      "Kept MySocketIOManager and ConnectionManager imported from app.core.socketio_manager.",
+      "Moved reset_socketio_manager import to app.core._socketio_manager_singleton.",
+      "Renamed unused AsyncMock patch context variables to _mock_emit where no assertions consume the variable."
+    ]
+  },
+  "gitnexus_pre_edit": {
+    "web/backend/tests/test_socketio_manager.py": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "affected_processes": 0
+    },
+    "web/backend/tests/test_socketio_streaming_integration.py": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "red_evidence": {
+    "test_socketio_manager_collect_only": {
+      "exit_code": 2,
+      "failure": "ImportError: cannot import name 'get_socketio_manager' from 'app.core.socketio_manager'"
+    },
+    "test_socketio_streaming_integration_collect_only": {
+      "exit_code": 2,
+      "failure": "ImportError: cannot import name 'reset_socketio_manager' from 'app.core.socketio_manager'"
+    },
+    "focused_consumer_injection_regression_baseline": {
+      "exit_code": 0,
+      "result": "2 passed in 1.02s"
+    }
+  },
+  "green_evidence": {
+    "test_socketio_manager_collect_only": {
+      "exit_code": 0,
+      "result": "26 tests collected in 1.13s"
+    },
+    "test_socketio_streaming_integration_collect_only": {
+      "exit_code": 0,
+      "result": "20 tests collected in 1.05s"
+    },
+    "focused_consumer_injection_regression": {
+      "exit_code": 0,
+      "result": "2 passed in 1.02s"
+    },
+    "ruff_touched_tests": {
+      "exit_code": 0,
+      "result": "All checks passed"
+    },
+    "test_socketio_manager_full_suite": {
+      "exit_code": 0,
+      "result": "26 passed, 1 warning in 1.17s"
+    }
+  },
+  "newly_exposed_baseline_debt": {
+    "test_socketio_streaming_integration_full_suite": {
+      "exit_code": 1,
+      "result": "1 failed, 19 passed in 2.45s",
+      "failure": "TestStreamingErrorHandling.test_exception_during_subscription expects a stream_error emission that was not observed",
+      "routing": "Do not expand G2.150. Route to a future Socket.IO streaming error-emission behavior triage package."
+    }
+  },
+  "non_goals": [
+    "No backend runtime source was edited.",
+    "No helper alias was restored in app.core.socketio_manager.",
+    "No realtime datetime debt was fixed.",
+    "No route/API, OpenAPI, frontend, PM2, OpenSpec, issue-label, or GitHub issue state was changed."
+  ],
+  "next_gate": "Review and merge this G2.150 package. If accepted, decide whether to start G2.151 Socket.IO streaming error-emission behavior triage or continue with G2.149 realtime datetime test authorization."
+}

--- a/docs/reports/quality/backend-socketio-test-import-alignment-2026-05-26.md
+++ b/docs/reports/quality/backend-socketio-test-import-alignment-2026-05-26.md
@@ -1,0 +1,135 @@
+# Backend Socket.IO Test Import Alignment
+
+Date: 2026-05-26
+
+Branch: `g2-150-socketio-test-import-alignment`
+
+Base: `wip/root-dirty-20260403` at `deb182e7f3ba7e50d0cc982c51248826e522dacd`
+
+Status: implementation complete, ready for review
+
+> **历史实施说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary: this is a test-only implementation package. It does not edit backend runtime source, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations.
+
+## Purpose
+
+G2.148 decided that the Socket.IO baseline blocker was stale test imports, not a
+missing runtime provider. Runtime composition already consumes
+`get_socketio_manager()` from `app.core._socketio_manager_singleton`.
+
+This package applies that decision by aligning the legacy Socket.IO tests to the
+canonical singleton helper import path.
+
+## Pre-Edit Evidence
+
+GitNexus pre-edit impact:
+
+- `web/backend/tests/test_socketio_manager.py`: LOW, impacted count 0, affected
+  processes 0.
+- `web/backend/tests/test_socketio_streaming_integration.py`: LOW, impacted
+  count 0, affected processes 0.
+
+Red evidence:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_manager.py --collect-only -q --no-cov --tb=short
+ImportError: cannot import name 'get_socketio_manager' from 'app.core.socketio_manager'
+```
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py --collect-only -q --no-cov --tb=short
+ImportError: cannot import name 'reset_socketio_manager' from 'app.core.socketio_manager'
+```
+
+Focused G2.145 regression baseline:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short
+2 passed in 1.02s
+```
+
+## Changes
+
+Edited only:
+
+- `web/backend/tests/test_socketio_manager.py`
+- `web/backend/tests/test_socketio_streaming_integration.py`
+
+Applied changes:
+
+- Kept `ConnectionManager` / `MySocketIOManager` imports on
+  `app.core.socketio_manager`.
+- Moved `get_socketio_manager` / `reset_socketio_manager` imports to
+  `app.core._socketio_manager_singleton`.
+- Renamed unused `AsyncMock` patch context variables to `_mock_emit` where the
+  variable is intentionally not asserted.
+
+No runtime source was changed.
+
+## Verification
+
+Collection blockers are resolved:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_manager.py --collect-only -q --no-cov --tb=short
+26 tests collected in 1.13s
+```
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py --collect-only -q --no-cov --tb=short
+20 tests collected in 1.05s
+```
+
+Focused regression remains green:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short
+2 passed in 1.02s
+```
+
+Touched test lint:
+
+```text
+ruff check web/backend/tests/test_socketio_manager.py web/backend/tests/test_socketio_streaming_integration.py
+All checks passed
+```
+
+Additional focused suite evidence:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_manager.py -q --no-cov --tb=short
+26 passed, 1 warning in 1.17s
+```
+
+The streaming integration suite now collects but exposes a separate behavior
+debt:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py -q --no-cov --tb=short
+1 failed, 19 passed in 2.45s
+FAILED test_exception_during_subscription
+```
+
+The failure expects a `stream_error` emission during a patched subscription
+exception. This is outside the import-alignment scope and should be triaged as a
+separate Socket.IO streaming error-emission behavior package.
+
+## Non-Goals
+
+- No `app.core.socketio_manager` helper alias restoration.
+- No edit to `web/backend/app/core/socketio_manager.py`.
+- No edit to `web/backend/app/core/_socketio_manager_singleton.py`.
+- No edit to `web/backend/app/services/realtime_streaming_service.py`.
+- No realtime datetime debt fix.
+- No route/API, OpenAPI, frontend, PM2, OpenSpec, issue-label, or GitHub issue
+  state change.
+
+## Next Gate
+
+Review and merge this G2.150 package. After acceptance, decide whether the next
+step is:
+
+- G2.151 Socket.IO streaming error-emission behavior triage, or
+- G2.149 realtime datetime test authorization.

--- a/governance/mainline/task-cards/pr-302.yaml
+++ b/governance/mainline/task-cards/pr-302.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-302"
+  title: "Align Socket.IO legacy test imports"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-socketio-test-import-alignment"
+  objective: "resolve Socket.IO legacy test collection blockers by aligning singleton helper imports to the canonical helper module"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-socketio-test-import-alignment"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Test-only import alignment; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - "web/backend/tests/test_socketio_manager.py"
+    - "web/backend/tests/test_socketio_streaming_integration.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/socketio-test-import-alignment-2026-05-26.json"
+    - "docs/reports/quality/backend-socketio-test-import-alignment-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-302.yaml"
+  forbidden_paths:
+    - "web/backend/app/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 301 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "pre-edit-gitnexus-impact"
+      command: "GitNexus impact on both touched test files"
+      required: true
+    - id: "red-collect-only-evidence"
+      command: "collect-only checks fail before edit for test_socketio_manager.py and test_socketio_streaming_integration.py"
+      required: true
+    - id: "green-collect-only-evidence"
+      command: "collect-only checks pass after edit for test_socketio_manager.py and test_socketio_streaming_integration.py"
+      required: true
+    - id: "focused-regression"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-tests"
+      command: "ruff check web/backend/tests/test_socketio_manager.py web/backend/tests/test_socketio_streaming_integration.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-socketio-test-import-alignment-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/socketio-test-import-alignment-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-302.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend runtime source in this implementation package."
+  - "Do not restore get_socketio_manager/reset_socketio_manager exports in app.core.socketio_manager."
+  - "Do not fix realtime streaming datetime test debt in this implementation package."
+  - "Do not fix the newly exposed streaming error-emission behavior assertion in this implementation package."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "Collection unlock can expose unrelated behavior failures; those must be routed separately instead of expanding this import-alignment lane."
+    - "Accidentally restoring helper aliases in app.core.socketio_manager would widen the runtime facade against the G2.148 decision."
+  rollback_plan: "revert this implementation PR to restore the stale test import state and remove only the evidence report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "align Socket.IO legacy tests to canonical singleton helper imports"
+    modified_scope: "two Socket.IO test files, steward tree, evidence report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "collection blockers removed; one behavior assertion debt is exposed and routed separately"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if collect-only, focused regression, ruff, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-26T17:56:00+08:00"
+    approval_note: "Implementation authorized by accepted G2.148 decision package"
+    secondary_approved: false
+

--- a/web/backend/tests/test_socketio_manager.py
+++ b/web/backend/tests/test_socketio_manager.py
@@ -14,6 +14,8 @@ import asyncio
 
 from app.core.socketio_manager import (
     ConnectionManager,
+)
+from app.core._socketio_manager_singleton import (
     get_socketio_manager,
     reset_socketio_manager,
 )

--- a/web/backend/tests/test_socketio_streaming_integration.py
+++ b/web/backend/tests/test_socketio_streaming_integration.py
@@ -15,6 +15,8 @@ from unittest.mock import AsyncMock, patch
 from app.core.socketio_manager import (
     MySocketIOManager,
     ConnectionManager,
+)
+from app.core._socketio_manager_singleton import (
     reset_socketio_manager,
 )
 from app.services.realtime_streaming_service import (
@@ -91,7 +93,7 @@ class TestSocketIOStreamingEventHandlers:
         """Test market stream subscription with field filter"""
         socketio_namespace.sio.connection_manager.add_connection("sid_001", "user_001")
 
-        with patch.object(socketio_namespace, "emit", new_callable=AsyncMock) as mock_emit:
+        with patch.object(socketio_namespace, "emit", new_callable=AsyncMock) as _mock_emit:
             await socketio_namespace.on_subscribe_market_stream(
                 "sid_001", {"symbol": "600519", "fields": ["price", "volume"]}
             )
@@ -184,7 +186,7 @@ class TestSocketIOStreamingEventHandlers:
         manager = MySocketIOManager()
         namespace = list(manager.sio.namespace_handlers.values())[0]
 
-        with patch.object(namespace, "emit", new_callable=AsyncMock) as mock_emit:
+        with patch.object(namespace, "emit", new_callable=AsyncMock) as _mock_emit:
             await namespace.on_connect("sid_001", {"HTTP_X_USER_ID": "user_001"})
 
             # Verify connection was added
@@ -306,7 +308,7 @@ class TestStreamingEventIntegration:
 
         streaming_service = get_streaming_service()
 
-        with patch.object(namespace, "emit", new_callable=AsyncMock) as mock_emit:
+        with patch.object(namespace, "emit", new_callable=AsyncMock) as _mock_emit:
             # Both subscribe to same symbol
             await namespace.on_subscribe_market_stream("sid_001", {"symbol": "600519"})
             await namespace.on_subscribe_market_stream("sid_002", {"symbol": "600519"})
@@ -323,7 +325,7 @@ class TestStreamingEventIntegration:
         manager.connection_manager.add_connection("sid_001", "user_001")
         streaming_service = get_streaming_service()
 
-        with patch.object(namespace, "emit", new_callable=AsyncMock) as mock_emit:
+        with patch.object(namespace, "emit", new_callable=AsyncMock) as _mock_emit:
             # Subscribe to multiple symbols
             symbols = ["600519", "000001", "600000"]
             for symbol in symbols:
@@ -343,7 +345,7 @@ class TestStreamingEventIntegration:
         manager.connection_manager.add_connection("sid_001", "user_001")
         streaming_service = get_streaming_service()
 
-        with patch.object(namespace, "emit", new_callable=AsyncMock) as mock_emit:
+        with patch.object(namespace, "emit", new_callable=AsyncMock) as _mock_emit:
             # Subscribe and then unsubscribe
             await namespace.on_subscribe_market_stream("sid_001", {"symbol": "600519"})
             assert "600519" in streaming_service.get_active_symbols()
@@ -366,7 +368,7 @@ class TestStreamingErrorHandling:
         manager = MySocketIOManager()
         namespace = list(manager.sio.namespace_handlers.values())[0]
 
-        with patch.object(namespace, "emit", new_callable=AsyncMock) as mock_emit:
+        with patch.object(namespace, "emit", new_callable=AsyncMock) as _mock_emit:
             # Don't add connection, just try to subscribe
             await namespace.on_subscribe_market_stream("nonexistent_sid", {"symbol": "600519"})
 


### PR DESCRIPTION
## Summary
- align legacy Socket.IO tests to import singleton helpers from app.core._socketio_manager_singleton
- keep MySocketIOManager and ConnectionManager imported from app.core.socketio_manager
- do not restore helper aliases in app.core.socketio_manager and do not edit runtime source
- record a newly exposed streaming integration behavior failure as separate follow-up debt

## Verification
- PR #301 verified merged at deb182e7f3ba7e50d0cc982c51248826e522dacd
- GitNexus pre-edit impact: both touched test files LOW, 0 affected processes
- red collect-only reproduced missing get_socketio_manager/reset_socketio_manager imports
- post-edit test_socketio_manager.py collect-only: 26 tests collected
- post-edit test_socketio_streaming_integration.py collect-only: 20 tests collected
- focused consumer-injection regression: 2 passed
- ruff touched tests: All checks passed
- test_socketio_manager.py full focused suite: 26 passed, 1 warning
- test_socketio_streaming_integration.py full focused suite: 19 passed, 1 failed in test_exception_during_subscription; routed as separate behavior debt, not fixed here
- JSON/YAML parse passed
- markdown governance gate passed with 0 errors
- git diff --check passed
- GitNexus staged scope: low risk, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore completed
