### PR TITLE
docs(governance): select strategy adapter residual track

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -3192,13 +3192,14 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              compatibility deletion, or issue-label change is performed
 │   │              here
 │   ├── G2.171 Backtest task resolver closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#324`
 │   │   ├── Evidence:
 │   │   │          `backend-backtest-task-resolver-closeout-2026-05-27.md`
 │   │   ├── Generated:
 │   │   │          `backtest-task-resolver-closeout-2026-05-27.json`
 │   │   ├── Parent: G2.170 accepted and merged by PR `#323`
 │   │   ├── Evidence HEAD: `d465e41950c2f6fe70ee9c923da3cc55c09212c3`
+│   │   ├── Merge HEAD: `68c6b4149984aab583dacebf9cdd1ff131189c3e`
 │   │   ├── Closeout: G2.170 is closed as the backtest task resolver seam
 │   │   │          only; public `get_strategy_service` remains unchanged,
 │   │   │          route provider fallback remains retained, and Strategy
@@ -3216,9 +3217,41 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              OpenSpec, config, script, compatibility deletion,
 │   │              issue-label change, or next implementation authorization is
 │   │              performed here
-│   └── Next gate: review G2.171; after acceptance, create a separate
-│                  decision-only or authorization-only packet before any
-│                  additional Strategy service getter source implementation
+│   ├── G2.172 Strategy residual current track decision
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-strategy-residual-current-track-decision-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `strategy-residual-current-track-decision-2026-05-27.json`
+│   │   ├── Parent: G2.171 accepted and merged by PR `#324`
+│   │   ├── Evidence HEAD: `68c6b4149984aab583dacebf9cdd1ff131189c3e`
+│   │   ├── Residual scan: `get_strategy_service` has `29` production text
+│   │   │          hits across `5` files; adapter/provider duplication owns
+│   │   │          `20` hits across `2` files, route provider fallback owns
+│   │   │          `6` hits, public getter definition owns `1`, and the
+│   │   │          closed backtest resolver helper owns `2`
+│   │   ├── Decision: retain route provider fallback, keep the backtest
+│   │   │          resolver closed, keep public `get_strategy_service`
+│   │   │          unchanged, and select Strategy adapter/provider
+│   │   │          duplication as the next design/authorization track
+│   │   ├── GitNexus evidence: broad `get_strategy_service` remains
+│   │   │          CRITICAL with `13` impacted symbols, `6` direct callers,
+│   │   │          and `0` affected processes; both adapter helper contexts
+│   │   │          have `_fetch_strategy_data` and `health_check` incoming
+│   │   │          callers and public `get_strategy_service` outgoing calls
+│   │   ├── Verification: backtest task regressions `3 passed`, strategy
+│   │   │          route provider regressions `5 passed`, adapter mock
+│   │   │          fallback controls `6 passed`, and OpenAPI smoke
+│   │   │          `routes=548`, `paths=500`,
+│   │   │          `duplicate_operation_ids=0`
+│   │   └── Boundary: decision-only; no backend source/test edit,
+│   │              route/API behavior, OpenAPI exposure, frontend, PM2,
+│   │              OpenSpec, config, script, compatibility deletion,
+│   │              issue-label change, adapter implementation authorization,
+│   │              or public getter retirement is performed here
+│   └── Next gate: review G2.172; if accepted, create G2.173 as a
+│                  Strategy adapter/provider duplication design or
+│                  authorization package before any source implementation
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/strategy-residual-current-track-decision-2026-05-27.json
+++ b/.planning/codebase/generated/strategy-residual-current-track-decision-2026-05-27.json
@@ -1,0 +1,157 @@
+{
+  "work_item": "G2.172",
+  "artifact_type": "decision_package",
+  "status": "ready_for_review",
+  "created_at": "2026-05-27T11:54:10+08:00",
+  "current_head": "68c6b4149984aab583dacebf9cdd1ff131189c3e",
+  "base_branch": "wip/root-dirty-20260403",
+  "parent": {
+    "work_item": "G2.171",
+    "pr": 324,
+    "state": "MERGED",
+    "merge_commit": "68c6b4149984aab583dacebf9cdd1ff131189c3e",
+    "title": "docs(governance): close out backtest task resolver seam"
+  },
+  "scope": {
+    "type": "decision_only_current_residual_refresh",
+    "source_files_changed": [],
+    "test_files_changed": [],
+    "governance_files": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/strategy-residual-current-track-decision-2026-05-27.json",
+      "docs/reports/quality/backend-strategy-residual-current-track-decision-2026-05-27.md",
+      "governance/mainline/task-cards/pr-325.yaml"
+    ]
+  },
+  "residual_scan": {
+    "root": "web/backend/app",
+    "token": "get_strategy_service",
+    "total_hits": 29,
+    "files": 5,
+    "by_classification": {
+      "route_provider_fallback_retained": {
+        "hits": 6,
+        "files": [
+          "web/backend/app/api/strategy_management/_strategy_execution_router.py"
+        ],
+        "decision": "retain"
+      },
+      "adapter_provider_duplication_track": {
+        "hits": 20,
+        "files": [
+          "web/backend/app/services/adapters/strategy_adapter.py",
+          "web/backend/app/services/data_adapters/strategy.py"
+        ],
+        "decision": "select_next_design_track"
+      },
+      "public_getter_definition": {
+        "hits": 1,
+        "files": [
+          "web/backend/app/services/strategy_service.py"
+        ],
+        "decision": "retain"
+      },
+      "backtest_task_resolver_closed": {
+        "hits": 2,
+        "files": [
+          "web/backend/app/tasks/backtest_tasks.py"
+        ],
+        "decision": "closed_no_reopen"
+      }
+    }
+  },
+  "route_fallback_state": {
+    "provider": "get_strategy_service_dependency",
+    "provider_lines": [33, 39],
+    "provider_direct_getter_calls": 1,
+    "route_handlers": [
+      {
+        "name": "query_strategy_results",
+        "lines": [379, 442],
+        "body_getter_mentions": 0,
+        "dependency_mentions": 1
+      },
+      {
+        "name": "get_matched_stocks",
+        "lines": [450, 489],
+        "body_getter_mentions": 0,
+        "dependency_mentions": 1
+      },
+      {
+        "name": "get_strategy_summary",
+        "lines": [497, 558],
+        "body_getter_mentions": 0,
+        "dependency_mentions": 1
+      }
+    ],
+    "decision": "retain"
+  },
+  "backtest_resolver_state": {
+    "resolver_direct_getter_mentions": 0,
+    "helper_public_getter_mentions": 2,
+    "provider_test_present": true,
+    "decision": "closed_no_reopen"
+  },
+  "adapter_provider_duplication_state": [
+    {
+      "file": "web/backend/app/services/adapters/strategy_adapter.py",
+      "helper_lines": [39, 50],
+      "helper_public_getter_mentions": 3,
+      "fetch_helper_mentions": 5,
+      "health_helper_mentions": 2,
+      "gitnexus_incoming": ["_fetch_strategy_data", "health_check"],
+      "gitnexus_outgoing": ["get_strategy_service"]
+    },
+    {
+      "file": "web/backend/app/services/data_adapters/strategy.py",
+      "helper_lines": [36, 47],
+      "helper_public_getter_mentions": 3,
+      "fetch_helper_mentions": 5,
+      "health_helper_mentions": 2,
+      "gitnexus_incoming": ["_fetch_strategy_data", "health_check"],
+      "gitnexus_outgoing": ["get_strategy_service"]
+    }
+  ],
+  "gitnexus": {
+    "target": "get_strategy_service",
+    "risk": "CRITICAL",
+    "impacted_count": 13,
+    "direct_callers": 6,
+    "affected_processes": 0,
+    "affected_modules": 5,
+    "module_hits": {
+      "Data_adapters": 4,
+      "Adapters": 4,
+      "Strategy_management": 3,
+      "Tasks": 1,
+      "Cdp": 1
+    }
+  },
+  "verification": {
+    "parent_pr_state": "MERGED",
+    "head_matches_remote": true,
+    "backtest_regressions": "3 passed in 2.05s",
+    "strategy_route_provider_regressions": "5 passed in 3.34s",
+    "adapter_mock_fallback_controls": "6 passed in 0.19s",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "total_warnings_captured": 121,
+      "env_note": "minimal non-secret placeholder env used for required import gate"
+    }
+  },
+  "decision": {
+    "next_work_item": "G2.173",
+    "next_track": "strategy_adapter_provider_duplication_design",
+    "next_track_type": "decision_or_authorization_only",
+    "implementation_authorized": false,
+    "ordering": [
+      "retain route provider fallback",
+      "keep backtest task resolver closed",
+      "retain public get_strategy_service",
+      "create adapter/provider duplication design package before any source implementation"
+    ]
+  }
+}

--- a/docs/reports/quality/backend-strategy-residual-current-track-decision-2026-05-27.md
+++ b/docs/reports/quality/backend-strategy-residual-current-track-decision-2026-05-27.md
@@ -1,0 +1,145 @@
+# Backend Strategy Residual Current Track Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Work item: G2.172
+- State: ready for review
+- Date: 2026-05-27
+- Current HEAD: `68c6b4149984aab583dacebf9cdd1ff131189c3e`
+- Parent PR: `#324` merged, `docs(governance): close out backtest task resolver seam`
+- Scope: decision-only current Strategy service getter residual refresh and next-track selection
+
+## Boundary
+
+This package does not edit backend source, tests, route behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec content, config, scripts, compatibility surfaces, or issue labels.
+
+This package does not authorize implementation. It only selects the next Strategy residual track that should receive its own design/authorization packet.
+
+## Parent State
+
+PR `#324` was merged into `wip/root-dirty-20260403` at:
+
+```text
+68c6b4149984aab583dacebf9cdd1ff131189c3e
+```
+
+The local evidence worktree and remote `wip/root-dirty-20260403` both pointed at that commit during collection.
+
+## Current Residual Scan
+
+Production scan under `web/backend/app` found `29` text hits across `5` files for `get_strategy_service`.
+
+| Classification | Hits | Files | Disposition |
+|---|---:|---:|---|
+| Route provider fallback retained | 6 | 1 | Retain. It is the G2.166 compatibility/provider seam and not a removal target. |
+| Adapter/provider duplication track | 20 | 2 | Select as next design packet. |
+| Public getter definition | 1 | 1 | Retain. Broad public getter retirement remains out of scope and CRITICAL. |
+| Backtest task resolver closed | 2 | 1 | Closed by G2.170/G2.171; no next action here. |
+
+Detailed files:
+
+| File | Classification | Hits | Key lines |
+|---|---|---:|---|
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | route provider fallback retained | 6 | `20`, `33`, `34`, `388`, `454`, `499` |
+| `web/backend/app/services/adapters/strategy_adapter.py` | adapter/provider duplication track | 10 | `39`, `43`, `45`, `102`, `116`, `132`, `149`, `179`, `328`, `340` |
+| `web/backend/app/services/data_adapters/strategy.py` | adapter/provider duplication track | 10 | `36`, `40`, `42`, `99`, `113`, `129`, `146`, `176`, `325`, `337` |
+| `web/backend/app/services/strategy_service.py` | public getter definition | 1 | `455` |
+| `web/backend/app/tasks/backtest_tasks.py` | backtest task resolver closed | 2 | `19`, `21` |
+
+## Route Fallback State
+
+The Strategy route provider fallback remains intentionally retained:
+
+- `get_strategy_service_dependency()` spans `web/backend/app/api/strategy_management/_strategy_execution_router.py:33-39`.
+- It calls public `get_strategy_service()` once.
+- Route handlers `query_strategy_results`, `get_matched_stocks`, and `get_strategy_summary` have `0` direct `get_strategy_service()` body calls.
+- Those route handlers each use `Depends(get_strategy_service_dependency)` once.
+
+Decision: do not retire or modify this fallback from the next lane. It is a known compatibility/provider seam, not a duplicate adapter problem.
+
+## Backtest Resolver State
+
+The backtest task resolver seam remains closed:
+
+- `_resolve_backtest_data_source()` has `0` direct `get_strategy_service` mentions.
+- `_get_strategy_data_source()` preserves the public getter fallback with `2` text mentions.
+- The provider-seam regression test remains present.
+
+Decision: do not reopen the backtest resolver lane from this package.
+
+## Adapter/Provider Duplication State
+
+Two parallel Strategy adapter modules retain nearly identical Strategy service provider helper patterns:
+
+| File | Helper lines | Helper public getter mentions | `_fetch_strategy_data` helper mentions | `health_check` helper mentions |
+|---|---:|---:|---:|---:|
+| `web/backend/app/services/adapters/strategy_adapter.py` | `39-50` | 3 | 5 | 2 |
+| `web/backend/app/services/data_adapters/strategy.py` | `36-47` | 3 | 5 | 2 |
+
+GitNexus context confirms each helper has the same local caller shape:
+
+- Incoming: `_fetch_strategy_data`, `health_check`
+- Outgoing: `web/backend/app/services/strategy_service.py::get_strategy_service`
+
+Decision: select this as the next Strategy residual design track. Because two package paths are involved, the next step should be a design/authorization packet that resolves ownership and migration shape before any source implementation.
+
+## GitNexus Evidence
+
+`get_strategy_service` remains broad and unsafe for direct retirement:
+
+- Risk: CRITICAL
+- Impacted count: `13`
+- Direct callers: `6`
+- Affected processes: `0`
+- Affected modules: `5`
+- Direct module hits include `Data_adapters`, `Adapters`, `Strategy_management`, and `Tasks`
+
+This reinforces the split-track approach. A future source lane must target a narrow adapter/provider seam, not public getter retirement.
+
+## Verification
+
+Executed at current HEAD `68c6b4149984aab583dacebf9cdd1ff131189c3e`:
+
+| Check | Result |
+|---|---|
+| Parent PR state | `#324` is `MERGED` |
+| Backtest task regressions | `3 passed in 2.05s` |
+| Strategy route provider regressions | `5 passed in 3.34s` |
+| Adapter mock fallback controls | `6 passed in 0.19s` |
+| OpenAPI smoke | `routes=548`, `paths=500`, `duplicate_operation_ids=0`, `duplicate_operation_id_warnings=0`, `total_warnings_captured=121` |
+
+OpenAPI smoke used minimal non-secret placeholder environment values to satisfy the application import gate. This decision package does not edit route or OpenAPI files.
+
+## Decision
+
+Approve the following next-track ordering:
+
+1. Keep route provider fallback retained.
+2. Keep backtest task resolver seam closed.
+3. Keep public `get_strategy_service()` available and unchanged.
+4. Start G2.173 as a decision-only or authorization-only Strategy adapter/provider duplication design package.
+
+G2.173 should decide:
+
+- whether `web/backend/app/services/adapters/strategy_adapter.py` and `web/backend/app/services/data_adapters/strategy.py` have separate ownership or one canonical implementation;
+- whether one package path is runtime-canonical and the other is compatibility/legacy;
+- whether a shared provider seam is appropriate;
+- exact future source scope, tests, rollback, and no-go paths;
+- whether any source implementation should be split into separate phases.
+
+## Non-Goals
+
+This package does not:
+
+- authorize edits to either adapter file;
+- authorize public `get_strategy_service()` removal;
+- authorize route provider fallback removal;
+- reopen the backtest task resolver lane;
+- edit route/API behavior, OpenAPI exposure, frontend, PM2, OpenSpec, config, scripts, or issue labels.
+
+## Rollback
+
+If this decision package is rejected, revert only the G2.172 governance PR. That removes this report, generated JSON, task card, and steward-tree update. No runtime behavior is affected.
+

--- a/governance/mainline/task-cards/pr-325.yaml
+++ b/governance/mainline/task-cards/pr-325.yaml
@@ -1,0 +1,120 @@
+version: "v0.2"
+
+task:
+  id: "pr-325"
+  title: "Select next Strategy residual track"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-strategy-residual-current-track-decision"
+  objective: "refresh current Strategy get_strategy_service residual state after G2.171 and select the next non-implementation track"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-strategy-residual-current-track-decision"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision-only residual refresh and next-track selection; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/strategy-residual-current-track-decision-2026-05-27.json"
+    - "docs/reports/quality/backend-strategy-residual-current-track-decision-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-325.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 324 --json number,state,mergeCommit,url,title"
+      required: true
+    - id: "residual-static-scan"
+      command: "scan web/backend/app for get_strategy_service residual hits and classify route fallback, adapter/provider duplication, public getter definition, and closed backtest resolver"
+      required: true
+    - id: "gitnexus-evidence"
+      command: "GitNexus impact for get_strategy_service and context for both adapter _get_strategy_service helpers"
+      required: true
+    - id: "focused-backtest-tests"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "route-provider-regression"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py -q --no-cov --tb=short"
+      required: true
+    - id: "adapter-mock-fallback-controls"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_adapter_mock_fallback_controls.py -q --no-cov --tb=short"
+      required: true
+    - id: "openapi-smoke"
+      command: "app.openapi() smoke with minimal non-secret env; record route count, path count, duplicate operation IDs, duplicate-operation-id warnings, and total captured warnings"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-strategy-residual-current-track-decision-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/strategy-residual-current-track-decision-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-325.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this decision package."
+  - "Do not authorize adapter source implementation directly from this package."
+  - "Do not remove or edit Strategy route provider fallback."
+  - "Do not reopen the backtest task resolver lane."
+  - "Do not delete, privatize, rename, or change get_strategy_service()."
+  - "Do not change route/API behavior, OpenAPI exposure, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this decision is treated as implementation authorization, two parallel Strategy adapter packages could be edited without an ownership/design gate."
+    - "If public get_strategy_service is treated as closed, a CRITICAL broad compatibility surface could be hidden by narrow residual closure work."
+  rollback_plan: "revert this decision PR to remove only the residual decision report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh current Strategy getter residual state and select adapter/provider duplication as the next design track"
+    modified_scope: "steward tree, decision report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, residual scan, GitNexus evidence, focused tests, OpenAPI smoke, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T11:54:10+08:00"
+    approval_note: "Decision-only current residual refresh after PR #324 merged the G2.171 closeout."
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary

- Merges PR #324 state into the steward tree and refreshes current Strategy `get_strategy_service` residuals at HEAD `68c6b414`.
- Classifies current residuals into route provider fallback, adapter/provider duplication, public getter definition, and closed backtest resolver helper.
- Selects Strategy adapter/provider duplication as the next design/authorization track; no implementation is authorized here.

## Verification

- Parent PR #324: MERGED at `68c6b4149984aab583dacebf9cdd1ff131189c3e`.
- Residual scan: 29 production text hits across 5 files.
- Adapter/provider duplication: 20 hits across `services/adapters/strategy_adapter.py` and `services/data_adapters/strategy.py`.
- Route provider fallback retained: 6 hits; route handler body direct getter mentions remain 0.
- GitNexus impact for `get_strategy_service`: CRITICAL, impacted=13, direct callers=6, affected processes=0.
- Backtest task regressions: 3 passed.
- Strategy route provider regressions: 5 passed.
- Adapter mock fallback controls: 6 passed.
- OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0, duplicate_operation_id_warnings=0.
- Markdown governance: 2 checked, 0 errors, 0 warnings.
- JSON/YAML parse passed; `git diff --check` passed.
- Staged GitNexus detect_changes: low risk, 0 changed symbols, 0 affected processes.
- Mainline scope gate: pass=True.
- `gitnexus analyze --with-gitignore`: 62,936 nodes / 146,128 edges / 300 flows.

## Boundary

- Decision-only package.
- No backend source/test edit, route/API behavior, OpenAPI exposure, frontend, PM2, OpenSpec, config, scripts, compatibility deletion, issue-label change, adapter implementation authorization, or public getter retirement.