### PR TITLE
docs(governance): decide strategy getter residual next gate

### DIFF
--- a/.planning/codebase/generated/strategy-getter-residual-refresh-decision-2026-05-27.json
+++ b/.planning/codebase/generated/strategy-getter-residual-refresh-decision-2026-05-27.json
@@ -1,0 +1,84 @@
+{
+  "work_item": "G2.181",
+  "title": "Strategy getter residual refresh decision",
+  "state": "ready-for-review",
+  "recorded_at": "2026-05-27T17:22:14+08:00",
+  "base_head": "ba929aee2e7fc0de0278f80f30caa185fafa6b5c",
+  "scope": {
+    "type": "governance-decision-package",
+    "source_edit_authority": false,
+    "route_behavior_changed": false,
+    "openapi_exposure_changed": false,
+    "compatibility_deleted": false,
+    "issue_label_changed": false,
+    "openspec_change_created": false
+  },
+  "parent_items": [
+    {
+      "work_item": "G2.178",
+      "github_pr": 331,
+      "merge_commit": "8bfb4dc74b06d6bb930e48ebf3d27bb28d908704",
+      "title": "Strategy adapter provider implementation"
+    },
+    {
+      "work_item": "G2.180",
+      "github_pr": 333,
+      "merge_commit": "ba929aee2e7fc0de0278f80f30caa185fafa6b5c",
+      "title": "Strategy adapter provider closeout"
+    }
+  ],
+  "residual_scan": {
+    "pattern": "get_strategy_service",
+    "root": "web/backend/app",
+    "total_hits": 19,
+    "files": {
+      "web/backend/app/tasks/backtest_tasks.py": {
+        "hits": 2,
+        "lines": [19, 21],
+        "classification": "backtest task helper residual",
+        "decision": "do not reopen from this package unless current evidence later contradicts the closed resolver-seam handling"
+      },
+      "web/backend/app/services/adapters/strategy_adapter.py": {
+        "hits": 10,
+        "lines": [40, 47, 49, 106, 120, 136, 153, 183, 332, 344],
+        "classification": "canonical adapter-local residual",
+        "decision": "keep under future adapter-local lifecycle cleanup consideration; do not start source edits from this package"
+      },
+      "web/backend/app/services/strategy_service.py": {
+        "hits": 1,
+        "lines": [455],
+        "classification": "public getter definition",
+        "decision": "retain as public compatibility entrypoint; not a deletion, rename, or privatization candidate here"
+      },
+      "web/backend/app/api/strategy_management/_strategy_execution_router.py": {
+        "hits": 6,
+        "lines": [20, 33, 34, 388, 454, 499],
+        "classification": "route provider fallback residual",
+        "decision": "recommended next governance target; requires a separate route/provider fallback decision package before source authorization"
+      }
+    }
+  },
+  "decision": {
+    "selected_next_governance_target": "strategy route provider fallback residual",
+    "recommended_next_work_item": "G2.182",
+    "recommended_next_package": "Strategy route provider fallback residual decision package",
+    "not_authorized": [
+      "backend source edits",
+      "test edits",
+      "route behavior changes",
+      "OpenAPI exposure changes",
+      "public get_strategy_service deletion or privatization",
+      "adapter-local cleanup implementation",
+      "backtest task helper implementation"
+    ]
+  },
+  "updated_steward_files": [
+    ".planning/codebase/steward-tree/current-next-gates.md",
+    ".planning/codebase/steward-tree/steward-index.json",
+    ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+    ".planning/codebase/steward-tree/branch-register.md",
+    ".planning/codebase/steward-tree/evidence-index.md",
+    ".planning/codebase/steward-tree/completed-ledger.md"
+  ],
+  "next_gate": "review G2.181; if accepted, prepare G2.182 route/provider fallback residual decision package before any Strategy getter source edits"
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-27T16:58:24+08:00`
-- Base HEAD checked: `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`
+- Prepared at: `2026-05-27T17:22:14+08:00`
+- Base HEAD checked: `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -17,12 +17,13 @@ PRs, change issue labels, or authorize source implementation.
 |---|---|---|---|---|
 | `#331` | `g2-178-strategy-adapter-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704` | Source implementation lane for G2.178 |
 | `#332` | `g2-179-steward-tree-governance-split` | `wip/root-dirty-20260403` | `MERGED` at `750fb7c797ff95f27152439ed988a7115252129e` | Steward tree split and machine-readable index |
+| `#333` | `g2-180-strategy-adapter-provider-closeout` | `wip/root-dirty-20260403` | `MERGED` at `ba929aee2e7fc0de0278f80f30caa185fafa6b5c` | Governance closeout for G2.178 and residual scan handoff |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-180-strategy-adapter-provider-closeout` | `origin/wip/root-dirty-20260403` at `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704` | Close G2.178 and refresh Strategy getter residual distribution | None |
+| `g2-181-strategy-getter-residual-refresh-decision` | `origin/wip/root-dirty-20260403` at `ba929aee2e7fc0de0278f80f30caa185fafa6b5c` | Recheck Strategy getter residual classes and select the next governance target | None |
 
 ## OpenSpec Relationship
 
@@ -38,5 +39,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.180 is a closeout branch only. It records the already merged state of PR
-`#331` and must not introduce another Strategy service getter implementation.
+G2.181 is a residual-refresh decision branch only. It records the already merged
+state of PR `#333`, selects route/provider fallback as the recommended next
+governance target, and must not introduce another Strategy service getter
+implementation.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-27T15:32:41+08:00`
-- Base HEAD checked: `3b8f95945fcb489316ddfaf919835d372122fa5f`
+- Prepared at: `2026-05-27T17:22:14+08:00`
+- Base HEAD checked: `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -20,7 +20,7 @@ exact verification output.
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
-| Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 records closeout and residual distribution |
+| Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 now reviews route/provider fallback as the next governance target |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-27T15:32:41+08:00`
-- Base HEAD checked: `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`
+- Prepared at: `2026-05-27T17:22:14+08:00`
+- Base HEAD checked: `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,7 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.180 Strategy adapter provider closeout | G/#79 service lifecycle DI | PR `#331` merged at `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`; closeout records residual `get_strategy_service` distribution | If accepted, prepare a separate residual-refresh decision package before any further Strategy getter source edits |
+| P0 | Review G2.181 Strategy getter residual refresh decision | G/#79 service lifecycle DI | PR `#333` merged at `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`; residual `get_strategy_service` distribution rechecked at the post-closeout HEAD | If accepted, prepare G2.182 route/provider fallback decision package before any further Strategy getter source edits |
 | P0 | Keep steward split structure active | CODEBASE-MAP steward governance | PR `#332` merged at `750fb7c797ff95f27152439ed988a7115252129e` | Future steward updates must use split files and `steward-index.json`, not the archived single-file tree |
 | P1 | Preserve implementation authorization boundary | All lanes | Active | Every source lane still needs its own authorization packet |
 | P1 | Keep Core Batch 2 blocked | Core split / compatibility wrappers | Blocked | Resolve Task 3.2 and shared evidence gate disposition before selecting Batch 2 |
@@ -28,5 +28,6 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 - Does the split preserve the full historical steward tree in archive?
 - Is the root entrypoint short enough to serve as a daily navigation file?
 - Does `steward-index.json` include enough fields for automated guards?
-- Does G2.180 keep closeout/residual-refresh governance separate from new source implementation?
+- Does G2.181 keep residual-refresh governance separate from new source implementation?
+- Is route/provider fallback the correct next decision target, with adapter-local, backtest, and public getter residuals explicitly deferred?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-27T15:32:41+08:00`
-- Base HEAD checked: `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`
+- Prepared at: `2026-05-27T17:22:14+08:00`
+- Base HEAD checked: `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -22,7 +22,9 @@ state transition.
 | `.planning/codebase/steward-tree/steward-index.json` | Machine-readable active steward state | Current for this branch; stale if base HEAD or PR state changes |
 | `.planning/codebase/steward-tree/current-next-gates.md` | Human-readable active gates | Current for this branch; stale if base HEAD changes |
 | `.planning/codebase/generated/strategy-adapter-provider-closeout-2026-05-27.json` | G2.180 closeout and residual-refresh evidence | Current for HEAD `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704` |
-| `docs/reports/quality/backend-strategy-adapter-provider-closeout-2026-05-27.md` | G2.180 human-readable closeout report | Review input until accepted |
+| `docs/reports/quality/backend-strategy-adapter-provider-closeout-2026-05-27.md` | G2.180 human-readable closeout report | Accepted by PR `#333`; superseded for residual next-gate selection by G2.181 |
+| `.planning/codebase/generated/strategy-getter-residual-refresh-decision-2026-05-27.json` | G2.181 residual class refresh and next-gate decision evidence | Current for HEAD `ba929aee2e7fc0de0278f80f30caa185fafa6b5c` |
+| `docs/reports/quality/backend-strategy-getter-residual-refresh-decision-2026-05-27.md` | G2.181 human-readable residual-refresh decision package | Review input until accepted |
 
 ## External State Inputs
 

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-27T16:58:24+08:00",
+  "generated_at": "2026-05-27T17:22:14+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "8bfb4dc74b06d6bb930e48ebf3d27bb28d908704",
-  "split_branch": "g2-180-strategy-adapter-provider-closeout",
-  "scope": "governance_closeout",
+  "base_head": "ba929aee2e7fc0de0278f80f30caa185fafa6b5c",
+  "split_branch": "g2-181-strategy-getter-residual-refresh-decision",
+  "scope": "governance_decision_package",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -134,9 +134,17 @@
     {
       "id": "g2-180-strategy-adapter-provider-closeout",
       "type": "closeout",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.178 Strategy adapter provider implementation",
+      "github_pr": {
+        "number": 333,
+        "url": "https://github.com/chengjon/mystocks/pull/333",
+        "state_at_closeout": "MERGED",
+        "mergeable_before_merge": "MERGEABLE",
+        "head_ref": "g2-180-strategy-adapter-provider-closeout",
+        "merge_commit": "ba929aee2e7fc0de0278f80f30caa185fafa6b5c"
+      },
       "source_edit_authority": false,
       "evidence": [
         ".planning/codebase/generated/strategy-adapter-provider-closeout-2026-05-27.json",
@@ -153,10 +161,47 @@
         }
       },
       "freshness": {
-        "current_head_checked": "8bfb4dc74b06d6bb930e48ebf3d27bb28d908704",
+        "source_evidence_head": "8bfb4dc74b06d6bb930e48ebf3d27bb28d908704",
+        "current_head_checked": "ba929aee2e7fc0de0278f80f30caa185fafa6b5c",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "Review closeout; if accepted, prepare a separate residual-refresh decision package before any further Strategy getter source edits."
+      "next_gate": "Superseded by G2.181 residual-refresh decision package for next-gate selection."
+    },
+    {
+      "id": "g2-181-strategy-getter-residual-refresh-decision",
+      "type": "decision_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.180 Strategy adapter provider closeout",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/strategy-getter-residual-refresh-decision-2026-05-27.json",
+        "docs/reports/quality/backend-strategy-getter-residual-refresh-decision-2026-05-27.md",
+        "governance/mainline/task-cards/pr-334.yaml"
+      ],
+      "residual": {
+        "get_strategy_service_hits": 19,
+        "files": {
+          "web/backend/app/tasks/backtest_tasks.py": 2,
+          "web/backend/app/services/adapters/strategy_adapter.py": 10,
+          "web/backend/app/services/strategy_service.py": 1,
+          "web/backend/app/api/strategy_management/_strategy_execution_router.py": 6
+        }
+      },
+      "decision": {
+        "selected_next_governance_target": "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+        "recommended_next_work_item": "G2.182 Strategy route provider fallback residual decision package",
+        "deferred_residuals": [
+          "canonical adapter-local lifecycle cleanup",
+          "backtest task helper follow-up",
+          "public getter retention"
+        ]
+      },
+      "freshness": {
+        "current_head_checked": "ba929aee2e7fc0de0278f80f30caa185fafa6b5c",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, prepare G2.182 route/provider fallback decision package before any Strategy getter source edits."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-27T15:32:41+08:00`
-- Base HEAD checked: `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`
+- Prepared at: `2026-05-27T17:22:14+08:00`
+- Base HEAD checked: `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -32,27 +32,29 @@ It proved a repeatable conveyor:
 | Steward split | Merged by PR `#332` | Root task tree is now a short entrypoint; active state belongs in this split track and `steward-index.json` |
 | G2.177 Strategy canonical adapter provider authorization | Accepted and merged by PR `#330` | Authorized only a constructor-level Strategy service provider seam in canonical `strategy_adapter.py` and focused tests |
 | G2.178 Strategy adapter provider implementation | Merged by PR `#331` | Added the approved optional constructor-level provider seam and reconciled the G2.178 steward update into the split tree |
-| G2.180 Strategy adapter provider closeout | For review | Records G2.178 as closed and refreshes residual Strategy getter distribution without source edits |
+| G2.180 Strategy adapter provider closeout | Merged by PR `#333` | Records G2.178 as closed and refreshes residual Strategy getter distribution without source edits |
+| G2.181 Strategy getter residual refresh decision | For review | Rechecks residual classes at HEAD `ba929aee2e7fc0de0278f80f30caa185fafa6b5c` and selects route/provider fallback as the next governance target |
 
 ## Current Strategy Getter Residuals
 
 At HEAD `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`, production `.py`
-`get_strategy_service` hits under `web/backend/app` remain `19`:
+At HEAD `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`, `get_strategy_service`
+hits under `web/backend/app` remain `19`:
 
-| File | Hits | Current interpretation |
+| File | Hits | Current decision |
 |---|---:|---|
-| `web/backend/app/services/adapters/strategy_adapter.py` | 10 | Canonical adapter-local residual; now has constructor provider seam |
-| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 6 | Route provider fallback residual; must stay governed by route/provider lane |
-| `web/backend/app/tasks/backtest_tasks.py` | 2 | Backtest task helper residual; previously closed as separate resolver seam |
-| `web/backend/app/services/strategy_service.py` | 1 | Public getter definition; do not delete, rename, or privatize here |
+| `web/backend/app/services/adapters/strategy_adapter.py` | 10 | Canonical adapter-local residual; defer future adapter-local lifecycle cleanup until a separate decision/authorization package exists |
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 6 | Route provider fallback residual; selected as recommended next governance target |
+| `web/backend/app/tasks/backtest_tasks.py` | 2 | Backtest task helper residual; do not reopen unless current evidence contradicts the closed resolver-seam handling |
+| `web/backend/app/services/strategy_service.py` | 1 | Public getter definition; retain as compatibility entrypoint and do not delete, rename, or privatize here |
 
 ## Next Gates
 
-- Review G2.180 closeout.
-- If accepted, prepare a separate residual-refresh decision package before any
-  further Strategy getter source edits.
-- Do not start another Strategy service getter source lane from this closeout
-  package.
+- Review G2.181 residual-refresh decision.
+- If accepted, prepare G2.182 route/provider fallback decision package before
+  any further Strategy getter source edits.
+- Do not start another Strategy service getter source lane from this
+  residual-refresh decision package.
 
 ## Forbidden Scope
 

--- a/docs/reports/quality/backend-strategy-getter-residual-refresh-decision-2026-05-27.md
+++ b/docs/reports/quality/backend-strategy-getter-residual-refresh-decision-2026-05-27.md
@@ -1,0 +1,78 @@
+# Backend Strategy Getter Residual Refresh Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Work item: G2.181
+- State: ready for review
+- Date: 2026-05-27
+- Base HEAD: `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`
+- Parent closeout: G2.180, PR `#333`, merge commit `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`
+- Scope: governance decision package only
+
+Boundary note: this report does not authorize backend source edits, frontend
+source edits, tests, generated client updates, docs/API edits, OpenSpec proposal
+creation, issue label changes, PM2 commands, runtime rollout, compatibility
+deletion, adapter-local cleanup implementation, backtest task helper
+implementation, route behavior changes, or OpenAPI exposure changes.
+
+## Purpose
+
+G2.180 closed the approved Strategy adapter provider implementation after PR
+`#331` and recorded that `get_strategy_service` residuals still exist. This
+package re-checks those residuals at the post-closeout base HEAD and decides
+which residual class should become the next governance target.
+
+This is a decision package, not an implementation package. It keeps the
+Strategy getter residual surfaces separated so future work cannot treat one
+residual count as broad permission to edit all Strategy-related files.
+
+## Residual Scan
+
+At HEAD `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`, production `.py`
+`get_strategy_service` hits under `web/backend/app` remain `19`:
+
+| File | Hits | Lines | Decision |
+|---|---:|---|---|
+| `web/backend/app/services/adapters/strategy_adapter.py` | 10 | `40`, `47`, `49`, `106`, `120`, `136`, `153`, `183`, `332`, `344` | Canonical adapter-local residual. Keep under future adapter-local lifecycle cleanup consideration; do not start source edits from this package. |
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 6 | `20`, `33`, `34`, `388`, `454`, `499` | Route provider fallback residual. Select as the recommended next governance target. |
+| `web/backend/app/tasks/backtest_tasks.py` | 2 | `19`, `21` | Backtest task helper residual. Do not reopen from this package unless later current-HEAD evidence contradicts the closed resolver-seam handling. |
+| `web/backend/app/services/strategy_service.py` | 1 | `455` | Public getter definition. Retain as public compatibility entrypoint; not a deletion, rename, or privatization candidate here. |
+
+## Decision
+
+Select `web/backend/app/api/strategy_management/_strategy_execution_router.py`
+as the next governance target, but only as a separate route/provider fallback
+decision package. The recommended next work item is:
+
+- G2.182: Strategy route provider fallback residual decision package
+
+G2.182 should decide the route/provider fallback boundary before any source
+authorization. It should not be treated as automatic permission to edit the
+route file.
+
+## Deferred Residuals
+
+The remaining residual classes stay explicitly deferred:
+
+- `strategy_adapter.py`: future adapter-local lifecycle cleanup candidate only.
+- `backtest_tasks.py`: no-op unless a fresh contradiction appears.
+- `strategy_service.py`: retained public getter definition.
+
+## Steward Updates
+
+This package updates the split steward tree only:
+
+- `.planning/codebase/steward-tree/current-next-gates.md`
+- `.planning/codebase/steward-tree/steward-index.json`
+- `.planning/codebase/steward-tree/tracks/service-lifecycle-di.md`
+- `.planning/codebase/steward-tree/branch-register.md`
+- `.planning/codebase/steward-tree/evidence-index.md`
+- `.planning/codebase/steward-tree/completed-ledger.md`
+- `.planning/codebase/generated/strategy-getter-residual-refresh-decision-2026-05-27.json`
+
+## Next Gate
+
+Review G2.181. If accepted, prepare G2.182 as a route/provider fallback
+decision package before any further Strategy getter source edits.

--- a/governance/mainline/task-cards/pr-334.yaml
+++ b/governance/mainline/task-cards/pr-334.yaml
@@ -1,0 +1,112 @@
+version: "v0.2"
+
+task:
+  id: "pr-334"
+  title: "Decide Strategy getter residual refresh next gate"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-strategy-getter-residual-refresh-decision"
+  objective: "refresh remaining Strategy getter residual classes and select the next governance target without source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance decision package only; refreshes Strategy getter residual classes and next-gate routing without changing runtime, routes, tests, frontend, OpenAPI, or product behavior."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/strategy-getter-residual-refresh-decision-2026-05-27.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-strategy-getter-residual-refresh-decision-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-334.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source edits"
+  - "No test edits"
+  - "No route, API, OpenAPI, PM2, frontend, config, script, or issue-label changes"
+  - "No deletion, rename, privatization, or behavior change of get_strategy_service()"
+  - "No adapter-local cleanup implementation"
+  - "No route/provider fallback source implementation"
+  - "No backtest task helper implementation"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/strategy-getter-residual-refresh-decision-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-334.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-strategy-getter-residual-refresh-decision-2026-05-27.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this decision package is read as source authorization, route/provider fallback work could start without a separate approval package."
+    - "If residual counts are used as permanent truth, later code changes may make them stale."
+  rollback_plan: "revert this PR to restore the pre-G2.181 steward state and remove the residual-refresh report, generated JSON, and task card."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh Strategy getter residual classes and select the route/provider fallback residual as the next governance target"
+    modified_scope: "split steward tree files, decision report, generated JSON, and task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no source or compatibility behavior changes"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if the residual classification or next-gate selection is rejected"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T17:22:14+08:00"
+    approval_note: "Human maintainer approved continuing after PR #333 merge; this lane is a residual-refresh decision package only."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- add G2.181 residual-refresh decision evidence for remaining `get_strategy_service` surfaces at `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`
- select the Strategy route/provider fallback residual as the recommended next governance target
- update split steward tree files and machine-readable index without source edits

## Boundary
- governance-only package
- no backend/frontend/source/test/OpenAPI/config/script changes
- no authorization for Strategy getter source implementation

## Verification
- JSON parse for `steward-index.json` and generated G2.181 artifact
- YAML parse for `governance/mainline/task-cards/pr-334.yaml`
- Markdown governance gate: 6 checked files, 0 errors
- `openspec validate migrate-backend-singletons-to-lifecycle-di --strict` valid; PostHog telemetry flush produced existing network noise
- `git diff --check` and `git diff --cached --check`
- GitNexus staged detect changes: low risk, 0 changed symbols, 0 affected processes
- Mainline scope gate: pass=True
- `gitnexus analyze --with-gitignore`: 62,948 nodes / 146,087 edges / 300 flows
EOF 2>&1
