### PR TITLE
docs(governance): close strategy adapter wrapper lane

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -3289,13 +3289,14 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              issue-label change, or source implementation is performed
 │   │              here
 │   ├── G2.174 Strategy legacy adapter wrapper implementation
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#327`
 │   │   ├── Evidence:
 │   │   │          `backend-strategy-adapter-wrapper-implementation-2026-05-27.md`
 │   │   ├── Generated:
 │   │   │          `strategy-adapter-wrapper-implementation-2026-05-27.json`
 │   │   ├── Parent: G2.173 accepted and merged by PR `#326`
 │   │   ├── Base HEAD: `1fca532a056549f1869773c7dcd9ae3be5170425`
+│   │   ├── Merge HEAD: `ba2572da6d31f05dcc65b735a361ceaa3435c280`
 │   │   ├── Implementation: `web/backend/app/services/data_adapters/strategy.py`
 │   │   │          is now a thin compatibility wrapper that re-exports
 │   │   │          canonical `StrategyDataSourceAdapter` from
@@ -3319,9 +3320,36 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              route/API behavior, OpenAPI exposure, frontend, PM2,
 │   │              OpenSpec, config, script, compatibility deletion, and
 │   │              issue-label state remain unchanged
-│   └── Next gate: review G2.174; if accepted, close the wrapper lane and
-│                  refresh remaining Strategy service getter residuals before
-│                  selecting the next Strategy or high-risk getter track
+│   ├── G2.175 Strategy legacy adapter wrapper closeout
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-strategy-adapter-wrapper-closeout-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `strategy-adapter-wrapper-closeout-2026-05-27.json`
+│   │   ├── Parent: G2.174 accepted and merged by PR `#327`
+│   │   ├── Current HEAD: `ba2572da6d31f05dcc65b735a361ceaa3435c280`
+│   │   ├── Closeout decision: G2.174 is closed as the legacy Strategy
+│   │   │          adapter compatibility-wrapper lane; no compatibility
+│   │   │          surface was deleted
+│   │   ├── Post-merge verification: adapter fallback tests `7 passed`,
+│   │   │          logging regression tests `10 passed`, strategy
+│   │   │          route/backtest sanity tests `8 passed`, ruff/black
+│   │   │          passed, and OpenAPI smoke `routes=548`, `paths=500`,
+│   │   │          `duplicate_operation_ids=0`
+│   │   ├── Residual scan: production `.py` `get_strategy_service` hits
+│   │   │          under `web/backend/app` are now `19`; legacy
+│   │   │          `data_adapters/strategy.py` owns `0` hits, route
+│   │   │          provider fallback owns `6`, closed backtest helper owns
+│   │   │          `2`, canonical `strategy_adapter.py` owns `10`, and
+│   │   │          public getter definition owns `1`
+│   │   └── Boundary: governance closeout only; no backend source/test edit,
+│   │              route/API behavior, OpenAPI exposure, frontend, PM2,
+│   │              OpenSpec, config, script, compatibility deletion,
+│   │              issue-label change, or implementation authorization is
+│   │              performed here
+│   └── Next gate: review G2.175; if accepted, open a separate residual-refresh
+│                  decision package before any further Strategy source
+│                  implementation
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/strategy-adapter-wrapper-closeout-2026-05-27.json
+++ b/.planning/codebase/generated/strategy-adapter-wrapper-closeout-2026-05-27.json
@@ -1,0 +1,57 @@
+{
+  "work_item": "G2.175",
+  "title": "Strategy legacy adapter wrapper closeout",
+  "state": "ready-for-review",
+  "recorded_at": "2026-05-27T13:24:00+08:00",
+  "current_head": "ba2572da6d31f05dcc65b735a361ceaa3435c280",
+  "parent": {
+    "work_item": "G2.174",
+    "pr": 327,
+    "state": "MERGED",
+    "merged_at": "2026-05-27T05:13:40Z",
+    "merge_commit": "ba2572da6d31f05dcc65b735a361ceaa3435c280",
+    "title": "refactor(backend): wrap legacy strategy adapter path"
+  },
+  "scope": {
+    "type": "governance-closeout",
+    "source_changes": false,
+    "test_changes": false,
+    "route_behavior_changes": false,
+    "openapi_exposure_changes": false
+  },
+  "closeout_decision": {
+    "g2_174_closed": true,
+    "legacy_path": "web/backend/app/services/data_adapters/strategy.py",
+    "canonical_path": "web/backend/app/services/adapters/strategy_adapter.py",
+    "compatibility_surface_deleted": false,
+    "legacy_direct_import_resolves_to_canonical_class": true
+  },
+  "post_merge_verification": {
+    "adapter_fallback_tests": "7 passed",
+    "logging_noise_tests": "10 passed",
+    "strategy_route_backtest_tests": "8 passed",
+    "ruff": "passed",
+    "black_check": "passed",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0
+    }
+  },
+  "residual_scan": {
+    "legacy_wrapper_lines": 9,
+    "legacy_reexports_canonical": true,
+    "legacy_has_class_def": false,
+    "legacy_has_get_strategy_service": false,
+    "production_py_get_strategy_service_hits": 19,
+    "production_py_get_strategy_service_files": {
+      "web/backend/app/api/strategy_management/_strategy_execution_router.py": 6,
+      "web/backend/app/tasks/backtest_tasks.py": 2,
+      "web/backend/app/services/adapters/strategy_adapter.py": 10,
+      "web/backend/app/services/strategy_service.py": 1
+    },
+    "legacy_direct_import_hits_in_web_backend_app": 0
+  },
+  "next_gate": "open a separate residual-refresh decision package before any further Strategy source implementation"
+}

--- a/docs/reports/quality/backend-strategy-adapter-wrapper-closeout-2026-05-27.md
+++ b/docs/reports/quality/backend-strategy-adapter-wrapper-closeout-2026-05-27.md
@@ -1,0 +1,86 @@
+# Backend Strategy Adapter Wrapper Closeout
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Work item: G2.175
+- State: ready for review
+- Date: 2026-05-27
+- Current HEAD: `ba2572da6d31f05dcc65b735a361ceaa3435c280`
+- Parent PR: `#327` merged, `refactor(backend): wrap legacy strategy adapter path`
+- Scope: governance closeout for the Strategy legacy adapter wrapper lane
+
+## Boundary
+
+This closeout records verification and residual state after PR `#327`. It does
+not edit backend source, backend tests, route/API behavior, OpenAPI exposure,
+frontend code, PM2 workflows, OpenSpec content, config, scripts, compatibility
+surfaces, or issue labels.
+
+## Closeout Decision
+
+G2.174 is closed as the legacy Strategy adapter compatibility-wrapper lane.
+
+The legacy direct import path remains available:
+
+```text
+app.services.data_adapters.strategy.StrategyDataSourceAdapter
+```
+
+It now resolves to the canonical implementation:
+
+```text
+app.services.adapters.strategy_adapter.StrategyDataSourceAdapter
+```
+
+No compatibility surface was deleted.
+
+## Post-Merge Verification
+
+Commands were rerun from the G2.175 closeout worktree at current HEAD
+`ba2572da6d31f05dcc65b735a361ceaa3435c280`.
+
+| Check | Result |
+|---|---|
+| `gh pr view 327 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,title,url` | `MERGED`, merge commit `ba2572da6d31f05dcc65b735a361ceaa3435c280` |
+| `pytest -o addopts= web/backend/tests/test_adapter_mock_fallback_controls.py -q --no-cov --tb=short` | `7 passed` |
+| `pytest -o addopts= web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short` | `10 passed` |
+| `pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov --tb=short` | `8 passed` |
+| `ruff check web/backend/app/services/data_adapters/strategy.py web/backend/tests/test_adapter_mock_fallback_controls.py` | passed |
+| `black --check web/backend/app/services/data_adapters/strategy.py web/backend/tests/test_adapter_mock_fallback_controls.py` | passed |
+| OpenAPI smoke | `routes=548`, `paths=500`, `duplicate_operation_ids=0`, `duplicate_operation_id_warnings=0` |
+
+OpenAPI smoke used placeholder non-secret environment values and did not start
+PM2 or execute stateful runtime gates.
+
+## Residual Scan
+
+Post-merge static scan at current HEAD:
+
+- `web/backend/app/services/data_adapters/strategy.py` line count: `9`
+- Legacy wrapper re-exports canonical class: yes
+- Legacy wrapper defines `class StrategyDataSourceAdapter`: no
+- Legacy wrapper contains direct `get_strategy_service`: no
+- Production `.py` `get_strategy_service` hits under `web/backend/app`: `19`
+
+Current production `.py` residual distribution:
+
+| File | Hits | Disposition |
+|---|---:|---|
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 6 | Route provider fallback retained by prior decision |
+| `web/backend/app/tasks/backtest_tasks.py` | 2 | Closed task-local provider helper; not a reopened lane |
+| `web/backend/app/services/adapters/strategy_adapter.py` | 10 | Canonical adapter/provider residual; candidate for future design refresh |
+| `web/backend/app/services/strategy_service.py` | 1 | Public getter definition retained |
+
+The legacy `app.services.data_adapters.strategy` path is no longer a production
+`.py` residual owner in `web/backend/app`.
+
+## Next Gate
+
+Open a separate residual-refresh decision package before any further Strategy
+source implementation. That package should decide whether the canonical
+`web/backend/app/services/adapters/strategy_adapter.py` helper calls are a safe
+next seam or whether Strategy should pause while the broader high-risk getter
+tracks continue with realtime/socket, Dashboard/TDX, Indicator/Data, root facade
+compatibility, or route dependency/provider governance.

--- a/governance/mainline/task-cards/pr-328.yaml
+++ b/governance/mainline/task-cards/pr-328.yaml
@@ -1,0 +1,112 @@
+version: "v0.2"
+
+task:
+  id: "pr-328"
+  title: "Close out Strategy adapter wrapper lane"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-strategy-adapter-wrapper-closeout"
+  objective: "record post-merge verification and residual state after the legacy Strategy adapter wrapper implementation"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-strategy-adapter-wrapper-closeout"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance closeout only; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/strategy-adapter-wrapper-closeout-2026-05-27.json"
+    - "docs/reports/quality/backend-strategy-adapter-wrapper-closeout-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-328.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 327 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,title,url"
+      required: true
+    - id: "post-merge-adapter-fallback-tests"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_adapter_mock_fallback_controls.py -q --no-cov --tb=short"
+      required: true
+    - id: "post-merge-logging-noise-tests"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "post-merge-strategy-route-backtest-sanity"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-strategy-adapter-wrapper-closeout-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/strategy-adapter-wrapper-closeout-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-328.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this closeout package."
+  - "Do not edit canonical strategy_adapter.py."
+  - "Do not edit the legacy wrapper implementation from PR #327."
+  - "Do not edit data_adapter.py or data_source_factory.py."
+  - "Do not remove or edit Strategy route provider fallback."
+  - "Do not reopen the backtest task resolver lane."
+  - "Do not delete, privatize, rename, or change get_strategy_service()."
+  - "Do not change route/API behavior, OpenAPI exposure, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is treated as implementation authorization, the next Strategy lane could skip residual-refresh review."
+    - "If historical counts are reused without current-head scan context, remaining Strategy getter ownership could be misclassified."
+  rollback_plan: "revert this closeout PR to remove only the closeout report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close the Strategy legacy adapter wrapper lane after PR #327 and record current residual state"
+    modified_scope: "steward tree, closeout report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, post-merge verification, residual scan, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T13:24:00+08:00"
+    approval_note: "Closeout package after PR #327 merged; governance-only residual record, no implementation authorization."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- close G2.174 after PR #327 merged the legacy Strategy adapter wrapper implementation
- record post-merge verification and current Strategy getter residual distribution
- update steward tree, closeout report, generated artifact, and task card only

## Verification
- PR #327 state: MERGED, merge commit ba2572da6d31f05dcc65b735a361ceaa3435c280
- adapter fallback tests: 7 passed
- logging noise tests: 10 passed
- strategy route/backtest sanity tests: 8 passed
- ruff and black passed for the PR #327 touched source/test files
- OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0, duplicate_operation_id_warnings=0
- residual scan: production .py get_strategy_service hits now 19; legacy data_adapters/strategy.py owns 0
- markdown governance: checked_files=2, errors=0
- JSON/YAML parse and git diff --check passed
- GitNexus staged detect_changes: low risk, 0 changed symbols, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: 62,950 nodes / 146,057 edges / 300 flows

## Boundary
- Governance closeout only. No backend source/test edits, route/API changes, OpenAPI exposure changes, frontend changes, OpenSpec changes, config/script changes, compatibility deletion, or issue-label changes.