### PR TITLE
docs(governance): select strategy service getter track

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2954,13 +2954,13 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              exposure, frontend, PM2, OpenSpec, config, script, or
 │   │              issue-label change
 │   ├── G2.163 Service getter inventory refresh after Indicator/Data
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#316`
 │   │   ├── Evidence:
 │   │   │          `backend-service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.md`
 │   │   ├── Generated:
 │   │   │          `service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.json`
 │   │   ├── Parent: G2.162 accepted and merged by PR `#315`
-│   │   ├── Current HEAD: `c9dc5de905e351c4675ee62201edfa1ce4e7ce97`
+│   │   ├── Evidence HEAD: `c9dc5de905e351c4675ee62201edfa1ce4e7ce97`
 │   │   ├── Scan snapshot: service files=`152`, API files=`219`,
 │   │   │          backend test files=`207`, top-level service
 │   │   │          `def get_*` definitions=`53`, root facade getters=`7`,
@@ -2987,9 +2987,38 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              PM2, OpenSpec, config, script, compatibility deletion,
 │   │              issue-label change, or implementation authorization
 │   │              is performed here
-│   └── Next gate: review G2.163; if accepted, start G2.164 as a
-│                  decision-only high-risk service getter track-selection
-│                  package before any further source implementation lane
+│   ├── G2.164 Next high-risk service getter track selection after
+│   │          Indicator/Data
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.json`
+│   │   ├── Parent: G2.163 accepted and merged by PR `#316`
+│   │   ├── Current HEAD: `8b5fb7359a007db704e9f3dfb575d4f5b656075d`
+│   │   ├── Refreshed impact: `get_data_service` remains CRITICAL
+│   │   │          `5/3/7`, `get_strategy_service` remains CRITICAL
+│   │   │          `13/6/0`, `get_streaming_service` remains HIGH
+│   │   │          `9/9/0`, and `get_tdx_service` remains CRITICAL
+│   │   │          `6/2/5`
+│   │   ├── Decision: select Strategy adapter / strategy-management
+│   │   │          `get_strategy_service` as the next high-risk service
+│   │   │          getter design track; defer realtime/socket,
+│   │   │          Dashboard/TDX residual, Indicator/Data residual, root
+│   │   │          facade compatibility, and cross-cutting route provider
+│   │   │          governance
+│   │   ├── G2.165 gate: prepare a Strategy service seam design and
+│   │   │          authorization package that separates adapter/provider,
+│   │   │          strategy-management route, and backtest task surfaces
+│   │   │          before any source implementation lane begins
+│   │   └── Boundary: decision-only; no backend source/test edit, route/API
+│   │              behavior, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │              config, script, compatibility deletion, issue-label
+│   │              change, or implementation authorization is performed
+│   │              here
+│   └── Next gate: review G2.164; if accepted, start G2.165 as a
+│                  Strategy service seam design and authorization package
+│                  before any strategy source implementation lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -3370,6 +3399,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
 | P2 | Review G2.32 `MarketDataServiceV2` dashboard helper provider migration implementation | Future service seam lane | PR `#171` merged; G2.32 implementation packet is review-ready, removes dashboard helper direct getter calls, preserves `get_market_data_service_v2()` fallback compatibility, and recommends a fresh service lifecycle DI candidate refresh before any next implementation lane |
+| P1 | Review G2.164 high-risk service getter track selection after Indicator/Data | G/#79 service lifecycle lane | Ready for review; selects Strategy service seam as next design/authorization track only, without source implementation authorization |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/generated/next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.json
+++ b/.planning/codebase/generated/next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.json
@@ -1,0 +1,161 @@
+{
+  "artifact": "next-high-risk-service-getter-track-selection-after-indicator-data",
+  "task_id": "G2.164",
+  "status": "review_ready",
+  "scope": "decision_only",
+  "created_at": "2026-05-27T02:13:55+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_head": "8b5fb7359a007db704e9f3dfb575d4f5b656075d",
+  "parent": {
+    "task_id": "G2.163",
+    "pr": 316,
+    "state": "merged",
+    "merge_commit": "8b5fb7359a007db704e9f3dfb575d4f5b656075d",
+    "report": "docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.md",
+    "artifact": ".planning/codebase/generated/service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.json"
+  },
+  "track_matrix": [
+    {
+      "track": "indicator_data_residual",
+      "getter": "get_data_service",
+      "risk": "CRITICAL",
+      "impacted": 5,
+      "direct": 3,
+      "processes": 7,
+      "disposition": "recently closed as direct body-call debt; retain as provider-governed runtime seam"
+    },
+    {
+      "track": "strategy_adapter_strategy_management",
+      "getter": "get_strategy_service",
+      "risk": "CRITICAL",
+      "impacted": 13,
+      "direct": 6,
+      "processes": 0,
+      "disposition": "selected for next design and authorization package"
+    },
+    {
+      "track": "realtime_streaming_socket",
+      "getter": "get_streaming_service",
+      "risk": "HIGH",
+      "impacted": 9,
+      "direct": 9,
+      "processes": 0,
+      "disposition": "deferred to dedicated realtime/socket track"
+    },
+    {
+      "track": "dashboard_tdx_residual",
+      "getter": "get_tdx_service",
+      "risk": "CRITICAL",
+      "impacted": 6,
+      "direct": 2,
+      "processes": 5,
+      "disposition": "deferred to dedicated Dashboard/TDX residual decision packet"
+    }
+  ],
+  "token_surface": {
+    "scan_scope": [
+      "web/backend/app/api",
+      "web/backend/app/services",
+      "web/backend/app/core",
+      "web/backend/tests"
+    ],
+    "get_data_service": {
+      "tokens": 9,
+      "files": 4
+    },
+    "get_strategy_service": {
+      "tokens": 10,
+      "files": 5
+    },
+    "get_streaming_service": {
+      "tokens": 25,
+      "files": 6
+    },
+    "get_tdx_service": {
+      "tokens": 6,
+      "files": 4
+    },
+    "get_market_data_service": {
+      "tokens": 19,
+      "files": 8
+    },
+    "get_market_data_service_v2_dependency": {
+      "tokens": 18,
+      "files": 4
+    },
+    "get_indicator_data_service": {
+      "tokens": 4,
+      "files": 2
+    },
+    "get_strategy_indicator_data_service": {
+      "tokens": 3,
+      "files": 2
+    },
+    "get_indicator_registry_dependency": {
+      "tokens": 5,
+      "files": 3
+    }
+  },
+  "selected_track": {
+    "task_id": "G2.165",
+    "name": "Strategy service seam design and authorization package",
+    "primary_getter": "get_strategy_service",
+    "source_implementation_authorized_by_g2_164": false,
+    "required_decision_surfaces": [
+      "strategy adapter/provider duplication",
+      "strategy-management route dependency/provider governance",
+      "task/backtest data-source resolution"
+    ],
+    "direct_callers": [
+      {
+        "symbol": "_get_strategy_service",
+        "file": "web/backend/app/services/data_adapters/strategy.py"
+      },
+      {
+        "symbol": "_get_strategy_service",
+        "file": "web/backend/app/services/adapters/strategy_adapter.py"
+      },
+      {
+        "symbol": "query_strategy_results",
+        "file": "web/backend/app/api/strategy_management/_strategy_execution_router.py"
+      },
+      {
+        "symbol": "get_matched_stocks",
+        "file": "web/backend/app/api/strategy_management/_strategy_execution_router.py"
+      },
+      {
+        "symbol": "get_strategy_summary",
+        "file": "web/backend/app/api/strategy_management/_strategy_execution_router.py"
+      },
+      {
+        "symbol": "_resolve_backtest_data_source",
+        "file": "web/backend/app/tasks/backtest_tasks.py"
+      }
+    ]
+  },
+  "deferred_tracks": [
+    "indicator_data_residual",
+    "realtime_streaming_socket",
+    "dashboard_tdx_residual",
+    "root_facade_compatibility",
+    "route_dependency_provider_governance_cross_cutting"
+  ],
+  "boundaries": {
+    "source_files_modified": false,
+    "tests_modified": false,
+    "openspec_modified": false,
+    "implementation_authorized": false,
+    "forbidden": [
+      "edit web/backend/app/services/strategy_service.py",
+      "delete, privatize, rename, or change get_strategy_service()",
+      "edit strategy adapter, strategy-management route, or backtest task source files",
+      "edit backend tests",
+      "change route paths, response models, OpenAPI exposure, frontend callers, PM2 workflows, config, scripts, OpenSpec state, or GitHub issue labels"
+    ]
+  },
+  "next_gate": {
+    "task_id": "G2.165",
+    "type": "design_authorization",
+    "description": "Strategy service seam design and authorization package before any source implementation lane"
+  }
+}

--- a/docs/reports/quality/backend-next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.md
+++ b/docs/reports/quality/backend-next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.md
@@ -1,0 +1,135 @@
+# Backend Next High-Risk Service Getter Track Selection After Indicator/Data
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Task: G2.164 next high-risk service getter track selection after Indicator/Data  
+Branch: `g2-164-high-risk-service-getter-track-selection-after-indicator-data`  
+Base: `wip/root-dirty-20260403`  
+Current HEAD: `8b5fb7359a007db704e9f3dfb575d4f5b656075d`  
+Created: 2026-05-27
+
+Boundary: this is a decision package only. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations. It does not authorize implementation.
+
+## Purpose
+
+G2.163 refreshed the high-risk service getter inventory after the Indicator/Data source provider seam closed. This package selects the next high-risk getter track from that refreshed matrix without opening a source implementation lane.
+
+## Parent State
+
+| Input | State |
+|---|---|
+| PR `#316` | merged into `wip/root-dirty-20260403` |
+| Merge commit | `8b5fb7359a007db704e9f3dfb575d4f5b656075d` |
+| Parent evidence | `docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.md` |
+| Parent generated artifact | `.planning/codebase/generated/service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.json` |
+
+G2.163 confirmed that Indicator/Data direct route/helper body calls to `get_data_service()` are closed. Remaining `get_data_service()` hits in the Indicator/Data scope are provider fallbacks in `get_indicator_data_service()` and `get_strategy_indicator_data_service()`.
+
+## Refreshed Track Evidence
+
+| Track | Primary getter | Risk | Impact | Current disposition |
+|---|---|---:|---|---|
+| Indicator/Data residual | `get_data_service` | CRITICAL | impacted `5`, direct `3`, processes `7` | Recently closed as a direct body-call debt; retain as provider-governed runtime seam, not the next source lane. |
+| Strategy adapter / strategy-management | `get_strategy_service` | CRITICAL | impacted `13`, direct `6`, processes `0` | Select as next design/authorization track. |
+| Realtime streaming/socket | `get_streaming_service` | HIGH | impacted `9`, direct `9`, processes `0` | Keep in the realtime/socket track; do not mix with strategy adapter work. |
+| Dashboard/TDX residual | `get_tdx_service` | CRITICAL | impacted `6`, direct `2`, processes `5` | Keep as a residual Dashboard/TDX decision packet; prior Dashboard/TDX lane closed direct helper debt. |
+
+## Current Token Surface
+
+Scope: `web/backend/app/api`, `web/backend/app/services`, `web/backend/app/core`, and `web/backend/tests` at HEAD `8b5fb7359a007db704e9f3dfb575d4f5b656075d`.
+
+| Getter | Token count | Files |
+|---|---:|---:|
+| `get_data_service` | `9` | `4` |
+| `get_strategy_service` | `10` | `5` |
+| `get_streaming_service` | `25` | `6` |
+| `get_tdx_service` | `6` | `4` |
+| `get_market_data_service` | `19` | `8` |
+| `get_market_data_service_v2_dependency` | `18` | `4` |
+| `get_indicator_data_service` | `4` | `2` |
+| `get_strategy_indicator_data_service` | `3` | `2` |
+| `get_indicator_registry_dependency` | `5` | `3` |
+
+## Strategy Track Detail
+
+GitNexus reports `get_strategy_service` as CRITICAL with `13` impacted symbols, `6` direct callers, and `5` affected modules.
+
+Direct caller set:
+
+| Direct caller | File | Track implication |
+|---|---|---|
+| `_get_strategy_service` | `web/backend/app/services/data_adapters/strategy.py` | Adapter/provider duplication surface. |
+| `_get_strategy_service` | `web/backend/app/services/adapters/strategy_adapter.py` | Adapter/provider duplication surface. |
+| `query_strategy_results` | `web/backend/app/api/strategy_management/_strategy_execution_router.py` | Route dependency/provider governance surface. |
+| `get_matched_stocks` | `web/backend/app/api/strategy_management/_strategy_execution_router.py` | Route dependency/provider governance surface. |
+| `get_strategy_summary` | `web/backend/app/api/strategy_management/_strategy_execution_router.py` | Route dependency/provider governance surface. |
+| `_resolve_backtest_data_source` | `web/backend/app/tasks/backtest_tasks.py` | Task/backtest resolution surface. |
+
+The strategy track should not be treated as a single mechanical getter replacement. It crosses three different decision surfaces:
+
+1. adapter/provider duplication in two strategy adapter modules;
+2. FastAPI route dependency/provider design for strategy-management endpoints;
+3. task/backtest data-source resolution behavior.
+
+## Decision
+
+Select the Strategy adapter / strategy-management seam as the next high-risk service getter track.
+
+The next gate is G2.165: Strategy service seam design and authorization package.
+
+G2.165 must remain a design/authorization gate unless explicitly approved otherwise. It should decide the split between adapter, route, and task/backtest surfaces, define the exact implementation scope, and identify TDD tests before any source implementation starts.
+
+## Deferred Tracks
+
+| Track | Deferred reason | Future gate |
+|---|---|---|
+| Indicator/Data residual | G2.162 closed direct body-call debt; remaining graph risk is expected provider runtime flow. | Revisit only if a current-head contradiction appears. |
+| Realtime streaming/socket | Socket manager and realtime lifecycle require a separate runtime/socket plan. | Dedicated realtime/socket decision or authorization package. |
+| Dashboard/TDX residual | Prior Dashboard/TDX lane closed direct helper debt; residual graph risk is not the same as a new source lane. | Dedicated Dashboard/TDX residual decision packet. |
+| Root facade compatibility | Active compatibility surface, not a cleanup candidate. | Separate compatibility-retirement decision only. |
+| Route dependency/provider governance | Cross-cutting FastAPI provider contract surface. | Govern through track-specific provider decisions. |
+
+## G2.165 Minimum Requirements
+
+G2.165 should produce a design/authorization package before any strategy source implementation lane begins.
+
+Minimum required content:
+
+1. refreshed GitNexus impact for `get_strategy_service`;
+2. static scan of `get_strategy_service()` call sites, separated into import/definition/provider/body-call categories;
+3. direct caller matrix for the two adapter modules, the three strategy-management route handlers, and `_resolve_backtest_data_source`;
+4. decision on whether the first implementation slice should target route provider injection, adapter provider consolidation, or task/backtest resolution;
+5. exact allowed source/test file list for the future implementation lane;
+6. focused TDD plan, including at least `test_strategy_mgmt_backtest_regressions.py`, `test_backtest_tasks_regressions.py`, and relevant strategy-management route tests if they are in scope;
+7. rollback plan that preserves `get_strategy_service()` public fallback compatibility unless a later compatibility-retirement decision explicitly allows changing it;
+8. OpenAPI/route smoke requirement if strategy-management route handlers are edited;
+9. explicit non-goals for realtime/socket, Dashboard/TDX, Indicator/Data, frontend, PM2, OpenSpec state, and issue-label state.
+
+## Explicit Boundaries
+
+This package does not authorize:
+
+- editing `web/backend/app/services/strategy_service.py`;
+- deleting, privatizing, renaming, or changing `get_strategy_service()`;
+- editing strategy adapter, strategy-management route, or backtest task source files;
+- editing backend tests;
+- changing route paths, response models, OpenAPI exposure, frontend callers, PM2 workflows, config, scripts, OpenSpec state, or GitHub issue labels;
+- folding realtime/socket, Dashboard/TDX, or Indicator/Data residual work into the strategy lane.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Parent PR state | PR `#316` merged; merge commit `8b5fb7359a007db704e9f3dfb575d4f5b656075d` |
+| Current HEAD | `8b5fb7359a007db704e9f3dfb575d4f5b656075d` |
+| GitNexus impact: `get_data_service` | CRITICAL, impacted `5`, direct `3`, processes `7` |
+| GitNexus impact: `get_strategy_service` | CRITICAL, impacted `13`, direct `6`, processes `0` |
+| GitNexus impact: `get_streaming_service` | HIGH, impacted `9`, direct `9`, processes `0` |
+| GitNexus impact: `get_tdx_service` | CRITICAL, impacted `6`, direct `2`, processes `5` |
+| Static token scan | completed at current HEAD; values recorded above and in generated JSON |
+
+## Next Gate
+
+Review this G2.164 decision package. If accepted and merged, start G2.165 as a Strategy service seam design and authorization package. Do not start a strategy source implementation lane directly from G2.164.

--- a/governance/mainline/task-cards/pr-317.yaml
+++ b/governance/mainline/task-cards/pr-317.yaml
@@ -1,0 +1,109 @@
+version: "v0.2"
+
+task:
+  id: "pr-317"
+  title: "Select next high-risk service getter track after Indicator/Data"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-high-risk-service-getter-track-selection-after-indicator-data"
+  objective: "select the next high-risk service getter design track after the Indicator/Data provider seam closed"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-high-risk-service-getter-track-selection-after-indicator-data"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only track-selection package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.json"
+    - "docs/reports/quality/backend-next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-317.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 316 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "gitnexus-impact-refresh"
+      command: "GitNexus impact for get_data_service, get_strategy_service, get_streaming_service, and get_tdx_service"
+      required: true
+    - id: "token-surface-scan"
+      command: "scan high-risk getter token and API body-call surface at current HEAD"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-317.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check -- .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md .planning/codebase/generated/next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.json docs/reports/quality/backend-next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.md governance/mainline/task-cards/pr-317.yaml"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this track-selection package."
+  - "Do not authorize or start a source implementation lane from this package."
+  - "Do not delete, privatize, rename, or change get_data_service(), get_strategy_service(), get_streaming_service(), or get_tdx_service()."
+  - "Do not fold realtime/socket, Dashboard/TDX, Indicator/Data residual, root facade compatibility, or cross-cutting route provider governance into the Strategy track."
+  - "Do not edit route/API behavior, OpenAPI exposure, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this decision package is treated as implementation authorization, the Strategy service seam could start source edits without a dedicated design/authorization gate."
+    - "If realtime/socket, Dashboard/TDX, or Indicator/Data residual work is mixed into the Strategy track, future implementation scope will be too broad to verify safely."
+  rollback_plan: "revert this governance PR to remove only the track-selection report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "select Strategy service seam as the next high-risk service getter design track after Indicator/Data"
+    modified_scope: "steward tree, decision report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, impact refresh, token scan, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T02:13:55+08:00"
+    approval_note: "Governance-only track selection after PR #316 merged the Indicator/Data service getter inventory refresh."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records G2.164 as a decision-only package after PR #316 merged
- selects the Strategy service seam (`get_strategy_service`) as the next high-risk getter design/authorization track
- updates the steward tree and task card without source, test, OpenSpec, route, frontend, PM2, or issue-label changes

## Verification
- PR #316 merged at `8b5fb7359a007db704e9f3dfb575d4f5b656075d`
- GitNexus impact refreshed for `get_data_service`, `get_strategy_service`, `get_streaming_service`, and `get_tdx_service`
- Markdown governance: 2 checked, 0 errors
- JSON/YAML parse: passed
- git diff --check: passed
- staged GitNexus detect changes: LOW, 0 changed symbols, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: 62,921 nodes / 146,082 edges / 300 flows

## Boundary
Decision-only governance PR. It does not authorize strategy source implementation. If accepted, the next gate is G2.165 Strategy service seam design and authorization.