### PR TITLE
docs(governance): authorize indicator data source lane

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2872,11 +2872,12 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              issue-label change, or GitHub issue state change is
 │   │              performed here
 │   ├── G2.160 Indicator/Data test-contract alignment
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#313`
 │   │   ├── Evidence: `backend-indicator-data-test-contract-alignment-2026-05-27.md`
 │   │   ├── Generated: `indicator-data-test-contract-alignment-2026-05-27.json`
 │   │   ├── Parent: G2.159 accepted and merged by PR `#312`
 │   │   ├── Current HEAD: `b31a1c69a96fa83f250e7577c4b21d3b4febbaeb`
+│   │   ├── Merge commit: `296957a12a6d1ce30919925e4637bd63bed5cc18`
 │   │   ├── Scope: `test_v1_indicators_regressions.py` plus governance
 │   │   │          records only; no application source, route/API, OpenAPI,
 │   │   │          frontend, PM2, OpenSpec, config, script, or issue-label
@@ -2892,9 +2893,37 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   │          authorization package
 │   │   └── Boundary: test-contract alignment only; no `get_data_service`
 │   │              definition or application consumer is changed here
-│   └── Next gate: review G2.160; if accepted, start G2.161 as an
-│                  Indicator/Data source implementation authorization
-│                  package before any `get_data_service` consumer edit
+│   ├── G2.161 Indicator/Data source implementation authorization package
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-indicator-data-source-implementation-authorization-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `indicator-data-source-implementation-authorization-2026-05-27.json`
+│   │   ├── Parent: G2.160 accepted and merged by PR `#313`
+│   │   ├── Current HEAD: `296957a12a6d1ce30919925e4637bd63bed5cc18`
+│   │   ├── GitNexus: `get_data_service` remains CRITICAL with `5`
+│   │   │          impacted symbols, `3` direct callers, and `7` affected
+│   │   │          processes; direct application-body callers are still
+│   │   │          limited to `indicator_cache.py:343`,
+│   │   │          `indicator_cache.py:613`, and
+│   │   │          `v1/strategy/indicators.py:201`
+│   │   ├── Baseline verification: v1 indicator regressions `2 passed`,
+│   │   │          indicator registry provider guard `2 passed`, and
+│   │   │          health route import/collection smoke `120 tests
+│   │   │          collected`
+│   │   ├── Decision: authorize future G2.162 only after this package is
+│   │   │          reviewed and merged; G2.162 may replace the `3` direct
+│   │   │          application-body `get_data_service()` calls with narrow
+│   │   │          consumer-local provider seams while preserving the
+│   │   │          public service getter fallback
+│   │   └── Boundary: authorization-only; no backend source/test edit,
+│   │              route/API, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │              config, script, compatibility wrapper deletion,
+│   │              issue-label change, or GitHub issue state change is
+│   │              performed here
+│   └── Next gate: review G2.161; if accepted, start G2.162 as the
+│                  narrow Indicator/Data source implementation lane for
+│                  `indicator_cache.py` and `v1/strategy/indicators.py`
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/indicator-data-source-implementation-authorization-2026-05-27.json
+++ b/.planning/codebase/generated/indicator-data-source-implementation-authorization-2026-05-27.json
@@ -1,0 +1,143 @@
+{
+  "artifact": "indicator-data-source-implementation-authorization-2026-05-27",
+  "task_id": "G2.161",
+  "status": "ready_for_review",
+  "scope": "authorization_package_only",
+  "created_at": "2026-05-27T01:13:49+08:00",
+  "parent": {
+    "task_id": "G2.160",
+    "pr": 313,
+    "merge_commit": "296957a12a6d1ce30919925e4637bd63bed5cc18"
+  },
+  "current_head": "296957a12a6d1ce30919925e4637bd63bed5cc18",
+  "decision": {
+    "next_gate": "G2.162",
+    "summary": "Authorize a future narrow Indicator/Data source implementation lane after G2.161 review and merge.",
+    "no_source_edits_in_this_package": true,
+    "implementation_start_requires_review_merge": true
+  },
+  "gitnexus": {
+    "get_data_service": {
+      "risk": "CRITICAL",
+      "impacted": 5,
+      "direct_callers": 3,
+      "processes": 7,
+      "d1_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py::calculate_indicators",
+        "web/backend/app/api/indicators/indicator_cache.py::_calculate_single_indicator",
+        "web/backend/app/api/v1/strategy/indicators.py::get_technical_indicators"
+      ]
+    },
+    "calculate_indicators": {
+      "risk": "LOW",
+      "impacted": 0,
+      "direct_callers": 0,
+      "processes": 0
+    },
+    "_calculate_single_indicator": {
+      "risk": "LOW",
+      "impacted": 3,
+      "direct_callers": 1,
+      "processes": 0
+    },
+    "calculate_single_request": {
+      "risk": "LOW",
+      "impacted": 2,
+      "direct_callers": 1,
+      "processes": 0
+    },
+    "limited_calculate": {
+      "risk": "LOW",
+      "impacted": 1,
+      "direct_callers": 1,
+      "processes": 0
+    }
+  },
+  "current_head_hit_classification": {
+    "service_definition": [
+      "web/backend/app/services/data_service.py:466"
+    ],
+    "application_import_sites": [
+      "web/backend/app/api/indicators/indicator_cache.py:40",
+      "web/backend/app/api/v1/strategy/indicators.py:17"
+    ],
+    "application_body_calls": [
+      "web/backend/app/api/indicators/indicator_cache.py:343",
+      "web/backend/app/api/indicators/indicator_cache.py:613",
+      "web/backend/app/api/v1/strategy/indicators.py:201"
+    ],
+    "focused_regression_test_monkeypatches": [
+      "web/backend/tests/test_v1_indicators_regressions.py:42",
+      "web/backend/tests/test_v1_indicators_regressions.py:59"
+    ],
+    "integration_test_direct_smoke_calls": [
+      "web/backend/tests/test_integration_e2e.py:201",
+      "web/backend/tests/test_integration_e2e.py:235"
+    ]
+  },
+  "target_g2_162_closure_metric": {
+    "application_body_get_data_service_calls_before": 3,
+    "application_body_get_data_service_calls_after": 0,
+    "preserve_public_get_data_service": true,
+    "integration_test_direct_smoke_calls_may_remain_without_explicit_review": true
+  },
+  "baseline_verification": [
+    {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short",
+      "result": "2 passed in 1.94s"
+    },
+    {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --no-cov --tb=short",
+      "result": "2 passed in 2.08s"
+    },
+    {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov",
+      "result": "120 tests collected in 17.21s"
+    }
+  ],
+  "authorized_future_paths": {
+    "application_source": [
+      "web/backend/app/api/indicators/indicator_cache.py",
+      "web/backend/app/api/v1/strategy/indicators.py"
+    ],
+    "focused_tests": [
+      "web/backend/tests/test_v1_indicators_regressions.py",
+      "web/backend/tests/test_indicator_registry_route_provider.py",
+      "web/backend/tests/test_integration_e2e.py",
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "governance": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/*indicator-data*2026-05-27*.json",
+      "docs/reports/quality/*indicator-data*2026-05-27*.md",
+      "governance/mainline/task-cards/pr-*.yaml"
+    ]
+  },
+  "forbidden_future_paths_or_actions": [
+    "web/backend/app/services/data_service.py",
+    "delete_privativize_rename_or_change_get_data_service",
+    "strategy_adapter_internals",
+    "root_facade_compatibility_surfaces",
+    "route_path_or_openapi_exposure_changes_without_explicit_scope_expansion",
+    "frontend_pm2_config_scripts_issue_labels",
+    "dashboard_tdx_realtime_backup_or_route_provider_governance_scope_mix"
+  ],
+  "required_g2_162_gates": {
+    "before_source_edits": [
+      "confirm implementation worktree contains PR #313",
+      "run GitNexus impact for get_data_service and each direct caller to be edited",
+      "stop if new HIGH or CRITICAL dependency appears outside recorded Indicator/Data scope"
+    ],
+    "before_commit": [
+      "focused v1 indicator regression tests",
+      "indicator registry route provider guard",
+      "health route collect-only import smoke",
+      "ruff check touched backend source/tests",
+      "json/yaml parse",
+      "markdown governance",
+      "git diff --check",
+      "staged GitNexus detect-changes",
+      "mainline scope gate"
+    ]
+  }
+}

--- a/docs/reports/quality/backend-indicator-data-source-implementation-authorization-2026-05-27.md
+++ b/docs/reports/quality/backend-indicator-data-source-implementation-authorization-2026-05-27.md
@@ -1,0 +1,167 @@
+# Backend Indicator/Data Source Implementation Authorization
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: Ready for review
+
+Scope: G2.161 authorization package only. No backend source, test, route, OpenAPI, frontend, PM2, OpenSpec, config, script, issue-label, or runtime behavior change is performed in this package.
+
+Boundary: this is a source-implementation authorization package only. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations. It does not perform implementation.
+
+Parent: G2.160, PR `#313`, merged as `296957a12a6d1ce30919925e4637bd63bed5cc18`.
+
+Current HEAD: `296957a12a6d1ce30919925e4637bd63bed5cc18`.
+
+Prepared at: `2026-05-27T01:13:49+08:00`.
+
+## Decision
+
+Authorize the next gate as G2.162: Indicator/Data source implementation lane.
+
+This authorization is conditional on review and merge of the G2.161 package. G2.161 does not itself authorize source edits in this PR.
+
+G2.162 may remove direct application-body `get_data_service()` calls from the Indicator/Data consumer modules by introducing narrow consumer-local provider seams that preserve the public `get_data_service()` fallback. It must not delete, privatize, or change `web/backend/app/services/data_service.py::get_data_service`.
+
+Reason:
+
+- G2.159 identified the Indicator/Data getter seam as small enough for a future implementation lane, but blocked source work until the v1 indicator error-contract test was aligned.
+- G2.160 aligned the v1 indicator regression test with the canonical `BusinessException` contract and merged as PR `#313`.
+- Current HEAD focused tests pass after that alignment.
+- GitNexus still classifies `get_data_service` as CRITICAL because it participates in Indicator/Data and Strategy flows, so the next source lane must be small, explicitly verified, and review-gated.
+
+## GitNexus Evidence
+
+| Symbol | Risk | Impacted | Direct callers | Processes | Notes |
+|---|---:|---:|---:|---:|---|
+| `get_data_service` | CRITICAL | 5 | 3 | 7 | Direct callers remain in Indicator/Data and Strategy indicator flows. |
+| `calculate_indicators` | LOW | 0 | 0 | 0 | Public indicator calculation route surface. |
+| `_calculate_single_indicator` | LOW | 3 | 1 | 0 | Helper used by single and batch calculation paths. |
+| `calculate_single_request` | LOW | 2 | 1 | 0 | Intermediate helper. |
+| `limited_calculate` | LOW | 1 | 1 | 0 | Batch-limiter helper. |
+
+`get_data_service` d1 callers at current HEAD:
+
+| File | Line | Surface |
+|---|---:|---|
+| `web/backend/app/api/indicators/indicator_cache.py` | 343 | `calculate_indicators` direct body call |
+| `web/backend/app/api/indicators/indicator_cache.py` | 613 | `_calculate_single_indicator` direct body call |
+| `web/backend/app/api/v1/strategy/indicators.py` | 201 | `get_technical_indicators` direct body call |
+
+Affected process names reported by GitNexus include:
+
+- `Calculate_indicators -> Warning`
+- `Calculate_indicators -> _dataframe_to_ohlcv_arrays`
+- `Get_technical_indicators -> ShouldAlwaysSelectNothing`
+- `Get_technical_indicators -> GetAttributeNS`
+- `Get_technical_indicators -> Strip`
+- `Get_technical_indicators -> _locationObjectNavigate`
+- `Get_technical_indicators -> ImplForWrapper`
+
+## Current-Head Hit Classification
+
+| Class | Count | Lines |
+|---|---:|---|
+| Service definition | 1 | `web/backend/app/services/data_service.py:466` |
+| Application import sites | 2 | `indicator_cache.py:40`, `v1/strategy/indicators.py:17` |
+| Application body calls | 3 | `indicator_cache.py:343`, `indicator_cache.py:613`, `v1/strategy/indicators.py:201` |
+| Focused regression-test monkeypatches | 2 | `test_v1_indicators_regressions.py:42`, `test_v1_indicators_regressions.py:59` |
+| Integration-test direct smoke calls | 2 | `test_integration_e2e.py:201`, `test_integration_e2e.py:235` |
+
+Target G2.162 closure metric:
+
+- Application body calls should move from `3` to `0`.
+- The public service definition should remain present.
+- Direct integration-test smoke calls may remain unless the G2.162 implementation package explicitly chooses and reviews a test-provider adjustment.
+
+## Consumer Contract Matrix
+
+| Consumer | Current getter use | Contract to preserve |
+|---|---|---|
+| `calculate_indicators` | direct body call at `indicator_cache.py:343` | `UnifiedResponse[Dict]`, `create_success_response`, request validation, OHLCV retrieval, cache/accounting behavior, `InvalidDateRangeError -> ValidationException`, `StockDataNotFoundError -> NotFoundException`, `BusinessException` propagation |
+| `_calculate_single_indicator` | direct body call at `indicator_cache.py:613` | result dict shape, symbol/date semantics, `calculate_single_request`, `limited_calculate`, and `calculate_indicators_batch` behavior |
+| `get_technical_indicators` | direct body call at `strategy/indicators.py:201` | indicator normalization, `get_daily_ohlcv` behavior, pagination payload, unsupported indicator `BusinessException 400`, missing data `BusinessException 404`, generic fetch failure `BusinessException 503` |
+
+## Baseline Verification
+
+| Check | Result |
+|---|---|
+| `test_v1_indicators_regressions.py` | `2 passed in 1.94s` |
+| `test_indicator_registry_route_provider.py` | `2 passed in 2.08s` |
+| `test_health_route_conflicts.py --collect-only` | `120 tests collected in 17.21s` |
+| Static checkout summary | branch `g2-161-indicator-data-implementation-authorization`, HEAD `296957a12a6d`, status clean before edits |
+
+The first relative-path test attempt failed because context-mode executes from a temporary cwd. The absolute-path rerun is the authoritative baseline evidence.
+
+## G2.162 Authorized Scope
+
+Allowed application source paths:
+
+- `web/backend/app/api/indicators/indicator_cache.py`
+- `web/backend/app/api/v1/strategy/indicators.py`
+
+Allowed focused test paths:
+
+- `web/backend/tests/test_v1_indicators_regressions.py`
+- `web/backend/tests/test_indicator_registry_route_provider.py`
+- `web/backend/tests/test_integration_e2e.py`, only if the direct service smoke needs a reviewed provider-seam adjustment
+- `web/backend/tests/test_health_route_conflicts.py`, only for import/collection verification or a reviewed route-contract assertion update caused by the authorized source files
+
+Allowed governance paths:
+
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/*indicator-data*2026-05-27*.json`
+- `docs/reports/quality/*indicator-data*2026-05-27*.md`
+- `governance/mainline/task-cards/pr-*.yaml`
+
+Recommended implementation direction:
+
+- Introduce narrow module-local provider seams in the consuming modules.
+- Preserve fallback behavior through the existing public `get_data_service()` function.
+- Prefer dependency injection at the consumer edge over changing the shared service singleton implementation.
+- Keep route paths, response models, OpenAPI exposure, and error contracts unchanged.
+
+## G2.162 Forbidden Scope
+
+G2.162 must not:
+
+- edit `web/backend/app/services/data_service.py`;
+- delete, privatize, rename, or change `get_data_service()`;
+- edit Strategy adapter internals;
+- edit root facade compatibility surfaces;
+- change route paths, response models, OpenAPI exposure, tags, operation IDs, or endpoint examples unless a reviewer explicitly expands scope;
+- edit frontend files, PM2 workflows, deployment config, scripts, or issue labels;
+- mix this Indicator/Data source lane with Dashboard/TDX, realtime streaming/socket, backup route ownership, or route dependency/provider governance work.
+
+## Required G2.162 Gates
+
+Before source edits:
+
+- Refresh branch state and confirm the implementation worktree contains PR `#313`.
+- Run GitNexus impact for `get_data_service` and each direct caller to be edited.
+- Stop and return to review if any new HIGH or CRITICAL dependency appears outside the Indicator/Data scope already recorded here.
+
+During implementation:
+
+- Use a minimal red/green loop around the focused indicator tests.
+- Keep application-body `get_data_service()` call count moving from `3` to `0`.
+- Preserve all consumer contracts listed above.
+
+Before commit:
+
+- `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short`
+- `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py -q --no-cov --tb=short`
+- `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov`
+- `ruff check` for every touched backend source and test file.
+- JSON/YAML parse for generated artifacts and task card.
+- Markdown governance for touched Markdown files.
+- `git diff --check`.
+- Staged GitNexus detect-changes.
+- Mainline scope gate for the future PR task card.
+
+## Rollback
+
+If G2.162 causes route/API drift, error-contract drift, or broader service lifecycle impact, revert the implementation PR. The public `get_data_service()` function and current route contracts must remain available, so rollback should be a normal source revert rather than a compatibility-restoration project.
+
+## Next Gate
+
+Review this package. If accepted and merged, start G2.162 as the narrow Indicator/Data source implementation lane. Do not start source edits from G2.161 itself.

--- a/governance/mainline/task-cards/pr-314.yaml
+++ b/governance/mainline/task-cards/pr-314.yaml
@@ -1,0 +1,110 @@
+version: "v0.2"
+
+task:
+  id: "pr-314"
+  title: "Authorize Indicator/Data source implementation lane"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-indicator-data-source-implementation-authorization"
+  objective: "record the narrow source implementation boundary for removing direct application-body get_data_service calls from Indicator/Data consumers after G2.160 aligned the v1 indicator test contract"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-indicator-data-source-implementation-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Source implementation authorization governance package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/indicator-data-source-implementation-authorization-2026-05-27.json"
+    - "docs/reports/quality/backend-indicator-data-source-implementation-authorization-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-314.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 313 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "gitnexus-impact"
+      command: "GitNexus impact/context for get_data_service and Indicator/Data direct callers"
+      required: true
+    - id: "static-classification"
+      command: "classify current get_data_service textual hits as definition, import, application body call, test monkeypatch, or integration-test smoke call"
+      required: true
+    - id: "focused-baseline-tests"
+      command: "run focused indicator tests and health route collect-only import smoke after PR #313"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-indicator-data-source-implementation-authorization-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/indicator-data-source-implementation-authorization-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-314.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this authorization package."
+  - "Do not start Indicator/Data source implementation from this package."
+  - "Do not delete, privatize, rename, or change get_data_service()."
+  - "Do not edit web/backend/app/services/data_service.py."
+  - "Do not edit Strategy adapter, root facade compatibility, or route dependency/provider governance surfaces."
+  - "Do not change route/API, OpenAPI, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this package is treated as source implementation, a critical get_data_service seam could be edited without the separate G2.162 review gate."
+    - "If G2.162 scope is widened beyond the two authorized consumers, route/API or Strategy-adapter behavior could change under a narrow Indicator/Data lane."
+  rollback_plan: "revert this decision PR to remove only the authorization report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize the future narrow Indicator/Data source implementation lane"
+    modified_scope: "steward tree, authorization report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, GitNexus evidence, static classification, baseline test evidence, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T01:13:49+08:00"
+    approval_note: "Authorization package after PR #313 removed the v1 indicator BusinessException/HTTPException test-contract blocker."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Adds G2.161 Indicator/Data source implementation authorization package.
- Records PR #313 as merged and confirms the v1 indicator test-contract blocker is removed.
- Defines G2.162 allowed paths, forbidden scope, GitNexus risk, and verification gates without editing source or tests.

## Verification
- GitNexus impact recorded for get_data_service and Indicator/Data callers.
- pytest v1 indicator regressions: 2 passed.
- pytest indicator registry provider guard: 2 passed.
- health route collect-only smoke: 120 tests collected.
- JSON/YAML parse, markdown governance, git diff --check, staged GitNexus, mainline scope gate: passed.

## Boundary
- Governance-only authorization package. No backend source/test implementation in this PR.