### PR TITLE
refactor(backend): inject indicator data service providers

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2894,13 +2894,14 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   └── Boundary: test-contract alignment only; no `get_data_service`
 │   │              definition or application consumer is changed here
 │   ├── G2.161 Indicator/Data source implementation authorization package
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#314`
 │   │   ├── Evidence:
 │   │   │          `backend-indicator-data-source-implementation-authorization-2026-05-27.md`
 │   │   ├── Generated:
 │   │   │          `indicator-data-source-implementation-authorization-2026-05-27.json`
 │   │   ├── Parent: G2.160 accepted and merged by PR `#313`
 │   │   ├── Current HEAD: `296957a12a6d1ce30919925e4637bd63bed5cc18`
+│   │   ├── Merge commit: `9d31aec75dadf4e90cc438f342cdbe3c3778875b`
 │   │   ├── GitNexus: `get_data_service` remains CRITICAL with `5`
 │   │   │          impacted symbols, `3` direct callers, and `7` affected
 │   │   │          processes; direct application-body callers are still
@@ -2921,9 +2922,39 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              config, script, compatibility wrapper deletion,
 │   │              issue-label change, or GitHub issue state change is
 │   │              performed here
-│   └── Next gate: review G2.161; if accepted, start G2.162 as the
-│                  narrow Indicator/Data source implementation lane for
-│                  `indicator_cache.py` and `v1/strategy/indicators.py`
+│   ├── G2.162 Indicator/Data source provider seam implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-indicator-data-source-provider-seam-implementation-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `indicator-data-source-provider-seam-implementation-2026-05-27.json`
+│   │   ├── Parent: G2.161 accepted and merged by PR `#314`
+│   │   ├── Current HEAD before implementation:
+│   │   │          `9d31aec75dadf4e90cc438f342cdbe3c3778875b`
+│   │   ├── Source change: added `get_indicator_data_service()` and
+│   │   │          `get_strategy_indicator_data_service()` provider seams,
+│   │   │          injected them into Indicator/Data route consumers, and
+│   │   │          preserved public `get_data_service()` fallback behavior
+│   │   ├── Static closure: direct application route/helper body
+│   │   │          `get_data_service()` calls moved from `3` to `0`;
+│   │   │          remaining calls are provider fallback bodies only
+│   │   ├── TDD: red showed missing provider seams and missing
+│   │   │          `data_service` parameter; green produced v1 indicator
+│   │   │          regressions `3 passed` and indicator provider guard
+│   │   │          `3 passed`
+│   │   ├── Verification: health route collect-only `120 tests
+│   │   │          collected`, v1 indicator OpenAPI docs guard `1
+│   │   │          passed`, touched backend ruff passed, OpenAPI smoke
+│   │   │          `routes=548`, `paths=500`,
+│   │   │          `duplicate_operation_ids=0`
+│   │   └── Boundary: no edit to `web/backend/app/services/data_service.py`,
+│   │              no delete/privatize/rename/change of
+│   │              `get_data_service()`, and no route path, OpenAPI
+│   │              exposure, frontend, PM2, OpenSpec, config, script, or
+│   │              issue-label change
+│   └── Next gate: review G2.162; if accepted and merged, refresh the
+│                  high-risk service getter inventory before choosing the
+│                  next source implementation lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/indicator-data-source-provider-seam-implementation-2026-05-27.json
+++ b/.planning/codebase/generated/indicator-data-source-provider-seam-implementation-2026-05-27.json
@@ -1,0 +1,128 @@
+{
+  "artifact": "indicator-data-source-provider-seam-implementation-2026-05-27",
+  "task_id": "G2.162",
+  "status": "ready_for_review",
+  "scope": "narrow_source_implementation",
+  "created_at": "2026-05-27T01:41:49+08:00",
+  "parent": {
+    "task_id": "G2.161",
+    "pr": 314,
+    "merge_commit": "9d31aec75dadf4e90cc438f342cdbe3c3778875b"
+  },
+  "base_head": "9d31aec75dadf4e90cc438f342cdbe3c3778875b",
+  "changed_files": [
+    "web/backend/app/api/indicators/indicator_cache.py",
+    "web/backend/app/api/v1/strategy/indicators.py",
+    "web/backend/tests/test_indicator_registry_route_provider.py",
+    "web/backend/tests/test_v1_indicators_regressions.py",
+    ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+    ".planning/codebase/generated/indicator-data-source-provider-seam-implementation-2026-05-27.json",
+    "docs/reports/quality/backend-indicator-data-source-provider-seam-implementation-2026-05-27.md",
+    "governance/mainline/task-cards/pr-315.yaml"
+  ],
+  "source_changes": {
+    "providers_added": [
+      "web/backend/app/api/indicators/indicator_cache.py::get_indicator_data_service",
+      "web/backend/app/api/v1/strategy/indicators.py::get_strategy_indicator_data_service"
+    ],
+    "consumers_injected": [
+      "web/backend/app/api/indicators/indicator_cache.py::calculate_indicators",
+      "web/backend/app/api/indicators/indicator_cache.py::calculate_indicators_batch",
+      "web/backend/app/api/indicators/indicator_cache.py::_calculate_single_indicator",
+      "web/backend/app/api/v1/strategy/indicators.py::get_technical_indicators"
+    ],
+    "public_get_data_service_preserved": true,
+    "data_service_module_edited": false
+  },
+  "static_closure": {
+    "application_body_get_data_service_calls_before": 3,
+    "application_route_or_helper_body_get_data_service_calls_after": 0,
+    "remaining_provider_fallback_calls": [
+      "web/backend/app/api/indicators/indicator_cache.py::get_indicator_data_service",
+      "web/backend/app/api/v1/strategy/indicators.py::get_strategy_indicator_data_service"
+    ],
+    "import_sites_preserved": true
+  },
+  "gitnexus_pre_edit": {
+    "get_data_service": {
+      "risk": "CRITICAL",
+      "impacted": 5,
+      "direct_callers": 3,
+      "processes": 7
+    },
+    "calculate_indicators": {
+      "risk": "LOW",
+      "impacted": 0
+    },
+    "_calculate_single_indicator": {
+      "risk": "LOW",
+      "impacted": 3
+    },
+    "get_technical_indicators_context": {
+      "incoming_callers": 0,
+      "processes": 5,
+      "note": "Impact lookup by bare name is ambiguous; exact context was resolved by file path."
+    }
+  },
+  "tdd": {
+    "red": [
+      {
+        "command": "test_v1_indicators_regressions.py",
+        "result": "3 failed: missing data_service parameter and missing get_strategy_indicator_data_service"
+      },
+      {
+        "command": "test_indicator_registry_route_provider.py",
+        "result": "1 failed, 2 passed: missing get_indicator_data_service"
+      }
+    ],
+    "green": [
+      {
+        "command": "test_v1_indicators_regressions.py",
+        "result": "3 passed in 1.53s"
+      },
+      {
+        "command": "test_indicator_registry_route_provider.py",
+        "result": "3 passed in 1.86s"
+      }
+    ]
+  },
+  "verification": [
+    {
+      "check": "test_health_route_conflicts.py --collect-only",
+      "result": "120 tests collected in 13.74s"
+    },
+    {
+      "check": "test_v1_indicator_openapi_docs_guard",
+      "result": "1 passed in 13.06s"
+    },
+    {
+      "check": "ruff_touched_backend_files",
+      "result": "All checks passed"
+    },
+    {
+      "check": "openapi_smoke",
+      "result": {
+        "routes": 548,
+        "paths": 500,
+        "duplicate_operation_ids": 0
+      }
+    },
+    {
+      "check": "staged_gitnexus_detect_changes",
+      "result": {
+        "risk_level": "high",
+        "changed_files": 8,
+        "changed_symbols": 23,
+        "affected_processes": 7,
+        "expected_within_authorized_critical_seam": true
+      }
+    }
+  ],
+  "forbidden_scope_preserved": {
+    "web_backend_app_services_data_service_py_edited": false,
+    "get_data_service_deleted_or_privatized": false,
+    "route_path_or_openapi_exposure_changed": false,
+    "frontend_pm2_config_scripts_issue_labels_changed": false
+  },
+  "next_gate": "review_and_merge_g2_162_then_refresh_high_risk_service_getter_inventory"
+}

--- a/docs/reports/quality/backend-indicator-data-source-provider-seam-implementation-2026-05-27.md
+++ b/docs/reports/quality/backend-indicator-data-source-provider-seam-implementation-2026-05-27.md
@@ -1,0 +1,118 @@
+# Backend Indicator/Data Source Provider Seam Implementation
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: Ready for review
+
+Scope: G2.162 narrow source implementation lane.
+
+Boundary: this package changes only the authorized Indicator/Data consumer files, focused tests, and governance records. It does not edit `web/backend/app/services/data_service.py`, delete or privatize `get_data_service()`, change route paths, change OpenAPI exposure, edit frontend code, edit PM2 workflows, change OpenSpec state, or change GitHub issue labels.
+
+Parent: G2.161, PR `#314`, merged as `9d31aec75dadf4e90cc438f342cdbe3c3778875b`.
+
+Current HEAD before implementation: `9d31aec75dadf4e90cc438f342cdbe3c3778875b`.
+
+Prepared at: `2026-05-27T01:41:49+08:00`.
+
+## Decision
+
+Implement the Indicator/Data source provider seam now authorized by G2.161.
+
+The implementation replaces the three direct application-body `get_data_service()` calls in Indicator/Data consumers with consumer-local FastAPI dependency provider seams:
+
+- `get_indicator_data_service()` in `web/backend/app/api/indicators/indicator_cache.py`
+- `get_strategy_indicator_data_service()` in `web/backend/app/api/v1/strategy/indicators.py`
+
+The public service getter remains available as the fallback used by those providers.
+
+## Changed Source
+
+| File | Change |
+|---|---|
+| `web/backend/app/api/indicators/indicator_cache.py` | Adds `get_indicator_data_service()`, injects `data_service` into `calculate_indicators` and `calculate_indicators_batch`, and passes that service into `_calculate_single_indicator`. |
+| `web/backend/app/api/v1/strategy/indicators.py` | Adds `get_strategy_indicator_data_service()`, injects `data_service` into `get_technical_indicators`, and uses the injected service for `get_daily_ohlcv`. |
+| `web/backend/tests/test_indicator_registry_route_provider.py` | Adds a route-provider guard asserting the calculation handlers expose the Indicator/Data data-service dependency. |
+| `web/backend/tests/test_v1_indicators_regressions.py` | Converts direct v1 tests from monkeypatching the root getter to explicit fake-service injection, and adds a provider-dependency signature guard. |
+
+## GitNexus Evidence
+
+Pre-edit impact at current index:
+
+| Symbol | Risk | Impacted | Direct callers | Processes |
+|---|---:|---:|---:|---:|
+| `get_data_service` | CRITICAL | 5 | 3 | 7 |
+| `calculate_indicators` | LOW | 0 | 0 | 0 |
+| `_calculate_single_indicator` | LOW | 3 | 1 | 0 |
+| `get_technical_indicators` | LOW via exact context; direct impact lookup is ambiguous without uid | 0 incoming callers in symbol context | 0 | participates in 5 v1 strategy indicator processes |
+
+`get_data_service` d1 callers before implementation:
+
+- `indicator_cache.py::calculate_indicators`
+- `indicator_cache.py::_calculate_single_indicator`
+- `v1/strategy/indicators.py::get_technical_indicators`
+
+## TDD Evidence
+
+Red:
+
+| Check | Expected failure |
+|---|---|
+| `test_v1_indicators_regressions.py` | `3 failed`: route did not accept `data_service`, and `get_strategy_indicator_data_service` was absent. |
+| `test_indicator_registry_route_provider.py` | `1 failed, 2 passed`: `get_indicator_data_service` was absent. |
+
+Green:
+
+| Check | Result |
+|---|---|
+| `test_v1_indicators_regressions.py` | `3 passed in 1.53s` |
+| `test_indicator_registry_route_provider.py` | `3 passed in 1.86s` |
+
+## Static Closure
+
+Before G2.162:
+
+- Application body `get_data_service()` calls: `3`
+- Direct sites:
+  - `indicator_cache.py:343`
+  - `indicator_cache.py:613`
+  - `v1/strategy/indicators.py:201`
+
+After G2.162:
+
+- Application route/helper body `get_data_service()` calls: `0`
+- Remaining `get_data_service()` calls are provider fallback bodies only:
+  - `indicator_cache.py:get_indicator_data_service`
+  - `v1/strategy/indicators.py:get_strategy_indicator_data_service`
+- Import sites remain because the provider seams intentionally preserve the public service getter fallback.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `test_v1_indicators_regressions.py` | `3 passed in 1.53s` |
+| `test_indicator_registry_route_provider.py` | `3 passed in 1.86s` |
+| `test_health_route_conflicts.py --collect-only` | `120 tests collected in 13.74s` |
+| `test_health_route_conflicts.py::test_v1_indicator_endpoints_have_examples_parameter_docs_and_descriptions` | `1 passed in 13.06s` |
+| `ruff check` for touched backend source/tests | `All checks passed!` |
+| OpenAPI smoke with non-secret minimal env | `routes=548`, `paths=500`, `duplicate_operation_ids=0` |
+| Staged GitNexus detect-changes | `risk_level=high`, `changed_files=8`, `changed_symbols=23`, `affected_processes=7` |
+
+OpenAPI smoke used dummy non-secret startup values for required environment variables. It did not read or disclose local secrets.
+
+The staged GitNexus risk is expected for this lane because `get_data_service` was pre-classified as a CRITICAL seam. The affected processes remain the Indicator/Data and v1 strategy indicator processes recorded before implementation:
+
+- `Calculate_indicators -> Warning`
+- `Calculate_indicators -> _dataframe_to_ohlcv_arrays`
+- `Get_technical_indicators -> Strip`
+- `Get_technical_indicators -> ShouldAlwaysSelectNothing`
+- `Get_technical_indicators -> ImplForWrapper`
+- `Get_technical_indicators -> GetAttributeNS`
+- `Get_technical_indicators -> _locationObjectNavigate`
+
+## Rollback
+
+Rollback is a normal PR revert. The public `get_data_service()` function is preserved, so reverting this implementation restores previous direct consumer calls without a compatibility restoration project.
+
+## Next Gate
+
+Review this package. If accepted, merge G2.162 and refresh the high-risk service getter inventory before selecting the next track. Do not start another source implementation lane directly from this package.

--- a/governance/mainline/task-cards/pr-315.yaml
+++ b/governance/mainline/task-cards/pr-315.yaml
@@ -1,0 +1,129 @@
+version: "v0.2"
+
+task:
+  id: "pr-315"
+  title: "Implement Indicator/Data source provider seam"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-indicator-data-source-provider-seam"
+  objective: "remove direct application-body get_data_service calls from authorized Indicator/Data consumers while preserving the public service getter fallback"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-indicator-data-source-provider-seam"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Narrow provider-seam implementation under an approved service-lifecycle cleanup lane; route paths, public API exposure, OpenAPI paths, PM2 workflows, and frontend behavior are unchanged"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/api/indicators/indicator_cache.py"
+    - "web/backend/app/api/v1/strategy/indicators.py"
+    - "web/backend/tests/test_indicator_registry_route_provider.py"
+    - "web/backend/tests/test_v1_indicators_regressions.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/indicator-data-source-provider-seam-implementation-2026-05-27.json"
+    - "docs/reports/quality/backend-indicator-data-source-provider-seam-implementation-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-315.yaml"
+  forbidden_paths:
+    - "web/backend/app/services/data_service.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 314 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "gitnexus-impact"
+      command: "GitNexus impact/context for get_data_service and Indicator/Data direct callers before source edits"
+      required: true
+    - id: "tdd-red"
+      command: "focused provider-seam tests fail before implementation"
+      required: true
+    - id: "tdd-green"
+      command: "focused provider-seam tests pass after implementation"
+      required: true
+    - id: "static-closure"
+      command: "application route/helper body get_data_service calls move from 3 to 0, preserving provider fallback calls"
+      required: true
+    - id: "health-collect-only"
+      command: "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov"
+      required: true
+    - id: "v1-indicator-openapi-docs"
+      command: "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_v1_indicator_endpoints_have_examples_parameter_docs_and_descriptions -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched"
+      command: "ruff check web/backend/app/api/indicators/indicator_cache.py web/backend/app/api/v1/strategy/indicators.py web/backend/tests/test_indicator_registry_route_provider.py web/backend/tests/test_v1_indicators_regressions.py"
+      required: true
+    - id: "openapi-smoke"
+      command: "app.openapi() smoke with non-secret minimal env; record route count, path count, and duplicate operation IDs"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-indicator-data-source-provider-seam-implementation-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/indicator-data-source-provider-seam-implementation-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-315.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit web/backend/app/services/data_service.py."
+  - "Do not delete, privatize, rename, or change get_data_service()."
+  - "Do not edit Strategy adapter, root facade compatibility, Dashboard/TDX, realtime streaming/socket, backup route ownership, or route dependency/provider governance surfaces."
+  - "Do not change route paths, response models, OpenAPI exposure, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+  - "Do not start a new source implementation lane from this PR."
+
+risk_and_rollback:
+  risks:
+    - "get_data_service remains a CRITICAL seam; widening scope beyond the two authorized consumers could cross Strategy and Indicators processes."
+    - "If provider defaults are changed incorrectly, direct unit calls may receive FastAPI Depends sentinels instead of fake services."
+  rollback_plan: "revert this PR to restore previous direct consumer calls; public get_data_service remains unchanged throughout"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "remove direct application-body get_data_service calls from Indicator/Data consumers"
+    modified_scope: "two backend consumer files, two focused test files, steward tree, implementation report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "public get_data_service fallback preserved through consumer-local providers"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if TDD red/green, static closure, health collection, v1 indicator docs guard, ruff, OpenAPI smoke, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-27T01:41:49+08:00"
+    approval_note: "Approved by G2.161 PR #314 for the narrow Indicator/Data source implementation lane."
+    secondary_approved: false
+

--- a/web/backend/app/api/indicators/indicator_cache.py
+++ b/web/backend/app/api/indicators/indicator_cache.py
@@ -37,12 +37,16 @@ from app.schemas.indicator_response import (
     IndicatorMetadata,
     IndicatorRegistryResponse,
 )
-from app.services.data_service import InvalidDateRangeError, StockDataNotFoundError, get_data_service
+from app.services.data_service import DataService, InvalidDateRangeError, StockDataNotFoundError, get_data_service
 from app.services.indicator_calculator import IndicatorCalculationError, InsufficientDataError, get_indicator_calculator
 from app.services.indicator_registry import IndicatorCategory, IndicatorRegistry, get_indicator_registry_dependency
 
 logger = structlog.get_logger()
 router = APIRouter()
+
+
+def get_indicator_data_service() -> DataService:
+    return get_data_service()
 
 
 from app.api.indicators._indicator_cache_responses import (
@@ -263,6 +267,7 @@ async def get_indicators_by_category(
 async def calculate_indicators(
     request: IndicatorCalculateRequest = Body(..., example=INDICATOR_CALCULATE_REQUEST_EXAMPLE),
     current_user: User = Depends(get_current_active_user),
+    data_service: DataService = Depends(get_indicator_data_service),
 ):
     """
     计算技术指标 - Phase 4C Enhanced
@@ -338,9 +343,6 @@ async def calculate_indicators(
 
         # 缓存未命中，执行计算
         indicator_cache._total_requests = getattr(indicator_cache, "_total_requests", 0) + 1
-
-        # Load OHLCV data from database via DataService
-        data_service = get_data_service()
 
         # Convert date strings to datetime
         from datetime import datetime
@@ -517,6 +519,7 @@ async def calculate_indicators(
 async def calculate_indicators_batch(
     request: IndicatorCalculateBatchRequest = Body(..., example=INDICATOR_CALCULATE_BATCH_REQUEST_EXAMPLE),
     current_user: User = Depends(get_current_active_user),
+    data_service: DataService = Depends(get_indicator_data_service),
 ) -> Dict:
     """
     批量计算技术指标 - Phase 4C Enhanced
@@ -545,7 +548,7 @@ async def calculate_indicators_batch(
                     "start_date": str(calc_request.start_date),
                     "end_date": str(calc_request.end_date),
                     "success": True,
-                    "data": await _calculate_single_indicator(calc_request, current_user),
+                    "data": await _calculate_single_indicator(calc_request, current_user, data_service),
                 }
             except Exception as e:
                 logger.error("单个指标计算失败", user_id=current_user.id, symbol=calc_request.symbol, error=str(e))
@@ -604,13 +607,12 @@ async def calculate_indicators_batch(
         )
 
 
-async def _calculate_single_indicator(request, current_user):
+async def _calculate_single_indicator(request, current_user, data_service: DataService):
     """内部函数：计算单个指标请求"""
     # 重用calculate_indicators的核心逻辑
     # 这里简化实现，实际应该提取共同逻辑
     indicator_specs = [{"abbreviation": ind.abbreviation, "parameters": ind.parameters} for ind in request.indicators]
 
-    data_service = get_data_service()
     calculator = get_indicator_calculator()
 
     # 获取数据并计算

--- a/web/backend/app/api/v1/strategy/indicators.py
+++ b/web/backend/app/api/v1/strategy/indicators.py
@@ -9,12 +9,12 @@ from typing import Any, Dict, List
 
 import math
 import pandas as pd
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 from app.core.exceptions import BusinessException
 from pydantic import BaseModel, Field
 
 from app.core.responses import UnifiedResponse
-from app.services.data_service import StockDataNotFoundError, get_data_service
+from app.services.data_service import DataService, StockDataNotFoundError, get_data_service
 from src.indicators.implementations.momentum.rsi import RSIIndicator
 from src.indicators.implementations.trend.ema import EMAIndicator
 from src.indicators.implementations.trend.macd import MACDIndicator
@@ -24,6 +24,10 @@ router = APIRouter(
     prefix="/technical-indicators",
     tags=["Technical Indicators"],
 )
+
+
+def get_strategy_indicator_data_service() -> DataService:
+    return get_data_service()
 
 
 TECHNICAL_INDICATORS_SUCCESS_EXAMPLE = {
@@ -185,6 +189,7 @@ async def get_technical_indicators(
     symbol: str = Query(..., description="Stock symbol"),
     indicators: List[str] = Query(..., description="Indicator names (sma,ema,rsi,macd)"),
     period: int = Query(14, ge=2, le=250, description="Calculation period"),
+    data_service: DataService = Depends(get_strategy_indicator_data_service),
 ):
     """
     计算技术指标。
@@ -198,7 +203,7 @@ async def get_technical_indicators(
     start_dt = end_dt - timedelta(days=lookback_days)
 
     try:
-        frame, _ = get_data_service().get_daily_ohlcv(symbol=symbol, start_date=start_dt, end_date=end_dt)
+        frame, _ = data_service.get_daily_ohlcv(symbol=symbol, start_date=start_dt, end_date=end_dt)
     except StockDataNotFoundError as exc:
         raise BusinessException(status_code=404, detail=str(exc)) from exc
     except Exception as exc:

--- a/web/backend/tests/test_indicator_registry_route_provider.py
+++ b/web/backend/tests/test_indicator_registry_route_provider.py
@@ -51,6 +51,19 @@ def test_indicator_registry_routes_expose_app_state_dependency() -> None:
         assert getattr(registry_parameter.default, "dependency", None) is dependency
 
 
+def test_indicator_calculation_routes_expose_data_service_dependency() -> None:
+    dependency = getattr(indicator_cache, "get_indicator_data_service", None)
+
+    assert dependency is not None
+
+    for handler in (
+        indicator_cache.calculate_indicators,
+        indicator_cache.calculate_indicators_batch,
+    ):
+        data_service_parameter = inspect.signature(handler).parameters["data_service"]
+        assert getattr(data_service_parameter.default, "dependency", None) is dependency
+
+
 def test_indicator_registry_routes_accept_injected_registry() -> None:
     registry = _FakeIndicatorRegistry()
     user = SimpleNamespace(id="route-provider-test")

--- a/web/backend/tests/test_v1_indicators_regressions.py
+++ b/web/backend/tests/test_v1_indicators_regressions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import sys
 from pathlib import Path
 
@@ -39,9 +40,13 @@ def _load_module():
 
 async def test_v1_indicators_returns_runtime_indicator_values():
     module = _load_module()
-    module.get_data_service = lambda: _FakeDataService()
 
-    payload = await module.get_technical_indicators("IF9999.CCFX", ["rsi", "macd", "sma", "ema"], 14)
+    payload = await module.get_technical_indicators(
+        "IF9999.CCFX",
+        ["rsi", "macd", "sma", "ema"],
+        14,
+        data_service=_FakeDataService(),
+    )
 
     assert payload.success is True
     assert payload.code == 200
@@ -56,10 +61,24 @@ async def test_v1_indicators_returns_runtime_indicator_values():
 
 async def test_v1_indicators_rejects_unsupported_indicator():
     module = _load_module()
-    module.get_data_service = lambda: _FakeDataService()
 
     with pytest.raises(BusinessException) as exc_info:
-        await module.get_technical_indicators("IF9999.CCFX", ["bollinger"], 14)
+        await module.get_technical_indicators(
+            "IF9999.CCFX",
+            ["bollinger"],
+            14,
+            data_service=_FakeDataService(),
+        )
 
     assert exc_info.value.status_code == 400
     assert "Unsupported indicators" in exc_info.value.detail
+
+
+def test_v1_indicators_route_exposes_data_service_dependency():
+    module = _load_module()
+    dependency = getattr(module, "get_strategy_indicator_data_service", None)
+
+    assert dependency is not None
+
+    data_service_parameter = inspect.signature(module.get_technical_indicators).parameters["data_service"]
+    assert getattr(data_service_parameter.default, "dependency", None) is dependency


### PR DESCRIPTION
## Summary
- Implements the G2.162 Indicator/Data source provider seam authorized by PR #314.
- Replaces three direct application-body get_data_service() calls with consumer-local FastAPI provider dependencies.
- Preserves public get_data_service() fallback and does not edit web/backend/app/services/data_service.py.

## Verification
- TDD red: v1 indicator provider seam 3 failed; indicator cache provider seam 1 failed / 2 passed.
- TDD green: v1 indicator regressions 3 passed; indicator cache provider guard 3 passed.
- health route collect-only: 120 tests collected.
- v1 indicator OpenAPI docs guard: 1 passed.
- ruff touched backend files: passed.
- OpenAPI smoke with non-secret env: routes=548, paths=500, duplicate_operation_ids=0.
- JSON/YAML parse, markdown governance, git diff --check, staged GitNexus, mainline scope gate: passed.

## Risk
- Staged GitNexus risk is high as expected for the pre-authorized CRITICAL get_data_service seam; affected processes remain within recorded Indicator/Data and v1 strategy indicator flows.