### PR TITLE
docs(governance): authorize indicator data design lane

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2815,11 +2815,12 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              change, or GitHub issue state change is performed here
 │   ├── G2.158 Next high-risk service getter track selection after
 │   │          Dashboard/TDX
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#311`
 │   │   ├── Evidence: `backend-next-high-risk-service-getter-track-selection-after-dashboard-tdx-2026-05-26.md`
 │   │   ├── Generated: `next-high-risk-service-getter-track-selection-after-dashboard-tdx-2026-05-26.json`
 │   │   ├── Parent: G2.157 accepted and merged by PR `#310`
 │   │   ├── Current HEAD: `97442014ea3ea3e63ffa170cd00b54889c158924`
+│   │   ├── Merge commit: `aef7e765b0c0472c2b2f907463345c964735b1f9`
 │   │   ├── Refreshed impact: `get_data_service` remains CRITICAL with
 │   │   │          impacted `5`, direct callers `3`, and processes `7`;
 │   │   │          `get_strategy_service` remains CRITICAL with impacted
@@ -2840,8 +2841,37 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              OpenAPI exposure, frontend, PM2, OpenSpec, config,
 │   │              script, compatibility wrapper deletion, issue-label
 │   │              change, or GitHub issue state change is performed here
-│   └── Next gate: review G2.158; if accepted, start G2.159
-│                  Indicator/Data design and authorization package before
+│   ├── G2.159 Indicator/Data design and authorization package
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-indicator-data-design-authorization-2026-05-27.md`
+│   │   ├── Generated: `indicator-data-design-authorization-2026-05-27.json`
+│   │   ├── Parent: G2.158 accepted and merged by PR `#311`
+│   │   ├── Current HEAD: `aef7e765b0c0472c2b2f907463345c964735b1f9`
+│   │   ├── GitNexus evidence: `get_data_service` remains CRITICAL with
+│   │   │          impacted `5`, direct callers `3`, and processes `7`;
+│   │   │          direct callers are `calculate_indicators`,
+│   │   │          `_calculate_single_indicator`, and
+│   │   │          `get_technical_indicators`; downstream indicator-cache
+│   │   │          callers remain LOW-risk helper surfaces
+│   │   ├── Current-head static classification: application direct
+│   │   │          `get_data_service()` body calls are `3` across
+│   │   │          `indicator_cache.py` and `api/v1/strategy/indicators.py`;
+│   │   │          test references are monkeypatches or direct service smokes
+│   │   ├── Verification: `test_indicator_registry_route_provider.py`
+│   │   │          passed `2`; `test_v1_indicators_regressions.py` has
+│   │   │          `1` pass and `1` existing failure because it still expects
+│   │   │          `module.HTTPException` while current code raises canonical
+│   │   │          `BusinessException`
+│   │   ├── Decision: do not open Indicator/Data source implementation yet;
+│   │   │          route the next gate to G2.160 test-contract alignment
+│   │   │          before any `get_data_service` consumer edit
+│   │   └── Boundary: design-authorization only; no backend source/test edit,
+│   │              route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │              config, script, compatibility wrapper deletion,
+│   │              issue-label change, or GitHub issue state change is
+│   │              performed here
+│   └── Next gate: review G2.159; if accepted, start G2.160 as a narrow
+│                  Indicator/Data test-contract alignment package before
 │                  any Indicator/Data source implementation begins
 │
 ├── H. Decision-Only Track: CSRF composition root

--- a/.planning/codebase/generated/indicator-data-design-authorization-2026-05-27.json
+++ b/.planning/codebase/generated/indicator-data-design-authorization-2026-05-27.json
@@ -1,0 +1,254 @@
+{
+  "artifact": "indicator-data-design-authorization-2026-05-27",
+  "generated_at": "2026-05-27T00:19:54+08:00",
+  "worktree": ".worktrees/g2-159-indicator-data-design-authorization",
+  "branch": "g2-159-indicator-data-design-authorization",
+  "base_head": "aef7e765b0c0472c2b2f907463345c964735b1f9",
+  "task": {
+    "id": "G2.159",
+    "title": "Indicator/Data design and authorization package",
+    "scope": "governance design and authorization only",
+    "authorization": "G2.158 accepted by user and merged through PR #311"
+  },
+  "parent": {
+    "task": "G2.158",
+    "pull_request": 311,
+    "state": "MERGED",
+    "merge_commit": "aef7e765b0c0472c2b2f907463345c964735b1f9",
+    "decision": "Indicator/Data selected as the next high-risk service getter design track."
+  },
+  "source_inputs": [
+    "docs/reports/quality/backend-high-risk-service-getter-strategy-decision-2026-05-26.md",
+    "docs/reports/quality/backend-next-high-risk-service-getter-track-selection-after-dashboard-tdx-2026-05-26.md",
+    "docs/reports/quality/backend-dashboard-tdx-verification-closeout-2026-05-26.md"
+  ],
+  "gitnexus_impact": {
+    "get_data_service": {
+      "risk": "CRITICAL",
+      "impacted_count": 5,
+      "direct_callers": 3,
+      "processes_affected": 7,
+      "modules_affected": [
+        "Indicators",
+        "Strategy"
+      ],
+      "d1_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py::calculate_indicators",
+        "web/backend/app/api/indicators/indicator_cache.py::_calculate_single_indicator",
+        "web/backend/app/api/v1/strategy/indicators.py::get_technical_indicators"
+      ],
+      "d2_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py::calculate_single_request"
+      ],
+      "d3_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py::limited_calculate"
+      ]
+    },
+    "calculate_indicators": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct_callers": 0,
+      "processes_affected": 0
+    },
+    "_calculate_single_indicator": {
+      "risk": "LOW",
+      "impacted_count": 3,
+      "direct_callers": 1,
+      "processes_affected": 0,
+      "d1_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py::calculate_single_request"
+      ],
+      "d2_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py::limited_calculate"
+      ],
+      "d3_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py::calculate_indicators_batch"
+      ]
+    },
+    "get_technical_indicators": {
+      "note": "The name is ambiguous in GitNexus; context lookup was used to select web/backend/app/api/v1/strategy/indicators.py::get_technical_indicators.",
+      "uid": "Function:web/backend/app/api/v1/strategy/indicators.py:get_technical_indicators",
+      "processes": [
+        "Get_technical_indicators -> ShouldAlwaysSelectNothing",
+        "Get_technical_indicators -> ImplForWrapper",
+        "Get_technical_indicators -> GetAttributeNS",
+        "Get_technical_indicators -> Strip",
+        "Get_technical_indicators -> _locationObjectNavigate"
+      ]
+    },
+    "calculate_single_request": {
+      "risk": "LOW",
+      "impacted_count": 2,
+      "direct_callers": 1,
+      "processes_affected": 0,
+      "d1_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py::limited_calculate"
+      ]
+    },
+    "limited_calculate": {
+      "risk": "LOW",
+      "impacted_count": 1,
+      "direct_callers": 1,
+      "processes_affected": 0,
+      "d1_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py::calculate_indicators_batch"
+      ]
+    }
+  },
+  "current_head_hit_classification": {
+    "web/backend/app/services/data_service.py": [
+      {
+        "line": 466,
+        "kind": "definition",
+        "text": "def get_data_service() -> DataService:"
+      }
+    ],
+    "web/backend/app/api/indicators/indicator_cache.py": [
+      {
+        "line": 40,
+        "kind": "import",
+        "text": "from app.services.data_service import InvalidDateRangeError, StockDataNotFoundError, get_data_service"
+      },
+      {
+        "line": 343,
+        "kind": "direct_body_call",
+        "text": "data_service = get_data_service()"
+      },
+      {
+        "line": 613,
+        "kind": "direct_body_call",
+        "text": "data_service = get_data_service()"
+      }
+    ],
+    "web/backend/app/api/v1/strategy/indicators.py": [
+      {
+        "line": 17,
+        "kind": "import",
+        "text": "from app.services.data_service import StockDataNotFoundError, get_data_service"
+      },
+      {
+        "line": 201,
+        "kind": "direct_body_call",
+        "text": "frame, _ = get_data_service().get_daily_ohlcv(symbol=symbol, start_date=start_dt, end_date=end_dt)"
+      }
+    ],
+    "web/backend/tests/test_v1_indicators_regressions.py": [
+      {
+        "line": 39,
+        "kind": "test_monkeypatch",
+        "text": "module.get_data_service = lambda: _FakeDataService()"
+      },
+      {
+        "line": 56,
+        "kind": "test_monkeypatch",
+        "text": "module.get_data_service = lambda: _FakeDataService()"
+      }
+    ],
+    "web/backend/tests/test_integration_e2e.py": [
+      {
+        "line": 198,
+        "kind": "test_import",
+        "text": "from app.services.data_service import get_data_service"
+      },
+      {
+        "line": 201,
+        "kind": "test_reference",
+        "text": "data_service = get_data_service()"
+      },
+      {
+        "line": 233,
+        "kind": "test_import",
+        "text": "from app.services.data_service import get_data_service"
+      },
+      {
+        "line": 235,
+        "kind": "test_reference",
+        "text": "data_service = get_data_service()"
+      }
+    ]
+  },
+  "consumer_contract_matrix": [
+    {
+      "consumer": "calculate_indicators",
+      "file": "web/backend/app/api/indicators/indicator_cache.py",
+      "contract": "public indicator calculation flow; must preserve request validation, OHLCV retrieval, cache/accounting behavior, success payload, and canonical exception mapping",
+      "current_getter_use": "direct body call at line 343",
+      "must_preserve": [
+        "UnifiedResponse[Dict] route response",
+        "create_success_response success envelope",
+        "InvalidDateRangeError -> ValidationException",
+        "StockDataNotFoundError -> NotFoundException",
+        "BusinessException propagation"
+      ]
+    },
+    {
+      "consumer": "_calculate_single_indicator",
+      "file": "web/backend/app/api/indicators/indicator_cache.py",
+      "contract": "single indicator calculation helper used by batch/single request paths; must preserve returned dict shape and downstream error handling",
+      "current_getter_use": "direct body call at line 613",
+      "must_preserve": [
+        "indicator result dict shape",
+        "symbol/date input semantics",
+        "calculate_single_request compatibility",
+        "limited_calculate and calculate_indicators_batch behavior"
+      ]
+    },
+    {
+      "consumer": "get_technical_indicators",
+      "file": "web/backend/app/api/v1/strategy/indicators.py",
+      "contract": "strategy indicator API flow; must preserve indicator normalization, get_daily_ohlcv data source behavior, pagination payload, and canonical BusinessException contract",
+      "current_getter_use": "direct body call at line 201",
+      "must_preserve": [
+        "unsupported indicator -> BusinessException 400",
+        "StockDataNotFoundError -> BusinessException 404",
+        "generic data fetch failure -> BusinessException 500",
+        "supported indicator result payloads"
+      ]
+    }
+  ],
+  "verification": {
+    "indicator_registry_route_provider": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --no-cov --tb=short",
+      "result": "2 passed in 2.05s"
+    },
+    "v1_indicators_regressions": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short",
+      "result": "1 failed, 1 passed in 1.81s",
+      "blocker": "test_v1_indicators_rejects_unsupported_indicator still expects module.HTTPException, while current code raises canonical BusinessException for unsupported indicators."
+    },
+    "test_discovery": {
+      "indicator_related_test_files": 18
+    }
+  },
+  "decision": {
+    "status": "design_ready_but_source_blocked",
+    "source_implementation_authorized": false,
+    "next_gate": "G2.160 Indicator/Data test-contract alignment package",
+    "reason": "The seam is well scoped, but existing v1 indicator regression test debt must be aligned with the canonical BusinessException contract before source implementation is opened."
+  },
+  "future_lane_boundaries": {
+    "g2_160_allowed_scope": [
+      "web/backend/tests/test_v1_indicators_regressions.py",
+      "docs/reports/quality/*indicator-data*.md",
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/*indicator-data*.json",
+      "governance/mainline/task-cards/pr-*.yaml"
+    ],
+    "eventual_indicator_data_source_lane_allowed_source_paths": [
+      "web/backend/app/api/indicators/indicator_cache.py",
+      "web/backend/app/api/v1/strategy/indicators.py"
+    ],
+    "eventual_indicator_data_source_lane_allowed_test_paths": [
+      "web/backend/tests/test_v1_indicators_regressions.py",
+      "web/backend/tests/test_indicator_registry_route_provider.py",
+      "web/backend/tests/test_integration_e2e.py",
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "stop_conditions": [
+      "Do not edit web/backend/app/services/data_service.py without a new review.",
+      "Do not delete or privatize get_data_service().",
+      "Do not edit Strategy adapter, root facade compatibility, or route dependency/provider surfaces.",
+      "Do not change route path, response envelope, or OpenAPI exposure without a separate drift review."
+    ]
+  }
+}

--- a/docs/reports/quality/backend-indicator-data-design-authorization-2026-05-27.md
+++ b/docs/reports/quality/backend-indicator-data-design-authorization-2026-05-27.md
@@ -1,0 +1,143 @@
+# Backend Indicator/Data Design Authorization
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Date: 2026-05-27
+
+Status: Ready for review
+
+Scope: G2.159 design and authorization package only.
+
+Base HEAD: `aef7e765b0c0472c2b2f907463345c964735b1f9`
+
+Parent: G2.158, PR `#311`, merged as `aef7e765b0c0472c2b2f907463345c964735b1f9`.
+
+Boundary: this is a design-authorization package only. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations. It does not perform implementation.
+
+## Decision
+
+Do not open Indicator/Data source implementation yet.
+
+Authorize the next gate as G2.160: Indicator/Data test-contract alignment package.
+
+Reason: the Indicator/Data getter seam is small enough for a future implementation lane, but current focused verification shows an existing v1 indicator regression test still expects `HTTPException`, while the current code raises the canonical `BusinessException` contract. That test-contract debt should be aligned before changing `get_data_service` consumers.
+
+## GitNexus Evidence
+
+| Symbol | Risk | Impacted | Direct callers | Processes |
+|---|---:|---:|---:|---:|
+| `get_data_service` | CRITICAL | 5 | 3 | 7 |
+| `calculate_indicators` | LOW | 0 | 0 | 0 |
+| `_calculate_single_indicator` | LOW | 3 | 1 | 0 |
+| `calculate_single_request` | LOW | 2 | 1 | 0 |
+| `limited_calculate` | LOW | 1 | 1 | 0 |
+
+`get_data_service` direct callers:
+
+- `web/backend/app/api/indicators/indicator_cache.py::calculate_indicators`
+- `web/backend/app/api/indicators/indicator_cache.py::_calculate_single_indicator`
+- `web/backend/app/api/v1/strategy/indicators.py::get_technical_indicators`
+
+Downstream callers:
+
+- `web/backend/app/api/indicators/indicator_cache.py::calculate_single_request`
+- `web/backend/app/api/indicators/indicator_cache.py::limited_calculate`
+- `web/backend/app/api/indicators/indicator_cache.py::calculate_indicators_batch`
+
+`get_technical_indicators` is an ambiguous symbol name in GitNexus. This package used `context(name="get_technical_indicators", file_path="web/backend/app/api/v1/strategy/indicators.py")` to pin the intended route function.
+
+## Current-Head Hit Classification
+
+| File | Line | Classification | Text |
+|---|---:|---|---|
+| `web/backend/app/services/data_service.py` | 466 | definition | `def get_data_service() -> DataService:` |
+| `web/backend/app/api/indicators/indicator_cache.py` | 40 | import | imports `get_data_service` |
+| `web/backend/app/api/indicators/indicator_cache.py` | 343 | direct body call | `data_service = get_data_service()` |
+| `web/backend/app/api/indicators/indicator_cache.py` | 613 | direct body call | `data_service = get_data_service()` |
+| `web/backend/app/api/v1/strategy/indicators.py` | 17 | import | imports `get_data_service` |
+| `web/backend/app/api/v1/strategy/indicators.py` | 201 | direct body call | `get_data_service().get_daily_ohlcv(...)` |
+| `web/backend/tests/test_v1_indicators_regressions.py` | 39 | test monkeypatch | `module.get_data_service = lambda: _FakeDataService()` |
+| `web/backend/tests/test_v1_indicators_regressions.py` | 56 | test monkeypatch | `module.get_data_service = lambda: _FakeDataService()` |
+| `web/backend/tests/test_integration_e2e.py` | 198/201 | test import/reference | direct service smoke |
+| `web/backend/tests/test_integration_e2e.py` | 233/235 | test import/reference | direct service smoke |
+
+Direct application body calls: `3`.
+
+## Consumer Contract Matrix
+
+| Consumer | Surface | Current getter use | Contract to preserve |
+|---|---|---|---|
+| `calculate_indicators` | public indicator calculation flow | direct body call at `indicator_cache.py:343` | `UnifiedResponse[Dict]`, `create_success_response`, request validation, OHLCV retrieval, cache/accounting behavior, `InvalidDateRangeError -> ValidationException`, `StockDataNotFoundError -> NotFoundException`, `BusinessException` propagation |
+| `_calculate_single_indicator` | helper used by single/batch calculation paths | direct body call at `indicator_cache.py:613` | result dict shape, symbol/date semantics, `calculate_single_request`, `limited_calculate`, and `calculate_indicators_batch` behavior |
+| `get_technical_indicators` | v1 strategy indicator API flow | direct body call at `strategy/indicators.py:201` | indicator normalization, `get_daily_ohlcv` behavior, pagination payload, unsupported indicator `BusinessException 400`, missing data `BusinessException 404`, generic fetch failure `BusinessException 500` |
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --no-cov --tb=short` | 2 passed in 2.05s |
+| `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short` | 1 failed, 1 passed in 1.81s |
+| indicator-related test discovery | 18 candidate files |
+
+The failed test is `test_v1_indicators_rejects_unsupported_indicator`.
+
+Observed failure:
+
+- implementation raises `app.core.exceptions.BusinessException`;
+- test attempts to catch `module.HTTPException`;
+- module `app.api.v1.strategy.indicators` no longer exposes `HTTPException`.
+
+This is consistent with the repository's canonical exception direction. It is a test-contract alignment blocker, not evidence that G2.159 should edit source code.
+
+## G2.160 Authorization
+
+G2.160 should be a narrow Indicator/Data test-contract alignment package.
+
+Allowed G2.160 scope:
+
+- `web/backend/tests/test_v1_indicators_regressions.py`
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/*indicator-data*.json`
+- `docs/reports/quality/*indicator-data*.md`
+- `governance/mainline/task-cards/pr-*.yaml`
+
+G2.160 should align `test_v1_indicators_rejects_unsupported_indicator` with the canonical `BusinessException` contract or produce a review note explaining why the route-level HTTP translation should be tested differently.
+
+G2.160 must not modify application source unless a separate review explicitly authorizes it.
+
+## Eventual Source Lane Conditions
+
+After G2.160 passes, a later Indicator/Data source lane may be considered, but it must still be separately reviewed and approved.
+
+Potential source paths for that later lane:
+
+- `web/backend/app/api/indicators/indicator_cache.py`
+- `web/backend/app/api/v1/strategy/indicators.py`
+
+Potential focused test paths:
+
+- `web/backend/tests/test_v1_indicators_regressions.py`
+- `web/backend/tests/test_indicator_registry_route_provider.py`
+- `web/backend/tests/test_integration_e2e.py`
+- `web/backend/tests/test_health_route_conflicts.py`
+
+Required gates before any source edit:
+
+- fresh GitNexus impact for `get_data_service` and the direct caller being edited;
+- current-head hit classification;
+- focused tests passing after G2.160 alignment;
+- route/OpenAPI drift check if a public route dependency, response envelope, or documented example changes;
+- staged GitNexus detect before commit.
+
+Stop conditions:
+
+- do not edit `web/backend/app/services/data_service.py` without a new review;
+- do not delete or privatize `get_data_service()`;
+- do not touch Strategy adapter, root facade compatibility, or route dependency/provider governance surfaces;
+- do not change OpenAPI exposure or route paths from an Indicator/Data getter lane.
+
+## Next Gate
+
+Review this package. If accepted, start G2.160 as a narrow test-contract alignment package. Do not start Indicator/Data source implementation from G2.159.

--- a/governance/mainline/task-cards/pr-312.yaml
+++ b/governance/mainline/task-cards/pr-312.yaml
@@ -1,0 +1,111 @@
+version: "v0.2"
+
+task:
+  id: "pr-312"
+  title: "Authorize Indicator/Data design lane"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-indicator-data-design-authorization"
+  objective: "record Indicator/Data consumer contracts and route the existing v1 indicator test-contract blocker before any source implementation"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-indicator-data-design-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Design authorization governance package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/indicator-data-design-authorization-2026-05-27.json"
+    - "docs/reports/quality/backend-indicator-data-design-authorization-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-312.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 311 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "gitnexus-impact"
+      command: "GitNexus impact/context for get_data_service and Indicator/Data consumers"
+      required: true
+    - id: "static-classification"
+      command: "classify current get_data_service textual hits as definition, import, direct body call, test monkeypatch, or test reference"
+      required: true
+    - id: "focused-baseline-tests"
+      command: "run focused indicator tests and record pass/fail, including known v1 indicator test-contract blocker"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-indicator-data-design-authorization-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/indicator-data-design-authorization-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-312.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this design authorization package."
+  - "Do not authorize Indicator/Data source implementation from this package."
+  - "Do not delete or privatize get_data_service()."
+  - "Do not edit web/backend/app/services/data_service.py."
+  - "Do not edit Strategy adapter, root facade compatibility, or route dependency/provider surfaces."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this package is treated as implementation authorization, source edits could start while a focused v1 indicator regression test still fails."
+    - "If the existing HTTPException expectation is ignored, a later implementation lane may mix dependency injection changes with error-contract test repair."
+  rollback_plan: "revert this decision PR to remove only the design report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "record Indicator/Data design constraints and route the v1 indicator test-contract blocker"
+    modified_scope: "steward tree, design report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, GitNexus evidence, static classification, baseline test evidence, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T00:19:54+08:00"
+    approval_note: "Design authorization package after PR #311 selected Indicator/Data as the next high-risk getter track."
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary\n- adds G2.159 Indicator/Data design authorization package\n- records get_data_service impact, source hit classification, and consumer contract matrix\n- routes existing v1 indicator BusinessException/HTTPException test-contract blocker to G2.160 before any source implementation\n\n## Verification\n- GitNexus impact/context refreshed for get_data_service and Indicator/Data consumers\n- current-head get_data_service hit classification recorded\n- test_indicator_registry_route_provider.py: 2 passed\n- test_v1_indicators_regressions.py: 1 failed / 1 passed, recorded as existing test-contract blocker\n- JSON/YAML parse passed\n- markdown governance passed\n- git diff --check passed\n- GitNexus detect_changes(scope=staged): low risk, 0 changed symbols, 0 affected processes\n- mainline scope gate passed\n- gitnexus analyze --with-gitignore