### PR TITLE
G2.149 Authorize realtime streaming datetime fix

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2630,7 +2630,7 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              exposure, frontend, PM2, OpenSpec, issue-label change, or
 │   │              GitHub issue state change is performed here
 │   ├── G2.152 Socket.IO stream-error test patch-target alignment
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#304`
 │   │   ├── Evidence: `backend-socketio-stream-error-test-patch-alignment-2026-05-26.md`
 │   │   ├── Parent: G2.151 accepted and merged by PR `#303`
 │   │   ├── Current HEAD: `9288c3a7cdb8428c5ef984b9ba79e7e8fb2135dc`
@@ -2649,8 +2649,32 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              restoration, realtime datetime fix, route/API, OpenAPI
 │   │              exposure, frontend, PM2, OpenSpec, issue-label change, or
 │   │              GitHub issue state change is performed here
-│   └── Next gate: review G2.152; if accepted, return to the already split
-│                  G2.149 realtime datetime test authorization
+│   ├── G2.149 Realtime streaming datetime test authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-realtime-streaming-datetime-test-authorization-2026-05-26.md`
+│   │   ├── Parent: G2.152 accepted and merged by PR `#304`
+│   │   ├── Current HEAD: `6ca7c1860ff3f1c1a87f094a016bef3d296fff6d`
+│   │   ├── Result: classifies
+│   │   │          `test_realtime_streaming_service.py::TestStreamSubscriber::test_subscriber_update_activity`
+│   │   │          as a realtime streaming timestamp contract
+│   │   │          inconsistency, not a Socket.IO failure
+│   │   ├── Verification: focused realtime streaming service suite reports
+│   │   │          `1 failed, 42 passed`; diagnostic shows initial
+│   │   │          `StreamSubscriber.subscribed_at` has `tzinfo=None` from
+│   │   │          `datetime.utcnow`, while `update_activity()` assigns
+│   │   │          `datetime.now(timezone.utc)` with `tzinfo=UTC`
+│   │   ├── Decision: authorize a future G2.153 source plus focused-test lane
+│   │   │          for timezone-aware realtime streaming timestamps, covering
+│   │   │          `StreamSubscriber.subscribed_at` and reviewing
+│   │   │          `StreamData.created_at`
+│   │   └── Boundary: authorization-only; no backend source/test edit,
+│   │              Socket.IO change, realtime timestamp implementation,
+│   │              route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │              issue-label change, or GitHub issue state change is
+│   │              performed here
+│   └── Next gate: review G2.149; if accepted, start G2.153 realtime
+│                  streaming timezone-aware timestamps as a separate
+│                  source plus focused-test implementation lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/realtime-streaming-datetime-test-authorization-2026-05-26.json
+++ b/.planning/codebase/generated/realtime-streaming-datetime-test-authorization-2026-05-26.json
@@ -1,0 +1,97 @@
+{
+  "schema_version": "authorization-decision-v1",
+  "id": "g2-149-realtime-streaming-datetime-test-authorization",
+  "title": "Realtime streaming datetime test authorization",
+  "created_at": "2026-05-26T18:44:00+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "6ca7c1860ff3f1c1a87f094a016bef3d296fff6d",
+  "parent": {
+    "id": "g2-152-socketio-stream-error-test-patch-alignment",
+    "pr": 304,
+    "state": "merged",
+    "merge_commit": "6ca7c1860ff3f1c1a87f094a016bef3d296fff6d"
+  },
+  "scope": {
+    "mode": "authorization-only",
+    "runtime_source_edits": false,
+    "test_edits": false,
+    "openspec_edits": false,
+    "route_api_openapi_frontend_pm2_edits": false
+  },
+  "reproduction": {
+    "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py -q --no-cov --tb=short",
+    "exit_code": 1,
+    "result": "1 failed, 42 passed in 0.97s",
+    "failure": "TypeError: can't compare offset-naive and offset-aware datetimes in TestStreamSubscriber.test_subscriber_update_activity"
+  },
+  "root_cause": {
+    "summary": "StreamSubscriber.subscribed_at is initialized with datetime.utcnow, which returns an offset-naive datetime, while update_activity assigns datetime.now(timezone.utc), which returns an offset-aware datetime.",
+    "initial_state": {
+      "field": "StreamSubscriber.subscribed_at",
+      "factory": "datetime.utcnow",
+      "tzinfo": "None"
+    },
+    "after_update_activity": {
+      "assignment": "datetime.now(timezone.utc)",
+      "tzinfo": "UTC"
+    },
+    "related_inconsistency": {
+      "field": "StreamData.created_at",
+      "factory": "datetime.utcnow",
+      "reason_for_inclusion": "same realtime streaming service timestamp convention; no direct failing test yet"
+    }
+  },
+  "gitnexus_evidence": {
+    "StreamSubscriber": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "affected_processes": 0
+    },
+    "StreamData": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "affected_processes": 0
+    }
+  },
+  "decision": {
+    "classification": "runtime timestamp contract inconsistency exposed by test",
+    "test_only_fix_is_sufficient": false,
+    "recommended_next_lane": "g2-153-realtime-streaming-timezone-aware-timestamps",
+    "recommended_scope": "source plus focused test implementation",
+    "allowed_paths": [
+      "web/backend/app/services/realtime_streaming_service.py",
+      "web/backend/tests/test_realtime_streaming_service.py",
+      ".planning/codebase/**",
+      "docs/reports/quality/**",
+      "governance/mainline/task-cards/**"
+    ],
+    "forbidden_paths": [
+      "web/backend/app/core/**",
+      "web/backend/app/api/**",
+      "web/frontend/**",
+      "src/**",
+      "docs/api/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ]
+  },
+  "required_next_lane_gates": [
+    "Run GitNexus impact for StreamSubscriber and StreamData before editing source.",
+    "Use the current test_realtime_streaming_service.py failure as red evidence.",
+    "Make realtime streaming dataclass timestamps consistently timezone-aware UTC.",
+    "Add or preserve focused assertions that subscribed_at and created_at are offset-aware UTC.",
+    "Run the full test_realtime_streaming_service.py focused suite.",
+    "Run the Socket.IO regression suites from G2.152 if the touched service can affect them.",
+    "Run ruff on touched source and test files.",
+    "Run staged GitNexus detect_changes before commit.",
+    "Run mainline scope gate after commit."
+  ],
+  "non_goals": [
+    "Do not edit Socket.IO manager or Socket.IO tests in this authorization package.",
+    "Do not change route/API, OpenAPI, frontend, PM2, OpenSpec, issue labels, or GitHub issue state.",
+    "Do not perform the timezone-aware timestamp implementation in this authorization package."
+  ],
+  "next_gate": "Review and merge this G2.149 authorization package before starting G2.153 realtime streaming timezone-aware timestamps."
+}

--- a/docs/reports/quality/backend-realtime-streaming-datetime-test-authorization-2026-05-26.md
+++ b/docs/reports/quality/backend-realtime-streaming-datetime-test-authorization-2026-05-26.md
@@ -1,0 +1,139 @@
+# Backend Realtime Streaming Datetime Test Authorization
+
+Date: 2026-05-26
+
+Branch: `g2-149-realtime-datetime-test-authorization`
+
+Base: `wip/root-dirty-20260403` at `6ca7c1860ff3f1c1a87f094a016bef3d296fff6d`
+
+Status: authorization package ready for review
+
+> **历史决策说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary: this is an authorization-only package. It does not edit backend runtime source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations.
+
+## Purpose
+
+G2.147 split the remaining realtime/socket baseline debt into two independent
+tracks:
+
+- Socket.IO legacy export / error-emission debt, now handled through G2.148,
+  G2.150, G2.151, and G2.152.
+- Realtime streaming datetime debt, handled here as G2.149.
+
+This package authorizes the next implementation lane for the realtime streaming
+datetime failure. It does not implement the fix.
+
+## Reproduction
+
+Command:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py -q --no-cov --tb=short
+```
+
+Result:
+
+```text
+1 failed, 42 passed in 0.97s
+FAILED web/backend/tests/test_realtime_streaming_service.py::TestStreamSubscriber::test_subscriber_update_activity
+TypeError: can't compare offset-naive and offset-aware datetimes
+```
+
+The failing assertion is:
+
+```python
+old_time = subscriber.subscribed_at
+subscriber.update_activity()
+assert subscriber.subscribed_at >= old_time
+```
+
+## Root Cause
+
+`StreamSubscriber.subscribed_at` starts as an offset-naive datetime:
+
+```python
+subscribed_at: datetime = field(default_factory=datetime.utcnow)
+```
+
+`StreamSubscriber.update_activity()` then assigns an offset-aware datetime:
+
+```python
+self.subscribed_at = datetime.now(timezone.utc)
+```
+
+Diagnostic result:
+
+```text
+old_tz=None
+new_tz=UTC
+```
+
+The failure is therefore a runtime timestamp contract inconsistency exposed by
+the test, not a pure test assertion problem.
+
+Related inconsistency:
+
+```python
+StreamData.created_at: datetime = field(default_factory=datetime.utcnow)
+```
+
+`StreamData.created_at` is not the current failing assertion, but it belongs to
+the same realtime streaming timestamp surface and uses the same offset-naive
+factory.
+
+## GitNexus Evidence
+
+Pre-authorization impact checks:
+
+- `StreamSubscriber`: LOW, impacted count 0, affected processes 0.
+- `StreamData`: LOW, impacted count 0, affected processes 0.
+
+## Decision
+
+Authorize G2.153: realtime streaming timezone-aware timestamps.
+
+Recommended scope:
+
+- `web/backend/app/services/realtime_streaming_service.py`
+- `web/backend/tests/test_realtime_streaming_service.py`
+- focused governance artifacts
+
+Recommended implementation shape:
+
+- Make realtime streaming dataclass timestamp defaults consistently
+  timezone-aware UTC.
+- Cover `StreamSubscriber.subscribed_at`.
+- Include `StreamData.created_at` unless implementation review finds a concrete
+  reason to keep it offset-naive.
+- Add or preserve focused assertions that these dataclass timestamps are
+  offset-aware UTC.
+
+This should be a small source plus focused-test lane, not a Socket.IO route,
+OpenAPI, frontend, PM2, or OpenSpec lane.
+
+## Required G2.153 Gates
+
+- Run GitNexus impact for `StreamSubscriber` and `StreamData` before editing
+  source.
+- Use the current `test_realtime_streaming_service.py` failure as red evidence.
+- Run the full `test_realtime_streaming_service.py` focused suite after the
+  implementation.
+- Run the Socket.IO regression suites from G2.152 if the touched service could
+  affect them.
+- Run ruff on touched source and test files.
+- Run staged GitNexus detect_changes before commit.
+- Run mainline scope gate after commit.
+
+## Non-Goals
+
+- No implementation is performed by this authorization package.
+- No Socket.IO manager or Socket.IO test edit is included here.
+- No route/API, OpenAPI, frontend, PM2, OpenSpec, issue-label, or GitHub issue
+  state change is included here.
+
+## Next Gate
+
+Review and merge this G2.149 authorization package. After acceptance, start
+G2.153 as a separate implementation lane.

--- a/governance/mainline/task-cards/pr-305.yaml
+++ b/governance/mainline/task-cards/pr-305.yaml
@@ -1,0 +1,109 @@
+version: "v0.2"
+
+task:
+  id: "pr-305"
+  title: "Authorize realtime streaming datetime fix"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-realtime-streaming-datetime-authorization"
+  objective: "authorize the realtime streaming timezone-aware timestamp implementation lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-realtime-streaming-datetime-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/realtime-streaming-datetime-test-authorization-2026-05-26.json"
+    - "docs/reports/quality/backend-realtime-streaming-datetime-test-authorization-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-305.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 304 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "reproduction"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py -q --no-cov --tb=short"
+      required: true
+    - id: "datetime-diagnostic"
+      command: "diagnostic showing StreamSubscriber old_tz=None and new_tz=UTC"
+      required: true
+    - id: "gitnexus-impact"
+      command: "GitNexus impact for StreamSubscriber and StreamData"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-realtime-streaming-datetime-test-authorization-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/realtime-streaming-datetime-test-authorization-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-305.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this authorization package."
+  - "Do not implement timezone-aware realtime streaming timestamps in this authorization package."
+  - "Do not edit Socket.IO manager or Socket.IO tests in this authorization package."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this authorization package is treated as implementation authorization, realtime service source edits could bypass the dedicated G2.153 gate."
+    - "If only the assertion is changed in a future lane, the runtime naive/aware timestamp inconsistency would remain."
+  rollback_plan: "revert this authorization PR to remove only the decision report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize realtime streaming timezone-aware timestamp implementation"
+    modified_scope: "steward tree, authorization report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if reproduction, diagnostics, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T18:44:00+08:00"
+    approval_note: "Authorization-only package after accepted G2.152 merge returned to the split realtime datetime lane"
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary
- record PR #304 as merged and return to the previously split G2.149 realtime datetime lane
- reproduce the realtime streaming service datetime failure and classify it as runtime timestamp contract inconsistency
- authorize a future G2.153 source plus focused-test lane for timezone-aware realtime streaming timestamps
- keep this PR authorization-only: no source/test edits, no Socket.IO edits, no route/API/OpenAPI/frontend/PM2/OpenSpec changes

## Evidence
- PR #304 verified merged at 6ca7c1860ff3f1c1a87f094a016bef3d296fff6d
- reproduction: test_realtime_streaming_service.py -> 1 failed, 42 passed
- failure: TypeError comparing offset-naive and offset-aware datetimes in TestStreamSubscriber.test_subscriber_update_activity
- root cause: StreamSubscriber.subscribed_at uses datetime.utcnow, while update_activity uses datetime.now(timezone.utc)
- diagnostic: old_tz=None, new_tz=UTC
- related surface: StreamData.created_at also uses datetime.utcnow and should be reviewed in the implementation lane
- GitNexus impact: StreamSubscriber LOW, 0 affected processes; StreamData LOW, 0 affected processes

## Verification
- JSON/YAML parse passed
- markdown governance gate passed with 0 errors
- git diff --check passed
- GitNexus staged scope: low risk, 0 changed symbols, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore completed
