### PR TITLE
docs(governance): refresh service getter inventory

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2923,7 +2923,7 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              issue-label change, or GitHub issue state change is
 │   │              performed here
 │   ├── G2.162 Indicator/Data source provider seam implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#315`
 │   │   ├── Evidence:
 │   │   │          `backend-indicator-data-source-provider-seam-implementation-2026-05-27.md`
 │   │   ├── Generated:
@@ -2931,6 +2931,7 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   ├── Parent: G2.161 accepted and merged by PR `#314`
 │   │   ├── Current HEAD before implementation:
 │   │   │          `9d31aec75dadf4e90cc438f342cdbe3c3778875b`
+│   │   ├── Merge commit: `c9dc5de905e351c4675ee62201edfa1ce4e7ce97`
 │   │   ├── Source change: added `get_indicator_data_service()` and
 │   │   │          `get_strategy_indicator_data_service()` provider seams,
 │   │   │          injected them into Indicator/Data route consumers, and
@@ -2952,9 +2953,43 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              `get_data_service()`, and no route path, OpenAPI
 │   │              exposure, frontend, PM2, OpenSpec, config, script, or
 │   │              issue-label change
-│   └── Next gate: review G2.162; if accepted and merged, refresh the
-│                  high-risk service getter inventory before choosing the
-│                  next source implementation lane
+│   ├── G2.163 Service getter inventory refresh after Indicator/Data
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.json`
+│   │   ├── Parent: G2.162 accepted and merged by PR `#315`
+│   │   ├── Current HEAD: `c9dc5de905e351c4675ee62201edfa1ce4e7ce97`
+│   │   ├── Scan snapshot: service files=`152`, API files=`219`,
+│   │   │          backend test files=`207`, top-level service
+│   │   │          `def get_*` definitions=`53`, root facade getters=`7`,
+│   │   │          service dependency/provider getters=`9`, API local
+│   │   │          provider-like getters=`13`, API `Depends(get_*)`
+│   │   │          sites=`371`, API non-provider service-getter body
+│   │   │          sites=`19`
+│   │   ├── Indicator/Data closure: direct application route/helper body
+│   │   │          `get_data_service()` calls remain `0`; remaining
+│   │   │          `get_data_service()` hits are provider fallbacks in
+│   │   │          `get_indicator_data_service()` and
+│   │   │          `get_strategy_indicator_data_service()`
+│   │   ├── Refreshed high-risk matrix: `get_data_service`
+│   │   │          CRITICAL `5/3/7`, `get_strategy_service` CRITICAL
+│   │   │          `13/6/0`, `get_streaming_service` HIGH `9/9/0`,
+│   │   │          and `get_tdx_service` CRITICAL `6/2/5`
+│   │   ├── Verification: parent PR `#315` merged, v1 indicator
+│   │   │          regressions `3 passed`, indicator provider guard
+│   │   │          `3 passed`, OpenAPI smoke `routes=548`,
+│   │   │          `paths=500`, `duplicate_operation_ids=0`, GitNexus
+│   │   │          analyze refreshed `300` flows
+│   │   └── Boundary: governance-only refresh; no backend source/test
+│   │              edit, route/API behavior, OpenAPI exposure, frontend,
+│   │              PM2, OpenSpec, config, script, compatibility deletion,
+│   │              issue-label change, or implementation authorization
+│   │              is performed here
+│   └── Next gate: review G2.163; if accepted, start G2.164 as a
+│                  decision-only high-risk service getter track-selection
+│                  package before any further source implementation lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.json
+++ b/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.json
@@ -1,0 +1,133 @@
+{
+  "artifact": "service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27",
+  "task_id": "G2.163",
+  "status": "ready_for_review",
+  "scope": "governance_only_candidate_refresh",
+  "created_at": "2026-05-27T01:58:47+08:00",
+  "parent": {
+    "task_id": "G2.162",
+    "pr": 315,
+    "merge_commit": "c9dc5de905e351c4675ee62201edfa1ce4e7ce97"
+  },
+  "current_head": "c9dc5de905e351c4675ee62201edfa1ce4e7ce97",
+  "scan_snapshot": {
+    "service_python_files": 152,
+    "api_python_files": 219,
+    "backend_test_python_files": 207,
+    "top_level_service_getter_definitions": 53,
+    "root_facade_getters": 7,
+    "service_dependency_provider_getters": 9,
+    "top_level_api_getters": 32,
+    "api_local_provider_like_getters": 13,
+    "api_depends_getter_sites": 371,
+    "api_non_provider_service_getter_body_call_sites": 19
+  },
+  "indicator_data_closure": {
+    "direct_application_route_or_helper_body_get_data_service_calls": 0,
+    "remaining_provider_fallbacks": [
+      "web/backend/app/api/indicators/indicator_cache.py::get_indicator_data_service",
+      "web/backend/app/api/v1/strategy/indicators.py::get_strategy_indicator_data_service"
+    ],
+    "get_indicator_data_service": {
+      "count": 4,
+      "files": 2
+    },
+    "get_strategy_indicator_data_service": {
+      "count": 3,
+      "files": 2
+    }
+  },
+  "high_risk_getter_matrix": [
+    {
+      "getter": "get_data_service",
+      "risk": "CRITICAL",
+      "impacted": 5,
+      "direct": 3,
+      "processes": 7,
+      "interpretation": "Indicator/Data direct body debt closed; provider-governed runtime seam remains."
+    },
+    {
+      "getter": "get_strategy_service",
+      "risk": "CRITICAL",
+      "impacted": 13,
+      "direct": 6,
+      "processes": 0,
+      "interpretation": "Strong next decision candidate; crosses strategy adapters, strategy-management routes, and backtest task resolution."
+    },
+    {
+      "getter": "get_streaming_service",
+      "risk": "HIGH",
+      "impacted": 9,
+      "direct": 9,
+      "processes": 0,
+      "interpretation": "Realtime/socket lifecycle track; keep separate from strategy adapter work."
+    },
+    {
+      "getter": "get_tdx_service",
+      "risk": "CRITICAL",
+      "impacted": 6,
+      "direct": 2,
+      "processes": 5,
+      "interpretation": "Dashboard/TDX residual graph risk; needs residual decision packet before source work."
+    }
+  ],
+  "token_surface": {
+    "get_data_service": {
+      "count": 9,
+      "files": 4
+    },
+    "get_strategy_service": {
+      "count": 10,
+      "files": 5
+    },
+    "get_streaming_service": {
+      "count": 23,
+      "files": 5
+    },
+    "get_tdx_service": {
+      "count": 6,
+      "files": 4
+    },
+    "get_market_data_service": {
+      "count": 19,
+      "files": 8
+    },
+    "get_market_data_service_v2_dependency": {
+      "count": 18,
+      "files": 4
+    },
+    "get_indicator_data_service": {
+      "count": 4,
+      "files": 2
+    },
+    "get_strategy_indicator_data_service": {
+      "count": 3,
+      "files": 2
+    },
+    "get_indicator_registry_dependency": {
+      "count": 5,
+      "files": 3
+    }
+  },
+  "verification": {
+    "parent_pr_315": "MERGED",
+    "test_v1_indicators_regressions": "3 passed in 1.71s",
+    "test_indicator_registry_route_provider": "3 passed in 2.18s",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "duplicate_operation_ids": 0
+    },
+    "gitnexus_analyze": {
+      "nodes": 62910,
+      "edges": 146092,
+      "clusters": 3287,
+      "flows": 300
+    }
+  },
+  "decision": {
+    "source_implementation_selected": false,
+    "next_gate": "G2.164 high-risk service getter track selection after Indicator/Data",
+    "next_gate_type": "decision_only"
+  }
+}

--- a/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.md
+++ b/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.md
@@ -1,0 +1,119 @@
+# Backend Service Lifecycle Candidate Refresh After Indicator/Data
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: Ready for review
+
+Scope: G2.163 governance-only candidate refresh after G2.162.
+
+Boundary: this is a candidate refresh and routing package only. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations. It does not authorize implementation.
+
+Parent: G2.162, PR `#315`, merged as `c9dc5de905e351c4675ee62201edfa1ce4e7ce97`.
+
+Current HEAD: `c9dc5de905e351c4675ee62201edfa1ce4e7ce97`.
+
+Prepared at: `2026-05-27T01:58:47+08:00`.
+
+## Purpose
+
+Refresh the remaining service lifecycle getter/provider inventory after the Indicator/Data source provider seam implementation closed.
+
+This refresh is intentionally not a source implementation plan. Its job is to record the new baseline, distinguish static closure from remaining graph risk, and route the next step back through a decision package.
+
+## Parent Verification
+
+| Check | Result |
+|---|---|
+| PR `#315` state | `MERGED`, merge commit `c9dc5de905e351c4675ee62201edfa1ce4e7ce97` |
+| `test_v1_indicators_regressions.py` | `3 passed in 1.71s` |
+| `test_indicator_registry_route_provider.py` | `3 passed in 2.18s` |
+| OpenAPI smoke with non-secret minimal env | `routes=548`, `paths=500`, `duplicate_operation_ids=0` |
+| GitNexus analyze | `62,910 nodes`, `146,092 edges`, `3,287 clusters`, `300 flows` |
+
+## Scan Snapshot
+
+| Metric | Count |
+|---|---:|
+| Service Python files | 152 |
+| API Python files | 219 |
+| Backend test Python files | 207 |
+| Top-level `def get_*` definitions under `web/backend/app/services` | 53 |
+| Root facade getters in `web/backend/app/services/__init__.py` | 7 |
+| Service dependency/provider getter definitions | 9 |
+| Top-level API `def get_*` helpers/providers | 32 |
+| API local provider-like getters | 13 |
+| API `Depends(get_*)` sites | 371 |
+| API non-provider service-getter body call sites | 19 |
+
+The broad `def get_*` count includes business query methods such as stock-search or profile getters. It is not a deletion queue and must not be interpreted as direct singleton debt.
+
+## Indicator/Data Closure
+
+G2.162 changed the Indicator/Data seam from direct body calls to provider fallbacks.
+
+| Surface | Current state |
+|---|---|
+| Direct application route/helper body `get_data_service()` calls in the G2.162 scope | 0 |
+| Remaining `get_data_service()` hits in `indicator_cache.py` | import plus `get_indicator_data_service()` provider fallback |
+| Remaining `get_data_service()` hits in `api/v1/strategy/indicators.py` | import plus `get_strategy_indicator_data_service()` provider fallback |
+| `get_indicator_data_service` token surface | 4 hits across 2 files |
+| `get_strategy_indicator_data_service` token surface | 3 hits across 2 files |
+
+GitNexus still reports `get_data_service` as CRITICAL with `5` impacted symbols, `3` direct callers, and `7` affected processes. This is expected because the provider seam still participates in the same Indicator/Data and v1 strategy indicator execution flows. The static closure metric is therefore the implementation closure signal; the GitNexus risk remains the runtime flow risk signal.
+
+## Refreshed High-Risk Getter Matrix
+
+| Getter | GitNexus risk | Impacted | Direct | Processes | Current interpretation |
+|---|---:|---:|---:|---:|---|
+| `get_data_service` | CRITICAL | 5 | 3 | 7 | Indicator/Data direct body debt closed; keep as provider-governed runtime seam, not a new immediate source lane. |
+| `get_strategy_service` | CRITICAL | 13 | 6 | 0 | Strong next decision candidate; crosses strategy adapters, strategy-management routes, and backtest task resolution. |
+| `get_streaming_service` | HIGH | 9 | 9 | 0 | Realtime/socket lifecycle track; should remain separate from strategy adapter work. |
+| `get_tdx_service` | CRITICAL | 6 | 2 | 5 | Dashboard/TDX residual graph risk; prior Dashboard/TDX lane closed direct helper debt, so this needs a residual decision packet before source work. |
+
+## Token Surface
+
+| Token | Count | Files |
+|---|---:|---:|
+| `get_data_service` | 9 | 4 |
+| `get_strategy_service` | 10 | 5 |
+| `get_streaming_service` | 23 | 5 |
+| `get_tdx_service` | 6 | 4 |
+| `get_market_data_service` | 19 | 8 |
+| `get_market_data_service_v2_dependency` | 18 | 4 |
+| `get_indicator_data_service` | 4 | 2 |
+| `get_strategy_indicator_data_service` | 3 | 2 |
+| `get_indicator_registry_dependency` | 5 | 3 |
+
+## Non-Provider API Body Call Sample
+
+Current API non-provider service-getter body call sites include:
+
+- `web/backend/app/api/strategy_management/_strategy_execution_router.py:399`
+- `web/backend/app/api/strategy_management/_strategy_execution_router.py:461`
+- `web/backend/app/api/strategy_management/_strategy_execution_router.py:503`
+- `web/backend/app/api/dashboard_data_source.py:137`
+- `web/backend/app/api/dashboard_data_source.py:247`
+- `web/backend/app/api/dashboard_data_source.py:499`
+- `web/backend/app/api/dashboard_data_source.py:730`
+- `web/backend/app/api/v1/strategy/ml_runtime_helpers.py:59`
+- `web/backend/app/api/v1/analysis/backtest.py:338`
+- `web/backend/app/api/v1/system/health.py:232`
+
+These are not all the same kind of debt. Some are route-local private helpers, some are dashboard/TDX residuals, and some are strategy-management service calls. They should be split by track before any source edits.
+
+## Decision
+
+No new source implementation lane is selected by G2.163.
+
+Recommended next gate: G2.164 high-risk service getter track selection after Indicator/Data.
+
+G2.164 should be decision-only and choose one next track from the refreshed matrix. The most likely candidates are:
+
+- Strategy adapter / strategy-management `get_strategy_service` decision path.
+- Realtime streaming/socket `get_streaming_service` decision path.
+- Dashboard/TDX residual `get_tdx_service` decision path.
+- Route dependency/provider governance path for private route-local helpers.
+
+## Next Gate
+
+Review this package. If accepted, start G2.164 as a decision-only track-selection package. Do not start another source implementation lane directly from this refresh.

--- a/governance/mainline/task-cards/pr-316.yaml
+++ b/governance/mainline/task-cards/pr-316.yaml
@@ -1,0 +1,112 @@
+version: "v0.2"
+
+task:
+  id: "pr-316"
+  title: "Refresh service getter inventory after Indicator/Data"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-service-getter-inventory-refresh-after-indicator-data"
+  objective: "refresh the high-risk service getter/provider inventory after the Indicator/Data provider seam implementation closed"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-getter-inventory-refresh-after-indicator-data"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only inventory refresh; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.json"
+    - "docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-316.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 315 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "inventory-scan"
+      command: "scan service/API getter/provider counts at current HEAD"
+      required: true
+    - id: "gitnexus-impact-refresh"
+      command: "GitNexus impact for get_data_service, get_strategy_service, get_streaming_service, and get_tdx_service"
+      required: true
+    - id: "post-merge-focused-tests"
+      command: "run v1 indicator and indicator cache provider tests after PR #315 merge"
+      required: true
+    - id: "openapi-smoke"
+      command: "app.openapi() smoke with non-secret minimal env; record route count, path count, and duplicate operation IDs"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-316.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this inventory refresh package."
+  - "Do not select or start a source implementation lane from this package."
+  - "Do not delete, privatize, rename, or change get_data_service(), get_strategy_service(), get_streaming_service(), or get_tdx_service()."
+  - "Do not edit route/API behavior, OpenAPI exposure, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this refresh is treated as implementation authorization, a high-risk getter lane could start without a dedicated decision package."
+    - "If broad get_* counts are treated as deletion candidates, business query helpers may be misclassified as singleton debt."
+  rollback_plan: "revert this decision PR to remove only the refresh report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh high-risk service getter inventory after Indicator/Data provider seam closure"
+    modified_scope: "steward tree, refresh report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, inventory scan, GitNexus impact refresh, focused tests, OpenAPI smoke, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T01:58:47+08:00"
+    approval_note: "Governance-only inventory refresh after PR #315 merged the Indicator/Data source provider seam."
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary
- Adds G2.163 post-Indicator/Data service getter inventory refresh.
- Records PR #315 as merged and confirms Indicator/Data direct get_data_service body calls remain closed.
- Refreshes high-risk getter matrix without selecting or starting another source implementation lane.

## Verification
- Parent PR #315: MERGED at c9dc5de905e351c4675ee62201edfa1ce4e7ce97.
- v1 indicator regressions: 3 passed.
- indicator cache provider guard: 3 passed.
- OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0.
- JSON/YAML parse, markdown governance, git diff --check, staged GitNexus, mainline scope gate: passed.

## Boundary
- Governance-only inventory refresh. No backend source/test implementation in this PR.