### PR TITLE
docs(governance): authorize strategy service seam lane

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -2989,13 +2989,13 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              is performed here
 │   ├── G2.164 Next high-risk service getter track selection after
 │   │          Indicator/Data
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#317`
 │   │   ├── Evidence:
 │   │   │          `backend-next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.md`
 │   │   ├── Generated:
 │   │   │          `next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.json`
 │   │   ├── Parent: G2.163 accepted and merged by PR `#316`
-│   │   ├── Current HEAD: `8b5fb7359a007db704e9f3dfb575d4f5b656075d`
+│   │   ├── Evidence HEAD: `8b5fb7359a007db704e9f3dfb575d4f5b656075d`
 │   │   ├── Refreshed impact: `get_data_service` remains CRITICAL
 │   │   │          `5/3/7`, `get_strategy_service` remains CRITICAL
 │   │   │          `13/6/0`, `get_streaming_service` remains HIGH
@@ -3016,9 +3016,37 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              config, script, compatibility deletion, issue-label
 │   │              change, or implementation authorization is performed
 │   │              here
-│   └── Next gate: review G2.164; if accepted, start G2.165 as a
-│                  Strategy service seam design and authorization package
-│                  before any strategy source implementation lane
+│   ├── G2.165 Strategy service seam design and authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-strategy-service-seam-design-authorization-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `strategy-service-seam-design-authorization-2026-05-27.json`
+│   │   ├── Parent: G2.164 accepted and merged by PR `#317`
+│   │   ├── Current HEAD: `3355c50c5a0c9cf5b20dd9d33300a695e5a3807b`
+│   │   ├── GitNexus evidence: `get_strategy_service` remains CRITICAL
+│   │   │          `13/6/0`; direct caller surfaces split into two adapter
+│   │   │          provider calls, three strategy-management route calls,
+│   │   │          and one backtest task resolver call
+│   │   ├── Decision: authorize future G2.166 only as a narrow Strategy
+│   │   │          route provider injection lane for
+│   │   │          `_strategy_execution_router.py`; adapter/provider
+│   │   │          duplication and task/backtest resolution remain deferred
+│   │   ├── G2.166 target: replace the three route-handler body calls to
+│   │   │          `get_strategy_service()` with a local FastAPI provider
+│   │   │          wrapper while preserving public `get_strategy_service()`
+│   │   │          fallback compatibility and all route/OpenAPI contracts
+│   │   ├── Verification: parent PR `#317` merged, strategy route OpenAPI
+│   │   │          docs focused test `1 passed`, backtest task regressions
+│   │   │          `2 passed`, OpenAPI smoke `routes=548`, `paths=500`,
+│   │   │          `duplicate_operation_ids=0`
+│   │   └── Boundary: authorization-only; no backend source/test edit,
+│   │              route/API behavior, OpenAPI exposure, frontend, PM2,
+│   │              OpenSpec, config, script, compatibility deletion,
+│   │              issue-label change, or implementation is performed here
+│   └── Next gate: review G2.165; if accepted, start G2.166 as the
+│                  narrow Strategy route provider injection implementation
+│                  lane
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -3399,7 +3427,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
 | P2 | Review G2.32 `MarketDataServiceV2` dashboard helper provider migration implementation | Future service seam lane | PR `#171` merged; G2.32 implementation packet is review-ready, removes dashboard helper direct getter calls, preserves `get_market_data_service_v2()` fallback compatibility, and recommends a fresh service lifecycle DI candidate refresh before any next implementation lane |
-| P1 | Review G2.164 high-risk service getter track selection after Indicator/Data | G/#79 service lifecycle lane | Ready for review; selects Strategy service seam as next design/authorization track only, without source implementation authorization |
+| P1 | Review G2.165 Strategy service seam design and authorization | G/#79 service lifecycle lane | Ready for review; authorizes only a future narrow Strategy route provider injection implementation lane, without editing source in G2.165 |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/generated/strategy-service-seam-design-authorization-2026-05-27.json
+++ b/.planning/codebase/generated/strategy-service-seam-design-authorization-2026-05-27.json
@@ -1,0 +1,146 @@
+{
+  "artifact": "strategy-service-seam-design-authorization",
+  "task_id": "G2.165",
+  "status": "review_ready",
+  "scope": "authorization_package_only",
+  "created_at": "2026-05-27T08:02:56+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_head": "3355c50c5a0c9cf5b20dd9d33300a695e5a3807b",
+  "parent": {
+    "task_id": "G2.164",
+    "pr": 317,
+    "state": "merged",
+    "merge_commit": "3355c50c5a0c9cf5b20dd9d33300a695e5a3807b",
+    "report": "docs/reports/quality/backend-next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.md",
+    "artifact": ".planning/codebase/generated/next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.json"
+  },
+  "decision": {
+    "next_gate": "G2.166",
+    "summary": "Authorize a future narrow Strategy route provider injection implementation lane after G2.165 review and merge.",
+    "selected_slice": "strategy_management_route_provider_injection",
+    "no_source_edits_in_this_package": true,
+    "implementation_start_requires_review_merge": true
+  },
+  "gitnexus": {
+    "get_strategy_service": {
+      "risk": "CRITICAL",
+      "impacted": 13,
+      "direct": 6,
+      "processes": 0,
+      "affected_modules": [
+        "Data_adapters",
+        "Adapters",
+        "Strategy_management",
+        "Cdp",
+        "Tasks"
+      ]
+    },
+    "query_strategy_results": {
+      "risk": "LOW",
+      "impacted": 0,
+      "direct": 0,
+      "processes": 0
+    },
+    "_resolve_backtest_data_source": {
+      "risk": "LOW",
+      "impacted": 1,
+      "direct": 1,
+      "processes": 0
+    }
+  },
+  "current_head_hit_classification": {
+    "definition": 1,
+    "imports": 4,
+    "depends_sites": 0,
+    "application_body_calls": 6,
+    "backend_test_references": 1,
+    "body_calls": [
+      {
+        "file": "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+        "line": 399,
+        "disposition": "authorized_for_g2_166"
+      },
+      {
+        "file": "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+        "line": 461,
+        "disposition": "authorized_for_g2_166"
+      },
+      {
+        "file": "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+        "line": 503,
+        "disposition": "authorized_for_g2_166"
+      },
+      {
+        "file": "web/backend/app/services/adapters/strategy_adapter.py",
+        "line": 45,
+        "disposition": "deferred_adapter_provider_duplication"
+      },
+      {
+        "file": "web/backend/app/services/data_adapters/strategy.py",
+        "line": 42,
+        "disposition": "deferred_adapter_provider_duplication"
+      },
+      {
+        "file": "web/backend/app/tasks/backtest_tasks.py",
+        "line": 31,
+        "disposition": "deferred_task_backtest_resolution"
+      }
+    ]
+  },
+  "authorized_future_paths": {
+    "application_source": [
+      "web/backend/app/api/strategy_management/_strategy_execution_router.py"
+    ],
+    "focused_tests": [
+      "web/backend/tests/test_strategy_management_route_provider.py",
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "governance": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/strategy-service-route-provider-injection-implementation-2026-05-27.json",
+      "docs/reports/quality/backend-strategy-service-route-provider-injection-implementation-2026-05-27.md",
+      "governance/mainline/task-cards/pr-319.yaml"
+    ]
+  },
+  "forbidden_future_paths_or_actions": [
+    "edit web/backend/app/services/strategy_service.py",
+    "delete, privatize, rename, or change get_strategy_service()",
+    "edit web/backend/app/services/data_adapters/strategy.py",
+    "edit web/backend/app/services/adapters/strategy_adapter.py",
+    "edit web/backend/app/tasks/backtest_tasks.py",
+    "edit broad strategy-management routers outside _strategy_execution_router.py",
+    "change route paths, methods, response models, operation IDs, tags, summaries, descriptions, examples, OpenAPI exposure, or response body shapes",
+    "change frontend callers, PM2 workflows, config, scripts, OpenSpec state, or GitHub issue labels",
+    "fold realtime/socket, Dashboard/TDX, Indicator/Data residual, root facade compatibility, adapter/provider duplication, or task/backtest resolution into G2.166"
+  ],
+  "target_g2_166_closure_metric": {
+    "direct_body_calls_in_strategy_execution_router": {
+      "before": 3,
+      "target_after": 0
+    },
+    "public_get_strategy_service_definition": "unchanged",
+    "adapter_and_backtest_body_calls": "unchanged"
+  },
+  "baseline_verification": {
+    "parent_pr_317": "MERGED",
+    "strategy_route_docs_test": "1 passed in 18.87s",
+    "backtest_task_regressions": "2 passed in 3.14s",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "duplicate_operation_ids": 0,
+      "warnings": 0
+    }
+  },
+  "required_g2_166_gates": [
+    "confirm G2.166 worktree contains merged PR #318",
+    "rerun GitNexus impact for get_strategy_service and the three route handlers",
+    "use TDD with a focused route-provider test",
+    "run focused provider, strategy route OpenAPI docs, and backtest task regression tests",
+    "ruff touched backend files",
+    "OpenAPI smoke",
+    "staged GitNexus detect changes",
+    "mainline scope gate",
+    "gitnexus analyze --with-gitignore after commit"
+  ]
+}

--- a/docs/reports/quality/backend-strategy-service-seam-design-authorization-2026-05-27.md
+++ b/docs/reports/quality/backend-strategy-service-seam-design-authorization-2026-05-27.md
@@ -1,0 +1,187 @@
+# Backend Strategy Service Seam Design Authorization
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Task: G2.165 Strategy service seam design and authorization  
+Branch: `g2-165-strategy-service-seam-design-authorization`  
+Base: `wip/root-dirty-20260403`  
+Current HEAD: `3355c50c5a0c9cf5b20dd9d33300a695e5a3807b`  
+Created: 2026-05-27
+
+Scope: G2.165 authorization package only. No backend source, backend test, route/API behavior, OpenAPI exposure, frontend, PM2, OpenSpec, config, script, issue-label, or runtime behavior change is performed in this package.
+
+Boundary: this is a source-implementation authorization package only. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations. It does not perform implementation.
+
+## Decision
+
+Authorize the next gate as G2.166: Strategy route provider injection implementation lane.
+
+G2.166 may only address the three direct `get_strategy_service()` body calls in `web/backend/app/api/strategy_management/_strategy_execution_router.py`.
+
+G2.166 must not edit adapter/provider duplication or task/backtest data-source resolution. Those are separate surfaces with different runtime contracts and must remain deferred until a later decision package explicitly selects them.
+
+## Parent State
+
+| Input | State |
+|---|---|
+| Parent package | G2.164 next high-risk service getter track selection after Indicator/Data |
+| Parent PR | `#317`, merged |
+| Parent merge commit | `3355c50c5a0c9cf5b20dd9d33300a695e5a3807b` |
+| Parent evidence | `docs/reports/quality/backend-next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.md` |
+| Parent generated artifact | `.planning/codebase/generated/next-high-risk-service-getter-track-selection-after-indicator-data-2026-05-27.json` |
+
+G2.164 selected the Strategy adapter / strategy-management seam as the next high-risk service getter track, but did not authorize source implementation. G2.165 narrows that selected track into a single implementable slice.
+
+## GitNexus Evidence
+
+`get_strategy_service` remains a high-risk shared getter:
+
+| Target | Risk | Impacted | Direct callers | Affected processes | Affected modules |
+|---|---:|---:|---:|---:|---|
+| `get_strategy_service` | CRITICAL | `13` | `6` | `0` | `Data_adapters`, `Adapters`, `Strategy_management`, `Cdp`, `Tasks` |
+
+Direct caller matrix:
+
+| Direct caller | File | Surface | G2.165 disposition |
+|---|---|---|---|
+| `_get_strategy_service` | `web/backend/app/services/data_adapters/strategy.py` | Adapter/provider duplication | Defer. Do not touch in G2.166. |
+| `_get_strategy_service` | `web/backend/app/services/adapters/strategy_adapter.py` | Adapter/provider duplication | Defer. Do not touch in G2.166. |
+| `query_strategy_results` | `web/backend/app/api/strategy_management/_strategy_execution_router.py` | Strategy-management route handler | Authorize for G2.166 provider injection. |
+| `get_matched_stocks` | `web/backend/app/api/strategy_management/_strategy_execution_router.py` | Strategy-management route handler | Authorize for G2.166 provider injection. |
+| `get_strategy_summary` | `web/backend/app/api/strategy_management/_strategy_execution_router.py` | Strategy-management route handler | Authorize for G2.166 provider injection. |
+| `_resolve_backtest_data_source` | `web/backend/app/tasks/backtest_tasks.py` | Task/backtest resolution | Defer. Do not touch in G2.166. |
+
+Focused caller impact:
+
+| Target | Risk | Impact |
+|---|---:|---|
+| `query_strategy_results` | LOW | impacted `0`, direct `0`, processes `0` |
+| `_resolve_backtest_data_source` | LOW | impacted `1`, direct `1`, processes `0`; direct caller is `run_backtest_task` |
+
+This split shows that the route-handler body-call slice is the smallest safe first implementation lane. The shared getter itself remains CRITICAL, so the implementation must be narrow and preserve the public fallback.
+
+## Current-Head Hit Classification
+
+Scope: `web/backend/app/api`, `web/backend/app/services`, `web/backend/app/tasks`, and `web/backend/tests` at HEAD `3355c50c5a0c9cf5b20dd9d33300a695e5a3807b`.
+
+| Category | Count | Notes |
+|---|---:|---|
+| Definition | `1` | `web/backend/app/services/strategy_service.py:455` |
+| Import | `4` | route module, two adapter modules, backtest task module |
+| FastAPI `Depends(get_strategy_service...)` | `0` | no provider injection exists yet |
+| Application body calls | `6` | three route calls, two adapter lazy calls, one backtest task call |
+| Backend test references | `1` | `test_backtest_tasks_regressions.py` monkeypatches the service getter module |
+
+Application body calls:
+
+| Body call | G2.166 disposition |
+|---|---|
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py:399` | Replace through route provider injection. |
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py:461` | Replace through route provider injection. |
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py:503` | Replace through route provider injection. |
+| `web/backend/app/services/adapters/strategy_adapter.py:45` | Defer adapter/provider duplication. |
+| `web/backend/app/services/data_adapters/strategy.py:42` | Defer adapter/provider duplication. |
+| `web/backend/app/tasks/backtest_tasks.py:31` | Defer task/backtest resolution. |
+
+## Consumer Contract Matrix
+
+| Consumer | Current behavior | Contract to preserve in G2.166 |
+|---|---|---|
+| `query_strategy_results` | Builds optional date filter, calls `service.query_strategy_results(...)`, returns `UnifiedResponse[Dict[str, Any]]` success payload, raises `BusinessException` on failure. | Same route path, method, query parameters, response model, response body shape, error handling, tags, summaries, and examples. |
+| `get_matched_stocks` | Builds optional date filter, calls `service.query_strategy_results(...)`, filters matched stocks, returns `UnifiedResponse[Dict[str, Any]]`. | Same route contract and filtered payload shape. |
+| `get_strategy_summary` | Builds date filter, calls `service.get_strategy_definitions()` and `service.query_strategy_results(...)`, returns per-strategy summary. | Same route contract and summary payload shape. |
+| Strategy adapters | Lazy `_get_strategy_service()` caches public singleton fallback. | No change in G2.166. |
+| Backtest task | `_resolve_backtest_data_source()` uses public singleton fallback for `strategy_service` / `auto` modes. | No change in G2.166. |
+
+## G2.166 Authorized Scope
+
+Allowed application source paths:
+
+- `web/backend/app/api/strategy_management/_strategy_execution_router.py`
+
+Allowed focused test paths:
+
+- `web/backend/tests/test_strategy_management_route_provider.py` (new or existing if already present)
+- `web/backend/tests/test_health_route_conflicts.py`, only for import/collection verification or a reviewed route-contract assertion update caused by the authorized route file
+
+Allowed governance paths:
+
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/strategy-service-route-provider-injection-implementation-2026-05-27.json`
+- `docs/reports/quality/backend-strategy-service-route-provider-injection-implementation-2026-05-27.md`
+- `governance/mainline/task-cards/pr-319.yaml`
+
+Recommended implementation direction:
+
+1. Add a local FastAPI provider wrapper in `_strategy_execution_router.py`, for example `get_strategy_service_dependency() -> StrategyService`, which delegates to the existing public `get_strategy_service()` fallback.
+2. Inject that provider into `query_strategy_results`, `get_matched_stocks`, and `get_strategy_summary` with `Depends(...)`.
+3. Remove the three route-handler body calls to `get_strategy_service()`.
+4. Preserve the public `get_strategy_service()` function, singleton behavior, import compatibility, route paths, OpenAPI exposure, response models, operation IDs, examples, and frontend contract.
+
+Target closure metric:
+
+- direct body calls to `get_strategy_service()` in `_strategy_execution_router.py`: `3 -> 0`
+- direct body calls to `get_strategy_service()` outside `_strategy_execution_router.py`: unchanged in G2.166
+- public `get_strategy_service()` definition: unchanged
+
+## G2.166 Forbidden Scope
+
+G2.166 must not:
+
+- edit `web/backend/app/services/strategy_service.py`;
+- delete, privatize, rename, or change `get_strategy_service()`;
+- edit `web/backend/app/services/data_adapters/strategy.py`;
+- edit `web/backend/app/services/adapters/strategy_adapter.py`;
+- edit `web/backend/app/tasks/backtest_tasks.py`;
+- edit broad strategy-management routers outside `_strategy_execution_router.py`;
+- change route paths, methods, response models, operation IDs, tags, summaries, descriptions, examples, OpenAPI exposure, or response body shapes;
+- change frontend callers, PM2 workflows, config, scripts, OpenSpec state, or GitHub issue labels;
+- fold realtime/socket, Dashboard/TDX, Indicator/Data residual, root facade compatibility, adapter/provider duplication, or task/backtest resolution into the route provider implementation.
+
+## Required G2.166 Gates
+
+Before implementation:
+
+1. Confirm the G2.166 worktree contains PR `#318` after it is merged.
+2. Re-run GitNexus impact for `get_strategy_service` and the three route handlers.
+3. Stop and return to review if new HIGH or CRITICAL dependencies appear outside the route-handler scope recorded here.
+
+During implementation:
+
+1. Use TDD. Add a failing focused test that proves `_strategy_execution_router.py` exposes a route-local strategy service provider and that the three route handlers no longer call the public getter in their bodies.
+2. Add or update direct function tests with a fake strategy service when practical, so the route handlers are proven to consume the injected service.
+3. Keep route behavior and response contract unchanged.
+
+Before PR:
+
+1. `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py -q --no-cov`
+2. `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_v1_strategy_management_endpoints_have_success_examples_and_parameter_docs -q --no-cov`
+3. `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov`
+4. Ruff check for touched backend files.
+5. OpenAPI smoke: `routes=548`, `paths=500`, `duplicate_operation_ids=0` expected unless a later current-head baseline changes.
+6. Staged GitNexus detect changes.
+7. Mainline scope gate for the future PR task card.
+8. `gitnexus analyze --with-gitignore` after commit.
+
+## Baseline Verification
+
+| Check | Result |
+|---|---|
+| Parent PR state | PR `#317` merged; merge commit `3355c50c5a0c9cf5b20dd9d33300a695e5a3807b` |
+| Current HEAD | `3355c50c5a0c9cf5b20dd9d33300a695e5a3807b` |
+| GitNexus impact: `get_strategy_service` | CRITICAL, impacted `13`, direct `6`, processes `0` |
+| GitNexus context: `get_strategy_service` | incoming calls match the six direct callers listed above |
+| Static hit classification | completed; `6` application body calls, `3` authorized in G2.166 |
+| Strategy route OpenAPI docs focused test | `1 passed in 18.87s` |
+| Backtest task regressions | `2 passed in 3.14s` |
+| OpenAPI smoke | `routes=548`, `paths=500`, `duplicate_operation_ids=0`, `warnings=0` |
+
+## Rollback
+
+If G2.166 changes route behavior, OpenAPI exposure, response shape, or service lifecycle beyond the authorized route provider injection, revert the implementation PR. The public `get_strategy_service()` function and the adapter/backtest consumers must remain available, so rollback should be a normal source revert rather than a compatibility-restoration project.
+
+## Next Gate
+
+Review this package. If accepted and merged, start G2.166 as the narrow Strategy route provider injection source implementation lane. Do not start source edits from G2.165 itself.

--- a/governance/mainline/task-cards/pr-318.yaml
+++ b/governance/mainline/task-cards/pr-318.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-318"
+  title: "Authorize Strategy service seam route provider injection"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-strategy-service-seam-design-authorization"
+  objective: "authorize a narrow future Strategy route provider injection lane without implementing source changes"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-strategy-service-seam-design-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only governance package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/strategy-service-seam-design-authorization-2026-05-27.json"
+    - "docs/reports/quality/backend-strategy-service-seam-design-authorization-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-318.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 317 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "gitnexus-impact-refresh"
+      command: "GitNexus impact/context for get_strategy_service plus focused impact for query_strategy_results and _resolve_backtest_data_source"
+      required: true
+    - id: "hit-classification"
+      command: "classify get_strategy_service references into definition/import/Depends/body-call/test-reference categories"
+      required: true
+    - id: "focused-strategy-route-docs-test"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_v1_strategy_management_endpoints_have_success_examples_and_parameter_docs -q --no-cov"
+      required: true
+    - id: "focused-backtest-task-test"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov"
+      required: true
+    - id: "openapi-smoke"
+      command: "app.openapi() smoke with non-secret minimal env; record route count, path count, duplicate operation IDs, and warnings"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-strategy-service-seam-design-authorization-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/strategy-service-seam-design-authorization-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-318.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check -- .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md .planning/codebase/generated/strategy-service-seam-design-authorization-2026-05-27.json docs/reports/quality/backend-strategy-service-seam-design-authorization-2026-05-27.md governance/mainline/task-cards/pr-318.yaml"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this authorization package."
+  - "Do not start G2.166 source implementation before this package is reviewed and merged."
+  - "Do not delete, privatize, rename, or change get_strategy_service()."
+  - "Do not authorize adapter/provider duplication or task/backtest resolution work in G2.166."
+  - "Do not edit route/API behavior, OpenAPI exposure, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this package is treated as implementation, the CRITICAL shared get_strategy_service seam could be edited without the G2.166 TDD and route-contract gates."
+    - "If adapter/provider duplication or task/backtest resolution is folded into G2.166, the implementation scope becomes too broad for a narrow provider-injection lane."
+  rollback_plan: "revert this governance PR to remove only the authorization report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize future narrow Strategy route provider injection lane"
+    modified_scope: "steward tree, authorization report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, impact refresh, hit classification, focused tests, OpenAPI smoke, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T08:02:56+08:00"
+    approval_note: "Authorization-only package after PR #317 selected the Strategy service seam as the next high-risk getter design track."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records G2.165 as an authorization-only package after PR #317 merged
- authorizes future G2.166 only as a narrow Strategy route provider injection implementation lane
- limits future source scope to `web/backend/app/api/strategy_management/_strategy_execution_router.py` and focused tests
- explicitly defers adapter/provider duplication and task/backtest resolution

## Verification
- PR #317 merged at `3355c50c5a0c9cf5b20dd9d33300a695e5a3807b`
- GitNexus impact/context refreshed for `get_strategy_service`; focused impact refreshed for `query_strategy_results` and `_resolve_backtest_data_source`
- Static hit classification recorded: 6 application body calls, 3 authorized for future G2.166
- Strategy route docs focused test: 1 passed
- Backtest task regressions: 2 passed
- OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0, warnings=0
- Markdown governance: 2 checked, 0 errors
- JSON/YAML parse and git diff --check: passed
- staged GitNexus detect changes: LOW, 0 changed symbols, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: 62,906 nodes / 146,061 edges / 300 flows

## Boundary
Authorization-only governance PR. It does not edit backend source/tests and does not start G2.166. If accepted, the next gate is G2.166 Strategy route provider injection implementation.