### PR TITLE
G2.152 Align Socket.IO stream error test patch target

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2608,7 +2608,7 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              exposure, frontend, PM2, OpenSpec, issue-label change, or
 │   │              GitHub issue state change is performed here
 │   ├── G2.151 Socket.IO stream-error emission triage
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#303`
 │   │   ├── Evidence: `backend-socketio-stream-error-emission-triage-2026-05-26.md`
 │   │   ├── Parent: G2.150 accepted and merged by PR `#302`
 │   │   ├── Current HEAD: `34bb3873149aee0b2e4cd06e63a45484a33a068f`
@@ -2629,10 +2629,28 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              restoration, realtime datetime fix, route/API, OpenAPI
 │   │              exposure, frontend, PM2, OpenSpec, issue-label change, or
 │   │              GitHub issue state change is performed here
-│   └── Next gate: review G2.151; if accepted, start G2.152 Socket.IO
-│                  stream-error test patch-target alignment, then return to
-│                  the already split G2.149 realtime datetime test
-│                  authorization
+│   ├── G2.152 Socket.IO stream-error test patch-target alignment
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-socketio-stream-error-test-patch-alignment-2026-05-26.md`
+│   │   ├── Parent: G2.151 accepted and merged by PR `#303`
+│   │   ├── Current HEAD: `9288c3a7cdb8428c5ef984b9ba79e7e8fb2135dc`
+│   │   ├── Result: aligns
+│   │   │          `test_exception_during_subscription` to patch
+│   │   │          `manager.streaming_service.subscribe`, matching the
+│   │   │          current Socket.IO manager-level streaming dependency
+│   │   ├── Verification: red single-test failure reproduced before edit;
+│   │   │          after alignment, the single test reports `1 passed`,
+│   │   │          `test_socketio_streaming_integration.py` reports
+│   │   │          `20 passed`, `test_socketio_manager.py` reports
+│   │   │          `26 passed, 1 warning`, consumer-injection focused
+│   │   │          regression reports `2 passed`, and touched-test ruff
+│   │   │          reports `All checks passed`
+│   │   └── Boundary: test-only; no backend runtime source edit, helper alias
+│   │              restoration, realtime datetime fix, route/API, OpenAPI
+│   │              exposure, frontend, PM2, OpenSpec, issue-label change, or
+│   │              GitHub issue state change is performed here
+│   └── Next gate: review G2.152; if accepted, return to the already split
+│                  G2.149 realtime datetime test authorization
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/socketio-stream-error-test-patch-alignment-2026-05-26.json
+++ b/.planning/codebase/generated/socketio-stream-error-test-patch-alignment-2026-05-26.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": "implementation-evidence-v1",
+  "id": "g2-152-socketio-stream-error-test-patch-alignment",
+  "title": "Socket.IO stream-error test patch-target alignment",
+  "created_at": "2026-05-26T18:25:00+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "9288c3a7cdb8428c5ef984b9ba79e7e8fb2135dc",
+  "parent": {
+    "id": "g2-151-socketio-stream-error-emission-triage",
+    "pr": 303,
+    "state": "merged",
+    "merge_commit": "9288c3a7cdb8428c5ef984b9ba79e7e8fb2135dc"
+  },
+  "scope": {
+    "mode": "test-only implementation",
+    "runtime_source_edits": false,
+    "test_edits": true,
+    "openspec_edits": false,
+    "route_api_openapi_frontend_pm2_edits": false
+  },
+  "edited_files": [
+    "web/backend/tests/test_socketio_streaming_integration.py"
+  ],
+  "implementation": {
+    "test_exception_during_subscription": [
+      "Replaced the stale app.core.socketio_manager.get_streaming_service patch target.",
+      "Patched manager.streaming_service.subscribe, which is the current call path after Socket.IO manager consumer injection.",
+      "Kept runtime source unchanged."
+    ]
+  },
+  "gitnexus_pre_edit": {
+    "web/backend/tests/test_socketio_streaming_integration.py": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "red_evidence": {
+    "single_stream_error_test": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py::TestStreamingErrorHandling::test_exception_during_subscription -q --no-cov --tb=short",
+      "exit_code": 1,
+      "result": "1 failed because stream_error was not observed"
+    },
+    "socketio_manager_suite_baseline": {
+      "exit_code": 0,
+      "result": "26 passed, 1 warning in 1.01s"
+    },
+    "consumer_injection_regression_baseline": {
+      "exit_code": 0,
+      "result": "2 passed in 0.98s"
+    }
+  },
+  "green_evidence": {
+    "single_stream_error_test": {
+      "exit_code": 0,
+      "result": "1 passed in 0.85s"
+    },
+    "streaming_integration_suite": {
+      "exit_code": 0,
+      "result": "20 passed in 0.92s"
+    },
+    "socketio_manager_suite": {
+      "exit_code": 0,
+      "result": "26 passed, 1 warning in 0.90s"
+    },
+    "consumer_injection_regression": {
+      "exit_code": 0,
+      "result": "2 passed in 0.83s"
+    },
+    "ruff_touched_test": {
+      "exit_code": 0,
+      "result": "All checks passed"
+    }
+  },
+  "non_goals": [
+    "No backend runtime source was edited.",
+    "No helper aliases were restored in app.core.socketio_manager.",
+    "No realtime datetime debt was fixed.",
+    "No route/API, OpenAPI, frontend, PM2, OpenSpec, issue-label, or GitHub issue state was changed."
+  ],
+  "next_gate": "Review and merge this G2.152 package, then return to the already split G2.149 realtime datetime test authorization."
+}

--- a/docs/reports/quality/backend-socketio-stream-error-test-patch-alignment-2026-05-26.md
+++ b/docs/reports/quality/backend-socketio-stream-error-test-patch-alignment-2026-05-26.md
@@ -1,0 +1,114 @@
+# Backend Socket.IO Stream Error Test Patch Alignment
+
+Date: 2026-05-26
+
+Branch: `g2-152-socketio-stream-error-test-patch-alignment`
+
+Base: `wip/root-dirty-20260403` at `9288c3a7cdb8428c5ef984b9ba79e7e8fb2135dc`
+
+Status: implementation complete, ready for review
+
+> **历史实施说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary: this is a test-only implementation package. It does not edit backend runtime source, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations.
+
+## Purpose
+
+G2.151 classified
+`test_socketio_streaming_integration.py::TestStreamingErrorHandling::test_exception_during_subscription`
+as test patch-target drift after Socket.IO manager consumer injection.
+
+This package applies the test-only alignment. It changes the stale patch target
+from the old accessor to the current manager-level streaming dependency.
+
+## Pre-Edit Evidence
+
+GitNexus pre-edit impact:
+
+- `web/backend/tests/test_socketio_streaming_integration.py`: LOW, impacted
+  count 0, affected processes 0.
+
+Red evidence:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py::TestStreamingErrorHandling::test_exception_during_subscription -q --no-cov --tb=short
+1 failed because stream_error was not observed
+```
+
+Baseline checks:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_manager.py -q --no-cov --tb=short
+26 passed, 1 warning in 1.01s
+```
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short
+2 passed in 0.98s
+```
+
+## Change
+
+Edited only:
+
+- `web/backend/tests/test_socketio_streaming_integration.py`
+
+Implementation:
+
+- Replaced the stale
+  `patch("app.core.socketio_manager.get_streaming_service", ...)` target.
+- Patched `manager.streaming_service.subscribe`, which is the current call path
+  used by `on_subscribe_market_stream()`.
+- Kept runtime source unchanged.
+
+## Verification
+
+Single regression:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py::TestStreamingErrorHandling::test_exception_during_subscription -q --no-cov --tb=short
+1 passed in 0.85s
+```
+
+Streaming integration focused suite:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py -q --no-cov --tb=short
+20 passed in 0.92s
+```
+
+Socket.IO manager focused suite:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_manager.py -q --no-cov --tb=short
+26 passed, 1 warning in 0.90s
+```
+
+Consumer-injection focused regression:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short
+2 passed in 0.83s
+```
+
+Touched test lint:
+
+```text
+ruff check web/backend/tests/test_socketio_streaming_integration.py
+All checks passed
+```
+
+## Non-Goals
+
+- No backend runtime source edit.
+- No Socket.IO manager behavior change.
+- No restoration of `socketio_manager.py` helper aliases.
+- No realtime datetime debt fix.
+- No route/API, OpenAPI, frontend, PM2, OpenSpec, issue-label, or GitHub issue
+  state change.
+
+## Next Gate
+
+Review and merge this G2.152 package. After acceptance, return to the already
+split G2.149 realtime datetime test authorization.

--- a/governance/mainline/task-cards/pr-304.yaml
+++ b/governance/mainline/task-cards/pr-304.yaml
@@ -1,0 +1,122 @@
+version: "v0.2"
+
+task:
+  id: "pr-304"
+  title: "Align Socket.IO stream-error test patch target"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-socketio-stream-error-test-patch-alignment"
+  objective: "fix the Socket.IO streaming integration test patch target after manager-level consumer injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-socketio-stream-error-test-patch-alignment"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Test-only patch-target alignment; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - "web/backend/tests/test_socketio_streaming_integration.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/socketio-stream-error-test-patch-alignment-2026-05-26.json"
+    - "docs/reports/quality/backend-socketio-stream-error-test-patch-alignment-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-304.yaml"
+  forbidden_paths:
+    - "web/backend/app/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 303 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "pre-edit-gitnexus-impact"
+      command: "GitNexus impact on web/backend/tests/test_socketio_streaming_integration.py"
+      required: true
+    - id: "red-single-test"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py::TestStreamingErrorHandling::test_exception_during_subscription -q --no-cov --tb=short"
+      required: true
+    - id: "green-single-test"
+      command: "same single test after patch-target alignment"
+      required: true
+    - id: "streaming-integration-suite"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py -q --no-cov --tb=short"
+      required: true
+    - id: "socketio-manager-suite"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_manager.py -q --no-cov --tb=short"
+      required: true
+    - id: "consumer-injection-regression"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-test"
+      command: "ruff check web/backend/tests/test_socketio_streaming_integration.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-socketio-stream-error-test-patch-alignment-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/socketio-stream-error-test-patch-alignment-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-304.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend runtime source in this implementation package."
+  - "Do not restore get_socketio_manager/reset_socketio_manager exports in app.core.socketio_manager."
+  - "Do not fix realtime streaming datetime test debt in this implementation package."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this patch-target alignment expands into runtime source edits, it would violate the G2.151 triage decision."
+    - "If the current manager-level streaming dependency is ignored, the test could again patch an obsolete accessor."
+  rollback_plan: "revert this implementation PR to restore the prior stale patch target and remove only the evidence report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "align Socket.IO stream_error test patch target to current manager-level dependency"
+    modified_scope: "one Socket.IO test file, steward tree, evidence report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "streaming integration behavior test now passes without runtime source edits"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, ruff, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-26T18:25:00+08:00"
+    approval_note: "Implementation authorized by accepted G2.151 triage package"
+    secondary_approved: false
+

--- a/web/backend/tests/test_socketio_streaming_integration.py
+++ b/web/backend/tests/test_socketio_streaming_integration.py
@@ -386,11 +386,8 @@ class TestStreamingErrorHandling:
         manager.connection_manager.add_connection("sid_001", "user_001")
 
         with patch.object(namespace, "emit", new_callable=AsyncMock) as mock_emit:
-            # Force an exception in streaming service
-            with patch(
-                "app.core.socketio_manager.get_streaming_service",
-                side_effect=Exception("Service error"),
-            ):
+            # Force an exception through the current manager-level streaming dependency.
+            with patch.object(manager.streaming_service, "subscribe", side_effect=Exception("Service error")):
                 await namespace.on_subscribe_market_stream("sid_001", {"symbol": "600519"})
 
                 # Should emit error response


### PR DESCRIPTION
## Summary
- record PR #303 as merged and apply the G2.151 test-only patch-target decision
- update test_exception_during_subscription to patch manager.streaming_service.subscribe, the current call path after Socket.IO manager consumer injection
- keep runtime source unchanged and do not restore helper aliases in app.core.socketio_manager
- update steward tree, evidence JSON, report, and mainline task card

## Verification
- PR #303 verified merged at 9288c3a7cdb8428c5ef984b9ba79e7e8fb2135dc
- GitNexus pre-edit impact on test_socketio_streaming_integration.py: LOW, 0 affected processes
- red single test reproduced: test_exception_during_subscription failed because stream_error was not observed
- green single test: 1 passed
- streaming integration focused suite: 20 passed
- Socket.IO manager focused suite: 26 passed, 1 warning
- consumer-injection focused regression: 2 passed
- ruff touched test: All checks passed
- JSON/YAML parse passed
- markdown governance gate passed with 0 errors
- git diff --check passed
- GitNexus staged scope: low risk, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore completed
