### PR TITLE
docs(governance): select indicator data getter track

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2784,11 +2784,12 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              script, compatibility wrapper deletion, issue-label
 │   │              change, or GitHub issue state change is performed here
 │   ├── G2.157 Dashboard/TDX current-head verification closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#310`
 │   │   ├── Evidence: `backend-dashboard-tdx-verification-closeout-2026-05-26.md`
 │   │   ├── Generated: `dashboard-tdx-verification-closeout-2026-05-26.json`
 │   │   ├── Parent: G2.156 accepted and merged by PR `#309`
 │   │   ├── Current HEAD: `e7cb84fae5e0c65cb400f467f6d9b55c3b2775d4`
+│   │   ├── Merge commit: `97442014ea3ea3e63ffa170cd00b54889c158924`
 │   │   ├── GitNexus evidence: `get_tdx_service` remains CRITICAL
 │   │   │          with impacted `6`, direct callers `2`, and processes `5`;
 │   │   │          `_get_major_index_quotes` and
@@ -2812,10 +2813,36 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              OpenAPI exposure, frontend, PM2, OpenSpec, config,
 │   │              script, compatibility wrapper deletion, issue-label
 │   │              change, or GitHub issue state change is performed here
-│   └── Next gate: review G2.157; if accepted, return to the remaining
-│                  high-risk getter queue: Indicator/Data, Strategy adapter,
-│                  root facade compatibility, and route dependency/provider
-│                  governance
+│   ├── G2.158 Next high-risk service getter track selection after
+│   │          Dashboard/TDX
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-next-high-risk-service-getter-track-selection-after-dashboard-tdx-2026-05-26.md`
+│   │   ├── Generated: `next-high-risk-service-getter-track-selection-after-dashboard-tdx-2026-05-26.json`
+│   │   ├── Parent: G2.157 accepted and merged by PR `#310`
+│   │   ├── Current HEAD: `97442014ea3ea3e63ffa170cd00b54889c158924`
+│   │   ├── Refreshed impact: `get_data_service` remains CRITICAL with
+│   │   │          impacted `5`, direct callers `3`, and processes `7`;
+│   │   │          `get_strategy_service` remains CRITICAL with impacted
+│   │   │          `13`, direct callers `6`, and processes `0`;
+│   │   │          `get_streaming_service` remains HIGH with impacted `9`
+│   │   │          but realtime/socket is already closed for now
+│   │   ├── Decision: select Indicator/Data as the next design track because
+│   │   │          it is the smallest remaining CRITICAL implementation
+│   │   │          family after Dashboard/TDX closeout; defer Strategy
+│   │   │          adapter, root facade compatibility, and route
+│   │   │          dependency/provider governance to separate packages
+│   │   ├── G2.159 gate: prepare an Indicator/Data design and authorization
+│   │   │          package with consumer contract matrix, strategy indicator
+│   │   │          parity requirements, focused indicator tests, OpenAPI
+│   │   │          drift rule, allowed path list, and stop conditions before
+│   │   │          any source lane starts
+│   │   └── Boundary: decision-only; no backend source/test edit, route/API,
+│   │              OpenAPI exposure, frontend, PM2, OpenSpec, config,
+│   │              script, compatibility wrapper deletion, issue-label
+│   │              change, or GitHub issue state change is performed here
+│   └── Next gate: review G2.158; if accepted, start G2.159
+│                  Indicator/Data design and authorization package before
+│                  any Indicator/Data source implementation begins
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/next-high-risk-service-getter-track-selection-after-dashboard-tdx-2026-05-26.json
+++ b/.planning/codebase/generated/next-high-risk-service-getter-track-selection-after-dashboard-tdx-2026-05-26.json
@@ -1,0 +1,157 @@
+{
+  "artifact": "next-high-risk-service-getter-track-selection-after-dashboard-tdx-2026-05-26",
+  "generated_at": "2026-05-26T22:39:36+08:00",
+  "worktree": ".worktrees/g2-158-next-high-risk-getter-track-selection",
+  "branch": "g2-158-next-high-risk-getter-track-selection",
+  "base_head": "97442014ea3ea3e63ffa170cd00b54889c158924",
+  "task": {
+    "id": "G2.158",
+    "title": "Next high-risk service getter track selection after Dashboard/TDX closeout",
+    "scope": "governance decision only",
+    "authorization": "approved by user in current review thread"
+  },
+  "parent": {
+    "task": "G2.157",
+    "pull_request": 310,
+    "state": "MERGED",
+    "merge_commit": "97442014ea3ea3e63ffa170cd00b54889c158924",
+    "decision": "Dashboard/TDX closed without source implementation because direct dashboard helper getter debt was 0."
+  },
+  "source_inputs": [
+    "docs/reports/quality/backend-high-risk-service-getter-strategy-decision-2026-05-26.md",
+    "docs/reports/quality/backend-next-high-risk-service-getter-track-selection-2026-05-26.md",
+    "docs/reports/quality/backend-dashboard-tdx-verification-closeout-2026-05-26.md"
+  ],
+  "refreshed_impact": {
+    "get_data_service": {
+      "risk": "CRITICAL",
+      "impacted_count": 5,
+      "direct_callers": 3,
+      "processes_affected": 7,
+      "modules_affected": [
+        "Indicators",
+        "Strategy"
+      ],
+      "d1_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py::calculate_indicators",
+        "web/backend/app/api/indicators/indicator_cache.py::_calculate_single_indicator",
+        "web/backend/app/api/v1/strategy/indicators.py::get_technical_indicators"
+      ],
+      "d2_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py::calculate_single_request"
+      ],
+      "d3_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py::limited_calculate"
+      ]
+    },
+    "get_strategy_service": {
+      "risk": "CRITICAL",
+      "impacted_count": 13,
+      "direct_callers": 6,
+      "processes_affected": 0,
+      "modules_affected": [
+        "Data_adapters",
+        "Adapters",
+        "Strategy_management",
+        "Tasks"
+      ],
+      "d1_callers": [
+        "web/backend/app/services/data_adapters/strategy.py::_get_strategy_service",
+        "web/backend/app/services/adapters/strategy_adapter.py::_get_strategy_service",
+        "web/backend/app/api/strategy_management/_strategy_execution_router.py::query_strategy_results",
+        "web/backend/app/api/strategy_management/_strategy_execution_router.py::get_matched_stocks",
+        "web/backend/app/api/strategy_management/_strategy_execution_router.py::get_strategy_summary",
+        "web/backend/app/tasks/backtest_tasks.py::_resolve_backtest_data_source"
+      ]
+    },
+    "get_streaming_service": {
+      "risk": "HIGH",
+      "impacted_count": 9,
+      "direct_callers": 9,
+      "processes_affected": 0,
+      "disposition": "Realtime/socket subtrack already closed by G2.154; do not reopen from this selection package without a new contradiction."
+    }
+  },
+  "token_scan": {
+    "get_data_service": {
+      "total": 12,
+      "files": {
+        "web/backend/app/services/data_service.py": 1,
+        "web/backend/app/api/v1/strategy/indicators.py": 2,
+        "web/backend/app/api/indicators/indicator_cache.py": 3,
+        "web/backend/tests/test_v1_indicators_regressions.py": 2,
+        "web/backend/tests/test_integration_e2e.py": 4
+      }
+    },
+    "get_strategy_service": {
+      "total": 12,
+      "files": {
+        "web/backend/app/tasks/backtest_tasks.py": 2,
+        "web/backend/app/services/adapters/strategy_adapter.py": 2,
+        "web/backend/app/services/strategy_service.py": 1,
+        "web/backend/app/services/data_adapters/strategy.py": 2,
+        "web/backend/app/api/strategy_management/_strategy_execution_router.py": 4,
+        "web/backend/tests/test_backtest_tasks_regressions.py": 1
+      }
+    },
+    "route_dependency_provider_examples": {
+      "get_market_data_service_v2_dependency": 18,
+      "get_market_data_service_dependency": 16,
+      "get_indicator_registry_dependency": 5,
+      "get_tdx_service_dependency": 9
+    },
+    "root_facade_examples": {
+      "get_integrated_services": 10,
+      "get_market_data_service": 20
+    }
+  },
+  "decision": {
+    "selected_track": "Indicator/Data service seam",
+    "selection_reason": [
+      "It is the smallest remaining CRITICAL implementation family after Dashboard/TDX closeout.",
+      "Its current direct caller surface is three functions across indicator cache and strategy indicator API.",
+      "It has process participation and public indicator consumers, so it requires a dedicated design and authorization package before any source edit.",
+      "Strategy adapter remains broader, crossing adapters, data adapters, strategy-management routes, and backtest tasks.",
+      "Root facade compatibility and route dependency/provider governance are locked governance tracks, not singleton-retirement implementation candidates."
+    ],
+    "next_gate": "G2.159 Indicator/Data design and authorization package",
+    "source_implementation_authorized": false
+  },
+  "g2_159_minimum_requirements": [
+    "Refresh GitNexus impact for get_data_service and the three direct callers.",
+    "Produce an Indicator/Data consumer contract matrix for calculate_indicators, _calculate_single_indicator, get_technical_indicators, calculate_single_request, and limited_calculate.",
+    "Classify current get_data_service textual hits as definition, import, direct body call, test reference, or acceptable compatibility.",
+    "Define strategy indicator consumer parity requirements.",
+    "Define focused indicator cache and v1 strategy indicator tests.",
+    "Define OpenAPI example/drift rule if response contracts are touched.",
+    "Define allowed source/test paths and explicit stop conditions before implementation."
+  ],
+  "deferred_tracks": [
+    "Strategy adapter",
+    "root facade compatibility",
+    "route dependency/provider governance"
+  ],
+  "boundaries": {
+    "do_not_edit_in_g2_158": [
+      "web/backend/**",
+      "web/frontend/**",
+      "src/**",
+      "tests/**",
+      "docs/api/**",
+      "docs/guides/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ],
+    "do_not_authorize": [
+      "source implementation",
+      "get_data_service deletion or privatization",
+      "Strategy adapter edits",
+      "route dependency/provider cleanup",
+      "root facade compatibility retirement",
+      "OpenAPI exposure changes",
+      "issue-label changes"
+    ]
+  }
+}

--- a/docs/reports/quality/backend-next-high-risk-service-getter-track-selection-after-dashboard-tdx-2026-05-26.md
+++ b/docs/reports/quality/backend-next-high-risk-service-getter-track-selection-after-dashboard-tdx-2026-05-26.md
@@ -1,0 +1,138 @@
+# Backend Next High-Risk Service Getter Track Selection After Dashboard/TDX
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Date: 2026-05-26
+
+Status: Ready for review
+
+Scope: G2.158 governance decision only.
+
+Base HEAD: `97442014ea3ea3e63ffa170cd00b54889c158924`
+
+Parent: G2.157, PR `#310`, merged as `97442014ea3ea3e63ffa170cd00b54889c158924`.
+
+Boundary: this is a decision package only. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations. It does not authorize implementation.
+
+## Decision
+
+Select the Indicator/Data service seam as the next high-risk getter design track.
+
+The next gate is G2.159: Indicator/Data design and authorization package.
+
+G2.158 does not authorize source implementation.
+
+## Current Queue State
+
+Dashboard/TDX is closed by G2.157 without source implementation because current-head direct dashboard helper getter debt is `0`.
+
+Realtime/socket is also closed for now by the earlier G2.154 closeout. Do not reopen it from this package without a new current-head contradiction.
+
+Remaining queue:
+
+| Track | Status |
+|---|---|
+| Indicator/Data | Selected for next design package |
+| Strategy adapter | Deferred; broader cross-module impact |
+| root facade compatibility | Locked governance surface |
+| route dependency/provider governance | Locked route contract surface |
+
+## Refreshed Impact
+
+| Getter | Risk | Impacted | Direct callers | Processes | Disposition |
+|---|---:|---:|---:|---:|---|
+| `get_data_service` | CRITICAL | 5 | 3 | 7 | Select for G2.159 design package |
+| `get_strategy_service` | CRITICAL | 13 | 6 | 0 | Defer to dedicated Strategy adapter package |
+| `get_streaming_service` | HIGH | 9 | 9 | 0 | Already closed by realtime/socket closeout |
+
+`get_data_service` direct callers:
+
+- `web/backend/app/api/indicators/indicator_cache.py::calculate_indicators`
+- `web/backend/app/api/indicators/indicator_cache.py::_calculate_single_indicator`
+- `web/backend/app/api/v1/strategy/indicators.py::get_technical_indicators`
+
+`get_strategy_service` direct callers:
+
+- `web/backend/app/services/data_adapters/strategy.py::_get_strategy_service`
+- `web/backend/app/services/adapters/strategy_adapter.py::_get_strategy_service`
+- `web/backend/app/api/strategy_management/_strategy_execution_router.py::query_strategy_results`
+- `web/backend/app/api/strategy_management/_strategy_execution_router.py::get_matched_stocks`
+- `web/backend/app/api/strategy_management/_strategy_execution_router.py::get_strategy_summary`
+- `web/backend/app/tasks/backtest_tasks.py::_resolve_backtest_data_source`
+
+## Token Surface
+
+`get_data_service` current token scan:
+
+| File | Count |
+|---|---:|
+| `web/backend/app/services/data_service.py` | 1 |
+| `web/backend/app/api/v1/strategy/indicators.py` | 2 |
+| `web/backend/app/api/indicators/indicator_cache.py` | 3 |
+| `web/backend/tests/test_v1_indicators_regressions.py` | 2 |
+| `web/backend/tests/test_integration_e2e.py` | 4 |
+
+Current source hit lines:
+
+| File | Line | Text |
+|---|---:|---|
+| `web/backend/app/api/indicators/indicator_cache.py` | 40 | import `get_data_service` |
+| `web/backend/app/api/indicators/indicator_cache.py` | 343 | `data_service = get_data_service()` |
+| `web/backend/app/api/indicators/indicator_cache.py` | 613 | `data_service = get_data_service()` |
+| `web/backend/app/api/v1/strategy/indicators.py` | 17 | import `get_data_service` |
+| `web/backend/app/api/v1/strategy/indicators.py` | 201 | `get_data_service().get_daily_ohlcv(...)` |
+
+`get_strategy_service` current token scan:
+
+| File | Count |
+|---|---:|
+| `web/backend/app/tasks/backtest_tasks.py` | 2 |
+| `web/backend/app/services/adapters/strategy_adapter.py` | 2 |
+| `web/backend/app/services/strategy_service.py` | 1 |
+| `web/backend/app/services/data_adapters/strategy.py` | 2 |
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 4 |
+| `web/backend/tests/test_backtest_tasks_regressions.py` | 1 |
+
+## Selection Rationale
+
+Indicator/Data is the next most contained CRITICAL seam after Dashboard/TDX:
+
+- direct caller count is `3`, compared with Strategy adapter `6`;
+- impacted count is `5`, compared with Strategy adapter `13`;
+- affected modules are Indicators and Strategy, compared with Strategy adapter crossing adapters, data adapters, strategy-management routes, and backtest tasks;
+- the surface has clear focused test candidates: indicator cache, v1 strategy indicator regressions, and integration E2E references.
+
+This does not make Indicator/Data safe for direct source implementation. It has process participation and public API consumers, so it needs a dedicated design and authorization package before any edit.
+
+## G2.159 Minimum Requirements
+
+G2.159 must be a design and authorization package before implementation.
+
+It must include:
+
+- refreshed GitNexus impact for `get_data_service` and its three direct callers;
+- Indicator/Data consumer contract matrix for `calculate_indicators`, `_calculate_single_indicator`, `get_technical_indicators`, `calculate_single_request`, and `limited_calculate`;
+- current-head hit classification for each `get_data_service` textual hit;
+- strategy indicator consumer parity requirements;
+- focused test plan for indicator cache and v1 strategy indicator behavior;
+- OpenAPI example/drift rule if response contracts are touched;
+- explicit allowed source/test paths and stop conditions.
+
+## Explicit Boundaries
+
+Do not implement source changes from G2.158.
+
+Do not:
+
+- delete or privatize `get_data_service`;
+- edit Strategy adapter files;
+- retire root facade compatibility getters;
+- treat FastAPI dependency/provider getters as singleton cleanup;
+- change route paths, response contracts, or OpenAPI exposure;
+- change frontend, PM2, OpenSpec, config, scripts, issue labels, or GitHub issue state.
+
+## Next Gate
+
+Review this package. If accepted, start G2.159 as an Indicator/Data design and authorization package. G2.159 should still be source-closed until it defines exact paths, tests, rollback, impact evidence, and stop conditions.

--- a/governance/mainline/task-cards/pr-311.yaml
+++ b/governance/mainline/task-cards/pr-311.yaml
@@ -1,0 +1,110 @@
+version: "v0.2"
+
+task:
+  id: "pr-311"
+  title: "Select Indicator/Data getter track"
+  owner: "main"
+  created_at: "2026-05-26"
+
+mainline:
+  id: "L1-next-high-risk-getter-track-after-dashboard-tdx"
+  objective: "select Indicator/Data as the next high-risk service getter design track after Dashboard/TDX closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-next-high-risk-getter-track-after-dashboard-tdx"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision-only governance package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/next-high-risk-service-getter-track-selection-after-dashboard-tdx-2026-05-26.json"
+    - "docs/reports/quality/backend-next-high-risk-service-getter-track-selection-after-dashboard-tdx-2026-05-26.md"
+    - "governance/mainline/task-cards/pr-311.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 310 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "gitnexus-impact"
+      command: "GitNexus impact for get_data_service, get_strategy_service, and get_streaming_service"
+      required: true
+    - id: "token-scan"
+      command: "scan current token counts for get_data_service, get_strategy_service, route dependency providers, and root facade examples"
+      required: true
+    - id: "source-hit-lines"
+      command: "classify current source hit lines for get_data_service and get_strategy_service surfaces"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-next-high-risk-service-getter-track-selection-after-dashboard-tdx-2026-05-26.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/next-high-risk-service-getter-track-selection-after-dashboard-tdx-2026-05-26.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-311.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this decision package."
+  - "Do not authorize G2.159 source implementation from this package."
+  - "Do not delete or privatize get_data_service()."
+  - "Do not edit Strategy adapter, root facade compatibility, or route dependency/provider surfaces."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this selection is treated as source authorization, Indicator/Data could be edited without the required consumer contract matrix and stop conditions."
+    - "If Strategy adapter breadth is understated, a later source lane may cross adapter, route, and task boundaries without dedicated ownership review."
+  rollback_plan: "revert this decision PR to remove only the decision report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "select Indicator/Data as the next high-risk service getter design track"
+    modified_scope: "steward tree, decision report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, GitNexus impact evidence, token scan, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-26T22:39:36+08:00"
+    approval_note: "Decision-only track selection after PR #310 closed Dashboard/TDX without source implementation."
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary\n- selects Indicator/Data as the next high-risk service getter design track after Dashboard/TDX closeout\n- records refreshed impact for get_data_service, get_strategy_service, and get_streaming_service\n- updates steward tree and task card for a future G2.159 design authorization package\n\n## Verification\n- GitNexus impact refreshed for get_data_service, get_strategy_service, get_streaming_service\n- current token scan captured get_data_service and get_strategy_service surfaces\n- JSON/YAML parse passed\n- markdown governance passed\n- git diff --check passed\n- GitNexus detect_changes(scope=staged): low risk, 0 changed symbols, 0 affected processes\n- mainline scope gate passed\n- gitnexus analyze --with-gitignore