### PR TITLE
docs(governance): close strategy adapter provider lane

### DIFF
--- a/.planning/codebase/generated/strategy-adapter-provider-closeout-2026-05-27.json
+++ b/.planning/codebase/generated/strategy-adapter-provider-closeout-2026-05-27.json
@@ -1,0 +1,51 @@
+{
+  "work_item": "G2.180",
+  "title": "Strategy adapter provider closeout",
+  "state": "ready-for-review",
+  "recorded_at": "2026-05-27T16:58:24+08:00",
+  "base_head": "8bfb4dc74b06d6bb930e48ebf3d27bb28d908704",
+  "scope": {
+    "type": "governance-closeout",
+    "source_edit_authority": false,
+    "route_behavior_changed": false,
+    "openapi_exposure_changed": false,
+    "compatibility_deleted": false,
+    "issue_label_changed": false
+  },
+  "closed_item": {
+    "work_item": "G2.178",
+    "github_pr": 331,
+    "merge_commit": "8bfb4dc74b06d6bb930e48ebf3d27bb28d908704",
+    "title": "refactor(backend): inject strategy adapter provider"
+  },
+  "implementation_facts": {
+    "target_path": "web/backend/app/services/adapters/strategy_adapter.py",
+    "has_provider_parameter": true,
+    "stores_provider": true,
+    "uses_provider": true,
+    "preserves_public_getter_fallback": true,
+    "constructor_line": 24,
+    "helper_line": 40,
+    "strategy_adapter_lines": 372
+  },
+  "residual_scan": {
+    "pattern": "get_strategy_service",
+    "root": "web/backend/app",
+    "total_hits": 19,
+    "files": {
+      "web/backend/app/tasks/backtest_tasks.py": 2,
+      "web/backend/app/services/adapters/strategy_adapter.py": 10,
+      "web/backend/app/services/strategy_service.py": 1,
+      "web/backend/app/api/strategy_management/_strategy_execution_router.py": 6
+    }
+  },
+  "updated_steward_files": [
+    ".planning/codebase/steward-tree/current-next-gates.md",
+    ".planning/codebase/steward-tree/steward-index.json",
+    ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+    ".planning/codebase/steward-tree/branch-register.md",
+    ".planning/codebase/steward-tree/evidence-index.md",
+    ".planning/codebase/steward-tree/completed-ledger.md"
+  ],
+  "next_gate": "review G2.180 closeout; if accepted, prepare a separate residual-refresh decision package before further Strategy getter source edits"
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,23 +5,24 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-27T15:32:41+08:00`
-- Base HEAD checked: `3b8f95945fcb489316ddfaf919835d372122fa5f`
+- Prepared at: `2026-05-27T16:58:24+08:00`
+- Base HEAD checked: `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
 
-## Active GitHub PRs Relevant To The Steward Tree
+## Recent GitHub PRs Relevant To The Steward Tree
 
-| PR | Branch | Base | State at split | Relationship |
+| PR | Branch | Base | State | Relationship |
 |---|---|---|---|---|
-| `#331` | `g2-178-strategy-adapter-provider-implementation` | `wip/root-dirty-20260403` | `OPEN`, `MERGEABLE` | Source implementation lane for G2.178; intentionally not included in this governance split |
+| `#331` | `g2-178-strategy-adapter-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704` | Source implementation lane for G2.178 |
+| `#332` | `g2-179-steward-tree-governance-split` | `wip/root-dirty-20260403` | `MERGED` at `750fb7c797ff95f27152439ed988a7115252129e` | Steward tree split and machine-readable index |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-179-steward-tree-governance-split` | `origin/wip/root-dirty-20260403` at `3b8f95945fcb489316ddfaf919835d372122fa5f` | Split the steward tree by usage and add machine-readable index | None |
+| `g2-180-strategy-adapter-provider-closeout` | `origin/wip/root-dirty-20260403` at `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704` | Close G2.178 and refresh Strategy getter residual distribution | None |
 
 ## OpenSpec Relationship
 
@@ -37,7 +38,5 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-If PR `#331` merges before this split, update the service lifecycle track and
-`steward-index.json` to mark G2.178 as merged before merging this branch. If
-this split merges first, PR `#331` may need a small documentation-only
-reconciliation against the new split layout.
+G2.180 is a closeout branch only. It records the already merged state of PR
+`#331` and must not introduce another Strategy service getter implementation.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -20,7 +20,7 @@ exact verification output.
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
-| Strategy route/provider residuals | Route provider, backtest resolver, and adapter wrapper decisions narrowed residual `get_strategy_service` surfaces | PR `#331` handles G2.178 implementation separately |
+| Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 records closeout and residual distribution |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -6,7 +6,7 @@
 
 - Status: active gate register
 - Prepared at: `2026-05-27T15:32:41+08:00`
-- Base HEAD checked: `750fb7c797ff95f27152439ed988a7115252129e`
+- Base HEAD checked: `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,7 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.178 Strategy adapter provider implementation | G/#79 service lifecycle DI | PR `#331` is the active path-limited implementation lane and has been reconciled with the split steward tree | Human review/merge decision; if accepted, open the closeout or residual-refresh lane |
+| P0 | Review G2.180 Strategy adapter provider closeout | G/#79 service lifecycle DI | PR `#331` merged at `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`; closeout records residual `get_strategy_service` distribution | If accepted, prepare a separate residual-refresh decision package before any further Strategy getter source edits |
 | P0 | Keep steward split structure active | CODEBASE-MAP steward governance | PR `#332` merged at `750fb7c797ff95f27152439ed988a7115252129e` | Future steward updates must use split files and `steward-index.json`, not the archived single-file tree |
 | P1 | Preserve implementation authorization boundary | All lanes | Active | Every source lane still needs its own authorization packet |
 | P1 | Keep Core Batch 2 blocked | Core split / compatibility wrappers | Blocked | Resolve Task 3.2 and shared evidence gate disposition before selecting Batch 2 |
@@ -28,5 +28,5 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 - Does the split preserve the full historical steward tree in archive?
 - Is the root entrypoint short enough to serve as a daily navigation file?
 - Does `steward-index.json` include enough fields for automated guards?
-- Is PR `#331` reconciled with the split steward tree instead of the old single-file tree?
+- Does G2.180 keep closeout/residual-refresh governance separate from new source implementation?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -6,7 +6,7 @@
 
 - Status: active evidence index
 - Prepared at: `2026-05-27T15:32:41+08:00`
-- Base HEAD checked: `3b8f95945fcb489316ddfaf919835d372122fa5f`
+- Base HEAD checked: `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -20,14 +20,16 @@ state transition.
 | `.planning/codebase/CODEBASE-MAP-STEWARD-TREE-RETROSPECTIVE-2026-05-22.md` | Lessons and improvement opportunities | Historical; use as rationale for this split |
 | `.planning/codebase/CODEBASE-MAP-STEWARD-TREE-PRACTICE-GUIDE-2026-05-24.md` | Reusable operating model for other projects | Historical; superseded for this repo by `steward-tree/README.md` |
 | `.planning/codebase/steward-tree/steward-index.json` | Machine-readable active steward state | Current for this branch; stale if base HEAD or PR state changes |
-| `.planning/codebase/steward-tree/current-next-gates.md` | Human-readable active gates | Current for this branch; stale if PR `#331` state changes |
+| `.planning/codebase/steward-tree/current-next-gates.md` | Human-readable active gates | Current for this branch; stale if base HEAD changes |
+| `.planning/codebase/generated/strategy-adapter-provider-closeout-2026-05-27.json` | G2.180 closeout and residual-refresh evidence | Current for HEAD `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704` |
+| `docs/reports/quality/backend-strategy-adapter-provider-closeout-2026-05-27.md` | G2.180 human-readable closeout report | Review input until accepted |
 
 ## External State Inputs
 
 | Input | Current state at split | Notes |
 |---|---|---|
-| GitHub PR `#331` | `OPEN`, `MERGEABLE` | Separate G2.178 source implementation lane |
-| `origin/wip/root-dirty-20260403` | `3b8f95945fcb489316ddfaf919835d372122fa5f` | Base used for this governance split |
+| GitHub PR `#331` | `MERGED` | G2.178 source implementation lane closed by merge commit `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704` |
+| `origin/wip/root-dirty-20260403` | `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704` | Base used for this closeout branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-27T16:04:24+08:00",
+  "generated_at": "2026-05-27T16:58:24+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "750fb7c797ff95f27152439ed988a7115252129e",
-  "split_branch": "g2-178-strategy-adapter-provider-implementation",
-  "scope": "implementation_with_steward_reconciliation",
-  "source_edit_authority": true,
+  "base_head": "8bfb4dc74b06d6bb930e48ebf3d27bb28d908704",
+  "split_branch": "g2-180-strategy-adapter-provider-closeout",
+  "scope": "governance_closeout",
+  "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -107,15 +107,16 @@
     {
       "id": "g2-178-strategy-adapter-provider-implementation",
       "type": "implementation",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.177 Strategy canonical adapter provider authorization",
       "github_pr": {
         "number": 331,
         "url": "https://github.com/chengjon/mystocks/pull/331",
-        "state_at_split": "OPEN",
-        "mergeable_at_split": "MERGEABLE",
-        "head_ref": "g2-178-strategy-adapter-provider-implementation"
+        "state_at_closeout": "MERGED",
+        "mergeable_before_merge": "MERGEABLE",
+        "head_ref": "g2-178-strategy-adapter-provider-implementation",
+        "merge_commit": "8bfb4dc74b06d6bb930e48ebf3d27bb28d908704"
       },
       "source_edit_authority": true,
       "included_in_this_branch": true,
@@ -125,10 +126,37 @@
         "governance/mainline/task-cards/pr-331.yaml"
       ],
       "freshness": {
-        "current_head_checked": "750fb7c797ff95f27152439ed988a7115252129e",
+        "current_head_checked": "8bfb4dc74b06d6bb930e48ebf3d27bb28d908704",
         "stale_if_pr_state_changes": true
       },
-      "next_gate": "Human review/merge decision for PR #331; if accepted, create a closeout lane and refresh remaining Strategy getter residuals."
+      "next_gate": "Closed by G2.180 closeout; use the residual refresh gate for remaining Strategy getter surfaces."
+    },
+    {
+      "id": "g2-180-strategy-adapter-provider-closeout",
+      "type": "closeout",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.178 Strategy adapter provider implementation",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/strategy-adapter-provider-closeout-2026-05-27.json",
+        "docs/reports/quality/backend-strategy-adapter-provider-closeout-2026-05-27.md",
+        "governance/mainline/task-cards/pr-333.yaml"
+      ],
+      "residual": {
+        "get_strategy_service_hits": 19,
+        "files": {
+          "web/backend/app/tasks/backtest_tasks.py": 2,
+          "web/backend/app/services/adapters/strategy_adapter.py": 10,
+          "web/backend/app/services/strategy_service.py": 1,
+          "web/backend/app/api/strategy_management/_strategy_execution_router.py": 6
+        }
+      },
+      "freshness": {
+        "current_head_checked": "8bfb4dc74b06d6bb930e48ebf3d27bb28d908704",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "Review closeout; if accepted, prepare a separate residual-refresh decision package before any further Strategy getter source edits."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -6,7 +6,7 @@
 
 - Status: active track summary
 - Prepared at: `2026-05-27T15:32:41+08:00`
-- Base HEAD checked: `750fb7c797ff95f27152439ed988a7115252129e`
+- Base HEAD checked: `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -31,15 +31,28 @@ It proved a repeatable conveyor:
 |---|---|---|
 | Steward split | Merged by PR `#332` | Root task tree is now a short entrypoint; active state belongs in this split track and `steward-index.json` |
 | G2.177 Strategy canonical adapter provider authorization | Accepted and merged by PR `#330` | Authorized only a constructor-level Strategy service provider seam in canonical `strategy_adapter.py` and focused tests |
-| G2.178 Strategy adapter provider implementation | Ready for review in PR `#331` | Adds the approved optional constructor-level provider seam and reconciles the G2.178 steward update into the split tree |
+| G2.178 Strategy adapter provider implementation | Merged by PR `#331` | Added the approved optional constructor-level provider seam and reconciled the G2.178 steward update into the split tree |
+| G2.180 Strategy adapter provider closeout | For review | Records G2.178 as closed and refreshes residual Strategy getter distribution without source edits |
+
+## Current Strategy Getter Residuals
+
+At HEAD `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`, production `.py`
+`get_strategy_service` hits under `web/backend/app` remain `19`:
+
+| File | Hits | Current interpretation |
+|---|---:|---|
+| `web/backend/app/services/adapters/strategy_adapter.py` | 10 | Canonical adapter-local residual; now has constructor provider seam |
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 6 | Route provider fallback residual; must stay governed by route/provider lane |
+| `web/backend/app/tasks/backtest_tasks.py` | 2 | Backtest task helper residual; previously closed as separate resolver seam |
+| `web/backend/app/services/strategy_service.py` | 1 | Public getter definition; do not delete, rename, or privatize here |
 
 ## Next Gates
 
-- Review PR `#331` as the active G2.178 source implementation lane.
-- If PR `#331` is accepted, create a closeout lane that marks G2.178 as merged
-  and refreshes the remaining Strategy getter residuals.
-- Do not start another service source lane until G2.178 is merged, closed, or
-  explicitly superseded.
+- Review G2.180 closeout.
+- If accepted, prepare a separate residual-refresh decision package before any
+  further Strategy getter source edits.
+- Do not start another Strategy service getter source lane from this closeout
+  package.
 
 ## Forbidden Scope
 

--- a/docs/reports/quality/backend-strategy-adapter-provider-closeout-2026-05-27.md
+++ b/docs/reports/quality/backend-strategy-adapter-provider-closeout-2026-05-27.md
@@ -1,0 +1,77 @@
+# Backend Strategy Adapter Provider Closeout
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Work item: G2.180
+- State: ready for review
+- Date: 2026-05-27
+- Base HEAD: `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`
+- Closed item: G2.178 Strategy adapter provider implementation
+- Closed by PR: `#331`, merge commit `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`
+- Scope: governance closeout and residual-refresh evidence only
+
+Boundary note: this report does not authorize backend source edits, frontend
+source edits, tests, generated client updates, docs/API edits, OpenSpec proposal
+creation, issue label changes, PM2 commands, runtime rollout, compatibility
+deletion, or another Strategy getter implementation.
+
+## Closeout Decision
+
+G2.178 is closed as implemented and merged. The canonical
+`StrategyDataSourceAdapter` now has an optional constructor-level
+`strategy_service_provider` seam while preserving the default public
+`get_strategy_service()` fallback path.
+
+## Implementation Facts
+
+At HEAD `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`:
+
+| Fact | Value |
+|---|---|
+| Target file | `web/backend/app/services/adapters/strategy_adapter.py` |
+| Provider parameter present | yes |
+| Provider stored | yes |
+| Provider used by `_get_strategy_service()` | yes |
+| Public getter fallback preserved | yes |
+| Constructor line | `24` |
+| `_get_strategy_service()` line | `40` |
+| Adapter line count | `372` |
+
+## Residual Scan
+
+Production `.py` `get_strategy_service` hits under `web/backend/app` remain
+`19`:
+
+| File | Hits | Closeout interpretation |
+|---|---:|---|
+| `web/backend/app/services/adapters/strategy_adapter.py` | 10 | Canonical adapter-local residual; now has constructor provider seam |
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 6 | Route provider fallback residual; route/provider lane owns further movement |
+| `web/backend/app/tasks/backtest_tasks.py` | 2 | Backtest task helper residual; previous resolver seam lane already separated this surface |
+| `web/backend/app/services/strategy_service.py` | 1 | Public getter definition; not a deletion candidate in this lane |
+
+## Steward Updates
+
+This closeout updates the split steward tree only:
+
+- `.planning/codebase/steward-tree/current-next-gates.md`
+- `.planning/codebase/steward-tree/steward-index.json`
+- `.planning/codebase/steward-tree/tracks/service-lifecycle-di.md`
+- `.planning/codebase/steward-tree/branch-register.md`
+- `.planning/codebase/steward-tree/evidence-index.md`
+- `.planning/codebase/steward-tree/completed-ledger.md`
+- `.planning/codebase/generated/strategy-adapter-provider-closeout-2026-05-27.json`
+
+## Next Gate
+
+If this closeout is accepted, prepare a separate residual-refresh decision
+package before any further Strategy getter source edits. That package should
+decide whether the remaining residuals belong to:
+
+- canonical adapter-local lifecycle cleanup
+- route provider fallback governance
+- backtest task helper follow-up
+- public getter retention
+
+No source lane is opened by this closeout.

--- a/governance/mainline/task-cards/pr-333.yaml
+++ b/governance/mainline/task-cards/pr-333.yaml
@@ -1,0 +1,110 @@
+version: "v0.2"
+
+task:
+  id: "pr-333"
+  title: "Close Strategy adapter provider seam"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-strategy-adapter-provider-closeout"
+  objective: "record G2.178 as merged and refresh remaining Strategy getter residual distribution without source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance closeout only; records a merged source lane and residual scan without changing runtime, routes, tests, frontend, OpenAPI, or product behavior."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/strategy-adapter-provider-closeout-2026-05-27.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-strategy-adapter-provider-closeout-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-333.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source edits"
+  - "No test edits"
+  - "No route, API, OpenAPI, PM2, frontend, config, script, or issue-label changes"
+  - "No deletion, rename, privatization, or behavior change of get_strategy_service()"
+  - "No new Strategy getter source implementation lane"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/strategy-adapter-provider-closeout-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-333.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-strategy-adapter-provider-closeout-2026-05-27.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is read as source authorization, Strategy getter cleanup could restart without a residual decision package."
+    - "If residual counts are used as permanent truth, later code changes may make them stale."
+  rollback_plan: "revert this PR to restore the pre-closeout steward state and remove the closeout report, generated JSON, and task card."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close G2.178 after PR #331 merge and refresh Strategy getter residual distribution"
+    modified_scope: "split steward tree files, closeout report, generated JSON, and task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no source or compatibility behavior changes"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if closeout wording is rejected"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T16:58:24+08:00"
+    approval_note: "Human maintainer approved continuing after PR #331 merge; this lane is closeout/residual-refresh governance only."
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- Close G2.178 after PR #331 merged at 8bfb4dc74.
- Record Strategy adapter provider seam implementation facts and residual get_strategy_service distribution.
- Update split steward-tree files and machine-readable steward-index.json.
- Keep this as governance-only closeout; no source, tests, OpenSpec spec files, route/API, PM2, frontend, or issue-label changes.

## Evidence

- G2.178 merge: PR #331, merge commit 8bfb4dc74b06d6bb930e48ebf3d27bb28d908704
- Residual scan: 19 get_strategy_service hits across 4 production files
- Provider seam facts: provider parameter/stored/used; public getter fallback preserved

## Verification

- JSON/YAML parse passed
- markdown_governance_gate: 6 checked files, 0 errors
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: valid; PostHog ECONNREFUSED telemetry noise only
- git diff --check and git diff --cached --check
- GitNexus staged detect_changes: LOW, 0 affected processes
- mainline_scope_gate: pass=True
- gitnexus analyze --with-gitignore: 62,961 nodes / 146,096 edges / 300 flows

## Next Gate

If accepted, prepare a separate residual-refresh decision package before any further Strategy getter source edits.