### PR TITLE
test(backend): align indicator error contract

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2842,11 +2842,12 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              script, compatibility wrapper deletion, issue-label
 │   │              change, or GitHub issue state change is performed here
 │   ├── G2.159 Indicator/Data design and authorization package
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#312`
 │   │   ├── Evidence: `backend-indicator-data-design-authorization-2026-05-27.md`
 │   │   ├── Generated: `indicator-data-design-authorization-2026-05-27.json`
 │   │   ├── Parent: G2.158 accepted and merged by PR `#311`
 │   │   ├── Current HEAD: `aef7e765b0c0472c2b2f907463345c964735b1f9`
+│   │   ├── Merge commit: `b31a1c69a96fa83f250e7577c4b21d3b4febbaeb`
 │   │   ├── GitNexus evidence: `get_data_service` remains CRITICAL with
 │   │   │          impacted `5`, direct callers `3`, and processes `7`;
 │   │   │          direct callers are `calculate_indicators`,
@@ -2870,9 +2871,30 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              config, script, compatibility wrapper deletion,
 │   │              issue-label change, or GitHub issue state change is
 │   │              performed here
-│   └── Next gate: review G2.159; if accepted, start G2.160 as a narrow
-│                  Indicator/Data test-contract alignment package before
-│                  any Indicator/Data source implementation begins
+│   ├── G2.160 Indicator/Data test-contract alignment
+│   │   ├── State: ready for review
+│   │   ├── Evidence: `backend-indicator-data-test-contract-alignment-2026-05-27.md`
+│   │   ├── Generated: `indicator-data-test-contract-alignment-2026-05-27.json`
+│   │   ├── Parent: G2.159 accepted and merged by PR `#312`
+│   │   ├── Current HEAD: `b31a1c69a96fa83f250e7577c4b21d3b4febbaeb`
+│   │   ├── Scope: `test_v1_indicators_regressions.py` plus governance
+│   │   │          records only; no application source, route/API, OpenAPI,
+│   │   │          frontend, PM2, OpenSpec, config, script, or issue-label
+│   │   │          change
+│   │   ├── Red/green: focused v1 indicator regression test moved from
+│   │   │          `1 failed, 1 passed` to `2 passed` by asserting canonical
+│   │   │          `BusinessException` status/detail instead of legacy
+│   │   │          `module.HTTPException`; provider guard remained `2 passed`
+│   │   │          and ruff on the touched test passed
+│   │   ├── Decision: G2.159 test-contract blocker is removed; do not start
+│   │   │          source implementation from this package, but G2.161 may
+│   │   │          prepare an Indicator/Data source implementation
+│   │   │          authorization package
+│   │   └── Boundary: test-contract alignment only; no `get_data_service`
+│   │              definition or application consumer is changed here
+│   └── Next gate: review G2.160; if accepted, start G2.161 as an
+│                  Indicator/Data source implementation authorization
+│                  package before any `get_data_service` consumer edit
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/indicator-data-test-contract-alignment-2026-05-27.json
+++ b/.planning/codebase/generated/indicator-data-test-contract-alignment-2026-05-27.json
@@ -1,0 +1,88 @@
+{
+  "artifact": "indicator-data-test-contract-alignment-2026-05-27",
+  "generated_at": "2026-05-27T00:40:51+08:00",
+  "worktree": ".worktrees/g2-160-indicator-data-test-contract-alignment",
+  "branch": "g2-160-indicator-data-test-contract-alignment",
+  "base_head": "b31a1c69a96fa83f250e7577c4b21d3b4febbaeb",
+  "task": {
+    "id": "G2.160",
+    "title": "Indicator/Data test-contract alignment",
+    "scope": "narrow test-contract alignment plus governance records",
+    "authorization": "G2.159 accepted by user and merged through PR #312"
+  },
+  "parent": {
+    "task": "G2.159",
+    "pull_request": 312,
+    "state": "MERGED",
+    "merge_commit": "b31a1c69a96fa83f250e7577c4b21d3b4febbaeb",
+    "decision": "Do not open Indicator/Data source implementation until the existing v1 indicator BusinessException/HTTPException test-contract blocker is aligned."
+  },
+  "gitnexus_pre_edit": {
+    "test_v1_indicators_rejects_unsupported_indicator": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct_callers": 0,
+      "processes_affected": 0
+    },
+    "get_technical_indicators": {
+      "note": "Symbol name is ambiguous in GitNexus; context lookup pinned the intended route function at web/backend/app/api/v1/strategy/indicators.py::get_technical_indicators. No application source was edited."
+    }
+  },
+  "red_green": {
+    "red": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short",
+      "result": "1 failed, 1 passed in 1.87s",
+      "failure": "test_v1_indicators_rejects_unsupported_indicator expected module.HTTPException, but current implementation raises app.core.exceptions.BusinessException."
+    },
+    "green": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short",
+      "result": "2 passed in 1.61s"
+    }
+  },
+  "change": {
+    "file": "web/backend/tests/test_v1_indicators_regressions.py",
+    "summary": "Import pytest and BusinessException; replace try/except module.HTTPException assertion with pytest.raises(BusinessException) and status/detail assertions.",
+    "application_source_changed": false,
+    "route_or_openapi_changed": false
+  },
+  "verification": {
+    "v1_indicators_regressions": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short",
+      "result": "2 passed in 1.61s"
+    },
+    "indicator_registry_route_provider": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --no-cov --tb=short",
+      "result": "2 passed in 2.06s"
+    },
+    "ruff_touched_test": {
+      "command": "ruff check web/backend/tests/test_v1_indicators_regressions.py",
+      "result": "All checks passed"
+    }
+  },
+  "decision": {
+    "status": "test_contract_aligned",
+    "source_implementation_authorized": false,
+    "next_gate": "G2.161 Indicator/Data source implementation authorization package",
+    "reason": "The focused v1 indicator regression test now matches the canonical BusinessException contract, removing the blocker identified by G2.159."
+  },
+  "boundaries": {
+    "application_source_edits": "none",
+    "test_edit_scope": [
+      "web/backend/tests/test_v1_indicators_regressions.py"
+    ],
+    "do_not_change": [
+      "web/backend/app/**",
+      "web/frontend/**",
+      "src/**",
+      "docs/api/**",
+      "docs/guides/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**",
+      "route/API behavior",
+      "OpenAPI exposure",
+      "get_data_service definition or compatibility behavior"
+    ]
+  }
+}

--- a/docs/reports/quality/backend-indicator-data-test-contract-alignment-2026-05-27.md
+++ b/docs/reports/quality/backend-indicator-data-test-contract-alignment-2026-05-27.md
@@ -1,0 +1,98 @@
+# Backend Indicator/Data Test-Contract Alignment
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Date: 2026-05-27
+
+Status: Ready for review
+
+Scope: G2.160 narrow test-contract alignment plus governance records.
+
+Base HEAD: `b31a1c69a96fa83f250e7577c4b21d3b4febbaeb`
+
+Parent: G2.159, PR `#312`, merged as `b31a1c69a96fa83f250e7577c4b21d3b4febbaeb`.
+
+Boundary: this package changes only the focused v1 indicator regression test and governance records. It does not edit application source, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations. It does not authorize Indicator/Data source implementation.
+
+## Decision
+
+The v1 indicator test-contract blocker identified by G2.159 is aligned.
+
+Do not start Indicator/Data source implementation from this package. The next gate should be G2.161: Indicator/Data source implementation authorization package.
+
+## Pre-Edit Evidence
+
+GitNexus pre-edit impact:
+
+| Symbol | Risk | Impacted | Direct callers | Processes |
+|---|---:|---:|---:|---:|
+| `test_v1_indicators_rejects_unsupported_indicator` | LOW | 0 | 0 | 0 |
+
+`get_technical_indicators` is an ambiguous symbol name in GitNexus. Context lookup pinned the intended function at `web/backend/app/api/v1/strategy/indicators.py::get_technical_indicators`. No application source was edited.
+
+## Red-Green Evidence
+
+Red command:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short
+```
+
+Red result:
+
+- `1 failed, 1 passed in 1.87s`
+- failing test: `test_v1_indicators_rejects_unsupported_indicator`
+- cause: test expected `module.HTTPException`, while current implementation raises canonical `BusinessException`.
+
+Green command:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short
+```
+
+Green result:
+
+- `2 passed in 1.61s`
+
+## Change
+
+Changed file:
+
+- `web/backend/tests/test_v1_indicators_regressions.py`
+
+Patch summary:
+
+- import `pytest`;
+- import `BusinessException` from `app.core.exceptions`;
+- replace the legacy `try/except module.HTTPException` block with `pytest.raises(BusinessException)`;
+- preserve status/detail assertions:
+  - `status_code == 400`;
+  - detail contains `Unsupported indicators`.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short` | 2 passed in 1.61s |
+| `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --no-cov --tb=short` | 2 passed in 2.06s |
+| `ruff check web/backend/tests/test_v1_indicators_regressions.py` | All checks passed |
+
+No route/OpenAPI drift check was required because no application route, dependency, response model, or OpenAPI exposure changed.
+
+## Boundaries
+
+No application source was edited.
+
+This package does not:
+
+- edit `web/backend/app/**`;
+- delete or privatize `get_data_service()`;
+- change route paths, response envelopes, or OpenAPI exposure;
+- touch Strategy adapter, root facade compatibility, or route dependency/provider governance;
+- modify frontend, PM2, OpenSpec, config, scripts, or issue labels.
+
+## Next Gate
+
+Review this package. If accepted, start G2.161 as an Indicator/Data source implementation authorization package. G2.161 should re-run current-head impact and decide whether a source implementation lane can safely convert the three direct `get_data_service()` body calls without changing route/API contracts.

--- a/governance/mainline/task-cards/pr-313.yaml
+++ b/governance/mainline/task-cards/pr-313.yaml
@@ -1,0 +1,121 @@
+version: "v0.2"
+
+task:
+  id: "pr-313"
+  title: "Align Indicator/Data test contract"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-indicator-data-test-contract-alignment"
+  objective: "align the focused v1 indicator regression test with the canonical BusinessException contract before Indicator/Data source implementation is considered"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-indicator-data-test-contract-alignment"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Focused test-contract alignment and governance records; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - "web/backend/tests/test_v1_indicators_regressions.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/indicator-data-test-contract-alignment-2026-05-27.json"
+    - "docs/reports/quality/backend-indicator-data-test-contract-alignment-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-313.yaml"
+  forbidden_paths:
+    - "web/backend/app/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 312 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "standards-read"
+      command: "read architecture/STANDARDS.md before test edit"
+      required: true
+    - id: "gitnexus-impact"
+      command: "GitNexus impact for test_v1_indicators_rejects_unsupported_indicator and context lookup for web/backend/app/api/v1/strategy/indicators.py::get_technical_indicators"
+      required: true
+    - id: "red-test"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "green-test"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "provider-guard"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-test"
+      command: "ruff check web/backend/tests/test_v1_indicators_regressions.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-indicator-data-test-contract-alignment-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/indicator-data-test-contract-alignment-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-313.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit application source in this package."
+  - "Do not authorize Indicator/Data source implementation from this package."
+  - "Do not delete or privatize get_data_service()."
+  - "Do not edit web/backend/app/services/data_service.py."
+  - "Do not edit Strategy adapter, root facade compatibility, or route dependency/provider surfaces."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this package is treated as source implementation authorization, get_data_service consumer edits could start before a dedicated source authorization package."
+    - "If the test is changed without preserving status/detail assertions, the canonical BusinessException contract could be weakened."
+  rollback_plan: "revert this PR to restore the previous focused regression test and remove only the closeout report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "align v1 indicator regression test with canonical BusinessException contract"
+    modified_scope: "one focused test file, steward tree, report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; application source is not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if red-green evidence, provider guard, ruff, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-27T00:40:51+08:00"
+    approval_note: "Approved as G2.160 narrow test-contract alignment after PR #312 identified the v1 indicator BusinessException/HTTPException blocker."
+    secondary_approved: false
+

--- a/web/backend/tests/test_v1_indicators_regressions.py
+++ b/web/backend/tests/test_v1_indicators_regressions.py
@@ -5,6 +5,9 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+import pytest
+
+from app.core.exceptions import BusinessException
 
 
 ROOT = Path(__file__).resolve().parents[3]
@@ -55,10 +58,8 @@ async def test_v1_indicators_rejects_unsupported_indicator():
     module = _load_module()
     module.get_data_service = lambda: _FakeDataService()
 
-    try:
+    with pytest.raises(BusinessException) as exc_info:
         await module.get_technical_indicators("IF9999.CCFX", ["bollinger"], 14)
-    except module.HTTPException as exc:
-        assert exc.status_code == 400
-        assert "Unsupported indicators" in exc.detail
-    else:
-        raise AssertionError("Expected HTTPException for unsupported indicator")
+
+    assert exc_info.value.status_code == 400
+    assert "Unsupported indicators" in exc_info.value.detail


### PR DESCRIPTION
## Summary\n- aligns the focused v1 indicator regression test with the canonical BusinessException contract\n- records G2.160 red/green evidence and updates the steward tree\n- keeps application source, route/API behavior, OpenAPI, and get_data_service untouched\n\n## Verification\n- Red: test_v1_indicators_regressions.py was 1 failed / 1 passed before alignment\n- Green: env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short: 2 passed\n- env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --no-cov --tb=short: 2 passed\n- ruff check web/backend/tests/test_v1_indicators_regressions.py: all checks passed\n- JSON/YAML parse passed\n- markdown governance passed\n- git diff --check passed\n- GitNexus detect_changes(scope=staged): low risk, 0 affected processes\n- mainline scope gate passed\n- gitnexus analyze --with-gitignore