### PR TITLE
docs(governance): refresh strategy residual decision

### DIFF
--- a/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
+++ b/.planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md
@@ -3321,13 +3321,14 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              OpenSpec, config, script, compatibility deletion, and
 │   │              issue-label state remain unchanged
 │   ├── G2.175 Strategy legacy adapter wrapper closeout
-│   │   ├── State: ready for review
+│   │   ├── State: accepted and merged by PR `#328`
 │   │   ├── Evidence:
 │   │   │          `backend-strategy-adapter-wrapper-closeout-2026-05-27.md`
 │   │   ├── Generated:
 │   │   │          `strategy-adapter-wrapper-closeout-2026-05-27.json`
 │   │   ├── Parent: G2.174 accepted and merged by PR `#327`
 │   │   ├── Current HEAD: `ba2572da6d31f05dcc65b735a361ceaa3435c280`
+│   │   ├── Merge HEAD: `2718dd07ce10dbe94937ed0bb758956677b3dce4`
 │   │   ├── Closeout decision: G2.174 is closed as the legacy Strategy
 │   │   │          adapter compatibility-wrapper lane; no compatibility
 │   │   │          surface was deleted
@@ -3347,9 +3348,44 @@ CODEBASE-MAP Architecture Remediation Program
 │   │              OpenSpec, config, script, compatibility deletion,
 │   │              issue-label change, or implementation authorization is
 │   │              performed here
-│   └── Next gate: review G2.175; if accepted, open a separate residual-refresh
-│                  decision package before any further Strategy source
-│                  implementation
+│   ├── G2.176 Strategy residual refresh decision
+│   │   ├── State: ready for review
+│   │   ├── Evidence:
+│   │   │          `backend-strategy-residual-refresh-decision-2026-05-27.md`
+│   │   ├── Generated:
+│   │   │          `strategy-residual-refresh-decision-2026-05-27.json`
+│   │   ├── Parent: G2.175 accepted and merged by PR `#328`
+│   │   ├── Current HEAD: `2718dd07ce10dbe94937ed0bb758956677b3dce4`
+│   │   ├── Residual scan: production `.py` `get_strategy_service` hits
+│   │   │          under `web/backend/app` remain `19`; route provider
+│   │   │          fallback owns `6`, closed backtest helper owns `2`,
+│   │   │          canonical `strategy_adapter.py` owns `10`, public getter
+│   │   │          definition owns `1`, and legacy `data_adapters/strategy.py`
+│   │   │          owns `0`
+│   │   ├── GitNexus evidence: canonical `strategy_adapter.py` file impact
+│   │   │          is LOW with `5` impacted and `0` affected processes;
+│   │   │          public `get_strategy_service` remains CRITICAL at symbol
+│   │   │          level with `13` impacted, `6` direct callers, and `0`
+│   │   │          affected processes
+│   │   ├── Tooling note: symbol-level graph output still reports stale
+│   │   │          legacy helper symbols after fresh analyze; current-head
+│   │   │          static scan is the ownership source of truth for the
+│   │   │          legacy wrapper state
+│   │   ├── Decision: select canonical Strategy adapter provider seam as the
+│   │   │          next Strategy design/authorization track; immediate source
+│   │   │          implementation remains unauthorized
+│   │   ├── Verification: adapter fallback tests `7 passed`, strategy
+│   │   │          route/backtest sanity tests `8 passed`, and OpenAPI smoke
+│   │   │          `routes=548`, `paths=500`,
+│   │   │          `duplicate_operation_ids=0`
+│   │   └── Boundary: decision package only; no backend source/test edit,
+│   │              route/API behavior, OpenAPI exposure, frontend, PM2,
+│   │              OpenSpec, config, script, compatibility deletion,
+│   │              issue-label change, or source implementation authorization
+│   │              is performed here
+│   └── Next gate: review G2.176; if accepted, open G2.177 as a narrow
+│                  Strategy canonical adapter provider design/authorization
+│                  package before any further Strategy source implementation
 │
 ├── H. Decision-Only Track: CSRF composition root
 │   ├── Source evidence: backend-csrf-composition-root-decision-2026-05-19.md

--- a/.planning/codebase/generated/strategy-residual-refresh-decision-2026-05-27.json
+++ b/.planning/codebase/generated/strategy-residual-refresh-decision-2026-05-27.json
@@ -1,0 +1,90 @@
+{
+  "work_item": "G2.176",
+  "title": "Strategy residual refresh decision",
+  "state": "ready-for-review",
+  "recorded_at": "2026-05-27T13:41:32+08:00",
+  "current_head": "2718dd07ce10dbe94937ed0bb758956677b3dce4",
+  "parent": {
+    "work_item": "G2.175",
+    "pr": 328,
+    "state": "MERGED",
+    "merged_at": "2026-05-27T05:32:27Z",
+    "merge_commit": "2718dd07ce10dbe94937ed0bb758956677b3dce4",
+    "title": "docs(governance): close strategy adapter wrapper lane"
+  },
+  "scope": {
+    "type": "decision-package",
+    "source_changes": false,
+    "test_changes": false,
+    "route_behavior_changes": false,
+    "openapi_exposure_changes": false,
+    "implementation_authorized": false
+  },
+  "residual_scan": {
+    "production_py_get_strategy_service_hits": 19,
+    "files": {
+      "web/backend/app/api/strategy_management/_strategy_execution_router.py": 6,
+      "web/backend/app/tasks/backtest_tasks.py": 2,
+      "web/backend/app/services/adapters/strategy_adapter.py": 10,
+      "web/backend/app/services/strategy_service.py": 1
+    },
+    "classifications": {
+      "route_provider_fallback": 6,
+      "closed_backtest_helper": 2,
+      "canonical_adapter_provider": 10,
+      "public_getter_definition": 1,
+      "legacy_data_adapters_strategy": 0
+    },
+    "legacy_wrapper": {
+      "lines": 9,
+      "reexports_canonical": true,
+      "has_get_strategy_service": false,
+      "defines_strategy_data_source_adapter_class": false
+    }
+  },
+  "gitnexus": {
+    "analyze": {
+      "nodes": 62938,
+      "edges": 146073,
+      "clusters": 3285,
+      "flows": 300
+    },
+    "canonical_adapter_file_impact": {
+      "risk": "LOW",
+      "impacted_count": 5,
+      "direct": 2,
+      "processes_affected": 0
+    },
+    "legacy_wrapper_file_impact": {
+      "risk": "LOW",
+      "impacted_count": 1,
+      "direct": 1,
+      "processes_affected": 0
+    },
+    "public_getter_symbol_impact": {
+      "risk": "CRITICAL",
+      "impacted_count": 13,
+      "direct": 6,
+      "processes_affected": 0,
+      "modules_affected": 5
+    },
+    "tooling_note": "symbol-level impact still reports stale legacy data_adapters/strategy.py helper symbols after fresh analyze; current-head static scan is the ownership source of truth for the legacy wrapper state"
+  },
+  "verification": {
+    "adapter_fallback_tests": "7 passed",
+    "strategy_route_backtest_tests": "8 passed",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0
+    }
+  },
+  "decision": {
+    "selected_next_track": "canonical Strategy adapter provider seam",
+    "next_work_item": "G2.177",
+    "next_work_item_type": "design-authorization-package",
+    "source_implementation_authorized_now": false
+  },
+  "next_gate": "review G2.176; if accepted, open G2.177 as a narrow Strategy canonical adapter provider design/authorization package"
+}

--- a/docs/reports/quality/backend-strategy-residual-refresh-decision-2026-05-27.md
+++ b/docs/reports/quality/backend-strategy-residual-refresh-decision-2026-05-27.md
@@ -1,0 +1,146 @@
+# Backend Strategy Residual Refresh Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Work item: G2.176
+- State: ready for review
+- Date: 2026-05-27
+- Current HEAD: `2718dd07ce10dbe94937ed0bb758956677b3dce4`
+- Parent PR: `#328` merged, `docs(governance): close strategy adapter wrapper lane`
+- Scope: Strategy getter residual refresh and next-track selection
+
+## Boundary
+
+This package is a decision package only. It does not edit backend source, backend
+tests, route/API behavior, OpenAPI exposure, frontend code, PM2 workflows,
+OpenSpec content, config, scripts, compatibility surfaces, issue labels, or
+service getter implementations.
+
+This package does not authorize immediate source implementation. It only selects
+the next Strategy residual design/authorization package.
+
+## Parent State
+
+PR `#327` converted `web/backend/app/services/data_adapters/strategy.py` into a
+thin compatibility wrapper around canonical
+`web/backend/app/services/adapters/strategy_adapter.py`.
+
+PR `#328` closed that wrapper lane and recorded that the legacy direct import
+path remains available without owning a direct `get_strategy_service` residual.
+
+## Current Residual Scan
+
+At current HEAD `2718dd07ce10dbe94937ed0bb758956677b3dce4`, production `.py`
+`get_strategy_service` hits under `web/backend/app` are:
+
+| Owner | Hits | Current disposition |
+|---|---:|---|
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 6 | Route provider fallback retained by prior decision |
+| `web/backend/app/tasks/backtest_tasks.py` | 2 | Closed task-local provider helper; not reopened |
+| `web/backend/app/services/adapters/strategy_adapter.py` | 10 | Only unresolved Strategy residual owner |
+| `web/backend/app/services/strategy_service.py` | 1 | Public getter definition retained |
+| `web/backend/app/services/data_adapters/strategy.py` | 0 | Closed by wrapper conversion |
+
+The legacy wrapper state is:
+
+- line count: `9`
+- re-exports canonical `StrategyDataSourceAdapter`: yes
+- defines `class StrategyDataSourceAdapter`: no
+- contains direct `get_strategy_service`: no
+
+## Canonical Adapter Residual
+
+The remaining unresolved Strategy adapter residual is in:
+
+```text
+web/backend/app/services/adapters/strategy_adapter.py
+```
+
+Relevant helper sites:
+
+- `_get_strategy_service()` lazily imports and calls public
+  `app.services.strategy_service.get_strategy_service()`.
+- `_fetch_strategy_data()` calls `_get_strategy_service()` to determine service
+  availability and then uses mock fallback when configured.
+- `health_check()` calls `_get_strategy_service()` to report service
+  availability.
+
+This is no longer a duplicate-path cleanup problem. It is a canonical adapter
+provider seam problem.
+
+## GitNexus Evidence
+
+Fresh `gitnexus analyze --with-gitignore` was run before collecting graph
+evidence.
+
+File-level impact:
+
+- `web/backend/app/services/adapters/strategy_adapter.py`: LOW risk,
+  `5` impacted symbols/files, `2` direct import dependents, `0` affected
+  processes.
+- `web/backend/app/services/data_adapters/strategy.py`: LOW risk, `1` direct
+  test import, `0` affected processes.
+
+Public getter impact:
+
+- `get_strategy_service` remains CRITICAL at symbol level with `13` impacted
+  symbols, `6` direct callers, `0` affected processes, and `5` affected modules.
+
+Tooling note: the symbol-level graph still reports stale legacy
+`data_adapters/strategy.py` helper symbols even after a fresh analyze. The
+current-head static scan above is therefore the ownership source of truth for
+the legacy wrapper state; GitNexus file-level impact is still useful for the
+canonical adapter file and legacy wrapper file.
+
+## Verification
+
+Commands were run from the G2.176 worktree with current HEAD
+`2718dd07ce10dbe94937ed0bb758956677b3dce4`.
+
+| Check | Result |
+|---|---|
+| `gh pr view 328 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,title,url` | `MERGED`, merge commit `2718dd07ce10dbe94937ed0bb758956677b3dce4` |
+| `pytest -o addopts= web/backend/tests/test_adapter_mock_fallback_controls.py -q --no-cov --tb=short` | `7 passed` |
+| `pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov --tb=short` | `8 passed` |
+| OpenAPI smoke | `routes=548`, `paths=500`, `duplicate_operation_ids=0`, `duplicate_operation_id_warnings=0` |
+
+OpenAPI smoke used placeholder non-secret environment values and did not start
+PM2 or execute stateful runtime gates.
+
+## Decision
+
+Select the canonical Strategy adapter provider seam as the next Strategy
+decision track.
+
+The next package should be G2.177: a design/authorization package for
+`web/backend/app/services/adapters/strategy_adapter.py`.
+
+G2.177 should decide whether a later implementation may introduce an injectable
+provider seam for `StrategyDataSourceAdapter` while preserving:
+
+- public `get_strategy_service()` compatibility;
+- route provider fallback behavior;
+- backtest task resolver closure;
+- legacy `data_adapters/strategy.py` wrapper compatibility;
+- `data_adapter.py` and `data_source_factory` construction behavior;
+- route/API behavior and OpenAPI exposure.
+
+## Non-Authorization
+
+This package does not authorize editing:
+
+- `web/backend/app/services/adapters/strategy_adapter.py`
+- `web/backend/app/services/data_adapters/strategy.py`
+- `web/backend/app/services/data_adapter.py`
+- `web/backend/app/services/data_source_factory/**`
+- `web/backend/app/api/strategy_management/_strategy_execution_router.py`
+- `web/backend/app/tasks/backtest_tasks.py`
+- `web/backend/app/services/strategy_service.py`
+
+## Next Gate
+
+Review G2.176. If accepted and merged, open G2.177 as a narrow
+Strategy canonical adapter provider design/authorization package. Do not start a
+Strategy source implementation lane before G2.177 is approved.

--- a/governance/mainline/task-cards/pr-329.yaml
+++ b/governance/mainline/task-cards/pr-329.yaml
@@ -1,0 +1,113 @@
+version: "v0.2"
+
+task:
+  id: "pr-329"
+  title: "Refresh Strategy getter residuals after wrapper closeout"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-strategy-residual-refresh-decision"
+  objective: "refresh Strategy service getter residual ownership after the legacy adapter wrapper closeout and select the next design track"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "not-required-strategy-residual-refresh-decision"
+  approval_status: "not_required"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision package only; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md"
+    - ".planning/codebase/generated/strategy-residual-refresh-decision-2026-05-27.json"
+    - "docs/reports/quality/backend-strategy-residual-refresh-decision-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-329.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/guides/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 328 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,title,url"
+      required: true
+    - id: "residual-scan"
+      command: "rg --glob '*.py' 'get_strategy_service' web/backend/app"
+      required: true
+    - id: "focused-adapter-fallback-tests"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_adapter_mock_fallback_controls.py -q --no-cov --tb=short"
+      required: true
+    - id: "focused-strategy-route-backtest-tests"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md docs/reports/quality/backend-strategy-residual-refresh-decision-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/strategy-residual-refresh-decision-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-329.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit backend source or tests in this decision package."
+  - "Do not authorize immediate Strategy source implementation."
+  - "Do not edit canonical strategy_adapter.py."
+  - "Do not edit the legacy wrapper implementation from PR #327."
+  - "Do not edit data_adapter.py or data_source_factory.py."
+  - "Do not remove or edit Strategy route provider fallback."
+  - "Do not reopen the backtest task resolver lane."
+  - "Do not delete, privatize, rename, or change get_strategy_service()."
+  - "Do not change route/API behavior, OpenAPI exposure, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+
+risk_and_rollback:
+  risks:
+    - "If this decision package is treated as source authorization, canonical strategy_adapter.py could be changed before G2.177 design review."
+    - "If stale symbol-level graph output is used without the current static scan, removed legacy helper symbols could be misclassified as active residuals."
+  rollback_plan: "revert this decision PR to remove only the decision report, generated artifact, task card, and steward-tree update"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh Strategy getter residual ownership after the wrapper closeout and select canonical strategy_adapter.py as the next design track"
+    modified_scope: "steward tree, decision report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source and tests are not edited"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if parent state, residual scan, focused verification, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T13:41:32+08:00"
+    approval_note: "Decision package after PR #328 closeout; selects only the next design/authorization track and does not authorize source implementation."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- merge-aware G2.176 decision package after PR #328 closed the Strategy legacy adapter wrapper lane
- refresh current `get_strategy_service` residual ownership under `web/backend/app`
- select canonical `strategy_adapter.py` provider seam as the next Strategy design/authorization track, without authorizing source implementation

## Evidence
- PR #328 state: MERGED, merge commit 2718dd07ce10dbe94937ed0bb758956677b3dce4
- production `.py` `get_strategy_service` hits: 19
- distribution: route provider fallback 6, closed backtest helper 2, canonical strategy_adapter.py 10, public getter definition 1, legacy data_adapters/strategy.py 0
- GitNexus file impact: canonical strategy_adapter.py LOW, 5 impacted, 0 affected processes
- public getter symbol impact remains CRITICAL: 13 impacted, 6 direct callers, 0 affected processes
- focused tests: adapter fallback 7 passed; strategy route/backtest sanity 8 passed
- OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0, duplicate_operation_id_warnings=0
- markdown governance: checked_files=2, errors=0; JSON/YAML parse and diff check passed
- GitNexus staged detect_changes: low risk, 0 changed symbols, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: 62,934 nodes / 146,086 edges / 300 flows

## Boundary
- Decision package only. No backend source/test edits, route/API changes, OpenAPI exposure changes, frontend changes, OpenSpec changes, config/script changes, compatibility deletion, issue-label changes, or source implementation authorization.