### PR TITLE
refactor(backend): inject strategy route service provider

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -3017,13 +3017,13 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              change, or implementation authorization is performed
 │   │              here
 │   ├── G2.165 Strategy service seam design and authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#318`
 │   │   ├── Evidence:
 │   │   │          `backend-strategy-service-seam-design-authorization-2026-05-27.md`
 │   │   ├── Generated:
 │   │   │          `strategy-service-seam-design-authorization-2026-05-27.json`
 │   │   ├── Parent: G2.164 accepted and merged by PR `#317`
-│   │   ├── Current HEAD: `3355c50c5a0c9cf5b20dd9d33300a695e5a3807b`
+│   │   ├── Evidence HEAD: `3355c50c5a0c9cf5b20dd9d33300a695e5a3807b`
 │   │   ├── GitNexus evidence: `get_strategy_service` remains CRITICAL
 │   │   │          `13/6/0`; direct caller surfaces split into two adapter
 │   │   │          provider calls, three strategy-management route calls,
@@ -3044,9 +3044,37 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              route/API behavior, OpenAPI exposure, frontend, PM2,
 │   │              OpenSpec, config, script, compatibility deletion,
 │   │              issue-label change, or implementation is performed here
-│   └── Next gate: review G2.165; if accepted, start G2.166 as the
-│                  narrow Strategy route provider injection implementation
-│                  lane
+│   ├── G2.166 Strategy route provider injection implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-strategy-service-route-provider-injection-implementation-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `strategy-service-route-provider-injection-implementation-2026-05-27.json`
+│   │   ├── Parent: G2.165 accepted and merged by PR `#318`
+│   │   ├── Current HEAD before implementation commit:
+│   │   │          `e5f8a4a2a53bc707a57732ac5c6e14d1f63a5444`
+│   │   ├── Implementation: added
+│   │   │          `get_strategy_service_dependency()` provider in
+│   │   │          `_strategy_execution_router.py` and injected it into
+│   │   │          `query_strategy_results`, `get_matched_stocks`, and
+│   │   │          `get_strategy_summary`
+│   │   ├── Closure: authorized route-handler body calls to
+│   │   │          `get_strategy_service()` moved from `3` to `0`;
+│   │   │          route-local provider fallback call remains by design;
+│   │   │          adapter and backtest calls unchanged
+│   │   ├── Verification: TDD red `5 failed`, green `5 passed`,
+│   │   │          strategy route OpenAPI docs focused test `1 passed`,
+│   │   │          backtest task regressions `2 passed`, ruff passed,
+│   │   │          OpenAPI smoke `routes=548`, `paths=500`,
+│   │   │          `duplicate_operation_ids=0`
+│   │   └── Boundary: no edit to `strategy_service.py`, Strategy adapter
+│   │              modules, `backtest_tasks.py`, route paths, response
+│   │              models, OpenAPI exposure, frontend, PM2, OpenSpec,
+│   │              config, scripts, issue labels, or public
+│   │              `get_strategy_service()` fallback compatibility
+│   └── Next gate: review G2.166; if accepted, start G2.167 as a
+│                  governance-only service getter inventory refresh after
+│                  Strategy route provider injection
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md
@@ -3427,7 +3455,7 @@ and recording whether a contradiction requires reconciliation.
 | P1 | Refresh route/OpenAPI/probe evidence after runtime unblock | `sequence-backend-architecture-unblocks` | Complete; next gate is control-plane route governance classification, including `GET /metrics` duplicate path/method |
 | P1 | Keep Core Batch 2 blocked until Task 3.2 and #83 evidence gates are explicit | Core split lane | Blocked |
 | P2 | Review G2.32 `MarketDataServiceV2` dashboard helper provider migration implementation | Future service seam lane | PR `#171` merged; G2.32 implementation packet is review-ready, removes dashboard helper direct getter calls, preserves `get_market_data_service_v2()` fallback compatibility, and recommends a fresh service lifecycle DI candidate refresh before any next implementation lane |
-| P1 | Review G2.165 Strategy service seam design and authorization | G/#79 service lifecycle lane | Ready for review; authorizes only a future narrow Strategy route provider injection implementation lane, without editing source in G2.165 |
+| P1 | Review G2.166 Strategy route provider injection implementation | G/#79 service lifecycle lane | Ready for review; route-handler direct `get_strategy_service()` calls reduced `3 -> 0`, provider fallback preserved, adapter/backtest surfaces deferred |
 | P2 | Keep CSRF and miniQMT tracks decision/evidence-only | Decision and external evidence lanes | No implementation branch |
 
 ## Deferred Items

--- a/.planning/codebase/generated/strategy-service-route-provider-injection-implementation-2026-05-27.json
+++ b/.planning/codebase/generated/strategy-service-route-provider-injection-implementation-2026-05-27.json
@@ -1,0 +1,98 @@
+{
+  "artifact": "strategy-service-route-provider-injection-implementation",
+  "task_id": "G2.166",
+  "status": "review_ready",
+  "scope": "source_implementation",
+  "created_at": "2026-05-27T08:21:30+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_head_before_commit": "e5f8a4a2a53bc707a57732ac5c6e14d1f63a5444",
+  "parent": {
+    "task_id": "G2.165",
+    "pr": 318,
+    "state": "merged",
+    "merge_commit": "e5f8a4a2a53bc707a57732ac5c6e14d1f63a5444",
+    "report": "docs/reports/quality/backend-strategy-service-seam-design-authorization-2026-05-27.md",
+    "artifact": ".planning/codebase/generated/strategy-service-seam-design-authorization-2026-05-27.json"
+  },
+  "implementation": {
+    "source_files": [
+      "web/backend/app/api/strategy_management/_strategy_execution_router.py"
+    ],
+    "test_files": [
+      "web/backend/tests/test_strategy_management_route_provider.py"
+    ],
+    "provider_added": "get_strategy_service_dependency",
+    "injected_handlers": [
+      "query_strategy_results",
+      "get_matched_stocks",
+      "get_strategy_summary"
+    ],
+    "public_getter_compatibility_preserved": true,
+    "deferred_surfaces_unchanged": [
+      "web/backend/app/services/strategy_service.py",
+      "web/backend/app/services/data_adapters/strategy.py",
+      "web/backend/app/services/adapters/strategy_adapter.py",
+      "web/backend/app/tasks/backtest_tasks.py"
+    ]
+  },
+  "gitnexus_pre_edit": {
+    "get_strategy_service": {
+      "risk": "CRITICAL",
+      "impacted": 13,
+      "direct": 6,
+      "processes": 0
+    },
+    "query_strategy_results": {
+      "risk": "LOW",
+      "impacted": 0,
+      "direct": 0,
+      "processes": 0
+    },
+    "get_matched_stocks": {
+      "risk": "LOW",
+      "impacted": 1,
+      "direct": 1,
+      "processes": 0
+    },
+    "get_strategy_summary": {
+      "risk": "LOW",
+      "impacted": 0,
+      "direct": 0,
+      "processes": 0
+    }
+  },
+  "closure_metrics": {
+    "route_handler_body_get_strategy_service_calls": {
+      "before": 3,
+      "after": 0
+    },
+    "depends_get_strategy_service_dependency_sites": {
+      "before": 0,
+      "after": 3
+    },
+    "provider_fallback_get_strategy_service_calls": {
+      "before": 0,
+      "after": 1,
+      "expected": true
+    },
+    "adapter_and_backtest_body_calls": "unchanged"
+  },
+  "verification": {
+    "tdd_red": "5 failed in 4.57s",
+    "tdd_green": "5 passed in 4.36s",
+    "strategy_route_docs_focused_test": "1 passed in 13.62s",
+    "backtest_task_regressions": "2 passed in 1.94s",
+    "ruff_touched_backend_files": "All checks passed!",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "duplicate_operation_ids": 0,
+      "warnings": 0
+    }
+  },
+  "next_gate": {
+    "task_id": "G2.167",
+    "type": "governance_refresh",
+    "description": "refresh service getter inventory after Strategy route provider injection"
+  }
+}

--- a/docs/reports/quality/backend-strategy-service-route-provider-injection-implementation-2026-05-27.md
+++ b/docs/reports/quality/backend-strategy-service-route-provider-injection-implementation-2026-05-27.md
@@ -1,0 +1,146 @@
+# Backend Strategy Service Route Provider Injection Implementation
+
+> **历史文档说明**:
+> 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。
+> 若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Task: G2.166 Strategy route provider injection implementation  
+Branch: `g2-166-strategy-route-provider-injection`  
+Base: `wip/root-dirty-20260403`  
+Current HEAD before this commit: `e5f8a4a2a53bc707a57732ac5c6e14d1f63a5444`  
+Created: 2026-05-27
+
+Scope: G2.166 narrow source implementation lane authorized by G2.165. This implementation only changes the strategy execution route module, a focused route-provider test, the steward tree, this report, its generated JSON artifact, and the mainline task card.
+
+Boundary: this PR does not edit `web/backend/app/services/strategy_service.py`, adapter/provider duplication, task/backtest resolution, route paths, response models, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, config, or scripts. Public `get_strategy_service()` fallback compatibility is preserved.
+
+## Summary
+
+G2.166 replaced the three direct route-handler body calls to `get_strategy_service()` in `_strategy_execution_router.py` with a route-local FastAPI dependency provider.
+
+The new provider is:
+
+- `get_strategy_service_dependency() -> StrategyService`
+
+It delegates to the existing public `get_strategy_service()` fallback. The three route handlers now receive `strategy_service: StrategyService = Depends(get_strategy_service_dependency)` and use that injected object.
+
+## Parent Authorization
+
+| Input | State |
+|---|---|
+| Parent package | G2.165 Strategy service seam design and authorization |
+| Parent PR | `#318`, merged |
+| Parent merge commit | `e5f8a4a2a53bc707a57732ac5c6e14d1f63a5444` |
+| Parent evidence | `docs/reports/quality/backend-strategy-service-seam-design-authorization-2026-05-27.md` |
+| Parent generated artifact | `.planning/codebase/generated/strategy-service-seam-design-authorization-2026-05-27.json` |
+
+G2.165 authorized only this source slice:
+
+- application source: `web/backend/app/api/strategy_management/_strategy_execution_router.py`
+- focused test: `web/backend/tests/test_strategy_management_route_provider.py`
+
+## GitNexus Evidence Before Edits
+
+| Target | Risk | Impact |
+|---|---:|---|
+| `get_strategy_service` | CRITICAL | impacted `13`, direct `6`, processes `0` |
+| `query_strategy_results` | LOW | impacted `0`, direct `0`, processes `0` |
+| `get_matched_stocks` | LOW | impacted `1`, direct `1`, processes `0`; direct caller is `get_strategy_summary` |
+| `get_strategy_summary` | LOW | impacted `0`, direct `0`, processes `0` |
+
+The shared getter remains CRITICAL because it is still a public fallback used by adapter and task surfaces. The actual G2.166 edit target is the LOW-risk route-handler slice authorized by G2.165.
+
+## TDD Record
+
+Red test:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py -q --no-cov
+5 failed in 4.57s
+```
+
+Expected failures:
+
+- missing `get_strategy_service_dependency()`;
+- missing `strategy_service` handler parameters;
+- direct function calls could not pass an injected fake strategy service.
+
+Green test:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py -q --no-cov
+5 passed in 4.36s
+```
+
+The direct-call test had to pass explicit plain parameter values because direct invocation of FastAPI handlers otherwise passes `Query(...)` default objects into business logic. This is test-call hygiene only; it does not change runtime route behavior.
+
+## Implementation Details
+
+Changed source file:
+
+- `web/backend/app/api/strategy_management/_strategy_execution_router.py`
+
+Changes:
+
+- import `Depends`;
+- import `StrategyService` for dependency parameter typing;
+- add route-local provider `get_strategy_service_dependency()`;
+- inject `strategy_service` into:
+  - `query_strategy_results`;
+  - `get_matched_stocks`;
+  - `get_strategy_summary`;
+- replace each route handler's body-local `service = get_strategy_service()` with `service = strategy_service`.
+
+Changed focused test file:
+
+- `web/backend/tests/test_strategy_management_route_provider.py`
+
+Test coverage added:
+
+- provider delegates to public fallback;
+- all three handlers expose a `Depends(get_strategy_service_dependency)` parameter;
+- direct handler calls can use a fake injected service without calling the public singleton getter.
+
+## Closure Metrics
+
+| Metric | Before | After | Notes |
+|---|---:|---:|---|
+| Route-handler body calls to `get_strategy_service()` in `_strategy_execution_router.py` | `3` | `0` | Target met. |
+| `Depends(get_strategy_service_dependency)` sites in `_strategy_execution_router.py` | `0` | `3` | One per authorized handler. |
+| Route-local provider fallback call | `0` | `1` | Expected; preserves public fallback compatibility. |
+| Adapter lazy getter calls | unchanged | unchanged | Deferred by G2.165. |
+| Backtest task resolver call | unchanged | unchanged | Deferred by G2.165. |
+
+Static scan after implementation:
+
+```json
+{
+  "route_file_body_get_strategy_service_calls": 1,
+  "route_handler_body_get_strategy_service_calls": 0,
+  "provider_fallback_calls": 1,
+  "depends_sites": 3
+}
+```
+
+The remaining route-file call is the provider fallback itself: `return get_strategy_service()`.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Parent PR state | PR `#318` merged; merge commit `e5f8a4a2a53bc707a57732ac5c6e14d1f63a5444` |
+| TDD red | `5 failed in 4.57s` before implementation |
+| TDD green | `5 passed in 4.36s` after implementation |
+| Strategy route OpenAPI docs focused test | `1 passed in 13.62s` |
+| Backtest task regressions | `2 passed in 1.94s` |
+| Ruff touched backend files | `All checks passed!` |
+| OpenAPI smoke | `routes=548`, `paths=500`, `duplicate_operation_ids=0`, `warnings=0` |
+| Static closure scan | route handler body calls `3 -> 0`, provider fallback preserved |
+
+## Rollback
+
+If this implementation changes route behavior, OpenAPI exposure, response shape, adapter behavior, task/backtest resolution, or public `get_strategy_service()` compatibility, revert this PR. Rollback is a normal source/test/governance revert of this PR only.
+
+## Next Gate
+
+Review this implementation package. If accepted and merged, start G2.167 as a governance-only service getter inventory refresh after Strategy route provider injection.

--- a/governance/mainline/task-cards/pr-319.yaml
+++ b/governance/mainline/task-cards/pr-319.yaml
@@ -1,0 +1,131 @@
+version: "v0.2"
+
+task:
+  id: "pr-319"
+  title: "Inject Strategy route service provider"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-strategy-route-provider-injection"
+  objective: "replace direct Strategy route-handler get_strategy_service calls with a route-local provider injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-strategy-route-provider-injection"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorized narrow route-provider injection under G2.165; public route contract, OpenAPI exposure, PM2 workflow, frontend behavior, and service singleton implementation are unchanged"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/api/strategy_management/_strategy_execution_router.py"
+    - "web/backend/tests/test_strategy_management_route_provider.py"
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/strategy-service-route-provider-injection-implementation-2026-05-27.json"
+    - "docs/reports/quality/backend-strategy-service-route-provider-injection-implementation-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-319.yaml"
+  forbidden_paths:
+    - "web/backend/app/services/strategy_service.py"
+    - "web/backend/app/services/data_adapters/strategy.py"
+    - "web/backend/app/services/adapters/strategy_adapter.py"
+    - "web/backend/app/tasks/backtest_tasks.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 318 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "gitnexus-impact"
+      command: "GitNexus impact for get_strategy_service and route handlers before source edits"
+      required: true
+    - id: "tdd-red"
+      command: "focused strategy route provider tests fail before implementation"
+      required: true
+    - id: "tdd-green"
+      command: "focused strategy route provider tests pass after implementation"
+      required: true
+    - id: "static-closure"
+      command: "route-handler body get_strategy_service calls move from 3 to 0, preserving provider fallback call"
+      required: true
+    - id: "strategy-route-docs"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_health_route_conflicts.py::test_v1_strategy_management_endpoints_have_success_examples_and_parameter_docs -q --no-cov"
+      required: true
+    - id: "backtest-task-regressions"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov"
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/api/strategy_management/_strategy_execution_router.py web/backend/tests/test_strategy_management_route_provider.py"
+      required: true
+    - id: "openapi-smoke"
+      command: "app.openapi() smoke with non-secret minimal env; record route count, path count, duplicate operation IDs, and warnings"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-strategy-service-route-provider-injection-implementation-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/strategy-service-route-provider-injection-implementation-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-319.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check -- web/backend/app/api/strategy_management/_strategy_execution_router.py web/backend/tests/test_strategy_management_route_provider.py .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md .planning/codebase/generated/strategy-service-route-provider-injection-implementation-2026-05-27.json docs/reports/quality/backend-strategy-service-route-provider-injection-implementation-2026-05-27.md governance/mainline/task-cards/pr-319.yaml"
+      required: true
+
+non_goals:
+  - "Do not edit web/backend/app/services/strategy_service.py or change public get_strategy_service() fallback compatibility."
+  - "Do not edit Strategy adapter/provider duplication or task/backtest resolution surfaces."
+  - "Do not change route paths, methods, response models, operation IDs, examples, OpenAPI exposure, frontend callers, PM2 workflows, OpenSpec state, config, scripts, or issue-label state."
+  - "Do not fold realtime/socket, Dashboard/TDX, Indicator/Data residual, root facade compatibility, adapter/provider duplication, or task/backtest resolution into this implementation lane."
+
+risk_and_rollback:
+  risks:
+    - "If route dependency injection changes FastAPI route contracts, OpenAPI or frontend consumers could drift."
+    - "If the public get_strategy_service fallback is changed, deferred adapter and backtest consumers could break."
+  rollback_plan: "revert this PR to restore direct route-handler getter calls and remove the focused test/report/artifact/task-card/tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "replace direct Strategy route-handler service getter calls with route-local provider injection"
+    modified_scope: "one backend route module, one focused test file, steward tree, implementation report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "public get_strategy_service fallback and deferred adapter/backtest consumers are unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if TDD red/green, static closure, strategy route docs guard, backtest regressions, ruff, OpenAPI smoke, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-27T08:21:30+08:00"
+    approval_note: "Approved by G2.165 PR #318 for the narrow Strategy route provider injection implementation lane."
+    secondary_approved: false

--- a/web/backend/app/api/strategy_management/_strategy_execution_router.py
+++ b/web/backend/app/api/strategy_management/_strategy_execution_router.py
@@ -8,7 +8,7 @@ import re
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 
 from app.core.exceptions import BusinessException
 from pydantic import BaseModel, Field, field_validator
@@ -17,7 +17,7 @@ from app.openapi_config import COMMON_RESPONSES
 from ._strategy_execution_responses import (STRATEGY_DEFINITIONS_RESPONSES, STRATEGY_RUN_SINGLE_RESPONSES, STRATEGY_RUN_BATCH_RESPONSES, STRATEGY_RESULTS_RESPONSES, MATCHED_STOCKS_RESPONSES, STRATEGY_SUMMARY_RESPONSES)
 from app.core.responses import ErrorCodes, ResponseMessages, UnifiedResponse, create_error_response, create_success_response
 from app.services.data_source_factory import DataSourceFactory
-from app.services.strategy_service import get_strategy_service
+from app.services.strategy_service import StrategyService, get_strategy_service
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +28,11 @@ STRATEGY_ROUTE_RESPONSES = {
 }
 
 router = APIRouter(responses=STRATEGY_ROUTE_RESPONSES)
+
+
+def get_strategy_service_dependency() -> StrategyService:
+    return get_strategy_service()
+
 
 # ==================== 请求/响应模型 ====================
 
@@ -380,6 +385,7 @@ async def query_strategy_results(
     match_result: Optional[bool] = Query(None, description="是否匹配"),
     limit: int = Query(100, description="返回数量", ge=1, le=1000),
     offset: int = Query(0, description="偏移量", ge=0, le=10000),
+    strategy_service: StrategyService = Depends(get_strategy_service_dependency),
 ):
     """
     查询策略结果
@@ -396,7 +402,7 @@ async def query_strategy_results(
         策略结果列表
     """
     try:
-        service = get_strategy_service()
+        service = strategy_service
 
         # 解析日期
         check_date_obj = None
@@ -445,6 +451,7 @@ async def get_matched_stocks(
     strategy_code: str = Query(..., description="策略代码", min_length=1, max_length=50, pattern=r"^[a-z0-9_]+$"),
     check_date: Optional[str] = Query(None, description="检查日期 YYYY-MM-DD", pattern=r"^\d{4}-\d{2}-\d{2}$"),
     limit: int = Query(100, description="返回数量", ge=1, le=1000),
+    strategy_service: StrategyService = Depends(get_strategy_service_dependency),
 ):
     """
     获取匹配指定策略的股票列表
@@ -458,7 +465,7 @@ async def get_matched_stocks(
         匹配的股票列表
     """
     try:
-        service = get_strategy_service()
+        service = strategy_service
 
         # 解析日期
         check_date_obj = None
@@ -488,7 +495,8 @@ async def get_matched_stocks(
     responses=STRATEGY_SUMMARY_RESPONSES,
 )
 async def get_strategy_summary(
-    check_date: Optional[str] = Query(None, description="检查日期 YYYY-MM-DD", pattern=r"^\d{4}-\d{2}-\d{2}$")
+    check_date: Optional[str] = Query(None, description="检查日期 YYYY-MM-DD", pattern=r"^\d{4}-\d{2}-\d{2}$"),
+    strategy_service: StrategyService = Depends(get_strategy_service_dependency),
 ):
     """
     获取策略统计摘要
@@ -500,7 +508,7 @@ async def get_strategy_summary(
         各策略的匹配数量统计
     """
     try:
-        service = get_strategy_service()
+        service = strategy_service
 
         # 解析日期
         check_date_obj = None

--- a/web/backend/tests/test_strategy_management_route_provider.py
+++ b/web/backend/tests/test_strategy_management_route_provider.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from fastapi.params import Depends
+
+from app.api.strategy_management import _strategy_execution_router as module
+
+
+class FakeStrategyService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict]] = []
+
+    def query_strategy_results(self, **kwargs):
+        self.calls.append(("query_strategy_results", kwargs))
+        return [{"symbol": "600519.SH", "match_result": True}]
+
+    def get_matched_stocks(self, **kwargs):
+        self.calls.append(("get_matched_stocks", kwargs))
+        return ["600519.SH"]
+
+    def get_strategy_definitions(self):
+        self.calls.append(("get_strategy_definitions", {}))
+        return [
+            {
+                "strategy_code": "double_ma",
+                "strategy_name_cn": "双均线",
+                "strategy_name_en": "Double MA",
+            }
+        ]
+
+
+def test_strategy_execution_router_exposes_route_local_provider(monkeypatch):
+    fake_service = FakeStrategyService()
+    monkeypatch.setattr(module, "get_strategy_service", lambda: fake_service)
+
+    assert module.get_strategy_service_dependency() is fake_service
+
+
+def test_strategy_execution_handlers_depend_on_route_local_provider():
+    for handler in [
+        module.query_strategy_results,
+        module.get_matched_stocks,
+        module.get_strategy_summary,
+    ]:
+        parameter = inspect.signature(handler).parameters["strategy_service"]
+        default = parameter.default
+        assert isinstance(default, Depends)
+        assert default.dependency is module.get_strategy_service_dependency
+
+
+@pytest.mark.asyncio
+async def test_query_strategy_results_uses_injected_strategy_service(monkeypatch):
+    monkeypatch.setattr(
+        module,
+        "get_strategy_service",
+        lambda: (_ for _ in ()).throw(AssertionError("public getter should not be called")),
+    )
+    fake_service = FakeStrategyService()
+
+    response = await module.query_strategy_results(
+        strategy_code=None,
+        symbol=None,
+        check_date=None,
+        match_result=None,
+        limit=100,
+        offset=0,
+        strategy_service=fake_service,
+    )
+
+    assert fake_service.calls[0][0] == "query_strategy_results"
+    assert response.data["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_matched_stocks_uses_injected_strategy_service(monkeypatch):
+    monkeypatch.setattr(
+        module,
+        "get_strategy_service",
+        lambda: (_ for _ in ()).throw(AssertionError("public getter should not be called")),
+    )
+    fake_service = FakeStrategyService()
+
+    response = await module.get_matched_stocks(
+        strategy_code="double_ma",
+        check_date=None,
+        limit=100,
+        strategy_service=fake_service,
+    )
+
+    assert fake_service.calls[0][0] == "get_matched_stocks"
+    assert response.data["matched_stocks"] == ["600519.SH"]
+
+
+@pytest.mark.asyncio
+async def test_get_strategy_summary_uses_injected_strategy_service(monkeypatch):
+    monkeypatch.setattr(
+        module,
+        "get_strategy_service",
+        lambda: (_ for _ in ()).throw(AssertionError("public getter should not be called")),
+    )
+    fake_service = FakeStrategyService()
+
+    response = await module.get_strategy_summary(check_date=None, strategy_service=fake_service)
+
+    assert [name for name, _ in fake_service.calls] == [
+        "get_strategy_definitions",
+        "get_matched_stocks",
+    ]
+    assert response.data["strategy_summary"][0]["matched_count"] == 1


### PR DESCRIPTION
## Summary
- adds a route-local `get_strategy_service_dependency()` provider in `_strategy_execution_router.py`
- injects the provider into `query_strategy_results`, `get_matched_stocks`, and `get_strategy_summary`
- reduces authorized route-handler body calls to `get_strategy_service()` from 3 to 0 while preserving the provider fallback and public `get_strategy_service()` compatibility
- adds focused provider tests and updates the steward tree/report/artifact/task card

## Verification
- GitNexus impact before edits: `get_strategy_service` CRITICAL 13/6/0; route handlers LOW
- TDD red: 5 failed before implementation
- TDD green: 5 passed after implementation
- Strategy route OpenAPI docs focused test: 1 passed
- Backtest task regressions: 2 passed
- Ruff touched backend files: All checks passed
- OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0, warnings=0
- Static closure: route handler body calls 3 -> 0; provider fallback preserved
- Markdown governance: 2 checked, 0 errors
- JSON/YAML parse and git diff --check: passed
- staged GitNexus detect changes: LOW, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: 62,929 nodes / 146,429 edges / 300 flows

## Boundary
This PR does not edit `strategy_service.py`, Strategy adapter modules, `backtest_tasks.py`, route paths, response models, OpenAPI exposure, frontend, PM2, OpenSpec, config, scripts, issue labels, or public `get_strategy_service()` fallback compatibility. Next gate after merge is G2.167 governance-only inventory refresh.