### PR TITLE
fix(backend): use aware realtime streaming timestamps

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2650,10 +2650,10 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              exposure, frontend, PM2, OpenSpec, issue-label change, or
 │   │              GitHub issue state change is performed here
 │   ├── G2.149 Realtime streaming datetime test authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#305`
 │   │   ├── Evidence: `backend-realtime-streaming-datetime-test-authorization-2026-05-26.md`
 │   │   ├── Parent: G2.152 accepted and merged by PR `#304`
-│   │   ├── Current HEAD: `6ca7c1860ff3f1c1a87f094a016bef3d296fff6d`
+│   │   ├── Merge commit: `58bdc319c3ca00819b6b4fe7fefa59a5a321ba9d`
 │   │   ├── Result: classifies
 │   │   │          `test_realtime_streaming_service.py::TestStreamSubscriber::test_subscriber_update_activity`
 │   │   │          as a realtime streaming timestamp contract
@@ -2672,9 +2672,35 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │              issue-label change, or GitHub issue state change is
 │   │              performed here
-│   └── Next gate: review G2.149; if accepted, start G2.153 realtime
-│                  streaming timezone-aware timestamps as a separate
-│                  source plus focused-test implementation lane
+│   ├── G2.153 Realtime streaming timezone-aware timestamps
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-realtime-streaming-timezone-aware-timestamps-2026-05-26.md`
+│   │   ├── Generated: `realtime-streaming-timezone-aware-timestamps-2026-05-26.json`
+│   │   ├── Parent: G2.149 accepted and merged by PR `#305`
+│   │   ├── Current HEAD: `58bdc319c3ca00819b6b4fe7fefa59a5a321ba9d`
+│   │   ├── Scope: source plus focused-test implementation limited to
+│   │   │          `realtime_streaming_service.py` and
+│   │   │          `test_realtime_streaming_service.py`
+│   │   ├── Result: introduces `_utc_now()` and uses it for
+│   │   │          `StreamSubscriber.subscribed_at` and
+│   │   │          `StreamData.created_at`, making realtime streaming
+│   │   │          dataclass defaults timezone-aware UTC timestamps
+│   │   ├── Verification: TDD red `1 failed, 42 passed`, explicit
+│   │   │          timezone assertion red `3 failed, 40 passed`, focused
+│   │   │          green `43 passed`, Socket.IO streaming regression
+│   │   │          `20 passed`, Socket.IO manager regression
+│   │   │          `26 passed, 1 warning`, consumer-injection regression
+│   │   │          `2 passed`, and touched-file ruff reports
+│   │   │          `All checks passed`
+│   │   ├── GitNexus: pre-edit impact for `StreamSubscriber` and
+│   │   │          `StreamData` reports LOW risk and impacted count `0`
+│   │   └── Boundary: no Socket.IO manager source edit, route/API,
+│   │              OpenAPI exposure, frontend, PM2, OpenSpec, config,
+│   │              script, compatibility wrapper deletion, issue-label
+│   │              change, or GitHub issue state change is performed here
+│   └── Next gate: review G2.153; if accepted, merge it and decide
+│                  whether realtime/socket has remaining high-risk getter
+│                  work or can return to the broader G2 service getter queue
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/realtime-streaming-timezone-aware-timestamps-2026-05-26.json
+++ b/.planning/codebase/generated/realtime-streaming-timezone-aware-timestamps-2026-05-26.json
@@ -1,0 +1,109 @@
+{
+  "artifact": "realtime-streaming-timezone-aware-timestamps-2026-05-26",
+  "generated_at": "2026-05-26T18:58:02+08:00",
+  "worktree": ".worktrees/g2-153-realtime-streaming-timezone-aware-timestamps",
+  "branch": "g2-153-realtime-streaming-timezone-aware-timestamps",
+  "base_head": "58bdc319c3ca00819b6b4fe7fefa59a5a321ba9d",
+  "parent": {
+    "task": "G2.149",
+    "pull_request": 305,
+    "merge_commit": "58bdc319c3ca00819b6b4fe7fefa59a5a321ba9d"
+  },
+  "task": {
+    "id": "G2.153",
+    "title": "Realtime streaming timezone-aware timestamps",
+    "scope": "source plus focused tests",
+    "authorization": "approved by user in current review thread"
+  },
+  "problem": {
+    "failing_test": "web/backend/tests/test_realtime_streaming_service.py::TestStreamSubscriber::test_subscriber_update_activity",
+    "symptom": "TypeError comparing offset-naive and offset-aware datetimes",
+    "root_cause": "StreamSubscriber.subscribed_at and StreamData.created_at used datetime.utcnow while update paths already used datetime.now(timezone.utc)"
+  },
+  "gitnexus_impact": [
+    {
+      "target": "StreamSubscriber",
+      "direction": "upstream",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct": 0,
+      "processes_affected": 0
+    },
+    {
+      "target": "StreamData",
+      "direction": "upstream",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct": 0,
+      "processes_affected": 0
+    }
+  ],
+  "changes": [
+    {
+      "path": "web/backend/app/services/realtime_streaming_service.py",
+      "summary": "Added _utc_now() and used it for StreamSubscriber.subscribed_at and StreamData.created_at default factories."
+    },
+    {
+      "path": "web/backend/tests/test_realtime_streaming_service.py",
+      "summary": "Added timezone-awareness assertions for StreamSubscriber and StreamData timestamps."
+    }
+  ],
+  "line_references": {
+    "helper": "web/backend/app/services/realtime_streaming_service.py:29",
+    "subscriber_default": "web/backend/app/services/realtime_streaming_service.py:59",
+    "stream_data_default": "web/backend/app/services/realtime_streaming_service.py:78",
+    "subscriber_assertions": [
+      "web/backend/tests/test_realtime_streaming_service.py:33",
+      "web/backend/tests/test_realtime_streaming_service.py:52"
+    ],
+    "stream_data_assertions": [
+      "web/backend/tests/test_realtime_streaming_service.py:74"
+    ]
+  },
+  "red_green": {
+    "initial_red": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py -q --no-cov --tb=short",
+      "result": "1 failed, 42 passed",
+      "failure": "TypeError: can't compare offset-naive and offset-aware datetimes"
+    },
+    "explicit_assertion_red": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py -q --no-cov --tb=short",
+      "result": "3 failed, 40 passed",
+      "failures": [
+        "StreamSubscriber.subscribed_at.tzinfo is None",
+        "old_time.tzinfo is None",
+        "StreamData.created_at.tzinfo is None"
+      ]
+    },
+    "green": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py -q --no-cov --tb=short",
+      "result": "43 passed"
+    }
+  },
+  "verification": [
+    {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py -q --no-cov --tb=short",
+      "result": "20 passed"
+    },
+    {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_manager.py -q --no-cov --tb=short",
+      "result": "26 passed, 1 warning",
+      "note": "Existing RuntimeWarning for un-awaited asyncio.sleep in test_update_activity remains outside this lane."
+    },
+    {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short",
+      "result": "2 passed"
+    },
+    {
+      "command": "ruff check web/backend/app/services/realtime_streaming_service.py web/backend/tests/test_realtime_streaming_service.py",
+      "result": "All checks passed"
+    }
+  ],
+  "boundaries": [
+    "No Socket.IO manager source changes.",
+    "No route/API, OpenAPI, frontend, PM2, OpenSpec, config, or script changes.",
+    "No compatibility wrapper deletion.",
+    "No GitHub issue label or issue state changes."
+  ],
+  "next_gate": "Review and merge G2.153; then reassess whether the realtime/socket subtrack has remaining high-risk getter work or can return to the broader G2 high-risk service getter queue."
+}

--- a/docs/reports/quality/backend-realtime-streaming-timezone-aware-timestamps-2026-05-26.md
+++ b/docs/reports/quality/backend-realtime-streaming-timezone-aware-timestamps-2026-05-26.md
@@ -1,0 +1,94 @@
+# Backend Realtime Streaming Timezone-Aware Timestamps
+
+Date: 2026-05-26  
+Task: G2.153 realtime streaming timezone-aware timestamps  
+Branch: `g2-153-realtime-streaming-timezone-aware-timestamps`  
+Base HEAD: `58bdc319c3ca00819b6b4fe7fefa59a5a321ba9d`  
+Parent: G2.149, merged by PR `#305`
+
+> **历史文档说明**: This report records a narrow approved G2.153 implementation result and verification evidence. It does not authorize additional backend source changes, route/API changes, OpenAPI exposure changes, frontend changes, PM2 workflow changes, OpenSpec changes, issue-state changes, or compatibility wrapper deletion.
+
+## Scope
+
+This implementation closes the realtime streaming datetime inconsistency authorized by G2.149.
+
+Allowed files:
+
+- `web/backend/app/services/realtime_streaming_service.py`
+- `web/backend/tests/test_realtime_streaming_service.py`
+- G2.153 governance evidence, task card, and steward-tree updates
+
+Non-goals:
+
+- No Socket.IO manager behavior change.
+- No route/API, OpenAPI, frontend, PM2, OpenSpec, config, script, or issue-label change.
+- No compatibility wrapper deletion.
+
+## Problem
+
+`StreamSubscriber.subscribed_at` was initialized with `datetime.utcnow`, which produces an offset-naive datetime. `StreamSubscriber.update_activity()` already assigns `datetime.now(timezone.utc)`, which is offset-aware. The focused suite therefore failed when comparing the initial timestamp with the updated timestamp:
+
+```text
+TypeError: can't compare offset-naive and offset-aware datetimes
+```
+
+`StreamData.created_at` used the same naive `datetime.utcnow` default factory and was included in this lane to keep realtime streaming message timestamps on the same contract.
+
+## Impact Check
+
+GitNexus impact before source edit:
+
+| Target | Direction | Risk | Impacted | Direct | Processes |
+|---|---:|---:|---:|---:|---:|
+| `StreamSubscriber` | upstream | LOW | 0 | 0 | 0 |
+| `StreamData` | upstream | LOW | 0 | 0 | 0 |
+
+No HIGH or CRITICAL impact was reported.
+
+## Implementation
+
+`web/backend/app/services/realtime_streaming_service.py` now defines `_utc_now()` and uses it for both dataclass default factories:
+
+- `StreamSubscriber.subscribed_at`
+- `StreamData.created_at`
+
+`web/backend/tests/test_realtime_streaming_service.py` now asserts that both timestamp surfaces are timezone-aware before validating ordering or serialization behavior.
+
+## TDD Evidence
+
+Initial reproduction:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py -q --no-cov --tb=short
+1 failed, 42 passed
+```
+
+Explicit assertion red after adding timezone-awareness checks:
+
+```text
+3 failed, 40 passed
+```
+
+Green after implementation:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py -q --no-cov --tb=short
+43 passed
+```
+
+## Regression Evidence
+
+| Check | Result |
+|---|---|
+| `web/backend/tests/test_socketio_streaming_integration.py` | 20 passed |
+| `web/backend/tests/test_socketio_manager.py` | 26 passed, 1 existing warning |
+| `web/backend/tests/test_realtime_socket_manager_streaming_dependency.py` | 2 passed |
+| `ruff check web/backend/app/services/realtime_streaming_service.py web/backend/tests/test_realtime_streaming_service.py` | All checks passed |
+
+The Socket.IO manager warning is the existing `RuntimeWarning` for un-awaited `asyncio.sleep` in `test_update_activity`; it is not introduced or modified by this lane.
+
+## Decision
+
+G2.153 is ready for review as a narrow source plus focused-test fix. The realtime streaming timestamp contract now consistently uses timezone-aware UTC datetimes for the covered dataclass defaults and update path.
+
+Next gate: review and merge this PR, then update the steward tree to decide whether the realtime/socket subtrack has more remaining high-risk getter work or returns to the broader G2 service getter queue.

--- a/governance/mainline/task-cards/pr-306.yaml
+++ b/governance/mainline/task-cards/pr-306.yaml
@@ -1,0 +1,122 @@
+version: "v0.2"
+
+task:
+  id: "pr-306"
+  title: "Use timezone-aware realtime streaming timestamps"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-realtime-streaming-timezone-aware-timestamps"
+  objective: "close the realtime streaming naive/aware timestamp inconsistency"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-realtime-streaming-timezone-aware-timestamps"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow realtime streaming timestamp bugfix plus focused tests; no route, public API, OpenAPI exposure, PM2 workflow, frontend behavior, or FUNCTION_TREE entrypoint is changed"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/services/realtime_streaming_service.py"
+    - "web/backend/tests/test_realtime_streaming_service.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/realtime-streaming-timezone-aware-timestamps-2026-05-26.json"
+    - "docs/reports/quality/backend-realtime-streaming-timezone-aware-timestamps-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-306.yaml"
+  forbidden_paths:
+    - "web/backend/app/core/**"
+    - "web/backend/app/api/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 305 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "red-reproduction"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py -q --no-cov --tb=short"
+      required: true
+    - id: "gitnexus-impact"
+      command: "GitNexus impact for StreamSubscriber and StreamData before source edit"
+      required: true
+    - id: "focused-green"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py -q --no-cov --tb=short"
+      required: true
+    - id: "socketio-streaming-regression"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py -q --no-cov --tb=short"
+      required: true
+    - id: "socketio-manager-regression"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_manager.py -q --no-cov --tb=short"
+      required: true
+    - id: "consumer-injection-regression"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/services/realtime_streaming_service.py web/backend/tests/test_realtime_streaming_service.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-realtime-streaming-timezone-aware-timestamps-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/realtime-streaming-timezone-aware-timestamps-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-306.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit Socket.IO manager source or Socket.IO manager tests beyond regression execution."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+  - "Do not delete compatibility wrappers or start another high-risk getter implementation lane."
+
+risk_and_rollback:
+  risks:
+    - "If timezone-aware defaults are not applied consistently, realtime streaming tests can regress into naive/aware comparison failures."
+    - "If this lane expands into Socket.IO manager changes, it could duplicate already-closed G2.145 through G2.152 work."
+  rollback_plan: "revert this PR to restore the prior timestamp default factories, focused test assertions, report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "use timezone-aware UTC defaults for realtime streaming timestamps"
+    modified_scope: "one realtime streaming service file, one focused test file, steward tree, report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; Socket.IO manager and route/API behavior are not changed"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, regression tests, ruff, governance checks, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-26T18:44:00+08:00"
+    approval_note: "Approved after G2.149 identified the realtime streaming timestamp inconsistency and authorized G2.153 source plus focused-test implementation."
+    secondary_approved: false

--- a/web/backend/app/services/realtime_streaming_service.py
+++ b/web/backend/app/services/realtime_streaming_service.py
@@ -26,6 +26,10 @@ import structlog
 logger = structlog.get_logger()
 
 
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
 class StreamStatus(str, Enum):
     """流状态枚举"""
 
@@ -52,7 +56,7 @@ class StreamSubscriber:
 
     sid: str  # Socket.IO连接ID
     user_id: Optional[str] = None
-    subscribed_at: datetime = field(default_factory=datetime.utcnow)
+    subscribed_at: datetime = field(default_factory=_utc_now)
     fields: Set[str] = field(default_factory=lambda: {"price", "volume", "timestamp"})  # 订阅的字段
     last_message_id: Optional[str] = None  # 最后接收的消息ID
     messages_received: int = 0  # 接收消息计数
@@ -71,7 +75,7 @@ class StreamData:
     timestamp: int  # Unix毫秒时间戳
     data: Dict[str, Any]  # 实际数据
     version: int = 1  # 版本号（用于去重）
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=_utc_now)
 
     def to_dict(self) -> Dict[str, Any]:
         """转换为字典"""

--- a/web/backend/tests/test_realtime_streaming_service.py
+++ b/web/backend/tests/test_realtime_streaming_service.py
@@ -30,6 +30,8 @@ class TestStreamSubscriber:
 
         assert subscriber.sid == "sid_001"
         assert subscriber.user_id == "user_001"
+        assert subscriber.subscribed_at.tzinfo is not None
+        assert subscriber.subscribed_at.utcoffset() is not None
         assert subscriber.messages_received == 0
         assert "price" in subscriber.fields
 
@@ -47,6 +49,10 @@ class TestStreamSubscriber:
 
         subscriber.update_activity()
 
+        assert old_time.tzinfo is not None
+        assert old_time.utcoffset() is not None
+        assert subscriber.subscribed_at.tzinfo is not None
+        assert subscriber.subscribed_at.utcoffset() is not None
         assert subscriber.subscribed_at >= old_time
 
 
@@ -65,6 +71,8 @@ class TestStreamData:
         assert data.message_id == "msg_001"
         assert data.symbol == "600519"
         assert data.version == 1
+        assert data.created_at.tzinfo is not None
+        assert data.created_at.utcoffset() is not None
 
     def test_stream_data_to_dict(self):
         """测试流数据转换"""


### PR DESCRIPTION
## Summary
- add a small UTC-aware timestamp helper for realtime streaming dataclass defaults
- use it for StreamSubscriber.subscribed_at and StreamData.created_at
- add focused timezone-awareness assertions and update G2.153 governance evidence

## Verification
- env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py -q --no-cov --tb=short => 43 passed
- env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_streaming_integration.py -q --no-cov --tb=short => 20 passed
- env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_socketio_manager.py -q --no-cov --tb=short => 26 passed, 1 existing warning
- env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short => 2 passed
- ruff check web/backend/app/services/realtime_streaming_service.py web/backend/tests/test_realtime_streaming_service.py => All checks passed
- markdown governance => errors 0
- mainline scope gate => pass=True

## Boundary
No Socket.IO manager source edit, route/API change, OpenAPI exposure change, frontend change, PM2 change, OpenSpec change, config/script change, compatibility wrapper deletion, or issue-label change.