### PR TITLE
refactor(backend): inject backtest task resolver provider

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -3133,13 +3133,14 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              issue-label change, or implementation authorization is
 │   │              performed here
 │   ├── G2.169 Backtest task resolver authorization
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#322`
 │   │   ├── Evidence:
 │   │   │          `backend-backtest-task-resolver-authorization-2026-05-27.md`
 │   │   ├── Generated:
 │   │   │          `backtest-task-resolver-authorization-2026-05-27.json`
 │   │   ├── Parent: G2.168 accepted and merged by PR `#321`
 │   │   ├── Evidence HEAD: `9994a89c73e38a11b907060bb11663df35eff6e6`
+│   │   ├── Merge HEAD: `bc2c0b8e102c455c09ba718b3eff982bf0f6e5e7`
 │   │   ├── Target: future source-capable G2.170 may only touch
 │   │   │          `web/backend/app/tasks/backtest_tasks.py` and
 │   │   │          `web/backend/tests/test_backtest_tasks_regressions.py`
@@ -3161,9 +3162,37 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              fallback edit, route/API behavior, OpenAPI exposure,
 │   │              frontend, PM2, OpenSpec, config, script, compatibility
 │   │              deletion, or issue-label change is performed here
-│   └── Next gate: review G2.169; if accepted, start G2.170 as a
-│                  path-limited implementation lane for
-│                  `backtest_tasks.py::_resolve_backtest_data_source`
+│   ├── G2.170 Backtest task resolver implementation
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-backtest-task-resolver-implementation-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `backtest-task-resolver-implementation-2026-05-27.json`
+│   │   ├── Parent: G2.169 accepted and merged by PR `#322`
+│   │   ├── Base HEAD: `bc2c0b8e102c455c09ba718b3eff982bf0f6e5e7`
+│   │   ├── Implementation: introduced task-local
+│   │   │          `_get_strategy_data_source()` provider seam and changed
+│   │   │          `_resolve_backtest_data_source()` to delegate acquisition
+│   │   │          through that seam after preserving mode validation
+│   │   ├── Static result: resolver direct `get_strategy_service` mentions
+│   │   │          are `0`; helper `get_strategy_service` mentions are `2`;
+│   │   │          `run_backtest_task` still calls the resolver once
+│   │   ├── TDD evidence: provider-seam red test `1 failed`, then backtest
+│   │   │          task regressions `3 passed`
+│   │   ├── Verification: strategy route provider regressions `5 passed`,
+│   │   │          ruff passed, black check passed, and OpenAPI smoke
+│   │   │          `routes=548`, `paths=500`,
+│   │   │          `duplicate_operation_ids=0`
+│   │   └── Boundary: path-limited source implementation; public
+│   │              `get_strategy_service` remains unchanged, Strategy route
+│   │              provider fallback remains unchanged, adapter/provider
+│   │              helpers remain deferred, and no route/API behavior,
+│   │              OpenAPI exposure, frontend, PM2, OpenSpec, config, script,
+│   │              compatibility deletion, or issue-label change is performed
+│   │              here
+│   └── Next gate: review G2.170; if accepted, close out this backtest task
+│                  resolver seam before selecting another Strategy service
+│                  getter residual track
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/backtest-task-resolver-implementation-2026-05-27.json
+++ b/.planning/codebase/generated/backtest-task-resolver-implementation-2026-05-27.json
@@ -1,0 +1,108 @@
+{
+  "work_item": "G2.170",
+  "artifact_type": "implementation_package",
+  "status": "ready_for_review",
+  "created_at": "2026-05-27T10:58:14+08:00",
+  "base_head": "bc2c0b8e102c455c09ba718b3eff982bf0f6e5e7",
+  "base_branch": "wip/root-dirty-20260403",
+  "parent": {
+    "work_item": "G2.169",
+    "pr": 322,
+    "state": "MERGED",
+    "merge_commit": "bc2c0b8e102c455c09ba718b3eff982bf0f6e5e7",
+    "title": "docs(governance): authorize backtest task resolver seam"
+  },
+  "scope": {
+    "source_files": [
+      "web/backend/app/tasks/backtest_tasks.py"
+    ],
+    "test_files": [
+      "web/backend/tests/test_backtest_tasks_regressions.py"
+    ],
+    "governance_files": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/backtest-task-resolver-implementation-2026-05-27.json",
+      "docs/reports/quality/backend-backtest-task-resolver-implementation-2026-05-27.md",
+      "governance/mainline/task-cards/pr-323.yaml"
+    ],
+    "forbidden_paths_observed": false
+  },
+  "implementation": {
+    "new_helper": {
+      "symbol": "_get_strategy_data_source",
+      "file": "web/backend/app/tasks/backtest_tasks.py",
+      "lines": [18, 23],
+      "role": "task-local Strategy data-source provider seam"
+    },
+    "modified_resolver": {
+      "symbol": "_resolve_backtest_data_source",
+      "file": "web/backend/app/tasks/backtest_tasks.py",
+      "lines": [24, 38],
+      "change": "delegates data-source acquisition to _get_strategy_data_source after preserving mode validation"
+    },
+    "preserved_behavior": [
+      "data_source_mode default remains strategy_service",
+      "strategy_service mode remains supported",
+      "auto mode remains supported",
+      "unsupported mode still raises ValueError",
+      "run_backtest_task still calls _resolve_backtest_data_source once",
+      "public get_strategy_service remains available and unchanged"
+    ]
+  },
+  "static_scan": {
+    "resolver_direct_getter_mentions": 0,
+    "resolver_helper_mentions": 1,
+    "helper_getter_mentions": 2,
+    "run_task_resolver_mentions": 1,
+    "provider_test_present": true,
+    "unsupported_mode_pytest_raises": true
+  },
+  "gitnexus": {
+    "pre_edit_target": "_resolve_backtest_data_source",
+    "risk": "LOW",
+    "impacted_count": 1,
+    "direct_callers": 1,
+    "affected_processes": 0,
+    "direct_caller_symbols": [
+      "web/backend/app/tasks/backtest_tasks.py::run_backtest_task"
+    ]
+  },
+  "tdd": {
+    "red": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_tasks_regressions.py::test_resolve_backtest_data_source_uses_task_local_provider -q --no-cov --tb=short",
+      "result": "1 failed in 2.66s",
+      "expected_failure": "resolver ignored the task-local provider seam and returned the fallback service object"
+    },
+    "green": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov --tb=short",
+      "result": "3 passed in 2.60s"
+    },
+    "final": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov --tb=short",
+      "result": "3 passed in 3.18s"
+    }
+  },
+  "verification": {
+    "strategy_route_provider_regression": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py -q --no-cov --tb=short",
+      "result": "5 passed in 6.29s"
+    },
+    "ruff": {
+      "command": "ruff check web/backend/app/tasks/backtest_tasks.py web/backend/tests/test_backtest_tasks_regressions.py",
+      "result": "All checks passed!"
+    },
+    "black": {
+      "command": "black --check web/backend/app/tasks/backtest_tasks.py web/backend/tests/test_backtest_tasks_regressions.py",
+      "result": "2 files would be left unchanged"
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "total_warnings_captured": 121,
+      "env_note": "minimal non-secret placeholder env used for required import gate"
+    }
+  },
+  "next_gate": "Review G2.170. If accepted, close out this backtest resolver seam before selecting another Strategy service getter residual track."
+}

--- a/docs/reports/quality/backend-backtest-task-resolver-implementation-2026-05-27.md
+++ b/docs/reports/quality/backend-backtest-task-resolver-implementation-2026-05-27.md
@@ -1,0 +1,158 @@
+# Backend Backtest Task Resolver Implementation
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Work item: G2.170
+- State: ready for review
+- Date: 2026-05-27
+- Base HEAD: `bc2c0b8e102c455c09ba718b3eff982bf0f6e5e7`
+- Parent PR: `#322` merged, `docs(governance): authorize backtest task resolver seam`
+- Scope: path-limited source implementation for `web/backend/app/tasks/backtest_tasks.py::_resolve_backtest_data_source`
+
+## Boundary
+
+This implementation stays inside the G2.169 authorization boundary.
+
+Source/test files changed:
+
+- `web/backend/app/tasks/backtest_tasks.py`
+- `web/backend/tests/test_backtest_tasks_regressions.py`
+
+Governance artifacts changed:
+
+- `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md`
+- `.planning/codebase/generated/backtest-task-resolver-implementation-2026-05-27.json`
+- `docs/reports/quality/backend-backtest-task-resolver-implementation-2026-05-27.md`
+- `governance/mainline/task-cards/pr-323.yaml`
+
+Out of scope and untouched:
+
+- `web/backend/app/services/strategy_service.py`
+- `web/backend/app/api/strategy_management/_strategy_execution_router.py`
+- `web/backend/app/services/adapters/strategy_adapter.py`
+- `web/backend/app/services/data_adapters/strategy.py`
+- Route/API behavior
+- OpenAPI exposure
+- Frontend
+- PM2 workflows
+- OpenSpec changes/specs
+- Config/scripts
+- Issue labels
+
+## Implementation
+
+The backtest task resolver now has a task-local Strategy data-source provider seam:
+
+```python
+def _get_strategy_data_source():
+    from app.services.strategy_service import get_strategy_service
+
+    return get_strategy_service()
+```
+
+`_resolve_backtest_data_source()` now validates `data_source_mode` and delegates acquisition to `_get_strategy_data_source()`:
+
+```python
+return _get_strategy_data_source()
+```
+
+This keeps the public `get_strategy_service()` compatibility fallback intact while moving the resolver away from an inline direct getter call. Tests can now override the task-local provider seam without patching the service module directly.
+
+## Static Result
+
+Post-change scan:
+
+| Metric | Result |
+|---|---:|
+| `_get_strategy_data_source` lines | `18-23` |
+| `_resolve_backtest_data_source` lines | `24-38` |
+| `run_backtest_task` lines | `39-132` |
+| Resolver direct `get_strategy_service` mentions | `0` |
+| Resolver `_get_strategy_data_source` mentions | `1` |
+| Helper `get_strategy_service` mentions | `2` |
+| `run_backtest_task` resolver calls | `1` |
+| Provider seam test present | `true` |
+| Unsupported-mode test uses `pytest.raises` | `true` |
+
+## GitNexus Evidence
+
+Pre-edit impact for `_resolve_backtest_data_source`:
+
+- Risk: LOW
+- Direct impacted caller: `1`
+- Direct caller: `web/backend/app/tasks/backtest_tasks.py::run_backtest_task`
+- Affected processes: `0`
+- Affected modules: `1`
+
+No HIGH or CRITICAL warning was returned for the edited resolver symbol.
+
+## TDD Evidence
+
+Red test:
+
+```text
+web/backend/tests/test_backtest_tasks_regressions.py::test_resolve_backtest_data_source_uses_task_local_provider
+1 failed in 2.66s
+```
+
+Expected failure:
+
+```text
+AssertionError: assert <fallback object> is <fake provider object>
+```
+
+Green test:
+
+```text
+web/backend/tests/test_backtest_tasks_regressions.py
+3 passed in 2.60s
+```
+
+After ruff/format refactor, the final focused test remained green:
+
+```text
+web/backend/tests/test_backtest_tasks_regressions.py
+3 passed in 3.18s
+```
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Backtest task regressions | `3 passed in 3.18s` |
+| Strategy route provider regressions | `5 passed in 6.29s` |
+| Ruff touched backend files | `All checks passed!` |
+| Black touched backend files | `2 files would be left unchanged` |
+| OpenAPI smoke | `routes=548`, `paths=500`, `duplicate_operation_ids=0`, `duplicate_operation_id_warnings=0`, `total_warnings_captured=121` |
+
+OpenAPI smoke used minimal non-secret placeholder environment values because the application import gate requires runtime configuration variables. This implementation does not edit route registration or OpenAPI schema files.
+
+## Behavior Compatibility
+
+Preserved behavior:
+
+- `data_source_mode` default remains `strategy_service`.
+- `data_source_mode="strategy_service"` remains supported.
+- `data_source_mode="auto"` remains supported.
+- Unsupported mode still raises `ValueError` before engine construction.
+- `run_backtest_task` still calls `_resolve_backtest_data_source()` once.
+- Public `get_strategy_service()` remains available and unchanged.
+- Strategy route provider fallback remains unchanged.
+- Strategy adapter/provider helper duplication remains deferred to its own design track.
+
+## Review Gate
+
+Before accepting this PR, verify:
+
+1. The changed source/test paths match the G2.169 authorization boundary.
+2. The new task-local provider seam is enough for the intended future lifecycle-DI migration step.
+3. The public Strategy service getter is still retained.
+4. The Strategy adapter/provider track remains separate.
+5. The TDD red/green evidence and focused regressions are acceptable.
+
+## Rollback
+
+Revert this PR to restore the previous inline resolver behavior. The rollback removes only the task-local provider seam, the provider-seam regression test, and the governance artifacts for G2.170.
+

--- a/governance/mainline/task-cards/pr-323.yaml
+++ b/governance/mainline/task-cards/pr-323.yaml
@@ -1,0 +1,127 @@
+version: "v0.2"
+
+task:
+  id: "pr-323"
+  title: "Inject backtest task resolver provider seam"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-backtest-task-resolver-implementation"
+  objective: "introduce a task-local Strategy data-source provider seam for web/backend/app/tasks/backtest_tasks.py::_resolve_backtest_data_source"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-backtest-task-resolver-implementation"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Path-limited implementation inside an approved G2.169 authorization boundary; no route, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/backtest-task-resolver-implementation-2026-05-27.json"
+    - "docs/reports/quality/backend-backtest-task-resolver-implementation-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-323.yaml"
+    - "web/backend/app/tasks/backtest_tasks.py"
+    - "web/backend/tests/test_backtest_tasks_regressions.py"
+  forbidden_paths:
+    - "web/backend/app/services/strategy_service.py"
+    - "web/backend/app/api/strategy_management/_strategy_execution_router.py"
+    - "web/backend/app/services/adapters/strategy_adapter.py"
+    - "web/backend/app/services/data_adapters/strategy.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 322 --json number,state,mergeCommit,url,title"
+      required: true
+    - id: "gitnexus-pre-edit-impact"
+      command: "GitNexus impact for _resolve_backtest_data_source before source edit"
+      required: true
+    - id: "tdd-red"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_tasks_regressions.py::test_resolve_backtest_data_source_uses_task_local_provider -q --no-cov --tb=short"
+      required: true
+    - id: "tdd-green"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "route-provider-regression"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-touched-files"
+      command: "ruff check web/backend/app/tasks/backtest_tasks.py web/backend/tests/test_backtest_tasks_regressions.py"
+      required: true
+    - id: "black-check-touched-files"
+      command: "black --check web/backend/app/tasks/backtest_tasks.py web/backend/tests/test_backtest_tasks_regressions.py"
+      required: true
+    - id: "openapi-smoke"
+      command: "app.openapi() smoke with minimal non-secret env; record route count, path count, duplicate operation IDs, duplicate-operation-id warnings, and total captured warnings"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-backtest-task-resolver-implementation-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/backtest-task-resolver-implementation-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-323.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit strategy_service.py."
+  - "Do not edit Strategy route provider fallback."
+  - "Do not edit Strategy adapter/provider helper modules."
+  - "Do not delete, privatize, rename, or change get_strategy_service()."
+  - "Do not change Celery app configuration, task queue behavior, route/API behavior, OpenAPI exposure, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this implementation is expanded beyond the task-local resolver seam, it could mix a LOW task seam with the broader CRITICAL public Strategy service getter problem."
+    - "If adapter/provider helpers are changed here, their topology would bypass the separate adapter design gate."
+    - "If route provider fallback is changed here, G2.166 compatibility behavior could regress outside this lane."
+  rollback_plan: "revert this implementation PR to restore the previous inline resolver behavior and remove only the provider-seam test plus G2.170 governance artifacts"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "move backtest task Strategy data-source acquisition behind a task-local provider seam"
+    modified_scope: "backtest task resolver, focused regression test, steward tree, implementation report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "public get_strategy_service remains available and behavior-compatible"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if TDD red/green evidence, focused regressions, ruff/black, OpenAPI smoke, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-27T10:58:14+08:00"
+    approval_note: "User approved continuing after PR #322; implementation is limited to the G2.169 authorized backtest task resolver seam."
+    secondary_approved: false
+

--- a/web/backend/app/tasks/backtest_tasks.py
+++ b/web/backend/app/tasks/backtest_tasks.py
@@ -15,6 +15,12 @@ from app.core.celery_app import celery_app, get_progress_callback
 logger = logging.getLogger(__name__)
 
 
+def _get_strategy_data_source():
+    from app.services.strategy_service import get_strategy_service
+
+    return get_strategy_service()
+
+
 def _resolve_backtest_data_source(backtest_config: dict):
     """
     解析回测任务的数据源策略。
@@ -26,9 +32,7 @@ def _resolve_backtest_data_source(backtest_config: dict):
     if data_source_mode not in {"strategy_service", "auto"}:
         raise ValueError(f"不支持的回测数据源策略: {data_source_mode}")
 
-    from app.services.strategy_service import get_strategy_service
-
-    return get_strategy_service()
+    return _get_strategy_data_source()
 
 
 @celery_app.task(bind=True, name="app.tasks.backtest_tasks.run_backtest")

--- a/web/backend/tests/test_backtest_tasks_regressions.py
+++ b/web/backend/tests/test_backtest_tasks_regressions.py
@@ -2,6 +2,32 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import pytest
+
+
+def test_resolve_backtest_data_source_uses_task_local_provider(monkeypatch):
+    from app.tasks import backtest_tasks as module
+
+    fake_data_source = object()
+    fallback_data_source = object()
+
+    monkeypatch.setattr(
+        module,
+        "_get_strategy_data_source",
+        lambda: fake_data_source,
+        raising=False,
+    )
+
+    import app.services.strategy_service as strategy_service_module
+
+    monkeypatch.setattr(
+        strategy_service_module,
+        "get_strategy_service",
+        lambda: fallback_data_source,
+    )
+
+    assert module._resolve_backtest_data_source({"data_source_mode": "auto"}) is fake_data_source
+
 
 def test_run_backtest_task_uses_data_service_singleton(monkeypatch):
     from app.tasks import backtest_tasks as module
@@ -25,10 +51,18 @@ def test_run_backtest_task_uses_data_service_singleton(monkeypatch):
             }
 
     monkeypatch.setattr(module, "BacktestEngine", FakeEngine)
-    monkeypatch.setattr(module, "_save_backtest_results", lambda backtest_id, results: captured.setdefault("saved", results))
+    monkeypatch.setattr(
+        module,
+        "_save_backtest_results",
+        lambda backtest_id, results: captured.setdefault("saved", results),
+    )
     monkeypatch.setattr(module, "_update_backtest_status", lambda *args, **kwargs: None)
     monkeypatch.setattr(module, "get_progress_callback", lambda backtest_id: None)
-    monkeypatch.setattr(module.run_backtest_task, "update_state", lambda **kwargs: captured.setdefault("states", []).append(kwargs))
+    monkeypatch.setattr(
+        module.run_backtest_task,
+        "update_state",
+        lambda **kwargs: captured.setdefault("states", []).append(kwargs),
+    )
 
     import app.services.strategy_service as strategy_service_module
 
@@ -52,11 +86,19 @@ def test_run_backtest_task_rejects_unsupported_data_source_mode(monkeypatch):
     captured = {}
 
     monkeypatch.setattr(module, "_save_backtest_results", lambda *args, **kwargs: None)
-    monkeypatch.setattr(module, "_update_backtest_status", lambda *args, **kwargs: captured.setdefault("failed", args))
+    monkeypatch.setattr(
+        module,
+        "_update_backtest_status",
+        lambda *args, **kwargs: captured.setdefault("failed", args),
+    )
     monkeypatch.setattr(module, "get_progress_callback", lambda backtest_id: None)
-    monkeypatch.setattr(module.run_backtest_task, "update_state", lambda **kwargs: captured.setdefault("states", []).append(kwargs))
+    monkeypatch.setattr(
+        module.run_backtest_task,
+        "update_state",
+        lambda **kwargs: captured.setdefault("states", []).append(kwargs),
+    )
 
-    try:
+    with pytest.raises(ValueError, match="不支持的回测数据源策略"):
         module.run_backtest_task.run(
             backtest_id=8,
             strategy_config={"name": "demo"},
@@ -66,9 +108,5 @@ def test_run_backtest_task_rejects_unsupported_data_source_mode(monkeypatch):
                 "data_source_mode": "mock",
             },
         )
-    except ValueError as exc:
-        assert "不支持的回测数据源策略" in str(exc)
-    else:
-        raise AssertionError("expected ValueError for unsupported data_source_mode")
 
     assert captured["states"][-1]["state"] == "FAILURE"


### PR DESCRIPTION
## Summary

- Implements the G2.170 path-limited backtest task resolver seam approved by G2.169 / PR #322.
- Adds `_get_strategy_data_source()` as a task-local provider fallback and makes `_resolve_backtest_data_source()` delegate acquisition through it.
- Adds focused regression coverage proving the resolver uses the task-local provider seam while preserving existing mode behavior.
- Updates the steward tree, implementation report, generated evidence artifact, and PR task card.

## Verification

- GitNexus pre-edit impact for `_resolve_backtest_data_source`: LOW, one direct caller, zero affected processes.
- TDD red: provider-seam test failed as expected (`1 failed in 2.66s`).
- TDD green/final: `web/backend/tests/test_backtest_tasks_regressions.py` -> 3 passed.
- Strategy route provider regression: 5 passed.
- Ruff touched backend files: passed.
- Black touched backend files: passed.
- OpenAPI smoke with minimal non-secret env: routes=548, paths=500, duplicate_operation_ids=0, duplicate_operation_id_warnings=0.
- Markdown governance: 2 checked, 0 errors, 0 warnings.
- JSON/YAML parse passed; `git diff --check` passed.
- Staged GitNexus detect_changes: low risk, zero affected processes.
- Mainline scope gate: pass=True.
- `gitnexus analyze --with-gitignore`: 62,942 nodes / 146,128 edges / 300 flows.

## Boundary

- Public `get_strategy_service()` remains available and unchanged.
- No Strategy route provider fallback edit.
- No Strategy adapter/provider helper edit.
- No route/API behavior, OpenAPI exposure, frontend, PM2, OpenSpec, config, scripts, compatibility deletion, or issue-label change.