### PR TITLE
refactor(backend): inject strategy adapter provider

### DIFF
--- a/.planning/codebase/generated/strategy-adapter-provider-implementation-2026-05-27.json
+++ b/.planning/codebase/generated/strategy-adapter-provider-implementation-2026-05-27.json
@@ -1,0 +1,109 @@
+{
+  "work_item": "G2.178",
+  "title": "Strategy adapter provider implementation",
+  "state": "ready-for-review",
+  "recorded_at": "2026-05-27T14:35:50+08:00",
+  "base_head": "3b8f95945fcb489316ddfaf919835d372122fa5f",
+  "rebased_on": {
+    "recorded_at": "2026-05-27T16:04:24+08:00",
+    "base_head": "750fb7c797ff95f27152439ed988a7115252129e",
+    "reason": "PR #332 split the steward tree; G2.178 steward updates moved from the old root tree into split steward files"
+  },
+  "parent": {
+    "work_item": "G2.177",
+    "pr": 330,
+    "state": "MERGED",
+    "merge_commit": "3b8f95945fcb489316ddfaf919835d372122fa5f",
+    "title": "docs(governance): authorize strategy adapter provider seam"
+  },
+  "scope": {
+    "type": "source-implementation",
+    "allowed_paths": [
+      "web/backend/app/services/adapters/strategy_adapter.py",
+      "web/backend/tests/test_adapter_mock_fallback_controls.py"
+    ],
+    "forbidden_paths_preserved": [
+      "web/backend/app/services/data_adapters/strategy.py",
+      "web/backend/app/services/data_adapter.py",
+      "web/backend/app/services/data_source_factory/**",
+      "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+      "web/backend/app/tasks/backtest_tasks.py",
+      "web/backend/app/services/strategy_service.py"
+    ],
+    "route_behavior_changed": false,
+    "openapi_exposure_changed": false,
+    "public_getter_changed": false,
+    "compatibility_deleted": false
+  },
+  "implementation": {
+    "target_path": "web/backend/app/services/adapters/strategy_adapter.py",
+    "constructor_provider_parameter": "strategy_service_provider: Callable[[], Any] | None = None",
+    "provider_storage": "self._strategy_service_provider = strategy_service_provider",
+    "helper_access_point": "_get_strategy_service",
+    "default_public_getter_fallback_preserved": true,
+    "service_cache_preserved": true
+  },
+  "tdd": {
+    "red": "test_strategy_adapter_uses_injected_strategy_service_provider failed with unexpected keyword argument strategy_service_provider",
+    "green": "same focused test passed after optional provider implementation"
+  },
+  "static_guard": {
+    "strategy_adapter_lines": 372,
+    "constructor_line": 24,
+    "helper_line": 40,
+    "has_callable_import": true,
+    "has_provider_parameter": true,
+    "stores_provider": true,
+    "helper_uses_provider": true,
+    "helper_preserves_public_getter_fallback": true,
+    "test_has_provider_case": true,
+    "production_py_get_strategy_service_hits": 19,
+    "production_py_get_strategy_service_files": {
+      "web/backend/app/tasks/backtest_tasks.py": 2,
+      "web/backend/app/services/strategy_service.py": 1,
+      "web/backend/app/services/adapters/strategy_adapter.py": 10,
+      "web/backend/app/api/strategy_management/_strategy_execution_router.py": 6
+    }
+  },
+  "gitnexus_pre_edit": {
+    "canonical_adapter_file": {
+      "risk": "LOW",
+      "impacted_count": 5,
+      "direct": 2,
+      "processes_affected": 0
+    },
+    "focused_test_file": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct": 0,
+      "processes_affected": 0
+    }
+  },
+  "verification": {
+    "focused_red": "failed as expected",
+    "focused_green": "1 passed",
+    "adapter_fallback_tests": "8 passed",
+    "logging_noise_tests": "10 passed",
+    "strategy_route_backtest_tests": "8 passed",
+    "data_adapter_regression_tests": "9 passed",
+    "ruff": "passed",
+    "black_check": "passed",
+    "openapi_smoke": {
+      "routes": 548,
+      "paths": 500,
+      "duplicate_operation_ids": 0,
+      "duplicate_operation_id_warnings": 0
+    }
+  },
+  "steward_tree_reconciliation": {
+    "root_tree_modified": false,
+    "updated_paths": [
+      ".planning/codebase/steward-tree/current-next-gates.md",
+      ".planning/codebase/steward-tree/steward-index.json",
+      ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+      "governance/mainline/task-cards/pr-331.yaml"
+    ],
+    "archived_single_file_tree_used": false
+  },
+  "next_gate": "review G2.178 implementation package; if accepted, close out and refresh remaining Strategy getter residuals"
+}

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -6,7 +6,7 @@
 
 - Status: active gate register
 - Prepared at: `2026-05-27T15:32:41+08:00`
-- Base HEAD checked: `3b8f95945fcb489316ddfaf919835d372122fa5f`
+- Base HEAD checked: `750fb7c797ff95f27152439ed988a7115252129e`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,8 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Keep PR `#331` separate from steward split | G/#79 service lifecycle DI | PR `#331` is open and mergeable; not included in this branch | Human decides whether to merge PR `#331`; reconcile only after a PR lands |
-| P0 | Review steward-tree split | CODEBASE-MAP steward governance | In progress in `g2-179-steward-tree-governance-split` | Verify split files, JSON index, report, and task card |
+| P0 | Review G2.178 Strategy adapter provider implementation | G/#79 service lifecycle DI | PR `#331` is the active path-limited implementation lane and has been reconciled with the split steward tree | Human review/merge decision; if accepted, open the closeout or residual-refresh lane |
+| P0 | Keep steward split structure active | CODEBASE-MAP steward governance | PR `#332` merged at `750fb7c797ff95f27152439ed988a7115252129e` | Future steward updates must use split files and `steward-index.json`, not the archived single-file tree |
 | P1 | Preserve implementation authorization boundary | All lanes | Active | Every source lane still needs its own authorization packet |
 | P1 | Keep Core Batch 2 blocked | Core split / compatibility wrappers | Blocked | Resolve Task 3.2 and shared evidence gate disposition before selecting Batch 2 |
 | P1 | Use route/OpenAPI governance for route changes | Route/OpenAPI lane | Active | Route source changes require route ownership, OpenAPI exposure, and consumer-contract evidence |
@@ -28,5 +28,5 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 - Does the split preserve the full historical steward tree in archive?
 - Is the root entrypoint short enough to serve as a daily navigation file?
 - Does `steward-index.json` include enough fields for automated guards?
-- Are PR `#331` and this governance split clearly separated?
+- Is PR `#331` reconciled with the split steward tree instead of the old single-file tree?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-27T15:32:41+08:00",
+  "generated_at": "2026-05-27T16:04:24+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "3b8f95945fcb489316ddfaf919835d372122fa5f",
-  "split_branch": "g2-179-steward-tree-governance-split",
-  "scope": "governance_only",
-  "source_edit_authority": false,
+  "base_head": "750fb7c797ff95f27152439ed988a7115252129e",
+  "split_branch": "g2-178-strategy-adapter-provider-implementation",
+  "scope": "implementation_with_steward_reconciliation",
+  "source_edit_authority": true,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -74,7 +74,7 @@
     {
       "id": "steward-tree-v2-split",
       "type": "governance",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "CODEBASE-MAP steward governance",
       "parent": "single-file steward tree",
       "evidence": [
@@ -99,15 +99,15 @@
       ],
       "source_edit_authority": false,
       "freshness": {
-        "current_head_checked": "3b8f95945fcb489316ddfaf919835d372122fa5f",
+        "current_head_checked": "750fb7c797ff95f27152439ed988a7115252129e",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "Review and merge the governance split PR if the split files and JSON index are accepted."
+      "next_gate": "Use the split steward files for current state; do not append active updates to the archived single-file tree."
     },
     {
       "id": "g2-178-strategy-adapter-provider-implementation",
       "type": "implementation",
-      "state": "open_pr",
+      "state": "for_review",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.177 Strategy canonical adapter provider authorization",
       "github_pr": {
@@ -118,12 +118,17 @@
         "head_ref": "g2-178-strategy-adapter-provider-implementation"
       },
       "source_edit_authority": true,
-      "included_in_this_branch": false,
+      "included_in_this_branch": true,
+      "evidence": [
+        ".planning/codebase/generated/strategy-adapter-provider-implementation-2026-05-27.json",
+        "docs/reports/quality/backend-strategy-adapter-provider-implementation-2026-05-27.md",
+        "governance/mainline/task-cards/pr-331.yaml"
+      ],
       "freshness": {
-        "current_head_checked": "3b8f95945fcb489316ddfaf919835d372122fa5f",
+        "current_head_checked": "750fb7c797ff95f27152439ed988a7115252129e",
         "stale_if_pr_state_changes": true
       },
-      "next_gate": "Human merge/review decision for PR #331; do not mix this governance split with PR #331 source changes."
+      "next_gate": "Human review/merge decision for PR #331; if accepted, create a closeout lane and refresh remaining Strategy getter residuals."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -6,7 +6,7 @@
 
 - Status: active track summary
 - Prepared at: `2026-05-27T15:32:41+08:00`
-- Base HEAD checked: `3b8f95945fcb489316ddfaf919835d372122fa5f`
+- Base HEAD checked: `750fb7c797ff95f27152439ed988a7115252129e`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -29,18 +29,17 @@ It proved a repeatable conveyor:
 
 | Node | State | Notes |
 |---|---|---|
-| G2.177 Strategy canonical adapter provider authorization | Accepted by human review in the current workstream; base snapshot still records it as ready for review | Authorized only a constructor-level Strategy service provider seam in canonical `strategy_adapter.py` and focused tests |
-| G2.178 Strategy adapter provider implementation | Open PR `#331`, mergeable at split | Separate source implementation lane; not included in this governance split |
-| Steward split | For review | Reorganizes steward files and index only |
+| Steward split | Merged by PR `#332` | Root task tree is now a short entrypoint; active state belongs in this split track and `steward-index.json` |
+| G2.177 Strategy canonical adapter provider authorization | Accepted and merged by PR `#330` | Authorized only a constructor-level Strategy service provider seam in canonical `strategy_adapter.py` and focused tests |
+| G2.178 Strategy adapter provider implementation | Ready for review in PR `#331` | Adds the approved optional constructor-level provider seam and reconciles the G2.178 steward update into the split tree |
 
 ## Next Gates
 
-- Do not start another service source lane until PR `#331` is resolved or
+- Review PR `#331` as the active G2.178 source implementation lane.
+- If PR `#331` is accepted, create a closeout lane that marks G2.178 as merged
+  and refreshes the remaining Strategy getter residuals.
+- Do not start another service source lane until G2.178 is merged, closed, or
   explicitly superseded.
-- If PR `#331` merges first, update this track and `steward-index.json` to mark
-  G2.178 as merged and create a closeout lane.
-- If this governance split merges first, PR `#331` should reconcile steward file
-  paths if it also edits the root steward tree.
 
 ## Forbidden Scope
 

--- a/docs/reports/quality/backend-strategy-adapter-provider-implementation-2026-05-27.md
+++ b/docs/reports/quality/backend-strategy-adapter-provider-implementation-2026-05-27.md
@@ -1,0 +1,139 @@
+# Backend Strategy Adapter Provider Implementation
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Work item: G2.178
+- State: ready for review
+- Date: 2026-05-27
+- Original implementation base HEAD: `3b8f95945fcb489316ddfaf919835d372122fa5f`
+- Rebased stewardship base HEAD: `750fb7c797ff95f27152439ed988a7115252129e`
+- Parent PR: `#330` merged, `docs(governance): authorize strategy adapter provider seam`
+- Scope: path-limited canonical Strategy adapter provider implementation
+
+## Boundary
+
+This implementation modifies only the two files authorized by G2.177:
+
+- `web/backend/app/services/adapters/strategy_adapter.py`
+- `web/backend/tests/test_adapter_mock_fallback_controls.py`
+
+It does not edit the legacy `data_adapters/strategy.py` wrapper, data adapter
+factory, Strategy route provider fallback, backtest task resolver, public
+`get_strategy_service()`, route/API behavior, OpenAPI exposure, frontend code,
+PM2 workflows, OpenSpec content, config, scripts, compatibility surfaces, or
+issue labels.
+
+## Implementation
+
+G2.178 adds an optional constructor-level Strategy service provider seam to the
+canonical `StrategyDataSourceAdapter`.
+
+Implementation details:
+
+- `StrategyDataSourceAdapter.__init__()` now accepts
+  `strategy_service_provider: Callable[[], Any] | None = None`.
+- The provider is stored as `_strategy_service_provider`.
+- `_get_strategy_service()` still remains the single adapter-local access point.
+- `_get_strategy_service()` uses the injected provider when one is supplied.
+- Without an injected provider, `_get_strategy_service()` keeps the existing
+  public `get_strategy_service()` fallback path.
+- Service caching remains unchanged: the provider is called only on the first
+  successful service resolution.
+- Existing factory and direct construction callers remain compatible because the
+  new constructor parameter is optional.
+
+## TDD Evidence
+
+Red:
+
+- Added `test_strategy_adapter_uses_injected_strategy_service_provider`.
+- It failed before implementation with:
+  `TypeError: StrategyDataSourceAdapter.__init__() got an unexpected keyword argument 'strategy_service_provider'`.
+
+Green:
+
+- Added the optional provider parameter and provider-aware helper branch.
+- The focused test passed: `1 passed`.
+
+## Static Guard
+
+At base HEAD plus implementation changes:
+
+- `strategy_adapter.py` line count: `372`
+- Constructor line: `24`
+- `_get_strategy_service()` line: `40`
+- `Callable` import present: yes
+- Optional provider parameter present: yes
+- `_strategy_service_provider` is stored: yes
+- `_get_strategy_service()` uses the injected provider: yes
+- Public `get_strategy_service()` fallback is preserved: yes
+- Provider test is present: yes
+- Production `.py` `get_strategy_service` hits under `web/backend/app`: `19`
+
+Current residual distribution remains:
+
+| Owner | Hits |
+|---|---:|
+| `web/backend/app/tasks/backtest_tasks.py` | 2 |
+| `web/backend/app/services/strategy_service.py` | 1 |
+| `web/backend/app/services/adapters/strategy_adapter.py` | 10 |
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 6 |
+
+## GitNexus Evidence
+
+Before editing:
+
+- `web/backend/app/services/adapters/strategy_adapter.py`: LOW risk, `5`
+  impacted symbols/files, `2` direct import dependents, `0` affected processes.
+- `web/backend/tests/test_adapter_mock_fallback_controls.py`: LOW risk, `0`
+  upstream dependents, `0` affected processes.
+
+No HIGH or CRITICAL file-level warning was ignored.
+
+## Verification
+
+Commands were run from the G2.178 worktree with `PYTHONPATH=web/backend`.
+
+| Check | Result |
+|---|---|
+| TDD red focused test | failed for expected constructor keyword reason |
+| TDD green focused test | `1 passed` |
+| `pytest -o addopts= web/backend/tests/test_adapter_mock_fallback_controls.py -q --no-cov --tb=short` | `8 passed` |
+| `pytest -o addopts= web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short` | `10 passed` |
+| `pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov --tb=short` | `8 passed` |
+| `pytest -o addopts= tests/backend/test_data_adapter_regression.py -q --no-cov --tb=short` | `9 passed` |
+| `ruff check web/backend/app/services/adapters/strategy_adapter.py web/backend/tests/test_adapter_mock_fallback_controls.py` | passed |
+| `black --check web/backend/app/services/adapters/strategy_adapter.py web/backend/tests/test_adapter_mock_fallback_controls.py` | passed |
+| OpenAPI smoke | `routes=548`, `paths=500`, `duplicate_operation_ids=0`, `duplicate_operation_id_warnings=0` |
+
+OpenAPI smoke used placeholder non-secret environment values and did not start
+PM2 or execute stateful runtime gates.
+
+## Steward Tree Reconciliation
+
+After PR `#332` split the steward tree, this PR no longer writes G2.178 state
+to the old root task-tree body. The implementation state is recorded in:
+
+- `.planning/codebase/steward-tree/tracks/service-lifecycle-di.md`
+- `.planning/codebase/steward-tree/steward-index.json`
+- `.planning/codebase/steward-tree/current-next-gates.md`
+- `.planning/codebase/generated/strategy-adapter-provider-implementation-2026-05-27.json`
+
+The root entrypoint remains the PR `#332` split-navigation file.
+
+## Risk And Rollback
+
+The main risk is accidental expansion from a constructor seam into public getter
+or factory behavior. This implementation keeps the default constructor path and
+public getter fallback unchanged.
+
+Rollback is a normal PR revert. Reverting removes the optional provider
+parameter and focused test, restoring the previous canonical adapter behavior.
+
+## Next Gate
+
+Review this implementation package. If accepted and merged, close G2.178 in a
+separate governance closeout and refresh remaining Strategy service getter
+residuals before choosing any further Strategy source lane.

--- a/governance/mainline/task-cards/pr-331.yaml
+++ b/governance/mainline/task-cards/pr-331.yaml
@@ -1,0 +1,129 @@
+version: "v0.2"
+
+task:
+  id: "pr-331"
+  title: "Implement Strategy adapter provider seam"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-strategy-adapter-provider-implementation"
+  objective: "add an optional constructor-level provider seam to the canonical Strategy adapter while preserving default public getter fallback behavior"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Path-limited adapter constructor seam; no runtime route, page, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/strategy-adapter-provider-implementation-2026-05-27.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - "docs/reports/quality/backend-strategy-adapter-provider-implementation-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-331.yaml"
+    - "web/backend/app/services/adapters/strategy_adapter.py"
+    - "web/backend/tests/test_adapter_mock_fallback_controls.py"
+  forbidden_paths:
+    - "web/backend/app/services/data_adapters/strategy.py"
+    - "web/backend/app/services/data_adapter.py"
+    - "web/backend/app/services/data_source_factory.py"
+    - "web/backend/app/services/data_source_factory/**"
+    - "web/backend/app/api/strategy_management/_strategy_execution_router.py"
+    - "web/backend/app/tasks/backtest_tasks.py"
+    - "web/backend/app/services/strategy_service.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+acceptance:
+  checks:
+    - id: "parent-pr-state"
+      command: "gh pr view 330 --repo chengjon/mystocks --json number,state,mergedAt,mergeCommit,title,url"
+      required: true
+    - id: "adapter-fallback-tests"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_adapter_mock_fallback_controls.py -q --no-cov --tb=short"
+      required: true
+    - id: "logging-noise-tests"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "strategy-route-backtest-sanity"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py web/backend/tests/test_backtest_tasks_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "data-adapter-regression-tests"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= tests/backend/test_data_adapter_regression.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/services/adapters/strategy_adapter.py web/backend/tests/test_adapter_mock_fallback_controls.py"
+      required: true
+    - id: "black-check"
+      command: "black --check web/backend/app/services/adapters/strategy_adapter.py web/backend/tests/test_adapter_mock_fallback_controls.py"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md docs/reports/quality/backend-strategy-adapter-provider-implementation-2026-05-27.md"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/generated/strategy-adapter-provider-implementation-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-331.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+
+non_goals:
+  - "Do not edit data_adapters/strategy.py."
+  - "Do not edit data_adapter.py or data_source_factory.py."
+  - "Do not remove or edit Strategy route provider fallback."
+  - "Do not reopen the backtest task resolver lane."
+  - "Do not delete, privatize, rename, or change get_strategy_service()."
+  - "Do not change route/API behavior, OpenAPI exposure, PM2, frontend, OpenSpec, config, scripts, or issue-label state."
+  - "Do not append G2.178 state to the archived single-file steward tree; use the split steward files."
+
+risk_and_rollback:
+  risks:
+    - "If the default constructor path changes, data_source_factory construction could regress."
+    - "If public get_strategy_service is touched, this narrow adapter seam could enter the CRITICAL getter retirement problem."
+    - "If route provider or backtest files are edited, the lane would exceed G2.177 authorization."
+  rollback_plan: "revert this PR to remove the optional provider seam, focused test, implementation report, generated artifact, task card, and split steward-tree updates"
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "add an optional provider seam to the canonical Strategy adapter while preserving default public getter fallback behavior"
+    modified_scope: "strategy_adapter.py, focused adapter fallback test, split steward-tree files, implementation report, generated artifact, and task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "legacy wrapper and default construction remain compatible"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if TDD red/green evidence, focused tests, data-adapter regression, ruff, black, OpenAPI smoke, markdown governance, JSON/YAML parsing, staged GitNexus, mainline scope, or diff checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-27T14:35:50+08:00"
+    approval_note: "User requested continuing after PR #330 authorization; G2.178 is limited to the approved Strategy adapter provider seam implementation."
+    secondary_approved: false

--- a/web/backend/app/services/adapters/strategy_adapter.py
+++ b/web/backend/app/services/adapters/strategy_adapter.py
@@ -4,7 +4,7 @@
 
 import time
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 
 from app.services.data_source_interface import (
     HealthStatus,
@@ -21,12 +21,13 @@ from .metrics import DataSourceMetrics
 class StrategyDataSourceAdapter(IDataSource):
     """策略管理数据源适配器 - 集成现有策略服务到数据源工厂模式"""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], strategy_service_provider: Callable[[], Any] | None = None):
         self.config = config
         self.source_type = "strategy"
         self.name = config.get("name", "Strategy Management Source")
         self.mode = str(config.get("mode", "mock")).lower()
         self.fallback_enabled = bool(config.get("fallback_enabled", False))
+        self._strategy_service_provider = strategy_service_provider
 
         # Initialize services lazily (only when needed)
         self._strategy_service = None
@@ -40,9 +41,12 @@ class StrategyDataSourceAdapter(IDataSource):
         """Lazy initialization of strategy service"""
         if self._strategy_service is None:
             try:
-                from app.services.strategy_service import get_strategy_service
+                if self._strategy_service_provider is not None:
+                    self._strategy_service = self._strategy_service_provider()
+                else:
+                    from app.services.strategy_service import get_strategy_service
 
-                self._strategy_service = get_strategy_service()
+                    self._strategy_service = get_strategy_service()
             except Exception as e:
                 self._strategy_service = None
                 raise RuntimeError(f"Failed to initialize strategy service: {e}")

--- a/web/backend/tests/test_adapter_mock_fallback_controls.py
+++ b/web/backend/tests/test_adapter_mock_fallback_controls.py
@@ -13,6 +13,21 @@ def test_legacy_strategy_adapter_import_reexports_canonical_class():
     assert StrategyAdapter is CanonicalStrategyAdapter
 
 
+def test_strategy_adapter_uses_injected_strategy_service_provider():
+    provided_service = object()
+    calls = []
+
+    def provider():
+        calls.append("called")
+        return provided_service
+
+    adapter = StrategyAdapter({"mode": "real", "fallback_enabled": False}, strategy_service_provider=provider)
+
+    assert adapter._get_strategy_service() is provided_service
+    assert adapter._get_strategy_service() is provided_service
+    assert calls == ["called"]
+
+
 @pytest.mark.asyncio
 async def test_strategy_adapter_does_not_silently_fallback_when_disabled(monkeypatch):
     adapter = StrategyAdapter({"mode": "real", "fallback_enabled": False})


### PR DESCRIPTION
## Summary
- add an optional constructor-level `strategy_service_provider` seam to canonical `StrategyDataSourceAdapter`
- preserve default public `get_strategy_service()` fallback behavior and service caching
- add TDD coverage proving the injected provider is used and cached
- update G2.178 steward tree, implementation report, generated artifact, and task card

## Verification
- TDD red: provider test failed with unexpected keyword argument before implementation
- TDD green: focused provider test passed after implementation
- adapter fallback tests: 8 passed
- logging noise tests: 10 passed
- strategy route/backtest sanity tests: 8 passed
- data adapter regression tests: 9 passed
- ruff and black passed for touched source/test files
- OpenAPI smoke: routes=548, paths=500, duplicate_operation_ids=0, duplicate_operation_id_warnings=0
- GitNexus staged detect_changes: low risk, 0 affected processes
- mainline scope gate: pass=True
- gitnexus analyze --with-gitignore: 62,947 nodes / 146,077 edges / 300 flows

## Boundary
- Does not edit legacy wrapper, data_adapter.py, data_source_factory, Strategy route provider fallback, backtest task resolver, public `get_strategy_service`, route/API behavior, OpenAPI exposure, frontend, OpenSpec, config, scripts, compatibility deletion, or issue labels.