### PR TITLE
docs(governance): refresh service getter inventory after strategy route provider

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -3045,7 +3045,7 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              OpenSpec, config, script, compatibility deletion,
 │   │              issue-label change, or implementation is performed here
 │   ├── G2.166 Strategy route provider injection implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#319`
 │   │   ├── Evidence:
 │   │   │          `backend-strategy-service-route-provider-injection-implementation-2026-05-27.md`
 │   │   ├── Generated:
@@ -3053,6 +3053,7 @@ CODEBASE-MAP Architecture Remediation Program
 │   │   ├── Parent: G2.165 accepted and merged by PR `#318`
 │   │   ├── Current HEAD before implementation commit:
 │   │   │          `e5f8a4a2a53bc707a57732ac5c6e14d1f63a5444`
+│   │   ├── Merge commit: `03cff1a688337a170801add2dea52050b9bbea44`
 │   │   ├── Implementation: added
 │   │   │          `get_strategy_service_dependency()` provider in
 │   │   │          `_strategy_execution_router.py` and injected it into
@@ -3072,9 +3073,41 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              models, OpenAPI exposure, frontend, PM2, OpenSpec,
 │   │              config, scripts, issue labels, or public
 │   │              `get_strategy_service()` fallback compatibility
-│   └── Next gate: review G2.166; if accepted, start G2.167 as a
-│                  governance-only service getter inventory refresh after
-│                  Strategy route provider injection
+│   ├── G2.167 Service getter inventory refresh after Strategy route
+│   │          provider
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-service-lifecycle-candidate-refresh-after-strategy-route-provider-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `service-lifecycle-candidate-refresh-after-strategy-route-provider-2026-05-27.json`
+│   │   ├── Parent: G2.166 accepted and merged by PR `#319`
+│   │   ├── Evidence HEAD: `03cff1a688337a170801add2dea52050b9bbea44`
+│   │   ├── Strategy route closure: route-handler body
+│   │   │          `get_strategy_service()` calls remain `0`; route
+│   │   │          provider fallback call is `1`; and
+│   │   │          `Depends(get_strategy_service_dependency)` sites are `3`
+│   │   ├── Refreshed high-risk matrix: `get_strategy_service` remains
+│   │   │          CRITICAL `13/6/0`, `get_data_service` remains CRITICAL
+│   │   │          `5/3/7`, `get_streaming_service` remains HIGH `9/9/0`,
+│   │   │          and `get_tdx_service` remains CRITICAL `6/2/5`
+│   │   ├── Decision: no implementation is authorized; remaining
+│   │   │          Strategy residual must be split into adapter/provider
+│   │   │          duplication and backtest task data-source resolution
+│   │   │          before any source lane begins
+│   │   ├── Verification: parent PR `#319` merged, strategy route provider
+│   │   │          focused test `5 passed`, strategy route OpenAPI docs
+│   │   │          focused test `1 passed`, OpenAPI smoke `routes=548`,
+│   │   │          `paths=500`, `duplicate_operation_ids=0`, and
+│   │   │          `duplicate_operation_id_warnings=0`
+│   │   └── Boundary: governance-only refresh; no backend source/test
+│   │              edit, route/API behavior, OpenAPI exposure, frontend,
+│   │              PM2, OpenSpec, config, script, compatibility deletion,
+│   │              issue-label change, or implementation authorization
+│   │              is performed here
+│   └── Next gate: review G2.167; if accepted, start G2.168 as a
+│                  decision-only Strategy residual split package for
+│                  adapter/provider duplication vs backtest task
+│                  resolution
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-strategy-route-provider-2026-05-27.json
+++ b/.planning/codebase/generated/service-lifecycle-candidate-refresh-after-strategy-route-provider-2026-05-27.json
@@ -1,0 +1,154 @@
+{
+  "artifact": "service-lifecycle-candidate-refresh-after-strategy-route-provider-2026-05-27",
+  "task_id": "G2.167",
+  "status": "ready_for_review",
+  "scope": "governance_only_candidate_refresh",
+  "created_at": "2026-05-27T08:58:04+08:00",
+  "parent": {
+    "task_id": "G2.166",
+    "pr": 319,
+    "merge_commit": "03cff1a688337a170801add2dea52050b9bbea44",
+    "title": "refactor(backend): inject strategy route service provider"
+  },
+  "current_head": "03cff1a688337a170801add2dea52050b9bbea44",
+  "strategy_route_provider_closure": {
+    "route_handler_body_calls": 0,
+    "provider_fallback_calls": 1,
+    "depends_sites": 3,
+    "public_getter_fallback_preserved": true,
+    "note": "GitNexus still reports route handlers as direct upstream callers because provider-mediated route participation remains in the graph; static route-handler body calls are the closure metric."
+  },
+  "remaining_strategy_surfaces": [
+    {
+      "surface": "route_provider_fallback",
+      "file": "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+      "line": 34,
+      "status": "intentionally_retained"
+    },
+    {
+      "surface": "adapter_provider_duplication",
+      "file": "web/backend/app/services/adapters/strategy_adapter.py",
+      "line": 45,
+      "status": "deferred"
+    },
+    {
+      "surface": "adapter_provider_duplication",
+      "file": "web/backend/app/services/data_adapters/strategy.py",
+      "line": 42,
+      "status": "deferred"
+    },
+    {
+      "surface": "backtest_task_resolver",
+      "file": "web/backend/app/tasks/backtest_tasks.py",
+      "line": 31,
+      "status": "deferred"
+    }
+  ],
+  "high_risk_getter_matrix": [
+    {
+      "getter": "get_strategy_service",
+      "risk": "CRITICAL",
+      "impacted": 13,
+      "direct": 6,
+      "processes": 0,
+      "interpretation": "Route-handler body debt is closed; residual must be split into adapter/provider duplication and backtest task resolution before source work."
+    },
+    {
+      "getter": "get_data_service",
+      "risk": "CRITICAL",
+      "impacted": 5,
+      "direct": 3,
+      "processes": 7,
+      "interpretation": "Indicator/Data route body debt is already closed; keep as provider-governed runtime seam."
+    },
+    {
+      "getter": "get_streaming_service",
+      "risk": "HIGH",
+      "impacted": 9,
+      "direct": 9,
+      "processes": 0,
+      "interpretation": "Realtime/socket lifecycle track remains separate."
+    },
+    {
+      "getter": "get_tdx_service",
+      "risk": "CRITICAL",
+      "impacted": 6,
+      "direct": 2,
+      "processes": 5,
+      "interpretation": "Dashboard/TDX residual remains separate."
+    }
+  ],
+  "token_surface": {
+    "scope": [
+      "web/backend/app/api",
+      "web/backend/app/services",
+      "web/backend/app/tasks",
+      "web/backend/app/core"
+    ],
+    "exclude_backend_tests": true,
+    "tokens": {
+      "get_data_service": {
+        "count": 5,
+        "files": 3
+      },
+      "get_strategy_service": {
+        "count": 9,
+        "files": 5
+      },
+      "get_streaming_service": {
+        "count": 5,
+        "files": 3
+      },
+      "get_tdx_service": {
+        "count": 4,
+        "files": 2
+      },
+      "get_market_data_service": {
+        "count": 2,
+        "files": 2
+      },
+      "get_market_data_service_v2_dependency": {
+        "count": 17,
+        "files": 3
+      },
+      "get_indicator_data_service": {
+        "count": 3,
+        "files": 1
+      },
+      "get_strategy_indicator_data_service": {
+        "count": 2,
+        "files": 1
+      },
+      "get_indicator_registry_dependency": {
+        "count": 4,
+        "files": 2
+      }
+    }
+  },
+  "verification": {
+    "parent_pr": {
+      "number": 319,
+      "state": "MERGED",
+      "merge_commit": "03cff1a688337a170801add2dea52050b9bbea44"
+    },
+    "focused_tests": {
+      "web/backend/tests/test_strategy_management_route_provider.py": "5 passed in 3.32s",
+      "web/backend/tests/test_health_route_conflicts.py::test_v1_strategy_management_endpoints_have_success_examples_and_parameter_docs": "1 passed in 12.57s"
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "total_warnings_captured": 121
+    }
+  },
+  "decision": {
+    "implementation_authorized": false,
+    "next_gate": "G2.168 decision-only Strategy residual track-split package",
+    "recommended_split": [
+      "Strategy adapter/provider duplication",
+      "Backtest task data-source resolution"
+    ]
+  }
+}

--- a/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-strategy-route-provider-2026-05-27.md
+++ b/docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-strategy-route-provider-2026-05-27.md
@@ -1,0 +1,114 @@
+# Backend Service Lifecycle Candidate Refresh After Strategy Route Provider
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: Ready for review
+
+Scope: G2.167 governance-only candidate refresh after G2.166.
+
+Boundary: this is an inventory refresh and routing package only. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations. It does not authorize implementation.
+
+Parent: G2.166, PR `#319`, merged as `03cff1a688337a170801add2dea52050b9bbea44`.
+
+Current HEAD: `03cff1a688337a170801add2dea52050b9bbea44`.
+
+Prepared at: `2026-05-27T08:58:04+08:00`.
+
+## Purpose
+
+Refresh the remaining service lifecycle getter/provider inventory after the Strategy route provider injection closed the route-handler body-call slice.
+
+This refresh is intentionally not a source implementation plan. Its job is to record the new baseline, separate static route closure from remaining graph risk, and route the next step back through a decision package.
+
+## Parent Verification
+
+| Check | Result |
+|---|---|
+| PR `#319` state | `MERGED`, merge commit `03cff1a688337a170801add2dea52050b9bbea44` |
+| `test_strategy_management_route_provider.py` | `5 passed in 3.32s` |
+| Strategy route OpenAPI docs focused test | `1 passed in 12.57s` |
+| OpenAPI smoke with non-secret minimal env | `routes=548`, `paths=500`, `duplicate_operation_ids=0`, `duplicate_operation_id_warnings=0`, `total_warnings_captured=121` |
+
+The OpenAPI smoke reports duplicate-operation-id warnings separately from all captured warnings. The broader warning count includes unrelated import-time/runtime dependency warnings and is not treated as an operationId regression.
+
+## Strategy Route Provider Closure
+
+G2.166 changed the Strategy route surface from direct route-handler body calls to a local FastAPI dependency provider.
+
+| Surface | Current state |
+|---|---|
+| Route-handler body calls to `get_strategy_service()` in `query_strategy_results` | 0 |
+| Route-handler body calls to `get_strategy_service()` in `get_matched_stocks` | 0 |
+| Route-handler body calls to `get_strategy_service()` in `get_strategy_summary` | 0 |
+| Route-local provider fallback calls | 1, `get_strategy_service_dependency()` delegates to public `get_strategy_service()` |
+| `Depends(get_strategy_service_dependency)` sites | 3 |
+| Public `get_strategy_service()` fallback compatibility | preserved |
+
+GitNexus still reports `query_strategy_results`, `get_matched_stocks`, and `get_strategy_summary` as direct upstream callers of `get_strategy_service`. That signal now reflects provider-mediated route participation in the graph, not direct body-call debt in the route handlers. For closure, use the static route-handler body-call count; for blast radius, keep the GitNexus CRITICAL risk signal.
+
+## Remaining Strategy Surfaces
+
+| Surface | Current call site | Interpretation |
+|---|---|---|
+| Route provider fallback | `web/backend/app/api/strategy_management/_strategy_execution_router.py:34` | Deliberate compatibility fallback introduced by G2.166. |
+| Adapter/provider duplication | `web/backend/app/services/adapters/strategy_adapter.py:45` | Deferred adapter lane; should not be changed from a route-provider package. |
+| Adapter/provider duplication | `web/backend/app/services/data_adapters/strategy.py:42` | Deferred adapter lane; should not be changed from a route-provider package. |
+| Backtest task resolver | `web/backend/app/tasks/backtest_tasks.py:31` | Separate task/runtime contract lane; should not be bundled with adapter cleanup. |
+
+## Refreshed High-Risk Getter Matrix
+
+| Getter | GitNexus risk | Impacted | Direct | Processes | Static surface | Current interpretation |
+|---|---:|---:|---:|---:|---|---|
+| `get_strategy_service` | CRITICAL | 13 | 6 | 0 | 4 non-definition calls across route provider, two adapter modules, and backtest task resolver | Route-handler body debt closed; remaining residual must be split into adapter/provider duplication and backtest task resolution before source work. |
+| `get_data_service` | CRITICAL | 5 | 3 | 7 | Provider-governed Indicator/Data seam plus tests | Indicator/Data route body debt already closed; keep as runtime-flow risk, not the next immediate source lane. |
+| `get_streaming_service` | HIGH | 9 | 9 | 0 | Realtime/socket manager and streaming bridge | Realtime/socket lifecycle track remains separate. |
+| `get_tdx_service` | CRITICAL | 6 | 2 | 5 | Dashboard/TDX service seam | Dashboard/TDX residual remains separate. |
+
+## Token Surface
+
+The following token counts cover `web/backend/app/api`, `web/backend/app/services`, `web/backend/app/tasks`, and `web/backend/app/core`; backend tests are excluded from this table.
+
+| Token | Count | Files |
+|---|---:|---:|
+| `get_data_service` | 5 | 3 |
+| `get_strategy_service` | 9 | 5 |
+| `get_streaming_service` | 5 | 3 |
+| `get_tdx_service` | 4 | 2 |
+| `get_market_data_service` | 2 | 2 |
+| `get_market_data_service_v2_dependency` | 17 | 3 |
+| `get_indicator_data_service` | 3 | 1 |
+| `get_strategy_indicator_data_service` | 2 | 1 |
+| `get_indicator_registry_dependency` | 4 | 2 |
+
+Token counts are navigation aids, not deletion queues. Business query helpers and compatibility providers must be classified by track before any source edit.
+
+## Current Static Scan Notes
+
+| Metric | Count |
+|---|---:|
+| Service Python files | 152 |
+| API Python files | 219 |
+| Backend test Python files | 208 |
+| Top-level `def get_*` definitions under `web/backend/app/services` | 53 |
+| Root facade getters in `web/backend/app/services/__init__.py` | 7 |
+| Top-level API `def get_*` helpers/providers | 33 |
+| API `Depends(get_*)` sites | 374 |
+
+These broad counts are intentionally retained as rough trend signals only. They must not be used to infer singleton debt without per-symbol classification.
+
+## Decision
+
+No new source implementation lane is selected by G2.167.
+
+Recommended next gate: G2.168 decision-only Strategy residual split package.
+
+G2.168 should decide how to split the remaining `get_strategy_service` residual into separate tracks before any code is edited:
+
+1. Strategy adapter/provider duplication: `web/backend/app/services/adapters/strategy_adapter.py` and `web/backend/app/services/data_adapters/strategy.py`.
+2. Backtest task data-source resolution: `web/backend/app/tasks/backtest_tasks.py`.
+
+The adapter/provider duplication and backtest task resolver should not be implemented in the same source PR unless a later reviewed authorization package explicitly proves shared tests, rollback, and runtime boundaries.
+
+## Next Gate
+
+Review this package. If accepted, start G2.168 as a decision-only Strategy residual track-split package. Do not start another source implementation lane directly from this refresh.

--- a/governance/mainline/task-cards/pr-320.yaml
+++ b/governance/mainline/task-cards/pr-320.yaml
@@ -1,0 +1,113 @@
+version: "v0.2"
+
+task:
+  id: "pr-320"
+  title: "Refresh service getter inventory after Strategy route provider"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-service-getter-inventory-refresh-after-strategy-route-provider"
+  objective: "refresh the high-risk service getter/provider inventory after the Strategy route provider implementation closed"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-service-getter-inventory-refresh-after-strategy-route-provider"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only inventory refresh; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/service-lifecycle-candidate-refresh-after-strategy-route-provider-2026-05-27.json"
+    - "docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-strategy-route-provider-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-320.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 319 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "strategy-route-static-closure"
+      command: "scan Strategy route handler body calls, provider fallback calls, and Depends(get_strategy_service_dependency) sites at current HEAD"
+      required: true
+    - id: "gitnexus-impact-refresh"
+      command: "GitNexus impact for get_strategy_service, get_data_service, get_streaming_service, and get_tdx_service"
+      required: true
+    - id: "post-merge-focused-tests"
+      command: "run Strategy route provider and Strategy route OpenAPI docs focused tests after PR #319 merge"
+      required: true
+    - id: "openapi-smoke"
+      command: "app.openapi() smoke with non-secret minimal env; record route count, path count, duplicate operation IDs, duplicate-operation-id warnings, and total captured warnings"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-strategy-route-provider-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/service-lifecycle-candidate-refresh-after-strategy-route-provider-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-320.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this inventory refresh package."
+  - "Do not select or start a source implementation lane from this package."
+  - "Do not delete, privatize, rename, or change get_strategy_service(), get_data_service(), get_streaming_service(), or get_tdx_service()."
+  - "Do not edit Strategy adapter/provider duplication or backtest task resolution surfaces."
+  - "Do not edit route/API behavior, OpenAPI exposure, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this refresh is treated as implementation authorization, a high-risk Strategy residual lane could start without a dedicated decision package."
+    - "If GitNexus route-handler graph edges are treated as static body-call debt, G2.166 closure could be misread as incomplete."
+    - "If broad token counts are treated as deletion candidates, compatibility providers and business helpers may be misclassified."
+  rollback_plan: "revert this decision PR to remove only the refresh report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh high-risk service getter inventory after Strategy route provider closure"
+    modified_scope: "steward tree, refresh report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, strategy route static closure scan, GitNexus impact refresh, focused tests, OpenAPI smoke, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T08:58:04+08:00"
+    approval_note: "Governance-only inventory refresh after PR #319 merged the Strategy route provider injection."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record G2.167 governance-only refresh after PR #319 merged the Strategy route provider implementation
- document Strategy route static closure: route-handler body calls to `get_strategy_service()` are 0, provider fallback remains 1, and `Depends(get_strategy_service_dependency)` sites are 3
- refresh high-risk getter matrix and route the remaining Strategy residual into a future decision-only adapter/provider vs backtest task split

## Verification
- `test_strategy_management_route_provider.py`: 5 passed
- Strategy route OpenAPI docs focused test: 1 passed
- OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0, duplicate_operation_id_warnings=0
- Markdown governance: checked_files=2, errors=0
- JSON/YAML parse: passed
- GitNexus staged scope: low, 0 changed symbols, 0 affected processes
- Mainline scope gate: pass=True
- `gitnexus analyze --with-gitignore`: 62,930 nodes, 146,114 edges, 3,285 clusters, 300 flows

## Boundaries
- Governance-only; no backend source or test edits
- Does not authorize adapter/provider or backtest task implementation
- Does not change route/API behavior, OpenAPI exposure, frontend, PM2, OpenSpec, config, scripts, or issue labels
EOF 2>&1
