### PR TITLE
docs(governance): close out backtest task resolver seam

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -3163,13 +3163,14 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              frontend, PM2, OpenSpec, config, script, compatibility
 │   │              deletion, or issue-label change is performed here
 │   ├── G2.170 Backtest task resolver implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#323`
 │   │   ├── Evidence:
 │   │   │          `backend-backtest-task-resolver-implementation-2026-05-27.md`
 │   │   ├── Generated:
 │   │   │          `backtest-task-resolver-implementation-2026-05-27.json`
 │   │   ├── Parent: G2.169 accepted and merged by PR `#322`
 │   │   ├── Base HEAD: `bc2c0b8e102c455c09ba718b3eff982bf0f6e5e7`
+│   │   ├── Merge HEAD: `d465e41950c2f6fe70ee9c923da3cc55c09212c3`
 │   │   ├── Implementation: introduced task-local
 │   │   │          `_get_strategy_data_source()` provider seam and changed
 │   │   │          `_resolve_backtest_data_source()` to delegate acquisition
@@ -3190,9 +3191,34 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              OpenAPI exposure, frontend, PM2, OpenSpec, config, script,
 │   │              compatibility deletion, or issue-label change is performed
 │   │              here
-│   └── Next gate: review G2.170; if accepted, close out this backtest task
-│                  resolver seam before selecting another Strategy service
-│                  getter residual track
+│   ├── G2.171 Backtest task resolver closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-backtest-task-resolver-closeout-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `backtest-task-resolver-closeout-2026-05-27.json`
+│   │   ├── Parent: G2.170 accepted and merged by PR `#323`
+│   │   ├── Evidence HEAD: `d465e41950c2f6fe70ee9c923da3cc55c09212c3`
+│   │   ├── Closeout: G2.170 is closed as the backtest task resolver seam
+│   │   │          only; public `get_strategy_service` remains unchanged,
+│   │   │          route provider fallback remains retained, and Strategy
+│   │   │          adapter/provider duplication remains deferred
+│   │   ├── Post-merge static result: resolver direct
+│   │   │          `get_strategy_service` mentions remain `0`; helper
+│   │   │          `get_strategy_service` mentions remain `2`; provider seam
+│   │   │          test remains present
+│   │   ├── Verification: backtest task regressions `3 passed`, strategy
+│   │   │          route provider regressions `5 passed`, ruff/black passed,
+│   │   │          and OpenAPI smoke `routes=548`, `paths=500`,
+│   │   │          `duplicate_operation_ids=0`
+│   │   └── Boundary: governance-only closeout; no backend source/test edit,
+│   │              route/API behavior, OpenAPI exposure, frontend, PM2,
+│   │              OpenSpec, config, script, compatibility deletion,
+│   │              issue-label change, or next implementation authorization is
+│   │              performed here
+│   └── Next gate: review G2.171; after acceptance, create a separate
+│                  decision-only or authorization-only packet before any
+│                  additional Strategy service getter source implementation
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/backtest-task-resolver-closeout-2026-05-27.json
+++ b/.planning/codebase/generated/backtest-task-resolver-closeout-2026-05-27.json
@@ -1,0 +1,75 @@
+{
+  "work_item": "G2.171",
+  "artifact_type": "closeout_package",
+  "status": "ready_for_review",
+  "created_at": "2026-05-27T11:25:00+08:00",
+  "current_head": "d465e41950c2f6fe70ee9c923da3cc55c09212c3",
+  "base_branch": "wip/root-dirty-20260403",
+  "parent": {
+    "work_item": "G2.170",
+    "pr": 323,
+    "state": "MERGED",
+    "merge_commit": "d465e41950c2f6fe70ee9c923da3cc55c09212c3",
+    "title": "refactor(backend): inject backtest task resolver provider"
+  },
+  "scope": {
+    "type": "governance_only_closeout",
+    "source_files_changed": [],
+    "test_files_changed": [],
+    "governance_files": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/backtest-task-resolver-closeout-2026-05-27.json",
+      "docs/reports/quality/backend-backtest-task-resolver-closeout-2026-05-27.md",
+      "governance/mainline/task-cards/pr-324.yaml"
+    ]
+  },
+  "post_merge_static_scan": {
+    "helper_symbol": "_get_strategy_data_source",
+    "helper_lines": [18, 23],
+    "resolver_symbol": "_resolve_backtest_data_source",
+    "resolver_lines": [24, 38],
+    "run_task_symbol": "run_backtest_task",
+    "run_task_lines": [39, 132],
+    "resolver_direct_getter_mentions": 0,
+    "resolver_helper_mentions": 1,
+    "helper_getter_mentions": 2,
+    "run_task_resolver_mentions": 1,
+    "provider_test_present": true,
+    "unsupported_mode_pytest_raises": true
+  },
+  "verification": {
+    "parent_pr_state": "MERGED",
+    "head_matches_remote": true,
+    "backtest_regressions": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov --tb=short",
+      "result": "3 passed in 3.02s"
+    },
+    "strategy_route_provider_regressions": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py -q --no-cov --tb=short",
+      "result": "5 passed in 4.46s"
+    },
+    "ruff_black": {
+      "command": "ruff check web/backend/app/tasks/backtest_tasks.py web/backend/tests/test_backtest_tasks_regressions.py && black --check web/backend/app/tasks/backtest_tasks.py web/backend/tests/test_backtest_tasks_regressions.py",
+      "result": "All checks passed; 2 files would be left unchanged"
+    },
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "total_warnings_captured": 121,
+      "env_note": "minimal non-secret placeholder env used for required import gate"
+    }
+  },
+  "closeout_decision": {
+    "g2_170_closed": true,
+    "closed_scope": "backtest task resolver provider seam only",
+    "not_closed": [
+      "Strategy route provider fallback retention",
+      "Strategy adapter/provider duplication",
+      "public get_strategy_service compatibility surface",
+      "broad get_strategy_service retirement"
+    ]
+  },
+  "next_gate": "Create a new decision-only or authorization-only packet before any additional Strategy service getter source implementation."
+}

--- a/docs/reports/quality/backend-backtest-task-resolver-closeout-2026-05-27.md
+++ b/docs/reports/quality/backend-backtest-task-resolver-closeout-2026-05-27.md
@@ -1,0 +1,85 @@
+# Backend Backtest Task Resolver Closeout
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Work item: G2.171
+- State: ready for review
+- Date: 2026-05-27
+- Current HEAD: `d465e41950c2f6fe70ee9c923da3cc55c09212c3`
+- Parent PR: `#323` merged, `refactor(backend): inject backtest task resolver provider`
+- Scope: post-merge closeout for G2.170 backtest task resolver seam
+
+## Boundary
+
+This is a governance-only closeout package.
+
+No backend source, tests, route behavior, OpenAPI exposure, frontend, PM2 workflow, OpenSpec content, config, scripts, compatibility deletion, or issue-label state is changed here.
+
+## Parent Merge
+
+PR `#323` was merged into `wip/root-dirty-20260403` at:
+
+```text
+d465e41950c2f6fe70ee9c923da3cc55c09212c3
+```
+
+The local closeout worktree and remote `wip/root-dirty-20260403` both pointed at that commit during evidence collection.
+
+## Closeout Finding
+
+G2.170 is closed as implemented and post-merge verified.
+
+The backtest task Strategy data-source resolver now has a task-local provider seam:
+
+- `_get_strategy_data_source()` exists at `web/backend/app/tasks/backtest_tasks.py:18-23`.
+- `_resolve_backtest_data_source()` exists at `web/backend/app/tasks/backtest_tasks.py:24-38`.
+- `run_backtest_task()` still calls `_resolve_backtest_data_source()` once.
+- `_resolve_backtest_data_source()` has `0` direct `get_strategy_service` mentions.
+- `_resolve_backtest_data_source()` delegates through `_get_strategy_data_source()` once.
+- `_get_strategy_data_source()` preserves the public `get_strategy_service()` fallback.
+- The provider-seam regression test exists.
+- The unsupported-mode test uses `pytest.raises(ValueError, ...)`.
+
+## Post-Merge Verification
+
+Verification executed at current HEAD `d465e41950c2f6fe70ee9c923da3cc55c09212c3`:
+
+| Check | Result |
+|---|---|
+| Parent PR state | `#323` is `MERGED` |
+| Backtest task regressions | `3 passed in 3.02s` |
+| Strategy route provider regressions | `5 passed in 4.46s` |
+| Ruff touched files | `All checks passed!` |
+| Black touched files | `2 files would be left unchanged` |
+| OpenAPI smoke | `routes=548`, `paths=500`, `duplicate_operation_ids=0`, `duplicate_operation_id_warnings=0`, `total_warnings_captured=121` |
+
+OpenAPI smoke used minimal non-secret placeholder environment values to satisfy the application import gate. No route or OpenAPI files were changed by G2.170.
+
+## Remaining Strategy Getter Tracks
+
+This closeout closes only the backtest task resolver seam.
+
+Still separate and not solved by G2.170:
+
+- Strategy route provider fallback remains intentionally retained.
+- Strategy adapter/provider duplication remains deferred to a separate adapter design track.
+- Public `get_strategy_service()` remains available and unchanged.
+- Broad `get_strategy_service` retirement remains out of scope because prior evidence classified the broader seam as CRITICAL.
+
+## Next Gate
+
+Do not open another Strategy service getter source implementation directly from this closeout.
+
+Recommended next step:
+
+1. Create a new decision-only or authorization-only packet for the next Strategy residual track.
+2. Re-scan current residual Strategy getter sites at the new HEAD.
+3. Decide whether the next track is adapter/provider design, route-provider fallback retention closeout, or another narrow task/provider seam.
+4. Only after that review gate should a new source implementation lane begin.
+
+## Rollback
+
+If this closeout is rejected, revert only the G2.171 governance PR. That removes this report, generated JSON, task card, and steward-tree update. It does not alter the already-merged G2.170 source implementation.
+

--- a/governance/mainline/task-cards/pr-324.yaml
+++ b/governance/mainline/task-cards/pr-324.yaml
@@ -1,0 +1,116 @@
+version: "v0.2"
+
+task:
+  id: "pr-324"
+  title: "Close out backtest task resolver seam"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-backtest-task-resolver-closeout"
+  objective: "record post-merge closeout evidence for G2.170 backtest task resolver provider seam"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-backtest-task-resolver-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only post-merge closeout; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/backtest-task-resolver-closeout-2026-05-27.json"
+    - "docs/reports/quality/backend-backtest-task-resolver-closeout-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-324.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 323 --json number,state,mergeCommit,url,title"
+      required: true
+    - id: "post-merge-static-scan"
+      command: "scan backtest task resolver helper, resolver, run task, and focused regression test state at current HEAD"
+      required: true
+    - id: "focused-backtest-tests"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "route-provider-regression"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-black-post-merge"
+      command: "ruff check web/backend/app/tasks/backtest_tasks.py web/backend/tests/test_backtest_tasks_regressions.py && black --check web/backend/app/tasks/backtest_tasks.py web/backend/tests/test_backtest_tasks_regressions.py"
+      required: true
+    - id: "openapi-smoke"
+      command: "app.openapi() smoke with minimal non-secret env; record route count, path count, duplicate operation IDs, duplicate-operation-id warnings, and total captured warnings"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-backtest-task-resolver-closeout-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/backtest-task-resolver-closeout-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-324.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this closeout package."
+  - "Do not select or authorize the next Strategy service getter implementation lane from this package."
+  - "Do not edit strategy_service.py, Strategy route provider fallback, or Strategy adapter/provider helper modules."
+  - "Do not delete, privatize, rename, or change get_strategy_service()."
+  - "Do not change route/API behavior, OpenAPI exposure, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If closeout is treated as a new implementation authorization, the remaining Strategy service getter tracks could bypass their own decision gates."
+    - "If the broad get_strategy_service seam is marked resolved here, CRITICAL residual surfaces could be hidden by a narrow task-local closure."
+  rollback_plan: "revert this closeout PR to remove only the closeout report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out the merged G2.170 backtest task resolver provider seam"
+    modified_scope: "steward tree, closeout report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, post-merge scan, focused tests, ruff/black, OpenAPI smoke, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T11:25:00+08:00"
+    approval_note: "Governance-only closeout after PR #323 merged the G2.170 implementation."
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary

- Closes out G2.170 after PR #323 merged the backtest task resolver provider seam.
- Reconfirms the post-merge resolver/static state at current HEAD.
- Records focused test, ruff/black, and OpenAPI no-drift evidence.
- Updates the steward tree with G2.170 accepted/merged and adds G2.171 ready-for-review closeout.

## Verification

- Parent PR #323: MERGED at `d465e41950c2f6fe70ee9c923da3cc55c09212c3`.
- Static scan: resolver direct `get_strategy_service` mentions=0, helper getter mentions=2, provider test present=true.
- Backtest task regressions: 3 passed.
- Strategy route provider regressions: 5 passed.
- Ruff/black touched backend files: passed.
- OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0, duplicate_operation_id_warnings=0.
- Markdown governance: 2 checked, 0 errors, 0 warnings.
- JSON/YAML parse passed; `git diff --check` passed.
- Staged GitNexus detect_changes: low risk, 0 changed symbols, 0 affected processes.
- Mainline scope gate: pass=True.
- `gitnexus analyze --with-gitignore`: 62,947 nodes / 146,126 edges / 300 flows.

## Boundary

- Governance-only closeout.
- No backend source/test edit, route/API behavior, OpenAPI exposure, frontend, PM2, OpenSpec, config, scripts, compatibility deletion, issue-label change, or next implementation authorization.