### PR TITLE
docs(governance): design strategy adapter wrapper lane

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -3218,13 +3218,14 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              issue-label change, or next implementation authorization is
 │   │              performed here
 │   ├── G2.172 Strategy residual current track decision
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#325`
 │   │   ├── Evidence:
 │   │   │          `backend-strategy-residual-current-track-decision-2026-05-27.md`
 │   │   ├── Generated:
 │   │   │          `strategy-residual-current-track-decision-2026-05-27.json`
 │   │   ├── Parent: G2.171 accepted and merged by PR `#324`
 │   │   ├── Evidence HEAD: `68c6b4149984aab583dacebf9cdd1ff131189c3e`
+│   │   ├── Merge HEAD: `b867716f77f8f509d1a7ec49c76346422bfd66ac`
 │   │   ├── Residual scan: `get_strategy_service` has `29` production text
 │   │   │          hits across `5` files; adapter/provider duplication owns
 │   │   │          `20` hits across `2` files, route provider fallback owns
@@ -3249,9 +3250,46 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              OpenSpec, config, script, compatibility deletion,
 │   │              issue-label change, adapter implementation authorization,
 │   │              or public getter retirement is performed here
-│   └── Next gate: review G2.172; if accepted, create G2.173 as a
-│                  Strategy adapter/provider duplication design or
-│                  authorization package before any source implementation
+│   ├── G2.173 Strategy adapter/provider design
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-strategy-adapter-provider-design-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `strategy-adapter-provider-design-2026-05-27.json`
+│   │   ├── Parent: G2.172 accepted and merged by PR `#325`
+│   │   ├── Evidence HEAD: `b867716f77f8f509d1a7ec49c76346422bfd66ac`
+│   │   ├── Ownership decision: canonical implementation is
+│   │   │          `web/backend/app/services/adapters/strategy_adapter.py`;
+│   │   │          `web/backend/app/services/data_adapters/strategy.py` is
+│   │   │          the legacy direct import path and should become a thin
+│   │   │          compatibility wrapper in a future lane
+│   │   ├── Evidence: `data_adapter.py` declares implementations split to
+│   │   │          `app.services.adapters`, `adapters/__init__.py` exports
+│   │   │          `StrategyDataSourceAdapter`, `data_adapters/__init__.py`
+│   │   │          is absent, and factory construction resolves through
+│   │   │          `app.services.data_adapter` into `app.services.adapters`
+│   │   ├── GitNexus evidence: canonical adapter file impact is LOW with
+│   │   │          `2` upstream hits; legacy data-adapters file impact is
+│   │   │          LOW with `0` upstream hits; both helpers still have
+│   │   │          `_fetch_strategy_data` and `health_check` incoming callers
+│   │   ├── Authorization: future G2.174 may only convert
+│   │   │          `data_adapters/strategy.py` into a compatibility wrapper
+│   │   │          and update focused adapter fallback tests after review;
+│   │   │          canonical `strategy_adapter.py`, factory, route provider,
+│   │   │          backtest resolver, and public `get_strategy_service`
+│   │   │          remain locked out of scope
+│   │   ├── Verification: adapter/logging focused tests `16 passed`,
+│   │   │          strategy route/backtest sanity tests `8 passed`, and
+│   │   │          OpenAPI smoke `routes=548`, `paths=500`,
+│   │   │          `duplicate_operation_ids=0`
+│   │   └── Boundary: design/authorization only; no backend source/test edit,
+│   │              route/API behavior, OpenAPI exposure, frontend, PM2,
+│   │              OpenSpec, config, script, compatibility deletion,
+│   │              issue-label change, or source implementation is performed
+│   │              here
+│   └── Next gate: review G2.173; if accepted, start G2.174 as a
+│                  path-limited legacy wrapper implementation for
+│                  `data_adapters/strategy.py`
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/strategy-adapter-provider-design-2026-05-27.json
+++ b/.planning/codebase/generated/strategy-adapter-provider-design-2026-05-27.json
@@ -1,0 +1,162 @@
+{
+  "work_item": "G2.173",
+  "artifact_type": "design_authorization_package",
+  "status": "ready_for_review",
+  "created_at": "2026-05-27T12:23:11+08:00",
+  "current_head": "b867716f77f8f509d1a7ec49c76346422bfd66ac",
+  "base_branch": "wip/root-dirty-20260403",
+  "parent": {
+    "work_item": "G2.172",
+    "pr": 325,
+    "state": "MERGED",
+    "merge_commit": "b867716f77f8f509d1a7ec49c76346422bfd66ac",
+    "title": "docs(governance): select strategy adapter residual track"
+  },
+  "scope": {
+    "type": "design_authorization_only",
+    "source_files_changed": [],
+    "test_files_changed": [],
+    "governance_files": [
+      ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
+      ".planning/codebase/generated/strategy-adapter-provider-design-2026-05-27.json",
+      "docs/reports/quality/backend-strategy-adapter-provider-design-2026-05-27.md",
+      "governance/mainline/task-cards/pr-326.yaml"
+    ]
+  },
+  "ownership_decision": {
+    "canonical_implementation": "web/backend/app/services/adapters/strategy_adapter.py",
+    "legacy_compatibility_path": "web/backend/app/services/data_adapters/strategy.py",
+    "decision": "future implementation should convert the legacy path to a thin compatibility wrapper that re-exports the canonical StrategyDataSourceAdapter"
+  },
+  "current_shape": {
+    "canonical": {
+      "file": "web/backend/app/services/adapters/strategy_adapter.py",
+      "line_count": 368,
+      "class": "StrategyDataSourceAdapter",
+      "class_line": 21,
+      "helper": "_get_strategy_service",
+      "helper_line": 39
+    },
+    "legacy_duplicate": {
+      "file": "web/backend/app/services/data_adapters/strategy.py",
+      "line_count": 367,
+      "class": "StrategyDataSourceAdapter",
+      "class_line": 18,
+      "helper": "_get_strategy_service",
+      "helper_line": 36
+    },
+    "shared_methods": [
+      "_get_strategy_service",
+      "_get_mock_manager",
+      "_is_mock_mode",
+      "_should_use_mock_fallback",
+      "get_data",
+      "_fetch_strategy_data",
+      "_get_mock_strategy_data",
+      "health_check",
+      "get_metrics"
+    ]
+  },
+  "canonical_evidence": {
+    "data_adapter_compat_entrypoint": {
+      "file": "web/backend/app/services/data_adapter.py",
+      "statement": "actual implementations have been split to app.services.adapters",
+      "strategy_export": "StrategyDataSourceAdapter"
+    },
+    "adapters_package_export": {
+      "file": "web/backend/app/services/adapters/__init__.py",
+      "exports": ["StrategyDataSourceAdapter"]
+    },
+    "data_adapters_package_export": {
+      "file": "web/backend/app/services/data_adapters/__init__.py",
+      "exists": false
+    },
+    "factory_path": {
+      "file": "web/backend/app/services/data_source_factory/data_source_factory.py",
+      "import_path": "app.services.data_adapter -> app.services.adapters",
+      "strategy_construction_line": 125
+    },
+    "test_references": {
+      "canonical_path": [
+        "web/backend/tests/test_logging_noise_regressions.py"
+      ],
+      "legacy_direct_path": [
+        "web/backend/tests/test_adapter_mock_fallback_controls.py"
+      ]
+    }
+  },
+  "gitnexus": {
+    "file_impacts": [
+      {
+        "target": "web/backend/app/services/adapters/strategy_adapter.py",
+        "risk": "LOW",
+        "impacted_count": 2,
+        "direct_upstream": ["web/backend/app/services/adapters/__init__.py"]
+      },
+      {
+        "target": "web/backend/app/services/data_adapters/strategy.py",
+        "risk": "LOW",
+        "impacted_count": 0,
+        "direct_upstream": []
+      }
+    ],
+    "helper_contexts": [
+      {
+        "target": "web/backend/app/services/adapters/strategy_adapter.py::_get_strategy_service",
+        "incoming": ["_fetch_strategy_data", "health_check"],
+        "outgoing": ["get_strategy_service"]
+      },
+      {
+        "target": "web/backend/app/services/data_adapters/strategy.py::_get_strategy_service",
+        "incoming": ["_fetch_strategy_data", "health_check"],
+        "outgoing": ["get_strategy_service"]
+      }
+    ],
+    "public_getter_state": "get_strategy_service remains CRITICAL from G2.172 and is not authorized for retirement"
+  },
+  "verification": {
+    "parent_pr_state": "MERGED",
+    "head_matches_remote": true,
+    "adapter_and_logging_focused_tests": "16 passed in 4.24s",
+    "route_and_backtest_sanity": "8 passed in 5.43s",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0,
+      "total_warnings_captured": 121,
+      "env_note": "minimal non-secret placeholder env used for required import gate"
+    }
+  },
+  "future_authorization": {
+    "future_work_item": "G2.174",
+    "implementation_authorized_after_review": true,
+    "allowed_source_paths": [
+      "web/backend/app/services/data_adapters/strategy.py"
+    ],
+    "allowed_test_paths": [
+      "web/backend/tests/test_adapter_mock_fallback_controls.py"
+    ],
+    "required_properties": [
+      "canonical StrategyDataSourceAdapter remains web/backend/app/services/adapters/strategy_adapter.py",
+      "legacy direct import app.services.data_adapters.strategy.StrategyDataSourceAdapter remains functional",
+      "data_adapters/strategy.py becomes a thin wrapper instead of a duplicate implementation",
+      "public get_strategy_service remains unchanged",
+      "Strategy route provider fallback remains unchanged",
+      "backtest resolver remains closed"
+    ],
+    "forbidden_paths": [
+      "web/backend/app/services/adapters/strategy_adapter.py",
+      "web/backend/app/services/data_adapter.py",
+      "web/backend/app/services/data_source_factory/data_source_factory.py",
+      "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+      "web/backend/app/tasks/backtest_tasks.py",
+      "web/frontend/**",
+      "openspec/changes/**",
+      "openspec/specs/**",
+      "config/**",
+      "scripts/**"
+    ]
+  },
+  "next_gate": "Review G2.173. If accepted, start G2.174 path-limited wrapper implementation."
+}

--- a/docs/reports/quality/backend-strategy-adapter-provider-design-2026-05-27.md
+++ b/docs/reports/quality/backend-strategy-adapter-provider-design-2026-05-27.md
@@ -1,0 +1,185 @@
+# Backend Strategy Adapter Provider Design
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Work item: G2.173
+- State: ready for review
+- Date: 2026-05-27
+- Current HEAD: `b867716f77f8f509d1a7ec49c76346422bfd66ac`
+- Parent PR: `#325` merged, `docs(governance): select strategy adapter residual track`
+- Scope: design/authorization package for Strategy adapter/provider duplication
+
+## Boundary
+
+This package does not edit backend source, tests, route behavior, OpenAPI exposure, frontend code, PM2 workflows, OpenSpec content, config, scripts, compatibility surfaces, or issue labels.
+
+This package selects the canonical adapter ownership and authorizes only a future narrow G2.174 implementation lane after review. No source implementation is performed here.
+
+## Parent State
+
+PR `#325` was merged into `wip/root-dirty-20260403` at:
+
+```text
+b867716f77f8f509d1a7ec49c76346422bfd66ac
+```
+
+The local evidence worktree and remote `wip/root-dirty-20260403` both pointed at that commit during collection.
+
+## Current Shape
+
+Two modules define a full `StrategyDataSourceAdapter` implementation:
+
+| Path | Lines | Class | Role observed |
+|---|---:|---|---|
+| `web/backend/app/services/adapters/strategy_adapter.py` | 368 | `StrategyDataSourceAdapter` | Canonical implementation path through `app.services.adapters` and `app.services.data_adapter`. |
+| `web/backend/app/services/data_adapters/strategy.py` | 367 | `StrategyDataSourceAdapter` | Legacy direct path with duplicate implementation. |
+
+Both modules expose the same adapter class name and the same provider/helper shape:
+
+- `_get_strategy_service`
+- `_get_mock_manager`
+- `_is_mock_mode`
+- `_should_use_mock_fallback`
+- `get_data`
+- `_fetch_strategy_data`
+- `_get_mock_strategy_data`
+- `health_check`
+- `get_metrics`
+
+Both `_get_strategy_service` helpers call public `get_strategy_service()`.
+
+## Canonical Ownership Decision
+
+Canonical implementation path:
+
+```text
+web/backend/app/services/adapters/strategy_adapter.py
+```
+
+Reasons:
+
+- `web/backend/app/services/data_adapter.py` is explicitly documented as a backward-compatible entrypoint and states that actual implementations were split into `app.services.adapters`.
+- `web/backend/app/services/data_adapter.py` imports `StrategyDataSourceAdapter` from `app.services.adapters`.
+- `web/backend/app/services/adapters/__init__.py` exports `StrategyDataSourceAdapter` from `.strategy_adapter`.
+- `web/backend/app/services/data_source_factory/data_source_factory.py` imports `StrategyDataSourceAdapter` through `app.services.data_adapter`, which resolves to `app.services.adapters`.
+- `web/backend/tests/test_logging_noise_regressions.py` imports the canonical `app.services.adapters.strategy_adapter` path.
+
+Legacy compatibility path:
+
+```text
+web/backend/app/services/data_adapters/strategy.py
+```
+
+Reasons:
+
+- It has no package-level export through `web/backend/app/services/data_adapters/__init__.py` because that file is absent.
+- Production direct references to `app.services.data_adapters.strategy` were not found in the current scan.
+- `web/backend/tests/test_adapter_mock_fallback_controls.py` still imports this path directly, so compatibility behavior must be preserved during migration.
+
+## Reference Evidence
+
+Current reference scan:
+
+| Surface | Evidence |
+|---|---|
+| Factory path | `data_source_factory.py` imports `StrategyDataSourceAdapter` through `app.services.data_adapter`, which re-exports from `app.services.adapters`. |
+| Canonical package export | `web/backend/app/services/adapters/__init__.py` exports `StrategyDataSourceAdapter`. |
+| Legacy package export | `web/backend/app/services/data_adapters/__init__.py` is absent. |
+| Canonical test | `test_logging_noise_regressions.py` imports `app.services.adapters.strategy_adapter`. |
+| Legacy direct test | `test_adapter_mock_fallback_controls.py` imports `app.services.data_adapters.strategy`. |
+
+## GitNexus Evidence
+
+File-level impact:
+
+| Target | Risk | Impacted count | Direct upstream |
+|---|---|---:|---|
+| `web/backend/app/services/adapters/strategy_adapter.py` | LOW | 2 | `web/backend/app/services/adapters/__init__.py` |
+| `web/backend/app/services/data_adapters/strategy.py` | LOW | 0 | none |
+
+Class context:
+
+| Target | Context |
+|---|---|
+| `adapters/strategy_adapter.py::StrategyDataSourceAdapter` | Class found at `20-366`; no incoming class references in GitNexus; has `get_metrics` method edge. |
+| `data_adapters/strategy.py::StrategyDataSourceAdapter` | Class found at `17-365`; no incoming class references in GitNexus; has `close` method edge. |
+
+Helper context:
+
+| Target | Incoming | Outgoing |
+|---|---|---|
+| `adapters/strategy_adapter.py::_get_strategy_service` | `_fetch_strategy_data`, `health_check` | `get_strategy_service` |
+| `data_adapters/strategy.py::_get_strategy_service` | `_fetch_strategy_data`, `health_check` | `get_strategy_service` |
+
+Broad public getter state:
+
+- `get_strategy_service` remains CRITICAL from G2.172 evidence.
+- Public getter retirement is not authorized here.
+
+## Verification
+
+Executed at current HEAD `b867716f77f8f509d1a7ec49c76346422bfd66ac`:
+
+| Check | Result |
+|---|---|
+| Parent PR state | `#325` is `MERGED` |
+| Adapter and logging focused tests | `16 passed in 4.24s` |
+| Strategy route provider + backtest regressions | `8 passed in 5.43s` |
+| OpenAPI smoke | `routes=548`, `paths=500`, `duplicate_operation_ids=0`, `duplicate_operation_id_warnings=0`, `total_warnings_captured=121` |
+
+OpenAPI smoke used minimal non-secret placeholder environment values to satisfy the application import gate. This design package does not edit route or OpenAPI files.
+
+## Authorization Decision
+
+Authorize a future G2.174 source-capable implementation only after this design package is reviewed and accepted.
+
+Future G2.174 allowed source/test scope:
+
+| Path | Allowed future action |
+|---|---|
+| `web/backend/app/services/data_adapters/strategy.py` | Convert duplicate implementation into a thin compatibility wrapper that re-exports canonical `StrategyDataSourceAdapter` from `app.services.adapters.strategy_adapter`. |
+| `web/backend/tests/test_adapter_mock_fallback_controls.py` | Add or update focused tests proving the legacy direct import resolves to the canonical class and existing fallback controls remain intact. |
+| `.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md` | Record implementation and review state. |
+| `.planning/codebase/generated/*strategy-adapter-provider*2026-05-27.json` | Record machine-readable evidence. |
+| `docs/reports/quality/*strategy-adapter-provider*2026-05-27.md` | Record implementation or closeout evidence. |
+| `governance/mainline/task-cards/pr-*.yaml` | Record mainline scope gate metadata. |
+
+Future G2.174 required properties:
+
+- Keep `app.services.adapters.strategy_adapter.StrategyDataSourceAdapter` as the canonical implementation.
+- Preserve direct import compatibility for `app.services.data_adapters.strategy.StrategyDataSourceAdapter`.
+- Do not edit `web/backend/app/services/adapters/strategy_adapter.py`.
+- Do not edit `web/backend/app/services/data_adapter.py`.
+- Do not edit `web/backend/app/services/data_source_factory/data_source_factory.py`.
+- Do not edit Strategy route provider fallback.
+- Do not edit `web/backend/app/tasks/backtest_tasks.py`.
+- Do not delete or modify public `get_strategy_service()`.
+- Use TDD red/green before source implementation.
+- Run GitNexus impact before editing the authorized source symbol/file.
+- Run staged GitNexus `detect_changes` before commit.
+
+Expected future outcome:
+
+- `web/backend/app/services/data_adapters/strategy.py` stops carrying a full duplicate implementation.
+- Legacy direct import remains functional.
+- Current adapter behavior remains covered by focused tests.
+- Public Strategy service getter remains unchanged.
+
+## Non-Goals
+
+G2.174 must not:
+
+- remove the canonical adapter implementation;
+- edit `strategy_adapter.py`;
+- edit factory registration;
+- edit route provider fallback;
+- reopen the backtest resolver seam;
+- retire public `get_strategy_service()`;
+- change route/API behavior, OpenAPI exposure, frontend, PM2, OpenSpec, config, scripts, or issue labels.
+
+## Rollback
+
+If this design/authorization package is rejected, revert only the G2.173 governance PR. That removes this report, generated JSON, task card, and steward-tree update. No runtime behavior is affected.
+

--- a/governance/mainline/task-cards/pr-326.yaml
+++ b/governance/mainline/task-cards/pr-326.yaml
@@ -1,0 +1,120 @@
+version: "v0.2"
+
+task:
+  id: "pr-326"
+  title: "Design Strategy adapter compatibility wrapper lane"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-strategy-adapter-provider-design"
+  objective: "select canonical Strategy adapter ownership and authorize a future narrow wrapper implementation for the legacy data_adapters path"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-strategy-adapter-provider-design"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Design/authorization package only; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/strategy-adapter-provider-design-2026-05-27.json"
+    - "docs/reports/quality/backend-strategy-adapter-provider-design-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-326.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 325 --json number,state,mergeCommit,url,title"
+      required: true
+    - id: "adapter-ownership-scan"
+      command: "scan canonical adapters path, legacy data_adapters path, data_adapter compatibility entrypoint, package exports, factory imports, and tests"
+      required: true
+    - id: "gitnexus-evidence"
+      command: "GitNexus file impact for both Strategy adapter modules and context for both _get_strategy_service helpers"
+      required: true
+    - id: "focused-adapter-tests"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_adapter_mock_fallback_controls.py web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "route-backtest-sanity"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "openapi-smoke"
+      command: "app.openapi() smoke with minimal non-secret env; record route count, path count, duplicate operation IDs, duplicate-operation-id warnings, and total captured warnings"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-strategy-adapter-provider-design-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/strategy-adapter-provider-design-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-326.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this design package."
+  - "Do not implement the legacy wrapper conversion in this package."
+  - "Do not edit canonical strategy_adapter.py."
+  - "Do not edit data_adapter.py or data_source_factory.py."
+  - "Do not remove or edit Strategy route provider fallback."
+  - "Do not reopen the backtest task resolver lane."
+  - "Do not delete, privatize, rename, or change get_strategy_service()."
+  - "Do not change route/API behavior, OpenAPI exposure, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If the legacy path is deleted instead of wrapped, direct imports of app.services.data_adapters.strategy could break."
+    - "If canonical strategy_adapter.py is edited in the next lane, a low-risk wrapper conversion could expand into broader adapter behavior change."
+    - "If public get_strategy_service is touched, this lane could accidentally enter the broader CRITICAL getter retirement problem."
+  rollback_plan: "revert this design PR to remove only the design report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "select canonical Strategy adapter ownership and authorize a future legacy-wrapper implementation lane"
+    modified_scope: "steward tree, design report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, ownership scan, GitNexus evidence, focused tests, OpenAPI smoke, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T12:23:11+08:00"
+    approval_note: "Design/authorization package after PR #325 selected Strategy adapter/provider duplication as the next track."
+    secondary_approved: false
+


### PR DESCRIPTION
## Summary

- Records G2.173 Strategy adapter/provider ownership decision after PR #325 selected this track.
- Selects `web/backend/app/services/adapters/strategy_adapter.py` as the canonical implementation path.
- Classifies `web/backend/app/services/data_adapters/strategy.py` as the legacy direct-import path that should become a thin compatibility wrapper in a future G2.174 lane.
- Authorizes only the future wrapper lane after review; no source implementation is performed here.

## Verification

- Parent PR #325: MERGED at `b867716f77f8f509d1a7ec49c76346422bfd66ac`.
- Ownership scan: canonical path is exported by `app.services.adapters` and re-exported through `app.services.data_adapter`; `data_adapters/__init__.py` is absent.
- GitNexus file impact: canonical adapter LOW / impacted=2; legacy data_adapters strategy LOW / impacted=0.
- GitNexus helper context: both helpers are called by `_fetch_strategy_data` and `health_check`, and call public `get_strategy_service`.
- Adapter/logging focused tests: 16 passed.
- Strategy route/backtest sanity tests: 8 passed.
- OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0, duplicate_operation_id_warnings=0.
- Markdown governance: 2 checked, 0 errors, 0 warnings.
- JSON/YAML parse passed; `git diff --check` passed.
- Staged GitNexus detect_changes: low risk, 0 changed symbols, 0 affected processes.
- Mainline scope gate: pass=True.
- `gitnexus analyze --with-gitignore`: 62,959 nodes / 146,130 edges / 300 flows.

## Boundary

- Design/authorization package only.
- Future G2.174 may only convert `data_adapters/strategy.py` to a compatibility wrapper and update focused fallback tests after review.
- No backend source/test edit in this PR; no canonical adapter edit, factory edit, route provider fallback edit, backtest resolver edit, public getter retirement, route/API behavior, OpenAPI exposure, frontend, PM2, OpenSpec, config, scripts, or issue-label change.