### PR TITLE
G2.151 Triage Socket.IO stream error emission

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2583,7 +2583,7 @@ CODEBASE-MAP Architecture Remediation Program
 │   │                OpenAPI exposure, frontend, PM2, OpenSpec, issue-label
 │   │                change, or implementation work is performed here
 │   ├── G2.150 Socket.IO test import alignment
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#302`
 │   │   ├── Evidence: `backend-socketio-test-import-alignment-2026-05-26.md`
 │   │   ├── Parent: G2.148 accepted and merged by PR `#301`
 │   │   ├── Current HEAD: `deb182e7f3ba7e50d0cc982c51248826e522dacd`
@@ -2607,10 +2607,32 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              restoration, realtime datetime fix, route/API, OpenAPI
 │   │              exposure, frontend, PM2, OpenSpec, issue-label change, or
 │   │              GitHub issue state change is performed here
-│   └── Next gate: review G2.150; if accepted, route the exposed Socket.IO
-│                  streaming error-emission behavior debt as G2.151 or
-│                  continue with the already split G2.149 realtime datetime
-│                  test authorization
+│   ├── G2.151 Socket.IO stream-error emission triage
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-socketio-stream-error-emission-triage-2026-05-26.md`
+│   │   ├── Parent: G2.150 accepted and merged by PR `#302`
+│   │   ├── Current HEAD: `34bb3873149aee0b2e4cd06e63a45484a33a068f`
+│   │   ├── Result: classifies the newly exposed
+│   │   │          `test_exception_during_subscription` failure as test
+│   │   │          patch-target drift after Socket.IO manager consumer
+│   │   │          injection, not as proven runtime error-emission breakage
+│   │   ├── Verification: single-test reproduction still fails on missing
+│   │   │          `stream_error`; diagnostic with stale
+│   │   │          `app.core.socketio_manager.get_streaming_service` patch
+│   │   │          emits `stream_subscribed`, while diagnostic patching
+│   │   │          `manager.streaming_service.subscribe` emits
+│   │   │          `stream_error`
+│   │   ├── Decision: authorize a future G2.152 test-only patch-target
+│   │   │          alignment lane; do not edit runtime source or widen
+│   │   │          `socketio_manager.py`
+│   │   └── Boundary: triage-only; no backend source/test edit, helper alias
+│   │              restoration, realtime datetime fix, route/API, OpenAPI
+│   │              exposure, frontend, PM2, OpenSpec, issue-label change, or
+│   │              GitHub issue state change is performed here
+│   └── Next gate: review G2.151; if accepted, start G2.152 Socket.IO
+│                  stream-error test patch-target alignment, then return to
+│                  the already split G2.149 realtime datetime test
+│                  authorization
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/socketio-stream-error-emission-triage-2026-05-26.json
+++ b/.planning/codebase/generated/socketio-stream-error-emission-triage-2026-05-26.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": "triage-decision-v1",
+  "id": "g2-151-socketio-stream-error-emission-triage",
+  "title": "Socket.IO streaming error-emission behavior triage",
+  "created_at": "2026-05-26T18:12:00+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "34bb3873149aee0b2e4cd06e63a45484a33a068f",
+  "parent": {
+    "id": "g2-150-socketio-test-import-alignment",
+    "pr": 302,
+    "state": "merged",
+    "merge_commit": "34bb3873149aee0b2e4cd06e63a45484a33a068f"
+  },
+  "scope": {
+    "mode": "triage-only",
+    "runtime_source_edits": false,
+    "test_edits": false,
+    "openspec_edits": false,
+    "route_api_openapi_frontend_pm2_edits": false
+  },
+  "reproduction": {
+    "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py::TestStreamingErrorHandling::test_exception_during_subscription -q --no-cov --tb=short",
+    "exit_code": 1,
+    "failure": "assert any('stream_error' in str(call) for call in calls) is False"
+  },
+  "root_cause": {
+    "summary": "The test patches app.core.socketio_manager.get_streaming_service, but on_subscribe_market_stream now calls self.sio.streaming_service.subscribe after the G2.145 manager-level consumer injection change.",
+    "stale_patch_target": "app.core.socketio_manager.get_streaming_service",
+    "actual_call_path": "namespace.sio.streaming_service.subscribe(...)",
+    "source_location": "web/backend/app/core/socketio_manager.py:on_subscribe_market_stream"
+  },
+  "diagnostics": {
+    "stale_patch_target_result": {
+      "patched": "app.core.socketio_manager.get_streaming_service",
+      "has_stream_error": false,
+      "has_stream_subscribed": true,
+      "meaning": "The old patch target no longer affects the handler call path."
+    },
+    "instance_patch_result": {
+      "patched": "manager.streaming_service.subscribe",
+      "has_stream_error": true,
+      "emitted": "stream_error with error_code INTERNAL_ERROR",
+      "meaning": "The runtime error-emission branch still works when the current call path is patched."
+    }
+  },
+  "decision": {
+    "classification": "test patch-target drift after Socket.IO manager consumer injection",
+    "runtime_bug": false,
+    "recommended_next_lane": "g2-152-socketio-stream-error-test-patch-target-alignment",
+    "recommended_scope": "test-only alignment of test_exception_during_subscription to patch manager.streaming_service.subscribe or inject a fake streaming service",
+    "allowed_paths": [
+      "web/backend/tests/test_socketio_streaming_integration.py",
+      ".planning/codebase/**",
+      "docs/reports/quality/**",
+      "governance/mainline/task-cards/**"
+    ],
+    "forbidden_paths": [
+      "web/backend/app/**",
+      "web/frontend/**",
+      "src/**",
+      "docs/api/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ]
+  },
+  "required_next_lane_gates": [
+    "Run GitNexus impact before editing test_socketio_streaming_integration.py.",
+    "Use current failing test as red evidence.",
+    "Patch the current call path instead of the legacy get_streaming_service accessor.",
+    "Run the single failing test after the edit.",
+    "Run the full test_socketio_streaming_integration.py focused suite after the edit.",
+    "Run test_socketio_manager.py focused suite to ensure the previous G2.150 lane remains intact.",
+    "Run test_realtime_socket_manager_streaming_dependency.py focused regression.",
+    "Run ruff on the touched test file.",
+    "Run staged GitNexus detect_changes before commit.",
+    "Run mainline scope gate after commit."
+  ],
+  "non_goals": [
+    "Do not edit runtime source in this triage package.",
+    "Do not change Socket.IO manager error-emission behavior in this triage package.",
+    "Do not restore legacy helper aliases.",
+    "Do not touch realtime datetime debt.",
+    "Do not change route/API, OpenAPI, frontend, PM2, OpenSpec, or issue labels."
+  ],
+  "next_gate": "Review and merge this G2.151 triage package before starting G2.152 test-only patch-target alignment."
+}

--- a/docs/reports/quality/backend-socketio-stream-error-emission-triage-2026-05-26.md
+++ b/docs/reports/quality/backend-socketio-stream-error-emission-triage-2026-05-26.md
@@ -1,0 +1,110 @@
+# Backend Socket.IO Stream Error Emission Triage
+
+Date: 2026-05-26
+
+Branch: `g2-151-socketio-stream-error-emission-triage`
+
+Base: `wip/root-dirty-20260403` at `34bb3873149aee0b2e4cd06e63a45484a33a068f`
+
+Status: triage complete, ready for review
+
+> **历史决策说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary: this is a triage-only package. It does not edit backend runtime source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations.
+
+## Purpose
+
+G2.150 resolved the Socket.IO legacy import collection blocker and exposed a
+separate behavior failure in:
+
+```text
+web/backend/tests/test_socketio_streaming_integration.py::TestStreamingErrorHandling::test_exception_during_subscription
+```
+
+This package investigates that failure and decides the next implementation lane.
+It does not apply the fix.
+
+## Reproduction
+
+Command:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py::TestStreamingErrorHandling::test_exception_during_subscription -q --no-cov --tb=short
+```
+
+Result:
+
+```text
+FAILED test_exception_during_subscription
+assert any("stream_error" in str(call) for call in calls)
+```
+
+## Root Cause
+
+The test still patches the old accessor path:
+
+```python
+patch("app.core.socketio_manager.get_streaming_service", side_effect=Exception("Service error"))
+```
+
+That patch no longer affects the handler. After the G2.145 Socket.IO manager
+consumer-injection change, `on_subscribe_market_stream()` calls:
+
+```python
+self.sio.streaming_service.subscribe(sid, symbol, user_id, fields)
+```
+
+So the handler uses the manager-level injected dependency, not a fresh
+`get_streaming_service()` call. The test patch target is stale.
+
+## Diagnostics
+
+Stale patch-target diagnostic:
+
+- Patched: `app.core.socketio_manager.get_streaming_service`
+- Observed emission: `stream_subscribed`
+- `stream_error`: not emitted
+- Meaning: the patch no longer affects the subscription call path.
+
+Current call-path diagnostic:
+
+- Patched: `manager.streaming_service.subscribe`
+- Observed emission: `stream_error`
+- Error payload: `{"error_code": "INTERNAL_ERROR", "message": "Server error during subscription"}`
+- Meaning: the runtime error-emission branch still works when the current call
+  path is patched.
+
+## Decision
+
+Classification: test patch-target drift after Socket.IO manager consumer
+injection.
+
+Runtime bug: no evidence from this triage package.
+
+Recommended next lane: G2.152 Socket.IO stream-error test patch-target
+alignment.
+
+Recommended implementation scope:
+
+- Edit only `web/backend/tests/test_socketio_streaming_integration.py`.
+- Keep runtime source unchanged.
+- Patch `manager.streaming_service.subscribe` or inject a fake streaming service
+  into `MySocketIOManager`.
+- Run the single failing test, the full streaming integration focused suite,
+  the Socket.IO manager focused suite, the G2.145 regression test, and ruff on
+  the touched test file.
+
+## Non-Goals
+
+- No backend runtime source edit.
+- No Socket.IO manager behavior change.
+- No restoration of `socketio_manager.py` helper aliases.
+- No realtime datetime debt fix.
+- No route/API, OpenAPI, frontend, PM2, OpenSpec, issue-label, or GitHub issue
+  state change.
+
+## Next Gate
+
+Review and merge this G2.151 triage package. After acceptance, start G2.152 as
+a separate test-only implementation lane.

--- a/governance/mainline/task-cards/pr-303.yaml
+++ b/governance/mainline/task-cards/pr-303.yaml
@@ -1,0 +1,110 @@
+version: "v0.2"
+
+task:
+  id: "pr-303"
+  title: "Triage Socket.IO stream-error emission failure"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-socketio-stream-error-emission-triage"
+  objective: "classify the Socket.IO streaming integration stream_error failure exposed by G2.150"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-socketio-stream-error-emission-triage"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Triage-only package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/socketio-stream-error-emission-triage-2026-05-26.json"
+    - "docs/reports/quality/backend-socketio-stream-error-emission-triage-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-303.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 302 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "single-test-reproduction"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py::TestStreamingErrorHandling::test_exception_during_subscription -q --no-cov --tb=short"
+      required: true
+    - id: "diagnostic-stale-patch-target"
+      command: "diagnostic script proving app.core.socketio_manager.get_streaming_service patch emits stream_subscribed, not stream_error"
+      required: true
+    - id: "diagnostic-current-call-path"
+      command: "diagnostic script proving manager.streaming_service.subscribe patch emits stream_error"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-socketio-stream-error-emission-triage-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/socketio-stream-error-emission-triage-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-303.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this triage package."
+  - "Do not fix test_exception_during_subscription in this triage package."
+  - "Do not restore get_socketio_manager/reset_socketio_manager exports in app.core.socketio_manager."
+  - "Do not fix realtime streaming datetime test debt in this triage package."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this triage package is treated as implementation authorization, a stale test patch-target fix could be mixed with runtime Socket.IO source edits."
+    - "If the consumer-injection call path is ignored, future workers may patch the obsolete get_streaming_service accessor again."
+  rollback_plan: "revert this triage PR to remove only the triage report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "classify Socket.IO stream_error test failure after import alignment"
+    modified_scope: "steward tree, triage report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if diagnostics, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T18:12:00+08:00"
+    approval_note: "Triage-only package after accepted G2.150 merge exposed stream_error behavior test debt"
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary
- record PR #302 as merged and triage the Socket.IO stream_error behavior failure exposed after G2.150
- classify test_exception_during_subscription as test patch-target drift after Socket.IO manager consumer injection
- confirm the old get_streaming_service patch no longer affects on_subscribe_market_stream
- confirm patching manager.streaming_service.subscribe triggers the runtime stream_error branch
- authorize a future G2.152 test-only patch-target alignment lane; do not edit runtime source here

## Verification
- PR #302 verified merged at 34bb3873149aee0b2e4cd06e63a45484a33a068f
- single-test reproduction: test_exception_during_subscription still fails on missing stream_error emission
- stale patch diagnostic: patching app.core.socketio_manager.get_streaming_service emits stream_subscribed, not stream_error
- current call-path diagnostic: patching manager.streaming_service.subscribe emits stream_error with INTERNAL_ERROR
- JSON/YAML parse passed
- markdown governance gate passed with 0 errors
- git diff --check passed
- GitNexus staged scope: low risk, 0 changed symbols, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore completed
