### PR TITLE
docs(governance): close dashboard tdx verification lane

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2754,11 +2754,12 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              script, compatibility wrapper deletion, issue-label
 │   │              change, or GitHub issue state change is performed here
 │   ├── G2.156 Dashboard/TDX design and authorization package
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#309`
 │   │   ├── Evidence: `backend-dashboard-tdx-design-authorization-2026-05-26.md`
 │   │   ├── Generated: `dashboard-tdx-design-authorization-2026-05-26.json`
 │   │   ├── Parent: G2.155 accepted and merged by PR `#308`
 │   │   ├── Current HEAD: `ee2fad4c41b0f4585bc39d9adb59c18326bbbd8e`
+│   │   ├── Merge commit: `e7cb84fae5e0c65cb400f467f6d9b55c3b2775d4`
 │   │   ├── Impact evidence: `get_tdx_service`, `_get_major_index_quotes`,
 │   │   │          and `_get_tdx_live_market_snapshot` remain CRITICAL in
 │   │   │          GitNexus because dashboard helper flows still traverse the
@@ -2782,9 +2783,39 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              OpenAPI exposure, frontend, PM2, OpenSpec, config,
 │   │              script, compatibility wrapper deletion, issue-label
 │   │              change, or GitHub issue state change is performed here
-│   └── Next gate: review G2.156; if accepted, start G2.157 as a
-│                  current-head verification-first lane before any
-│                  Dashboard/TDX source implementation begins
+│   ├── G2.157 Dashboard/TDX current-head verification closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-dashboard-tdx-verification-closeout-2026-05-26.md`
+│   │   ├── Generated: `dashboard-tdx-verification-closeout-2026-05-26.json`
+│   │   ├── Parent: G2.156 accepted and merged by PR `#309`
+│   │   ├── Current HEAD: `e7cb84fae5e0c65cb400f467f6d9b55c3b2775d4`
+│   │   ├── GitNexus evidence: `get_tdx_service` remains CRITICAL
+│   │   │          with impacted `6`, direct callers `2`, and processes `5`;
+│   │   │          `_get_major_index_quotes` and
+│   │   │          `_get_tdx_live_market_snapshot` remain CRITICAL with
+│   │   │          impacted `5`, direct callers `2`, and processes `5`;
+│   │   │          `prewarm_dashboard_market_overview_cache` remains LOW
+│   │   ├── Current-head static classification:
+│   │   │          `dashboard_data_source.py` has five `get_tdx_service`
+│   │   │          textual hits, classified as import, constructor fallback
+│   │   │          provider, private helper definition, and two private helper
+│   │   │          calls; direct dashboard helper getter debt is `0`
+│   │   ├── Focused verification: `test_dashboard_data_source.py` `11`
+│   │   │          passed, `test_tdx_service_lifecycle_di.py` `4` passed,
+│   │   │          and `test_health_route_conflicts.py --collect-only`
+│   │   │          collected `120` tests
+│   │   ├── Decision: close Dashboard/TDX without source implementation;
+│   │   │          do not open another Dashboard/TDX source lane unless a
+│   │   │          future current-head contradiction shows new residual direct
+│   │   │          dashboard helper getter debt
+│   │   └── Boundary: closeout-only; no backend source/test edit, route/API,
+│   │              OpenAPI exposure, frontend, PM2, OpenSpec, config,
+│   │              script, compatibility wrapper deletion, issue-label
+│   │              change, or GitHub issue state change is performed here
+│   └── Next gate: review G2.157; if accepted, return to the remaining
+│                  high-risk getter queue: Indicator/Data, Strategy adapter,
+│                  root facade compatibility, and route dependency/provider
+│                  governance
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/dashboard-tdx-verification-closeout-2026-05-26.json
+++ b/.planning/codebase/generated/dashboard-tdx-verification-closeout-2026-05-26.json
@@ -1,0 +1,144 @@
+{
+  "artifact": "dashboard-tdx-verification-closeout-2026-05-26",
+  "generated_at": "2026-05-26T22:19:47+08:00",
+  "worktree": ".worktrees/g2-157-dashboard-tdx-verification-closeout",
+  "branch": "g2-157-dashboard-tdx-verification-closeout",
+  "base_head": "e7cb84fae5e0c65cb400f467f6d9b55c3b2775d4",
+  "task": {
+    "id": "G2.157",
+    "title": "Dashboard/TDX current-head verification closeout",
+    "scope": "verification-first closeout only",
+    "authorization": "G2.156 accepted by user and merged through PR #309"
+  },
+  "parent": {
+    "task": "G2.156",
+    "pull_request": 309,
+    "state": "MERGED",
+    "merge_commit": "e7cb84fae5e0c65cb400f467f6d9b55c3b2775d4",
+    "decision": "G2.157 must verify current HEAD first and close out without source edits if no residual direct dashboard helper getter debt remains."
+  },
+  "gitnexus_impact": {
+    "get_tdx_service": {
+      "risk": "CRITICAL",
+      "impacted_count": 6,
+      "direct_callers": 2,
+      "processes_affected": 5,
+      "d1_callers": [
+        "_get_major_index_quotes",
+        "_get_tdx_live_market_snapshot"
+      ],
+      "d2_callers": [
+        "_get_market_overview_data",
+        "prewarm_dashboard_market_overview_cache"
+      ],
+      "d3_callers": [
+        "get_market_overview_data",
+        "get_dashboard_summary"
+      ]
+    },
+    "_get_major_index_quotes": {
+      "risk": "CRITICAL",
+      "impacted_count": 5,
+      "direct_callers": 2,
+      "processes_affected": 5,
+      "d1_callers": [
+        "_get_market_overview_data",
+        "prewarm_dashboard_market_overview_cache"
+      ],
+      "d2_callers": [
+        "get_market_overview_data",
+        "get_dashboard_summary"
+      ],
+      "d3_callers": [
+        "get_market_overview"
+      ]
+    },
+    "_get_tdx_live_market_snapshot": {
+      "risk": "CRITICAL",
+      "impacted_count": 5,
+      "direct_callers": 2,
+      "processes_affected": 5,
+      "d1_callers": [
+        "_get_market_overview_data",
+        "prewarm_dashboard_market_overview_cache"
+      ],
+      "d2_callers": [
+        "get_market_overview_data",
+        "get_dashboard_summary"
+      ],
+      "d3_callers": [
+        "get_market_overview"
+      ]
+    },
+    "prewarm_dashboard_market_overview_cache": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct_callers": 0,
+      "processes_affected": 0
+    }
+  },
+  "current_head_static_classification": {
+    "file": "web/backend/app/api/dashboard_data_source.py",
+    "hit_count": 5,
+    "direct_dashboard_helper_getter_debt": 0,
+    "hits": [
+      {
+        "line": 24,
+        "kind": "import",
+        "text": "from app.services.tdx_service import TdxService, get_tdx_service"
+      },
+      {
+        "line": 62,
+        "kind": "constructor_default_provider",
+        "text": "self._tdx_service_provider = tdx_service_provider or get_tdx_service"
+      },
+      {
+        "line": 70,
+        "kind": "private_provider_helper_definition",
+        "text": "def _get_tdx_service(self) -> TdxService:"
+      },
+      {
+        "line": 247,
+        "kind": "private_provider_helper_call",
+        "text": "tdx_service = self._get_tdx_service()"
+      },
+      {
+        "line": 499,
+        "kind": "private_provider_helper_call",
+        "text": "tdx_service = self._get_tdx_service()"
+      }
+    ]
+  },
+  "focused_verification": {
+    "dashboard_data_source": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_dashboard_data_source.py -q --no-cov --tb=short",
+      "result": "11 passed in 5.40s"
+    },
+    "tdx_service_lifecycle_di": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tdx_service_lifecycle_di.py -q --no-cov --tb=short",
+      "result": "4 passed in 1.33s"
+    },
+    "health_route_conflicts_collect_only": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov",
+      "result": "120 tests collected in 16.10s"
+    }
+  },
+  "decision": {
+    "status": "closeout_only",
+    "source_implementation_required": false,
+    "reason": "Current HEAD has zero residual direct dashboard helper get_tdx_service debt and focused verification passed.",
+    "do_not_open_dashboard_tdx_source_lane_from_this_closeout": true
+  },
+  "remaining_tracks": [
+    "Indicator/Data",
+    "Strategy adapter",
+    "root facade compatibility",
+    "route dependency/provider governance"
+  ],
+  "boundaries": {
+    "no_source_or_test_edits": true,
+    "no_route_or_openapi_changes": true,
+    "no_get_tdx_service_deletion_or_privatization": true,
+    "no_pm2_frontend_openspec_config_script_or_issue_label_changes": true
+  }
+}

--- a/docs/reports/quality/backend-dashboard-tdx-verification-closeout-2026-05-26.md
+++ b/docs/reports/quality/backend-dashboard-tdx-verification-closeout-2026-05-26.md
@@ -1,0 +1,108 @@
+# Backend Dashboard/TDX Verification Closeout
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Date: 2026-05-26
+
+Status: Ready for review
+
+Scope: G2.157 current-head verification and closeout only.
+
+Base HEAD: `e7cb84fae5e0c65cb400f467f6d9b55c3b2775d4`
+
+Parent: G2.156, PR `#309`, merged as `e7cb84fae5e0c65cb400f467f6d9b55c3b2775d4`.
+
+Boundary: this is a verification closeout package only. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations. It does not perform implementation.
+
+## Decision
+
+Close the Dashboard/TDX source lane without implementation.
+
+Current HEAD has no residual direct dashboard helper `get_tdx_service()` debt. The remaining graph risk is real, but it represents active dashboard flow dependence on the TDX provider seam, not a pending direct-call cleanup that should be edited blindly.
+
+## GitNexus Impact
+
+| Symbol | Risk | Impacted | Direct callers | Processes |
+|---|---:|---:|---:|---:|
+| `get_tdx_service` | CRITICAL | 6 | 2 | 5 |
+| `_get_major_index_quotes` | CRITICAL | 5 | 2 | 5 |
+| `_get_tdx_live_market_snapshot` | CRITICAL | 5 | 2 | 5 |
+| `prewarm_dashboard_market_overview_cache` | LOW | 0 | 0 | 0 |
+
+For `get_tdx_service`, the direct graph callers remain:
+
+- `_get_major_index_quotes`
+- `_get_tdx_live_market_snapshot`
+
+The next layers remain:
+
+- `_get_market_overview_data`
+- `prewarm_dashboard_market_overview_cache`
+- `get_market_overview_data`
+- `get_dashboard_summary`
+
+This confirms the seam is still high-impact. It does not prove there is a remaining direct getter debt to patch.
+
+## Current-Head Static Classification
+
+File: `web/backend/app/api/dashboard_data_source.py`
+
+| Line | Classification | Text |
+|---:|---|---|
+| 24 | import | `from app.services.tdx_service import TdxService, get_tdx_service` |
+| 62 | constructor default provider | `self._tdx_service_provider = tdx_service_provider or get_tdx_service` |
+| 70 | private provider helper definition | `def _get_tdx_service(self) -> TdxService:` |
+| 247 | private provider helper call | `tdx_service = self._get_tdx_service()` |
+| 499 | private provider helper call | `tdx_service = self._get_tdx_service()` |
+
+Direct dashboard helper getter debt: `0`.
+
+The current shape preserves fallback compatibility while routing dashboard helper access through `RealBusinessDataSource` provider state and the private `_get_tdx_service()` helper.
+
+## Focused Verification
+
+| Check | Result |
+|---|---|
+| `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_dashboard_data_source.py -q --no-cov --tb=short` | 11 passed in 5.40s |
+| `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tdx_service_lifecycle_di.py -q --no-cov --tb=short` | 4 passed in 1.33s |
+| `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov` | 120 tests collected in 16.10s |
+
+No route/OpenAPI drift check was required because G2.157 changed no route-level dependency contract and made no source edits.
+
+## Closeout Result
+
+G2.157 should not open a Dashboard/TDX implementation PR from this closeout.
+
+Reasons:
+
+- Current direct dashboard helper getter debt is `0`.
+- Existing tests cover the dashboard data source and TDX lifecycle seam.
+- The health route collection smoke confirms the relevant route test module remains import-safe.
+- Any future edit to `get_tdx_service`, `/api/v1/tdx` route dependencies, or the public compatibility getter is a separate route dependency/provider governance problem, not a Dashboard/TDX helper cleanup problem.
+
+## Remaining Queue
+
+Return to the broader G2 high-risk service getter queue. Remaining tracks:
+
+- Indicator/Data
+- Strategy adapter
+- root facade compatibility
+- route dependency/provider governance
+
+Do not reopen Dashboard/TDX source implementation unless a future current-head contradiction shows new residual direct dashboard helper getter debt.
+
+## Acceptance Checklist
+
+- [x] Parent PR `#309` verified as merged.
+- [x] GitNexus impact refreshed for the Dashboard/TDX seam.
+- [x] Current-head static classification shows direct dashboard helper getter debt is `0`.
+- [x] Focused dashboard data source tests passed.
+- [x] Focused TDX lifecycle tests passed.
+- [x] Health route conflicts module collection passed.
+- [x] No backend source, backend tests, frontend, OpenSpec, PM2, config, or script files changed in G2.157.
+
+## Next Gate
+
+Review this closeout. If accepted, select the next high-risk getter track from the remaining queue. Do not start another Dashboard/TDX source lane from this evidence.

--- a/governance/mainline/task-cards/pr-310.yaml
+++ b/governance/mainline/task-cards/pr-310.yaml
@@ -1,0 +1,116 @@
+version: "v0.2"
+
+task:
+  id: "pr-310"
+  title: "Close Dashboard/TDX verification lane"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-dashboard-tdx-verification-closeout"
+  objective: "close Dashboard/TDX without source implementation after current-head verification shows zero residual direct helper getter debt"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-dashboard-tdx-verification-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Verification closeout package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/dashboard-tdx-verification-closeout-2026-05-26.json"
+    - "docs/reports/quality/backend-dashboard-tdx-verification-closeout-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-310.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 309 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "gitnexus-impact"
+      command: "GitNexus impact for get_tdx_service, _get_major_index_quotes, _get_tdx_live_market_snapshot, and prewarm_dashboard_market_overview_cache"
+      required: true
+    - id: "static-classification"
+      command: "classify current dashboard_data_source.py get_tdx_service textual hits and verify direct dashboard helper getter debt is 0"
+      required: true
+    - id: "dashboard-focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_dashboard_data_source.py -q --no-cov --tb=short"
+      required: true
+    - id: "tdx-lifecycle-focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tdx_service_lifecycle_di.py -q --no-cov --tb=short"
+      required: true
+    - id: "health-route-collect-only"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-dashboard-tdx-verification-closeout-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/dashboard-tdx-verification-closeout-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-310.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this closeout package."
+  - "Do not open a Dashboard/TDX source implementation lane from this evidence."
+  - "Do not edit web/backend/app/api/tdx.py or web/backend/app/services/tdx_service.py."
+  - "Do not delete, privatize, or change public compatibility behavior of get_tdx_service()."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If graph impact is mistaken for direct body-call debt, fallback compatibility could be removed unnecessarily."
+    - "If this closeout is treated as route-provider cleanup authorization, active /api/v1/tdx dependency contracts could be modified without the required governance package."
+  rollback_plan: "revert this closeout PR to remove only the closeout report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close Dashboard/TDX after verification shows no residual direct helper getter debt"
+    modified_scope: "steward tree, closeout report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, GitNexus impact evidence, static classification, focused tests, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T22:19:47+08:00"
+    approval_note: "Verification-first closeout after PR #309 authorized G2.157 and current HEAD showed zero residual direct dashboard helper getter debt."
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary\n- closes G2.157 Dashboard/TDX as verification-only, with no source implementation\n- records current-head direct dashboard helper getter debt as 0\n- updates steward tree and task card for the remaining high-risk getter queue\n\n## Verification\n- GitNexus impact refreshed for get_tdx_service, _get_major_index_quotes, _get_tdx_live_market_snapshot, prewarm_dashboard_market_overview_cache\n- current-head static classification: direct_dashboard_helper_getter_debt=0\n- env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_dashboard_data_source.py -q --no-cov --tb=short: 11 passed\n- env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_tdx_service_lifecycle_di.py -q --no-cov --tb=short: 4 passed\n- env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov: 120 collected\n- JSON/YAML parse passed\n- markdown governance passed\n- git diff --check passed\n- GitNexus detect_changes(scope=staged): low risk, 0 changed symbols, 0 affected processes\n- mainline scope gate passed\n- gitnexus analyze --with-gitignore