### PR TITLE
docs(governance): split strategy service residual tracks

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -3075,13 +3075,14 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              `get_strategy_service()` fallback compatibility
 │   ├── G2.167 Service getter inventory refresh after Strategy route
 │   │          provider
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#320`
 │   │   ├── Evidence:
 │   │   │          `backend-service-lifecycle-candidate-refresh-after-strategy-route-provider-2026-05-27.md`
 │   │   ├── Generated:
 │   │   │          `service-lifecycle-candidate-refresh-after-strategy-route-provider-2026-05-27.json`
 │   │   ├── Parent: G2.166 accepted and merged by PR `#319`
 │   │   ├── Evidence HEAD: `03cff1a688337a170801add2dea52050b9bbea44`
+│   │   ├── Merge commit: `8f3cc0c15ec80b5e9acdbdf83f407abee44a6bd2`
 │   │   ├── Strategy route closure: route-handler body
 │   │   │          `get_strategy_service()` calls remain `0`; route
 │   │   │          provider fallback call is `1`; and
@@ -3104,10 +3105,35 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              PM2, OpenSpec, config, script, compatibility deletion,
 │   │              issue-label change, or implementation authorization
 │   │              is performed here
-│   └── Next gate: review G2.167; if accepted, start G2.168 as a
-│                  decision-only Strategy residual split package for
-│                  adapter/provider duplication vs backtest task
-│                  resolution
+│   ├── G2.168 Strategy service residual split decision
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-strategy-service-residual-split-decision-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `strategy-service-residual-split-decision-2026-05-27.json`
+│   │   ├── Parent: G2.167 accepted and merged by PR `#320`
+│   │   ├── Evidence HEAD: `8f3cc0c15ec80b5e9acdbdf83f407abee44a6bd2`
+│   │   ├── Residual split: route provider fallback is intentionally
+│   │   │          retained; `backtest_tasks.py::_resolve_backtest_data_source`
+│   │   │          is selected as the next authorization candidate; and the
+│   │   │          two Strategy adapter `_get_strategy_service` helpers are
+│   │   │          deferred to a separate adapter design track
+│   │   ├── GitNexus evidence: `get_strategy_service` remains CRITICAL
+│   │   │          `13/6/0`, while `_resolve_backtest_data_source` is LOW
+│   │   │          `1/1/0`; both adapter helpers have two incoming callers
+│   │   │          each and still call public `get_strategy_service()`
+│   │   ├── Verification: strategy route provider focused test `5 passed`,
+│   │   │          backtest task regressions `2 passed`, adapter mock fallback
+│   │   │          controls `6 passed`, and OpenAPI smoke `routes=548`,
+│   │   │          `paths=500`, `duplicate_operation_ids=0`
+│   │   └── Boundary: decision-only; no backend source/test edit,
+│   │              route/API behavior, OpenAPI exposure, frontend, PM2,
+│   │              OpenSpec, config, script, compatibility deletion,
+│   │              issue-label change, or implementation authorization is
+│   │              performed here
+│   └── Next gate: review G2.168; if accepted, start G2.169 as an
+│                  authorization-only package for
+│                  `backtest_tasks.py::_resolve_backtest_data_source`
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/strategy-service-residual-split-decision-2026-05-27.json
+++ b/.planning/codebase/generated/strategy-service-residual-split-decision-2026-05-27.json
@@ -1,0 +1,106 @@
+{
+  "artifact": "strategy-service-residual-split-decision-2026-05-27",
+  "task_id": "G2.168",
+  "status": "ready_for_review",
+  "scope": "decision_only_strategy_residual_split",
+  "created_at": "2026-05-27T09:47:49+08:00",
+  "parent": {
+    "task_id": "G2.167",
+    "pr": 320,
+    "merge_commit": "8f3cc0c15ec80b5e9acdbdf83f407abee44a6bd2",
+    "title": "docs(governance): refresh service getter inventory after strategy route provider"
+  },
+  "current_head": "8f3cc0c15ec80b5e9acdbdf83f407abee44a6bd2",
+  "residual_map": [
+    {
+      "track": "route_provider_fallback",
+      "file": "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+      "line": 34,
+      "function": "get_strategy_service_dependency",
+      "disposition": "retain"
+    },
+    {
+      "track": "strategy_adapter_provider_duplication",
+      "file": "web/backend/app/services/adapters/strategy_adapter.py",
+      "line": 45,
+      "function": "_get_strategy_service",
+      "disposition": "defer_to_adapter_design_track"
+    },
+    {
+      "track": "strategy_adapter_provider_duplication",
+      "file": "web/backend/app/services/data_adapters/strategy.py",
+      "line": 42,
+      "function": "_get_strategy_service",
+      "disposition": "defer_to_adapter_design_track"
+    },
+    {
+      "track": "backtest_task_data_source_resolution",
+      "file": "web/backend/app/tasks/backtest_tasks.py",
+      "line": 31,
+      "function": "_resolve_backtest_data_source",
+      "disposition": "next_authorization_candidate"
+    }
+  ],
+  "route_static_status": {
+    "strategy_route_handler_body_calls": 0,
+    "route_provider_fallback_calls": 1,
+    "depends_get_strategy_service_dependency_sites": 3
+  },
+  "gitnexus": {
+    "get_strategy_service": {
+      "risk": "CRITICAL",
+      "impacted": 13,
+      "direct": 6,
+      "processes": 0
+    },
+    "_resolve_backtest_data_source": {
+      "risk": "LOW",
+      "impacted": 1,
+      "direct": 1,
+      "processes": 0
+    },
+    "adapter_helper_contexts": [
+      {
+        "file": "web/backend/app/services/adapters/strategy_adapter.py",
+        "symbol": "_get_strategy_service",
+        "incoming_callers": [
+          "_fetch_strategy_data",
+          "health_check"
+        ],
+        "outgoing": "get_strategy_service"
+      },
+      {
+        "file": "web/backend/app/services/data_adapters/strategy.py",
+        "symbol": "_get_strategy_service",
+        "incoming_callers": [
+          "_fetch_strategy_data",
+          "health_check"
+        ],
+        "outgoing": "get_strategy_service"
+      }
+    ]
+  },
+  "verification": {
+    "focused_tests": {
+      "web/backend/tests/test_strategy_management_route_provider.py": "5 passed in 4.07s",
+      "web/backend/tests/test_backtest_tasks_regressions.py": "2 passed in 2.33s",
+      "web/backend/tests/test_adapter_mock_fallback_controls.py": "6 passed in 0.23s"
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "total_warnings_captured": 121
+    }
+  },
+  "decision": {
+    "implementation_authorized": false,
+    "tracks": {
+      "route_provider_fallback": "retain",
+      "backtest_task_data_source_resolution": "next_authorization_candidate",
+      "strategy_adapter_provider_duplication": "defer_to_separate_adapter_design_track"
+    },
+    "next_gate": "G2.169 authorization-only package for web/backend/app/tasks/backtest_tasks.py::_resolve_backtest_data_source"
+  }
+}

--- a/docs/reports/quality/backend-strategy-service-residual-split-decision-2026-05-27.md
+++ b/docs/reports/quality/backend-strategy-service-residual-split-decision-2026-05-27.md
@@ -1,0 +1,98 @@
+# Backend Strategy Service Residual Split Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Status: Ready for review
+
+Scope: G2.168 decision-only Strategy residual split after G2.167.
+
+Boundary: this is a decision and routing package only. It does not edit backend source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec state, GitHub issue labels, or service getter implementations. It does not authorize implementation.
+
+Parent: G2.167, PR `#320`, merged as `8f3cc0c15ec80b5e9acdbdf83f407abee44a6bd2`.
+
+Current HEAD: `8f3cc0c15ec80b5e9acdbdf83f407abee44a6bd2`.
+
+Prepared at: `2026-05-27T09:47:49+08:00`.
+
+## Purpose
+
+Split the remaining `get_strategy_service()` residual after the Strategy route provider injection and candidate refresh.
+
+This package prevents the next agent from treating the remaining Strategy residual as one mechanical replacement. The remaining calls have different runtime surfaces, tests, and rollback boundaries.
+
+## Parent Verification
+
+| Check | Result |
+|---|---|
+| PR `#320` state | `MERGED`, merge commit `8f3cc0c15ec80b5e9acdbdf83f407abee44a6bd2` |
+| G2.167 conclusion | no source implementation authorized |
+| G2.167 next gate | split Strategy residual into adapter/provider duplication vs backtest task resolution |
+
+## Current Residual Map
+
+| Track | File | Line | Function | Current role | Disposition |
+|---|---|---:|---|---|---|
+| Route provider fallback | `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 34 | `get_strategy_service_dependency` | FastAPI provider fallback introduced by G2.166 | Retain; not a debt target. |
+| Strategy adapter/provider duplication | `web/backend/app/services/adapters/strategy_adapter.py` | 45 | `_get_strategy_service` | lazy service resolver for one adapter package | Separate adapter design track. |
+| Strategy adapter/provider duplication | `web/backend/app/services/data_adapters/strategy.py` | 42 | `_get_strategy_service` | lazy service resolver for the parallel adapter package | Separate adapter design track. |
+| Backtest task data-source resolution | `web/backend/app/tasks/backtest_tasks.py` | 31 | `_resolve_backtest_data_source` | Celery task data-source resolver | Next authorization candidate. |
+
+Static route status remains closed:
+
+| Route metric | Count |
+|---|---:|
+| Strategy route-handler body calls to `get_strategy_service()` | 0 |
+| Route provider fallback calls | 1 |
+| `Depends(get_strategy_service_dependency)` sites | 3 |
+
+## GitNexus Evidence
+
+| Symbol | Risk | Impacted | Direct | Processes | Interpretation |
+|---|---:|---:|---:|---:|---|
+| `get_strategy_service` | CRITICAL | 13 | 6 | 0 | Overall Strategy residual remains high-risk because adapter, route-provider, and task surfaces still converge on the public getter. |
+| `_resolve_backtest_data_source` | LOW | 1 | 1 | 0 | The backtest resolver itself has one direct caller, `run_backtest_task`; it is the narrowest remaining source candidate. |
+
+Adapter helper contexts:
+
+| Helper | Incoming callers | Outgoing getter |
+|---|---:|---|
+| `web/backend/app/services/adapters/strategy_adapter.py::_get_strategy_service` | 2, `_fetch_strategy_data` and `health_check` | `get_strategy_service` |
+| `web/backend/app/services/data_adapters/strategy.py::_get_strategy_service` | 2, `_fetch_strategy_data` and `health_check` | `get_strategy_service` |
+
+The adapter helpers are structurally duplicated but not low-risk cleanup. They sit in two adapter package topologies and should be governed through an adapter-specific design packet before source work.
+
+## Verification Snapshot
+
+| Check | Result |
+|---|---|
+| `test_strategy_management_route_provider.py` | `5 passed in 4.07s` |
+| `test_backtest_tasks_regressions.py` | `2 passed in 2.33s` |
+| `test_adapter_mock_fallback_controls.py` | `6 passed in 0.23s` |
+| OpenAPI smoke with non-secret minimal env | `routes=548`, `paths=500`, `duplicate_operation_ids=0`, `duplicate_operation_id_warnings=0`, `total_warnings_captured=121` |
+
+The OpenAPI smoke is included as a current-head sanity check. G2.168 does not modify route/OpenAPI code.
+
+## Decision
+
+Split the remaining Strategy residual into three tracks:
+
+1. Route provider fallback: retain as intentional compatibility and dependency-injection fallback.
+2. Backtest task data-source resolution: select as the next authorization candidate because its direct blast radius is LOW and it already has focused regression coverage.
+3. Strategy adapter/provider duplication: defer to a separate adapter design package because it spans two parallel adapter packages and should not be mixed with task runtime resolution.
+
+No source implementation is authorized by this package.
+
+## Next Gate
+
+Start G2.169 as an authorization-only package for `web/backend/app/tasks/backtest_tasks.py::_resolve_backtest_data_source`.
+
+G2.169 must define:
+
+- exact permitted source and test paths;
+- whether the task resolver receives an injectable resolver/provider or another narrow seam;
+- how `data_source_mode` behavior remains compatible for `strategy_service` and `auto`;
+- required red/green test expansion in `web/backend/tests/test_backtest_tasks_regressions.py`;
+- rollback condition that preserves public `get_strategy_service()` fallback compatibility;
+- explicit non-goals for Strategy adapter modules, Strategy route modules, `strategy_service.py`, route/OpenAPI contracts, frontend, PM2, OpenSpec, config, scripts, and issue labels.
+
+Only after G2.169 is reviewed and accepted should a source implementation lane be opened.

--- a/governance/mainline/task-cards/pr-321.yaml
+++ b/governance/mainline/task-cards/pr-321.yaml
@@ -1,0 +1,113 @@
+version: "v0.2"
+
+task:
+  id: "pr-321"
+  title: "Split Strategy service residual tracks"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-strategy-service-residual-split-decision"
+  objective: "split the remaining Strategy get_strategy_service residual into route fallback, adapter/provider, and backtest task tracks before any source implementation"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-strategy-service-residual-split-decision"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision-only Strategy residual split; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/strategy-service-residual-split-decision-2026-05-27.json"
+    - "docs/reports/quality/backend-strategy-service-residual-split-decision-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-321.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 320 --json number,state,mergedAt,mergeCommit,url,title"
+      required: true
+    - id: "residual-static-scan"
+      command: "scan current get_strategy_service residual sites and classify route fallback, adapter/provider duplication, and backtest task resolution"
+      required: true
+    - id: "gitnexus-evidence"
+      command: "GitNexus impact for get_strategy_service and _resolve_backtest_data_source; GitNexus context for both adapter _get_strategy_service helpers"
+      required: true
+    - id: "focused-tests"
+      command: "run Strategy route provider, backtest task regression, and adapter mock fallback focused tests"
+      required: true
+    - id: "openapi-smoke"
+      command: "app.openapi() smoke with non-secret minimal env; record route count, path count, duplicate operation IDs, duplicate-operation-id warnings, and total captured warnings"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-strategy-service-residual-split-decision-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/strategy-service-residual-split-decision-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-321.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this decision package."
+  - "Do not authorize source implementation directly from this package."
+  - "Do not edit Strategy route provider fallback, Strategy adapter modules, backtest task resolver, or strategy_service.py."
+  - "Do not delete, privatize, rename, or change get_strategy_service()."
+  - "Do not edit route/API behavior, OpenAPI exposure, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this decision package is treated as source authorization, adapter and task runtime surfaces could be mixed into one unsafe implementation lane."
+    - "If route provider fallback is treated as debt, G2.166's intentional compatibility seam could be removed without approval."
+    - "If the two adapter packages are treated as mechanical duplicates, their package topology and factory consumers could be missed."
+  rollback_plan: "revert this decision PR to remove only the split decision report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "split remaining Strategy service getter residual into separately governed tracks"
+    modified_scope: "steward tree, decision report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, residual scan, GitNexus evidence, focused tests, OpenAPI smoke, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T09:47:49+08:00"
+    approval_note: "Decision-only split after PR #320 merged the Strategy residual inventory refresh."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- record G2.168 as a decision-only Strategy residual split after PR #320
- classify the remaining `get_strategy_service()` residual into route provider fallback, Strategy adapter/provider duplication, and backtest task data-source resolution
- select `backtest_tasks.py::_resolve_backtest_data_source` as the next authorization candidate; defer the two Strategy adapter helpers to a separate adapter design track

## Verification
- Strategy route provider focused test: 5 passed
- Backtest task regressions: 2 passed
- Adapter mock fallback controls: 6 passed
- OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0, duplicate_operation_id_warnings=0
- Markdown governance: checked_files=2, errors=0
- JSON/YAML parse: passed
- GitNexus staged scope: low, 0 changed symbols, 0 affected processes
- Mainline scope gate: pass=True
- `gitnexus analyze --with-gitignore`: 62,941 nodes, 146,094 edges, 3,295 clusters, 300 flows

## Boundaries
- Decision-only; no backend source or test edits
- Does not authorize source implementation directly
- Does not change route/API behavior, OpenAPI exposure, frontend, PM2, OpenSpec, config, scripts, or issue labels
EOF 2>&1
