### PR TITLE
docs(governance): select dashboard tdx getter track

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2699,11 +2699,11 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              script, compatibility wrapper deletion, issue-label
 │   │              change, or GitHub issue state change is performed here
 │   ├── G2.154 Realtime/socket subtrack closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#307`
 │   │   ├── Evidence: `backend-realtime-socket-subtrack-closeout-2026-05-26.md`
 │   │   ├── Generated: `realtime-socket-subtrack-closeout-2026-05-26.json`
 │   │   ├── Parent: G2.153 accepted and merged by PR `#306`
-│   │   ├── Current HEAD: `bc795386313b40c4d87602fd80a09ad2d275f9d4`
+│   │   ├── Merge commit: `3beee4c192dd060dd5f54022cf30f0d3ea1d7294`
 │   │   ├── Result: closes the dedicated realtime/socket subtrack for now
 │   │   │          after PRs `#297` through `#306` completed the authorized
 │   │   │          manager-level injection, legacy export/test import
@@ -2725,9 +2725,36 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              OpenAPI exposure, frontend, PM2, OpenSpec, config,
 │   │              script, compatibility wrapper deletion, issue-label
 │   │              change, or GitHub issue state change is performed here
-│   └── Next gate: review G2.154; if accepted, select the next high-risk
-│                  service getter track through a separate decision or
-│                  authorization package before any new source lane starts
+│   ├── G2.155 Next high-risk service getter track selection
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-next-high-risk-service-getter-track-selection-2026-05-26.md`
+│   │   ├── Generated: `next-high-risk-service-getter-track-selection-2026-05-26.json`
+│   │   ├── Parent: G2.154 accepted and merged by PR `#307`
+│   │   ├── Current HEAD: `3beee4c192dd060dd5f54022cf30f0d3ea1d7294`
+│   │   ├── Refreshed impact: `get_tdx_service` remains CRITICAL with
+│   │   │          impacted `4`, direct callers `2`, and processes `5`;
+│   │   │          `get_data_service` remains CRITICAL with impacted `4`,
+│   │   │          direct callers `3`, and processes `7`; `get_strategy_service`
+│   │   │          remains CRITICAL with impacted `11`, direct callers `6`,
+│   │   │          and processes `0`
+│   │   ├── Decision: select Dashboard/TDX runtime seam as the next
+│   │   │          high-risk service getter design track because its direct
+│   │   │          caller surface is smallest and concentrated in
+│   │   │          `dashboard_data_source.py` helpers; defer Indicator/Data,
+│   │   │          Strategy adapter, root facade compatibility, and route
+│   │   │          dependency/provider governance to separate packages
+│   │   ├── G2.156 gate: prepare a Dashboard/TDX design and authorization
+│   │   │          package with dashboard consumer contract matrix, TDX
+│   │   │          fallback behavior, focused route tests or smoke plan,
+│   │   │          allowed path list, and route/OpenAPI drift rule before
+│   │   │          any Dashboard/TDX source lane starts
+│   │   └── Boundary: decision-only; no backend source/test edit, route/API,
+│   │              OpenAPI exposure, frontend, PM2, OpenSpec, config,
+│   │              script, compatibility wrapper deletion, issue-label
+│   │              change, or GitHub issue state change is performed here
+│   └── Next gate: review G2.155; if accepted, start G2.156 Dashboard/TDX
+│                  design and authorization package before any Dashboard/TDX
+│                  source implementation begins
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/next-high-risk-service-getter-track-selection-2026-05-26.json
+++ b/.planning/codebase/generated/next-high-risk-service-getter-track-selection-2026-05-26.json
@@ -1,0 +1,146 @@
+{
+  "artifact": "next-high-risk-service-getter-track-selection-2026-05-26",
+  "generated_at": "2026-05-26T20:30:33+08:00",
+  "worktree": ".worktrees/g2-155-next-high-risk-getter-track-selection",
+  "branch": "g2-155-next-high-risk-getter-track-selection",
+  "base_head": "3beee4c192dd060dd5f54022cf30f0d3ea1d7294",
+  "task": {
+    "id": "G2.155",
+    "title": "Next high-risk service getter track selection",
+    "scope": "governance decision only",
+    "authorization": "approved by user in current review thread"
+  },
+  "parent": {
+    "task": "G2.154",
+    "pull_request": 307,
+    "merge_commit": "3beee4c192dd060dd5f54022cf30f0d3ea1d7294",
+    "decision": "Realtime/socket subtrack is closed for now; return to broader G2 high-risk service getter queue."
+  },
+  "source_inputs": [
+    "docs/reports/quality/backend-high-risk-service-getter-strategy-decision-2026-05-26.md",
+    "docs/reports/quality/backend-realtime-socket-subtrack-closeout-2026-05-26.md",
+    ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+    "OpenSpec active list and spec list checked on 2026-05-26; PostHog ECONNREFUSED remains telemetry noise"
+  ],
+  "refreshed_impact": [
+    {
+      "track": "Dashboard/TDX",
+      "primary_surface": "get_tdx_service",
+      "risk": "CRITICAL",
+      "impacted_count": 4,
+      "direct_callers": 2,
+      "processes_affected": 5,
+      "d1_callers": [
+        "web/backend/app/api/dashboard_data_source.py::_get_major_index_quotes",
+        "web/backend/app/api/dashboard_data_source.py::_get_tdx_live_market_snapshot"
+      ]
+    },
+    {
+      "track": "Indicator/Data",
+      "primary_surface": "get_data_service",
+      "risk": "CRITICAL",
+      "impacted_count": 4,
+      "direct_callers": 3,
+      "processes_affected": 7,
+      "d1_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py::calculate_indicators",
+        "web/backend/app/api/indicators/indicator_cache.py::_calculate_single_indicator",
+        "web/backend/app/api/v1/strategy/indicators.py::get_technical_indicators"
+      ]
+    },
+    {
+      "track": "Strategy adapter",
+      "primary_surface": "get_strategy_service",
+      "risk": "CRITICAL",
+      "impacted_count": 11,
+      "direct_callers": 6,
+      "processes_affected": 0,
+      "d1_callers": [
+        "web/backend/app/services/data_adapters/strategy.py::_get_strategy_service",
+        "web/backend/app/services/adapters/strategy_adapter.py::_get_strategy_service",
+        "web/backend/app/api/strategy_management/_strategy_execution_router.py::query_strategy_results",
+        "web/backend/app/api/strategy_management/_strategy_execution_router.py::get_matched_stocks",
+        "web/backend/app/api/strategy_management/_strategy_execution_router.py::get_strategy_summary",
+        "web/backend/app/tasks/backtest_tasks.py::_resolve_backtest_data_source"
+      ]
+    },
+    {
+      "track": "Root facade compatibility",
+      "primary_surface": "web/backend/app/services/__init__.py",
+      "risk": "locked governance surface",
+      "impacted_count": 1,
+      "direct_callers": 1,
+      "processes_affected": 0,
+      "note": "GitNexus file impact is LOW, but G2.143 keeps this track locked because active compatibility exports require a dedicated retirement decision record."
+    }
+  ],
+  "token_scan": {
+    "get_tdx_service": {
+      "files": 3,
+      "hits": 14,
+      "top": [
+        "web/backend/app/api/tdx.py: 6",
+        "web/backend/app/api/dashboard_data_source.py: 5",
+        "web/backend/app/services/tdx_service.py: 3"
+      ]
+    },
+    "get_data_service": {
+      "files": 5,
+      "hits": 10,
+      "top": [
+        "web/backend/app/api/indicators/indicator_cache.py: 3",
+        "web/backend/app/api/v1/strategy/indicators.py: 2",
+        "web/backend/app/api/v1/strategy/ml_runtime_helpers.py: 2",
+        "web/backend/app/api/v1/system/health.py: 2",
+        "web/backend/app/services/data_service.py: 1"
+      ]
+    },
+    "get_strategy_service": {
+      "files": 5,
+      "hits": 27,
+      "top": [
+        "web/backend/app/services/adapters/strategy_adapter.py: 10",
+        "web/backend/app/services/data_adapters/strategy.py: 10",
+        "web/backend/app/api/strategy_management/_strategy_execution_router.py: 4",
+        "web/backend/app/tasks/backtest_tasks.py: 2",
+        "web/backend/app/services/strategy_service.py: 1"
+      ]
+    },
+    "route_provider_surfaces": {
+      "get_market_data_service_v2_dependency": "17 hits across 3 files",
+      "get_tdx_service_dependency": "7 hits across 2 files",
+      "get_indicator_registry_dependency": "4 hits across 2 files"
+    }
+  },
+  "decision": {
+    "selected_track": "Dashboard/TDX runtime seam",
+    "selection_reason": [
+      "It is the smallest remaining CRITICAL implementation family by direct caller count.",
+      "Its current d=1 surface is concentrated in dashboard_data_source helper functions.",
+      "Prior TDX route/provider work exists, so the next package can focus on dashboard consumer contract and fallback behavior instead of inventing a new provider pattern.",
+      "Indicator/Data and Strategy adapter remain broader and should wait for separate dedicated packages."
+    ],
+    "next_gate": "G2.156 Dashboard/TDX design and authorization package",
+    "source_implementation_authorized": false
+  },
+  "g2_156_minimum_requirements": [
+    "Refresh GitNexus impact for get_tdx_service and dashboard_data_source helper callers.",
+    "Produce a dashboard/TDX consumer contract matrix for _get_major_index_quotes, _get_tdx_live_market_snapshot, and their dashboard summary callers.",
+    "Document TDX unavailable/fallback behavior and test-double strategy.",
+    "Define allowed source and test paths before any implementation lane starts.",
+    "Require focused dashboard/TDX route tests or import-safe smoke tests.",
+    "Require route/OpenAPI drift check if the approved implementation touches route-level dependency contracts.",
+    "Explicitly exclude Indicator/Data, Strategy adapter, root facade compatibility, and route dependency/provider governance from the first Dashboard/TDX implementation lane."
+  ],
+  "deferred_tracks": [
+    "Indicator/Data service seam",
+    "Strategy adapter seam",
+    "Root facade compatibility seam",
+    "Route dependency/provider governance seam"
+  ],
+  "boundaries": [
+    "No backend source or test files are edited in G2.155.",
+    "No route/API, OpenAPI, frontend, PM2, OpenSpec, config, script, compatibility wrapper, issue label, or GitHub issue state change is made here.",
+    "This selection does not authorize G2.156 source implementation; it only authorizes drafting the G2.156 design/authorization package."
+  ]
+}

--- a/docs/reports/quality/backend-next-high-risk-service-getter-track-selection-2026-05-26.md
+++ b/docs/reports/quality/backend-next-high-risk-service-getter-track-selection-2026-05-26.md
@@ -1,0 +1,86 @@
+# Backend Next High-Risk Service Getter Track Selection
+
+Date: 2026-05-26  
+Task: G2.155 next high-risk service getter track selection  
+Branch: `g2-155-next-high-risk-getter-track-selection`  
+Base HEAD: `3beee4c192dd060dd5f54022cf30f0d3ea1d7294`  
+Parent: G2.154, merged by PR `#307`
+
+> **历史决策说明**: This report records a G2.155 governance decision only. It does not authorize backend source changes, backend test changes, route/API changes, OpenAPI exposure changes, frontend changes, PM2 workflow changes, OpenSpec changes, issue-state changes, compatibility wrapper deletion, or the G2.156 source implementation lane.
+
+## Purpose
+
+G2.154 closed the realtime/socket subtrack and returned control to the broader G2 high-risk service getter queue. G2.155 selects the next track from the remaining G2.143 tracks without opening a source implementation lane.
+
+## Inputs
+
+- `docs/reports/quality/backend-high-risk-service-getter-strategy-decision-2026-05-26.md`
+- `docs/reports/quality/backend-realtime-socket-subtrack-closeout-2026-05-26.md`
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- OpenSpec active list and spec list, checked on 2026-05-26; PostHog `ECONNREFUSED` remains telemetry noise
+
+## Refreshed Track Evidence
+
+| Track | Primary surface | Risk | Impact | Current disposition |
+|---|---|---:|---:|---|
+| Dashboard/TDX | `get_tdx_service` | CRITICAL | impacted 4, direct 2, processes 5 | Select next design/authorization track |
+| Indicator/Data | `get_data_service` | CRITICAL | impacted 4, direct 3, processes 7 | Defer to later dedicated package |
+| Strategy adapter | `get_strategy_service` | CRITICAL | impacted 11, direct 6, processes 0 | Defer to later dedicated package |
+| Root facade compatibility | `web/backend/app/services/__init__.py` | locked | active compatibility surface | Keep locked; not a cleanup candidate |
+| Route dependency/provider governance | FastAPI provider getters | locked | active route dependency contracts | Keep locked; not a singleton-retirement candidate |
+
+Dashboard/TDX currently has the smallest direct caller count among the remaining CRITICAL implementation families. Its d=1 callers are concentrated in `web/backend/app/api/dashboard_data_source.py`:
+
+- `_get_major_index_quotes`
+- `_get_tdx_live_market_snapshot`
+
+Current token scan:
+
+| Token | Files | Hits | Main surfaces |
+|---|---:|---:|---|
+| `get_tdx_service` | 3 | 14 | `api/tdx.py`, `api/dashboard_data_source.py`, `services/tdx_service.py` |
+| `get_data_service` | 5 | 10 | indicator cache, strategy indicators, system health, service provider |
+| `get_strategy_service` | 5 | 27 | strategy adapters, strategy execution router, backtest task, service provider |
+
+Route-provider surfaces remain active contracts:
+
+- `get_market_data_service_v2_dependency`: 17 hits across 3 files
+- `get_tdx_service_dependency`: 7 hits across 2 files
+- `get_indicator_registry_dependency`: 4 hits across 2 files
+
+## Decision
+
+Select the Dashboard/TDX runtime seam as the next high-risk service getter track.
+
+This selection is narrower than Indicator/Data and Strategy adapter:
+
+- Dashboard/TDX has two direct callers, both dashboard helper functions.
+- Prior TDX route/provider work exists, so the next package can focus on dashboard consumer contracts and fallback behavior.
+- Indicator/Data crosses indicator cache, strategy indicators, system health, and strategy runtime helpers.
+- Strategy adapter crosses adapter wrappers, strategy execution routes, and backtest task resolution.
+
+## G2.156 Gate
+
+The next package should be G2.156 Dashboard/TDX design and authorization.
+
+Minimum requirements for G2.156:
+
+- Refresh GitNexus impact for `get_tdx_service` and the dashboard helper callers.
+- Produce a Dashboard/TDX consumer contract matrix for `_get_major_index_quotes`, `_get_tdx_live_market_snapshot`, and their dashboard summary callers.
+- Document TDX unavailable/fallback behavior and the test-double strategy.
+- Define allowed source and test paths before any implementation lane starts.
+- Require focused dashboard/TDX route tests or import-safe smoke tests.
+- Require route/OpenAPI drift check if the approved implementation touches route-level dependency contracts.
+- Explicitly exclude Indicator/Data, Strategy adapter, root facade compatibility, and route dependency/provider governance from the first Dashboard/TDX implementation lane.
+
+## Non-Goals
+
+- No backend source or test edit.
+- No route/API or OpenAPI change.
+- No provider, getter, or compatibility wrapper deletion.
+- No implementation authorization for G2.156 source changes.
+- No GitHub issue label or state change.
+
+## Next Gate
+
+Review and merge this G2.155 decision package. If accepted, start G2.156 as a Dashboard/TDX design and authorization package before any Dashboard/TDX source implementation begins.

--- a/governance/mainline/task-cards/pr-308.yaml
+++ b/governance/mainline/task-cards/pr-308.yaml
@@ -1,0 +1,108 @@
+version: "v0.2"
+
+task:
+  id: "pr-308"
+  title: "Select next high-risk service getter track"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-next-high-risk-service-getter-track-selection"
+  objective: "select Dashboard/TDX as the next high-risk service getter design track after realtime/socket closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-next-high-risk-service-getter-track-selection"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision-only governance package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/next-high-risk-service-getter-track-selection-2026-05-26.json"
+    - "docs/reports/quality/backend-next-high-risk-service-getter-track-selection-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-308.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 307 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "openspec-context"
+      command: "openspec list && openspec list --specs"
+      required: true
+    - id: "gitnexus-impact"
+      command: "GitNexus impact for get_tdx_service, get_data_service, get_strategy_service, and web/backend/app/services/__init__.py"
+      required: true
+    - id: "token-scan"
+      command: "scan current token counts for get_tdx_service, get_data_service, get_strategy_service, and route provider getters"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-next-high-risk-service-getter-track-selection-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/next-high-risk-service-getter-track-selection-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-308.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this decision package."
+  - "Do not authorize G2.156 source implementation from this package."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+  - "Do not delete compatibility wrappers or provider getters."
+
+risk_and_rollback:
+  risks:
+    - "If this selection is treated as source authorization, Dashboard/TDX code could be modified without the required G2.156 design and authorization package."
+    - "If the route dependency/provider surfaces are treated as cleanup candidates, active FastAPI dependency contracts could be broken."
+  rollback_plan: "revert this decision PR to remove only the decision report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "select Dashboard/TDX as the next high-risk service getter design track"
+    modified_scope: "steward tree, decision report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, GitNexus impact evidence, token scan, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T20:30:33+08:00"
+    approval_note: "Decision-only track selection after PR #307 closed the realtime/socket subtrack."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- mark G2.154 / PR #307 as accepted and merged in the steward tree
- refresh high-risk getter evidence for Dashboard/TDX, Indicator/Data, Strategy adapter, and locked governance surfaces
- select Dashboard/TDX as the next high-risk service getter design track

## Decision
G2.155 selects Dashboard/TDX as the next track because get_tdx_service is still CRITICAL but has the smallest direct caller surface among the remaining implementation families: 2 direct dashboard helper callers, 5 affected processes.

This PR does not authorize source implementation. The next gate is G2.156 Dashboard/TDX design and authorization package.

## Verification
- gh pr view 307 => MERGED, merge commit 3beee4c192dd060dd5f54022cf30f0d3ea1d7294
- openspec list && openspec list --specs => checked; PostHog ECONNREFUSED telemetry noise only
- GitNexus impact refreshed for get_tdx_service, get_data_service, get_strategy_service, and services/__init__.py
- token scan refreshed for remaining getter/provider surfaces
- markdown governance => errors 0
- JSON/YAML parse => passed
- git diff --check => passed
- GitNexus staged detect changes => low risk, affected 0
- mainline scope gate => pass=True

## Boundary
Decision-only. No backend source/test edit, route/API change, OpenAPI exposure change, frontend change, PM2 change, OpenSpec change, config/script change, compatibility wrapper deletion, issue-label change, or G2.156 source implementation authorization.