### PR TITLE
docs(governance): close realtime socket subtrack

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2673,11 +2673,11 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              issue-label change, or GitHub issue state change is
 │   │              performed here
 │   ├── G2.153 Realtime streaming timezone-aware timestamps
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#306`
 │   │   ├── Evidence: `backend-realtime-streaming-timezone-aware-timestamps-2026-05-26.md`
 │   │   ├── Generated: `realtime-streaming-timezone-aware-timestamps-2026-05-26.json`
 │   │   ├── Parent: G2.149 accepted and merged by PR `#305`
-│   │   ├── Current HEAD: `58bdc319c3ca00819b6b4fe7fefa59a5a321ba9d`
+│   │   ├── Merge commit: `bc795386313b40c4d87602fd80a09ad2d275f9d4`
 │   │   ├── Scope: source plus focused-test implementation limited to
 │   │   │          `realtime_streaming_service.py` and
 │   │   │          `test_realtime_streaming_service.py`
@@ -2698,9 +2698,36 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              OpenAPI exposure, frontend, PM2, OpenSpec, config,
 │   │              script, compatibility wrapper deletion, issue-label
 │   │              change, or GitHub issue state change is performed here
-│   └── Next gate: review G2.153; if accepted, merge it and decide
-│                  whether realtime/socket has remaining high-risk getter
-│                  work or can return to the broader G2 service getter queue
+│   ├── G2.154 Realtime/socket subtrack closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-realtime-socket-subtrack-closeout-2026-05-26.md`
+│   │   ├── Generated: `realtime-socket-subtrack-closeout-2026-05-26.json`
+│   │   ├── Parent: G2.153 accepted and merged by PR `#306`
+│   │   ├── Current HEAD: `bc795386313b40c4d87602fd80a09ad2d275f9d4`
+│   │   ├── Result: closes the dedicated realtime/socket subtrack for now
+│   │   │          after PRs `#297` through `#306` completed the authorized
+│   │   │          manager-level injection, legacy export/test import
+│   │   │          alignment, stream-error patch-target alignment, and
+│   │   │          timezone-aware realtime streaming timestamp fix
+│   │   ├── Verification: merged-base focused regression across
+│   │   │          `test_realtime_streaming_service.py`,
+│   │   │          `test_socketio_streaming_integration.py`,
+│   │   │          `test_socketio_manager.py`, and
+│   │   │          `test_realtime_socket_manager_streaming_dependency.py`
+│   │   │          reports `91 passed, 1 warning`; static token scan reports
+│   │   │          `datetime.utcnow=0` on the realtime/socket source surfaces
+│   │   │          checked for this closeout
+│   │   ├── Decision: do not open another realtime/socket source lane from
+│   │   │          this closeout; return to the broader G2 high-risk service
+│   │   │          getter queue for a separate next-track decision or
+│   │   │          authorization package
+│   │   └── Boundary: closeout-only; no backend source/test edit, route/API,
+│   │              OpenAPI exposure, frontend, PM2, OpenSpec, config,
+│   │              script, compatibility wrapper deletion, issue-label
+│   │              change, or GitHub issue state change is performed here
+│   └── Next gate: review G2.154; if accepted, select the next high-risk
+│                  service getter track through a separate decision or
+│                  authorization package before any new source lane starts
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/realtime-socket-subtrack-closeout-2026-05-26.json
+++ b/.planning/codebase/generated/realtime-socket-subtrack-closeout-2026-05-26.json
@@ -1,0 +1,124 @@
+{
+  "artifact": "realtime-socket-subtrack-closeout-2026-05-26",
+  "generated_at": "2026-05-26T19:24:08+08:00",
+  "worktree": ".worktrees/g2-154-realtime-socket-subtrack-closeout",
+  "branch": "g2-154-realtime-socket-subtrack-closeout",
+  "base_head": "bc795386313b40c4d87602fd80a09ad2d275f9d4",
+  "task": {
+    "id": "G2.154",
+    "title": "Realtime/socket subtrack closeout",
+    "scope": "governance closeout only",
+    "authorization": "approved by user in current review thread"
+  },
+  "merged_prs": [
+    {
+      "task": "G2.143",
+      "pull_request": 296,
+      "title": "Decide high-risk service getter strategy"
+    },
+    {
+      "task": "G2.144",
+      "pull_request": 297,
+      "title": "Authorize realtime streaming socket lane"
+    },
+    {
+      "task": "G2.145",
+      "pull_request": 298,
+      "title": "Inject Socket.IO streaming service dependency"
+    },
+    {
+      "task": "G2.146",
+      "pull_request": 299,
+      "title": "Close realtime socket injection lane"
+    },
+    {
+      "task": "G2.147",
+      "pull_request": 300,
+      "title": "Route realtime socket baseline blockers"
+    },
+    {
+      "task": "G2.148",
+      "pull_request": 301,
+      "title": "Authorize Socket.IO legacy export contract routing"
+    },
+    {
+      "task": "G2.150",
+      "pull_request": 302,
+      "title": "Align Socket.IO legacy test imports"
+    },
+    {
+      "task": "G2.151",
+      "pull_request": 303,
+      "title": "Triage Socket.IO stream error emission"
+    },
+    {
+      "task": "G2.152",
+      "pull_request": 304,
+      "title": "Align Socket.IO stream error test patch target"
+    },
+    {
+      "task": "G2.149",
+      "pull_request": 305,
+      "title": "Authorize realtime streaming datetime fix"
+    },
+    {
+      "task": "G2.153",
+      "pull_request": 306,
+      "title": "Use aware realtime streaming timestamps",
+      "merge_commit": "bc795386313b40c4d87602fd80a09ad2d275f9d4",
+      "merged_at": "2026-05-26T11:17:58Z"
+    }
+  ],
+  "post_merge_verification": {
+    "focused_tests": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py web/backend/tests/test_socketio_streaming_integration.py web/backend/tests/test_socketio_manager.py web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short",
+      "result": "91 passed, 1 warning",
+      "warning": "Existing RuntimeWarning for un-awaited asyncio.sleep in test_socketio_manager.py::TestConnectionManager::test_update_activity remains outside this closeout."
+    },
+    "static_scan": [
+      {
+        "file": "web/backend/app/core/socketio_manager.py",
+        "datetime.utcnow": 0,
+        "get_streaming_service": 2,
+        "interpretation": "Remaining references are import plus constructor fallback; handler-level repeated direct calls remain removed."
+      },
+      {
+        "file": "web/backend/app/services/realtime_streaming_service.py",
+        "datetime.utcnow": 0,
+        "_utc_now": 3,
+        "get_streaming_service": 1,
+        "interpretation": "Remaining getter is the service singleton provider itself."
+      },
+      {
+        "file": "web/backend/tests/test_socketio_manager.py",
+        "get_socketio_manager": 8,
+        "reset_socketio_manager": 5,
+        "interpretation": "Tests use the explicit singleton helper module contract restored by G2.150."
+      },
+      {
+        "file": "web/backend/tests/test_socketio_streaming_integration.py",
+        "reset_socketio_manager": 18,
+        "interpretation": "Streaming integration tests use the aligned reset helper and manager-level patch target."
+      }
+    ]
+  },
+  "decision": {
+    "realtime_socket_subtrack_state": "closed for now",
+    "reason": "The authorized realtime/socket dependency-injection lane, legacy export/test import follow-ups, stream-error patch-target alignment, and realtime timestamp inconsistency are all merged with focused post-merge verification.",
+    "next_queue": "Return to the broader G2 high-risk service getter queue.",
+    "next_candidates": [
+      "Dashboard/TDX",
+      "Indicator/Data",
+      "Strategy adapter",
+      "root facade compatibility",
+      "route dependency/provider governance"
+    ],
+    "new_source_lane_authorized": false
+  },
+  "boundaries": [
+    "No backend source or test files are edited in G2.154.",
+    "No Socket.IO manager, realtime streaming service, route/API, OpenAPI, frontend, PM2, OpenSpec, config, script, compatibility wrapper, issue label, or GitHub issue state change is made here.",
+    "This closeout does not authorize the next source implementation lane."
+  ],
+  "next_gate": "Review and merge G2.154; after acceptance, create a separate decision or authorization package for the next high-risk service getter track."
+}

--- a/docs/reports/quality/backend-realtime-socket-subtrack-closeout-2026-05-26.md
+++ b/docs/reports/quality/backend-realtime-socket-subtrack-closeout-2026-05-26.md
@@ -1,0 +1,80 @@
+# Backend Realtime Socket Subtrack Closeout
+
+Date: 2026-05-26  
+Task: G2.154 realtime/socket subtrack closeout  
+Branch: `g2-154-realtime-socket-subtrack-closeout`  
+Base HEAD: `bc795386313b40c4d87602fd80a09ad2d275f9d4`  
+Parent: G2.153, merged by PR `#306`
+
+> **历史文档说明**: This report records the G2.154 governance closeout result for the realtime/socket subtrack. It does not authorize backend source changes, backend test changes, route/API changes, OpenAPI exposure changes, frontend changes, PM2 workflow changes, OpenSpec changes, issue-state changes, compatibility wrapper deletion, or the next service getter implementation lane.
+
+## Scope
+
+G2.154 is closeout-only. It records the accepted sequence from high-risk getter strategy selection through realtime/socket implementation, follow-up routing, and timestamp fix.
+
+Allowed files:
+
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/realtime-socket-subtrack-closeout-2026-05-26.json`
+- `docs/reports/quality/backend-realtime-socket-subtrack-closeout-2026-05-26.md`
+- `governance/mainline/task-cards/pr-307.yaml`
+
+## Closed Sequence
+
+| Task | PR | Result |
+|---|---:|---|
+| G2.143 | #296 | High-risk service getter strategy decision selected realtime streaming/socket as a dedicated track. |
+| G2.144 | #297 | Authorized the realtime streaming socket lane. |
+| G2.145 | #298 | Injected the Socket.IO streaming service dependency at manager level. |
+| G2.146 | #299 | Closed the realtime socket injection lane and routed baseline blockers. |
+| G2.147 | #300 | Split baseline blockers into legacy export contract and datetime debt lanes. |
+| G2.148 | #301 | Authorized Socket.IO legacy export contract routing. |
+| G2.150 | #302 | Aligned Socket.IO legacy test imports. |
+| G2.151 | #303 | Triaged the stream-error emission failure as patch-target drift. |
+| G2.152 | #304 | Aligned the stream-error test patch target. |
+| G2.149 | #305 | Authorized realtime streaming timezone timestamp implementation. |
+| G2.153 | #306 | Implemented timezone-aware realtime streaming dataclass defaults. |
+
+## Post-Merge Verification
+
+Focused post-merge regression on the merged base:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py web/backend/tests/test_socketio_streaming_integration.py web/backend/tests/test_socketio_manager.py web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short
+91 passed, 1 warning
+```
+
+The warning is the existing `RuntimeWarning` for un-awaited `asyncio.sleep` in `test_socketio_manager.py::TestConnectionManager::test_update_activity`; it is not introduced or modified by this closeout.
+
+Static scan on the closeout base:
+
+| Surface | Observation | Interpretation |
+|---|---|---|
+| `web/backend/app/core/socketio_manager.py` | `datetime.utcnow=0`, `get_streaming_service=2` | Remaining getter references are import plus constructor fallback; repeated handler-level direct calls remain removed. |
+| `web/backend/app/services/realtime_streaming_service.py` | `datetime.utcnow=0`, `_utc_now=3`, `get_streaming_service=1` | Realtime streaming timestamp defaults are timezone-aware; remaining getter is the singleton provider itself. |
+| `web/backend/tests/test_socketio_manager.py` | `get_socketio_manager=8`, `reset_socketio_manager=5` | Tests use the explicit singleton helper module contract restored by G2.150. |
+| `web/backend/tests/test_socketio_streaming_integration.py` | `reset_socketio_manager=18` | Streaming integration tests use the aligned reset helper and manager-level patch target. |
+
+## Decision
+
+The realtime/socket subtrack is closed for now.
+
+This closeout does not mean every high-risk getter in the project is retired. It means the dedicated realtime/socket slice has completed its authorized sequence:
+
+- manager-level streaming service dependency injection is merged;
+- legacy Socket.IO helper import/test compatibility is aligned;
+- stream-error patch-target drift is resolved in tests;
+- realtime streaming timestamp inconsistency is fixed;
+- the focused merged-base regression suite is green.
+
+The broader G2 high-risk service getter queue remains active. The next implementation lane should not start from this closeout. It should be selected by a separate decision or authorization package from the remaining G2.143 tracks:
+
+- Dashboard/TDX
+- Indicator/Data
+- Strategy adapter
+- root facade compatibility
+- route dependency/provider governance
+
+## Next Gate
+
+Review and merge this closeout package. After acceptance, create a separate next-track decision or authorization package before any new backend source implementation starts.

--- a/governance/mainline/task-cards/pr-307.yaml
+++ b/governance/mainline/task-cards/pr-307.yaml
@@ -1,0 +1,105 @@
+version: "v0.2"
+
+task:
+  id: "pr-307"
+  title: "Close realtime socket subtrack"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-realtime-socket-subtrack-closeout"
+  objective: "record the merged realtime/socket sequence and return to the broader high-risk service getter queue"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-realtime-socket-subtrack-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only governance package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/realtime-socket-subtrack-closeout-2026-05-26.json"
+    - "docs/reports/quality/backend-realtime-socket-subtrack-closeout-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-307.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 306 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "focused-post-merge-regression"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_realtime_streaming_service.py web/backend/tests/test_socketio_streaming_integration.py web/backend/tests/test_socketio_manager.py web/backend/tests/test_realtime_socket_manager_streaming_dependency.py -q --no-cov --tb=short"
+      required: true
+    - id: "static-token-scan"
+      command: "scan realtime/socket source and tests for datetime.utcnow, _utc_now, get_streaming_service, get_socketio_manager, and reset_socketio_manager counts"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-realtime-socket-subtrack-closeout-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/realtime-socket-subtrack-closeout-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-307.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this closeout package."
+  - "Do not start the next service getter implementation lane from this closeout package."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+  - "Do not delete compatibility wrappers."
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is treated as implementation authorization, the next high-risk getter lane could start without a separate decision package."
+    - "If the realtime/socket subtrack remains open after G2.153, future workers may duplicate already-merged follow-up work."
+  rollback_plan: "revert this closeout PR to remove only the decision report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close the realtime/socket subtrack and return to the broader high-risk service getter queue"
+    modified_scope: "steward tree, closeout report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused regression, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T19:24:08+08:00"
+    approval_note: "Closeout-only package after PR #306 was approved and merged."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- mark G2.153 / PR #306 as accepted and merged in the steward tree
- add G2.154 closeout evidence for the realtime/socket subtrack
- return the next step to the broader high-risk service getter queue instead of opening another realtime/socket source lane

## Verification
- gh pr view 306 => MERGED, merge commit bc795386313b40c4d87602fd80a09ad2d275f9d4
- focused merged-base regression => 91 passed, 1 existing warning
- static scan => datetime.utcnow=0 on checked realtime/socket source surfaces
- markdown governance => errors 0
- JSON/YAML parse => passed
- git diff --check => passed
- GitNexus staged detect changes => low risk, affected 0
- mainline scope gate => pass=True

## Boundary
Closeout-only. No backend source/test edit, route/API change, OpenAPI exposure change, frontend change, PM2 change, OpenSpec change, config/script change, compatibility wrapper deletion, issue-label change, or new implementation authorization.