### PR TITLE
docs(governance): authorize backtest task resolver seam

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -3106,13 +3106,14 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              issue-label change, or implementation authorization
 │   │              is performed here
 │   ├── G2.168 Strategy service residual split decision
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#321`
 │   │   ├── Evidence:
 │   │   │          `backend-strategy-service-residual-split-decision-2026-05-27.md`
 │   │   ├── Generated:
 │   │   │          `strategy-service-residual-split-decision-2026-05-27.json`
 │   │   ├── Parent: G2.167 accepted and merged by PR `#320`
 │   │   ├── Evidence HEAD: `8f3cc0c15ec80b5e9acdbdf83f407abee44a6bd2`
+│   │   ├── Merge HEAD: `9994a89c73e38a11b907060bb11663df35eff6e6`
 │   │   ├── Residual split: route provider fallback is intentionally
 │   │   │          retained; `backtest_tasks.py::_resolve_backtest_data_source`
 │   │   │          is selected as the next authorization candidate; and the
@@ -3131,8 +3132,37 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              OpenSpec, config, script, compatibility deletion,
 │   │              issue-label change, or implementation authorization is
 │   │              performed here
-│   └── Next gate: review G2.168; if accepted, start G2.169 as an
-│                  authorization-only package for
+│   ├── G2.169 Backtest task resolver authorization
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-backtest-task-resolver-authorization-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `backtest-task-resolver-authorization-2026-05-27.json`
+│   │   ├── Parent: G2.168 accepted and merged by PR `#321`
+│   │   ├── Evidence HEAD: `9994a89c73e38a11b907060bb11663df35eff6e6`
+│   │   ├── Target: future source-capable G2.170 may only touch
+│   │   │          `web/backend/app/tasks/backtest_tasks.py` and
+│   │   │          `web/backend/tests/test_backtest_tasks_regressions.py`
+│   │   │          plus governance artifacts after this authorization is
+│   │   │          reviewed and accepted
+│   │   ├── Current resolver facts: `_resolve_backtest_data_source` still
+│   │   │          owns the task-local Strategy data-source fallback,
+│   │   │          accepts `strategy_service` and `auto`, and is called once
+│   │   │          by `run_backtest_task`
+│   │   ├── GitNexus evidence: `_resolve_backtest_data_source` is LOW
+│   │   │          with `1` direct caller, `0` affected processes, and the
+│   │   │          direct caller is `run_backtest_task`; broader public
+│   │   │          `get_strategy_service` remains out of scope
+│   │   ├── Verification: parent PR `#321` merged, backtest task regressions
+│   │   │          `2 passed`, and strategy route provider regressions
+│   │   │          `5 passed`
+│   │   └── Boundary: authorization-only; no backend source/test edit,
+│   │              Strategy adapter/provider edit, Strategy route provider
+│   │              fallback edit, route/API behavior, OpenAPI exposure,
+│   │              frontend, PM2, OpenSpec, config, script, compatibility
+│   │              deletion, or issue-label change is performed here
+│   └── Next gate: review G2.169; if accepted, start G2.170 as a
+│                  path-limited implementation lane for
 │                  `backtest_tasks.py::_resolve_backtest_data_source`
 │
 ├── H. Decision-Only Track: CSRF composition root

--- a/.planning/codebase/generated/backtest-task-resolver-authorization-2026-05-27.json
+++ b/.planning/codebase/generated/backtest-task-resolver-authorization-2026-05-27.json
@@ -1,0 +1,100 @@
+{
+  "work_item": "G2.169",
+  "artifact_type": "authorization_package",
+  "status": "ready_for_review",
+  "created_at": "2026-05-27T10:14:06+08:00",
+  "current_head": "9994a89c73e38a11b907060bb11663df35eff6e6",
+  "base_branch": "wip/root-dirty-20260403",
+  "parent": {
+    "work_item": "G2.168",
+    "pr": 321,
+    "state": "MERGED",
+    "merge_commit": "9994a89c73e38a11b907060bb11663df35eff6e6",
+    "title": "docs(governance): split strategy service residual tracks"
+  },
+  "target": {
+    "file": "web/backend/app/tasks/backtest_tasks.py",
+    "symbol": "_resolve_backtest_data_source",
+    "symbol_lines": [18, 34],
+    "direct_caller": "run_backtest_task",
+    "direct_caller_lines": [35, 128],
+    "current_modes": ["auto", "strategy_service"],
+    "current_internal_getter": "get_strategy_service"
+  },
+  "gitnexus": {
+    "target": "_resolve_backtest_data_source",
+    "risk": "LOW",
+    "impacted_count": 1,
+    "direct_callers": 1,
+    "affected_processes": 0,
+    "affected_modules": 1,
+    "direct_caller_symbols": [
+      "web/backend/app/tasks/backtest_tasks.py::run_backtest_task"
+    ],
+    "outgoing_symbols": [
+      "web/backend/app/services/strategy_service.py::get_strategy_service"
+    ],
+    "note": "Broader get_strategy_service remains CRITICAL from G2.168 evidence and is not authorized for removal here."
+  },
+  "verification": {
+    "parent_pr_state": "MERGED",
+    "static_scan": {
+      "resolver_get_strategy_service_mentions": 2,
+      "task_resolver_mentions": 1,
+      "route_provider_body_calls": 0,
+      "route_provider_fallback_calls": 1
+    },
+    "tests": [
+      {
+        "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov",
+        "result": "2 passed in 2.18s"
+      },
+      {
+        "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py -q --no-cov",
+        "result": "5 passed in 3.71s"
+      }
+    ],
+    "openapi_smoke": "not_required_for_authorization_only_package"
+  },
+  "authorization": {
+    "future_work_item": "G2.170",
+    "future_scope_type": "source_capable_after_review",
+    "allowed_paths": [
+      "web/backend/app/tasks/backtest_tasks.py",
+      "web/backend/tests/test_backtest_tasks_regressions.py",
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/*backtest-task-resolver*2026-05-27.json",
+      "docs/reports/quality/*backtest-task-resolver*2026-05-27.md",
+      "governance/mainline/task-cards/pr-*.yaml"
+    ],
+    "required_future_properties": [
+      "preserve data_source_mode compatibility for strategy_service and auto",
+      "preserve unsupported-mode ValueError behavior",
+      "keep public get_strategy_service available and unchanged",
+      "leave Strategy route provider fallback untouched",
+      "leave Strategy adapter/provider helpers to their own design track",
+      "use TDD red/green before implementation",
+      "run GitNexus impact before source edits",
+      "run staged GitNexus detect_changes before commit"
+    ],
+    "forbidden_paths": [
+      "web/backend/app/services/strategy_service.py",
+      "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+      "web/backend/app/services/adapters/strategy_adapter.py",
+      "web/backend/app/services/data_adapters/strategy.py",
+      "web/frontend/**",
+      "openspec/changes/**",
+      "openspec/specs/**",
+      "config/**",
+      "scripts/**"
+    ]
+  },
+  "non_goals": [
+    "do not edit source or tests in G2.169",
+    "do not delete or change public get_strategy_service",
+    "do not change route/API behavior or OpenAPI exposure",
+    "do not change Celery task queue semantics, retry behavior, status persistence, or result persistence",
+    "do not treat the broader Strategy service getter seam as solved"
+  ],
+  "next_gate": "Review and accept G2.169 before opening G2.170 source implementation."
+}

--- a/docs/reports/quality/backend-backtest-task-resolver-authorization-2026-05-27.md
+++ b/docs/reports/quality/backend-backtest-task-resolver-authorization-2026-05-27.md
@@ -1,0 +1,149 @@
+# Backend Backtest Task Resolver Authorization
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Work item: G2.169
+- State: ready for review
+- Date: 2026-05-27
+- Current HEAD: `9994a89c73e38a11b907060bb11663df35eff6e6`
+- Parent PR: `#321` merged, `docs(governance): split strategy service residual tracks`
+- Scope: authorization-only package for `web/backend/app/tasks/backtest_tasks.py::_resolve_backtest_data_source`
+
+## Boundary
+
+This package does not edit backend source, tests, runtime behavior, route behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec content, scripts, config, or issue labels.
+
+The only decision made here is whether a future G2.170 source lane may be opened for the backtest task resolver seam. Source implementation remains frozen until this package is reviewed and accepted.
+
+## Parent Decision
+
+G2.168 split the remaining Strategy service getter residual into three separately governed tracks:
+
+| Track | Disposition |
+|---|---|
+| Strategy route provider fallback | Retain as intentional compatibility/provider fallback. |
+| Backtest task data-source resolver | Select as next narrow authorization candidate. |
+| Strategy adapter/provider duplication | Defer to a separate adapter design track. |
+
+PR `#321` merged that split into `wip/root-dirty-20260403` at `9994a89c73e38a11b907060bb11663df35eff6e6`.
+
+## Current Resolver State
+
+Target file: `web/backend/app/tasks/backtest_tasks.py`
+
+Current resolver facts:
+
+- `_resolve_backtest_data_source` spans lines `18-34`.
+- `run_backtest_task` spans lines `35-128`.
+- `run_backtest_task` calls `_resolve_backtest_data_source` once.
+- `_resolve_backtest_data_source` accepts `data_source_mode` values `strategy_service` and `auto`.
+- `_resolve_backtest_data_source` imports and calls public `get_strategy_service()` internally.
+- Unsupported mode still raises `ValueError` with the existing Chinese message.
+
+Current resolver body excerpt:
+
+```python
+def _resolve_backtest_data_source(backtest_config: dict):
+    data_source_mode = backtest_config.get("data_source_mode", "strategy_service")
+    if data_source_mode not in {"strategy_service", "auto"}:
+        raise ValueError(f"不支持的回测数据源策略: {data_source_mode}")
+
+    from app.services.strategy_service import get_strategy_service
+
+    return get_strategy_service()
+```
+
+## GitNexus Evidence
+
+`_resolve_backtest_data_source`:
+
+- Risk: LOW
+- Direct impacted caller: `1`
+- Affected processes: `0`
+- Affected modules: `1`
+- Direct caller: `web/backend/app/tasks/backtest_tasks.py::run_backtest_task`
+- Outgoing call: `web/backend/app/services/strategy_service.py::get_strategy_service`
+
+`run_backtest_task`:
+
+- Located at `web/backend/app/tasks/backtest_tasks.py:35-128`
+- Calls `_resolve_backtest_data_source`, `_save_backtest_results`, and `_update_backtest_status`
+- No GitNexus execution process was attached to this task symbol in the current index
+
+The target is a narrow task-local seam. The broader public `get_strategy_service` getter remains CRITICAL from prior G2.168 evidence and must not be treated as mechanically safe to remove.
+
+## Verification
+
+Commands executed at current HEAD `9994a89c73e38a11b907060bb11663df35eff6e6`:
+
+| Check | Result |
+|---|---|
+| Parent PR state | `#321` is `MERGED`; merge commit `9994a89c73e38a11b907060bb11663df35eff6e6` |
+| GitNexus impact | `_resolve_backtest_data_source` LOW, direct caller `run_backtest_task` |
+| Static scan | resolver still owns direct internal `get_strategy_service()` fallback |
+| Backtest regression test | `web/backend/tests/test_backtest_tasks_regressions.py`: `2 passed` |
+| Strategy route provider regression | `web/backend/tests/test_strategy_management_route_provider.py`: `5 passed` |
+
+No OpenAPI smoke was required for this authorization package because no route, response model, OpenAPI schema, or runtime endpoint file is edited. Future G2.170 may include OpenAPI smoke only as a no-drift sanity check if the implementer decides it is useful.
+
+## Authorization Decision
+
+Approve a future G2.170 source-capable lane only if it stays within the scope below.
+
+Allowed future source/test scope:
+
+| Path | Future role |
+|---|---|
+| `web/backend/app/tasks/backtest_tasks.py` | Introduce a narrow backtest task resolver/provider seam while preserving current data-source behavior. |
+| `web/backend/tests/test_backtest_tasks_regressions.py` | Add or update focused regression coverage for the resolver seam and existing mode behavior. |
+| `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md` | Record completion and review state. |
+| `.planning/codebase/generated/*backtest-task-resolver*2026-05-27.json` | Record machine-readable evidence. |
+| `docs/reports/quality/*backtest-task-resolver*2026-05-27.md` | Record implementation or closeout evidence. |
+| `governance/mainline/task-cards/pr-*.yaml` | Record mainline scope gate metadata. |
+
+Required future implementation properties:
+
+- Preserve `data_source_mode` compatibility for `strategy_service` and `auto`.
+- Preserve the existing unsupported-mode `ValueError` behavior.
+- Keep public `get_strategy_service()` available and unchanged.
+- Avoid editing Strategy route provider fallback from G2.166.
+- Avoid editing Strategy adapter/provider helpers from the separate adapter design track.
+- Use TDD red/green before source implementation.
+- Run GitNexus impact before editing `_resolve_backtest_data_source` or any other modified symbol.
+- Run staged GitNexus `detect_changes` before commit.
+
+Expected future implementation outcome:
+
+- `run_backtest_task` behavior remains unchanged.
+- The resolver gains a testable dependency seam for the Strategy data-source provider.
+- Direct Strategy service acquisition remains available as a compatibility fallback, but the task resolver becomes easier to override in tests and future lifecycle-DI migration.
+
+## Non-Goals
+
+G2.170 must not:
+
+- Edit `web/backend/app/services/strategy_service.py`.
+- Edit `web/backend/app/api/strategy_management/_strategy_execution_router.py`.
+- Edit `web/backend/app/services/adapters/strategy_adapter.py`.
+- Edit `web/backend/app/services/data_adapters/strategy.py`.
+- Delete, privatize, rename, or change public `get_strategy_service()`.
+- Change Celery app configuration, task queue semantics, retry behavior, status persistence, or result persistence.
+- Change route/API behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec changes, scripts, config, or issue-label state.
+- Treat the broader Strategy service getter seam as solved by the backtest task resolver lane.
+
+## Review Gate
+
+Before opening G2.170, a reviewer must confirm:
+
+1. G2.169 is accepted as authorization-only.
+2. The future source scope remains limited to `backtest_tasks.py` plus focused regression tests.
+3. Strategy adapter/provider duplication is still deferred to its own design track.
+4. Route provider fallback remains intentionally retained.
+5. No implementation work is performed from this G2.169 package.
+
+## Rollback
+
+If this authorization is rejected or superseded, revert only the G2.169 governance PR. That removes this report, the generated JSON artifact, the PR task card, and the steward-tree entry. No backend runtime behavior is affected because no source or test file is edited here.
+

--- a/governance/mainline/task-cards/pr-322.yaml
+++ b/governance/mainline/task-cards/pr-322.yaml
@@ -1,0 +1,114 @@
+version: "v0.2"
+
+task:
+  id: "pr-322"
+  title: "Authorize backtest task resolver seam"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-backtest-task-resolver-authorization"
+  objective: "authorize a narrow future implementation lane for web/backend/app/tasks/backtest_tasks.py::_resolve_backtest_data_source without editing source in this package"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-backtest-task-resolver-authorization"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only backtest task resolver seam package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/backtest-task-resolver-authorization-2026-05-27.json"
+    - "docs/reports/quality/backend-backtest-task-resolver-authorization-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-322.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 321 --json number,state,mergeCommit,url,title"
+      required: true
+    - id: "resolver-static-scan"
+      command: "scan web/backend/app/tasks/backtest_tasks.py for _resolve_backtest_data_source, run_backtest_task, current data_source_mode values, and current get_strategy_service fallback"
+      required: true
+    - id: "gitnexus-evidence"
+      command: "GitNexus impact/context for _resolve_backtest_data_source and context for web/backend/app/tasks/backtest_tasks.py::run_backtest_task"
+      required: true
+    - id: "focused-backtest-tests"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov"
+      required: true
+    - id: "route-provider-regression"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py -q --no-cov"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-backtest-task-resolver-authorization-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/backtest-task-resolver-authorization-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-322.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this authorization package."
+  - "Do not authorize broad Strategy service getter removal."
+  - "Do not edit strategy_service.py, Strategy route provider fallback, or Strategy adapter/provider helper modules."
+  - "Do not delete, privatize, rename, or change get_strategy_service()."
+  - "Do not change Celery app configuration, task queue behavior, route/API behavior, OpenAPI exposure, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this authorization package is treated as implementation, a narrow task-local seam could be mixed with the broader CRITICAL get_strategy_service retirement problem."
+    - "If the adapter/provider helper track is pulled into G2.170, Strategy adapter topology could be changed without its own design review."
+    - "If route provider fallback is edited from this lane, G2.166's compatibility seam could be broken outside its approved path."
+  rollback_plan: "revert this authorization PR to remove only the backtest resolver authorization report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize a narrow future source lane for the backtest task Strategy data-source resolver seam"
+    modified_scope: "steward tree, authorization report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, resolver scan, GitNexus evidence, focused tests, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T10:14:06+08:00"
+    approval_note: "Authorization-only package after PR #321 split Strategy residual tracks and selected backtest task resolver as the next candidate."
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary

- Adds the G2.169 authorization-only package for `backtest_tasks.py::_resolve_backtest_data_source`.
- Records PR #321 as merged and scopes any future G2.170 source lane to `backtest_tasks.py` plus focused backtest regressions.
- Updates the steward tree with the accepted G2.168 state and the new G2.169 review gate.

## Verification

- GitNexus impact/context: `_resolve_backtest_data_source` LOW, one direct caller (`run_backtest_task`), zero affected processes.
- `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov` -> 2 passed.
- `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py -q --no-cov` -> 5 passed.
- Markdown governance: 2 checked, 0 errors, 0 warnings.
- JSON/YAML parse passed; `git diff --check` passed.
- GitNexus staged detect_changes: low risk, 0 changed symbols, 0 affected processes.
- Mainline scope gate: pass=True.
- `gitnexus analyze --with-gitignore`: 62,929 nodes / 146,118 edges / 300 flows.

## Boundary

- Governance-only authorization package.
- No backend source/test edit, route/API behavior, OpenAPI exposure, frontend, PM2, OpenSpec, config, script, compatibility deletion, or issue-label change.