### PR TITLE
docs(governance): decide strategy route provider fallback

### DIFF
--- a/.planning/codebase/generated/strategy-route-provider-fallback-decision-2026-05-27.json
+++ b/.planning/codebase/generated/strategy-route-provider-fallback-decision-2026-05-27.json
@@ -1,0 +1,101 @@
+{
+  "work_item": "G2.182",
+  "title": "Strategy route provider fallback decision",
+  "state": "ready-for-review",
+  "recorded_at": "2026-05-27T17:44:36+08:00",
+  "base_head": "0398eb81259bba5c7d8c8ba6479056554e13d064",
+  "scope": {
+    "type": "governance-decision-package",
+    "source_edit_authority": false,
+    "route_behavior_changed": false,
+    "openapi_exposure_changed": false,
+    "compatibility_deleted": false,
+    "issue_label_changed": false,
+    "openspec_change_created": false
+  },
+  "parent_item": {
+    "work_item": "G2.181",
+    "github_pr": 334,
+    "merge_commit": "0398eb81259bba5c7d8c8ba6479056554e13d064",
+    "title": "Strategy getter residual refresh decision"
+  },
+  "route_provider_evidence": {
+    "target_path": "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+    "line_count": 558,
+    "get_strategy_service_hits": 6,
+    "hit_classes": {
+      "import": {
+        "line": 20,
+        "text": "from app.services.strategy_service import StrategyService, get_strategy_service"
+      },
+      "route_local_provider": {
+        "definition_line": 33,
+        "fallback_call_line": 34,
+        "function": "get_strategy_service_dependency"
+      },
+      "route_depends_usages": [
+        {
+          "line": 388,
+          "function": "query_strategy_results",
+          "method": "GET",
+          "path": "/results"
+        },
+        {
+          "line": 454,
+          "function": "get_matched_stocks",
+          "method": "GET",
+          "path": "/matched-stocks"
+        },
+        {
+          "line": 499,
+          "function": "get_strategy_summary",
+          "method": "GET",
+          "path": "/stats/summary"
+        }
+      ]
+    },
+    "comparison": {
+      "backend_api_files_with_get_dependency_pattern": 21,
+      "interpretation": "route-local Depends(get_*_dependency) provider functions are an established backend API pattern"
+    },
+    "focused_test": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py -q --no-cov --tb=short",
+      "result": "5 passed in 4.79s",
+      "test_file": "web/backend/tests/test_strategy_management_route_provider.py"
+    }
+  },
+  "decision": {
+    "classification": "retained route-local provider fallback",
+    "source_lane_recommendation": "do-not-open-from-this-residual",
+    "rationale": [
+      "The route handlers do not call get_strategy_service directly; they depend on get_strategy_service_dependency via FastAPI Depends.",
+      "The remaining direct fallback call is inside the route-local provider helper.",
+      "Focused tests already verify that the route exposes the local provider and the three affected handlers depend on it.",
+      "Removing or replacing the fallback would be a broader route dependency-provider policy change, not a narrow bug fix."
+    ],
+    "retained_endpoints": [
+      "GET /results",
+      "GET /matched-stocks",
+      "GET /stats/summary"
+    ],
+    "not_authorized": [
+      "backend source edits",
+      "test edits",
+      "route behavior changes",
+      "OpenAPI exposure changes",
+      "public get_strategy_service deletion or privatization",
+      "adapter-local cleanup implementation",
+      "backtest task helper implementation"
+    ],
+    "recommended_next_work_item": "G2.183 Strategy getter remaining residual track closeout / adapter-local decision"
+  },
+  "updated_steward_files": [
+    ".planning/codebase/steward-tree/current-next-gates.md",
+    ".planning/codebase/steward-tree/steward-index.json",
+    ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+    ".planning/codebase/steward-tree/branch-register.md",
+    ".planning/codebase/steward-tree/evidence-index.md",
+    ".planning/codebase/steward-tree/completed-ledger.md"
+  ],
+  "next_gate": "review G2.182; if accepted, prepare G2.183 to decide whether remaining Strategy getter work is track closeout or adapter-local lifecycle cleanup authorization"
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-27T17:22:14+08:00`
-- Base HEAD checked: `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`
+- Prepared at: `2026-05-27T17:44:36+08:00`
+- Base HEAD checked: `0398eb81259bba5c7d8c8ba6479056554e13d064`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -18,12 +18,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#331` | `g2-178-strategy-adapter-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704` | Source implementation lane for G2.178 |
 | `#332` | `g2-179-steward-tree-governance-split` | `wip/root-dirty-20260403` | `MERGED` at `750fb7c797ff95f27152439ed988a7115252129e` | Steward tree split and machine-readable index |
 | `#333` | `g2-180-strategy-adapter-provider-closeout` | `wip/root-dirty-20260403` | `MERGED` at `ba929aee2e7fc0de0278f80f30caa185fafa6b5c` | Governance closeout for G2.178 and residual scan handoff |
+| `#334` | `g2-181-strategy-getter-residual-refresh-decision` | `wip/root-dirty-20260403` | `MERGED` at `0398eb81259bba5c7d8c8ba6479056554e13d064` | Residual refresh and next target selection |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-181-strategy-getter-residual-refresh-decision` | `origin/wip/root-dirty-20260403` at `ba929aee2e7fc0de0278f80f30caa185fafa6b5c` | Recheck Strategy getter residual classes and select the next governance target | None |
+| `g2-182-strategy-route-provider-fallback-decision` | `origin/wip/root-dirty-20260403` at `0398eb81259bba5c7d8c8ba6479056554e13d064` | Decide whether the Strategy route/provider fallback opens a source lane | None |
 
 ## OpenSpec Relationship
 
@@ -39,7 +40,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.181 is a residual-refresh decision branch only. It records the already merged
-state of PR `#333`, selects route/provider fallback as the recommended next
-governance target, and must not introduce another Strategy service getter
+G2.182 is a route/provider fallback decision branch only. It records the already
+merged state of PR `#334`, classifies the fallback as a retained route-local
+provider seam, and must not introduce another Strategy service getter
 implementation.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-27T17:22:14+08:00`
-- Base HEAD checked: `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`
+- Prepared at: `2026-05-27T17:44:36+08:00`
+- Base HEAD checked: `0398eb81259bba5c7d8c8ba6479056554e13d064`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -20,7 +20,7 @@ exact verification output.
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
-| Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 now reviews route/provider fallback as the next governance target |
+| Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 now reviews retaining route/provider fallback |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-27T17:22:14+08:00`
-- Base HEAD checked: `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`
+- Prepared at: `2026-05-27T17:44:36+08:00`
+- Base HEAD checked: `0398eb81259bba5c7d8c8ba6479056554e13d064`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,7 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.181 Strategy getter residual refresh decision | G/#79 service lifecycle DI | PR `#333` merged at `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`; residual `get_strategy_service` distribution rechecked at the post-closeout HEAD | If accepted, prepare G2.182 route/provider fallback decision package before any further Strategy getter source edits |
+| P0 | Review G2.182 Strategy route/provider fallback decision | G/#79 service lifecycle DI | PR `#334` merged at `0398eb81259bba5c7d8c8ba6479056554e13d064`; route/provider fallback classified as retained route-local provider seam | If accepted, prepare G2.183 to decide track closeout vs adapter-local lifecycle cleanup authorization |
 | P0 | Keep steward split structure active | CODEBASE-MAP steward governance | PR `#332` merged at `750fb7c797ff95f27152439ed988a7115252129e` | Future steward updates must use split files and `steward-index.json`, not the archived single-file tree |
 | P1 | Preserve implementation authorization boundary | All lanes | Active | Every source lane still needs its own authorization packet |
 | P1 | Keep Core Batch 2 blocked | Core split / compatibility wrappers | Blocked | Resolve Task 3.2 and shared evidence gate disposition before selecting Batch 2 |
@@ -28,6 +28,6 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 - Does the split preserve the full historical steward tree in archive?
 - Is the root entrypoint short enough to serve as a daily navigation file?
 - Does `steward-index.json` include enough fields for automated guards?
-- Does G2.181 keep residual-refresh governance separate from new source implementation?
-- Is route/provider fallback the correct next decision target, with adapter-local, backtest, and public getter residuals explicitly deferred?
+- Does G2.182 correctly retain the route-local provider fallback without opening a source lane?
+- Is G2.183 the right next gate for track closeout vs adapter-local lifecycle cleanup authorization?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-27T17:22:14+08:00`
-- Base HEAD checked: `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`
+- Prepared at: `2026-05-27T17:44:36+08:00`
+- Base HEAD checked: `0398eb81259bba5c7d8c8ba6479056554e13d064`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -24,7 +24,9 @@ state transition.
 | `.planning/codebase/generated/strategy-adapter-provider-closeout-2026-05-27.json` | G2.180 closeout and residual-refresh evidence | Current for HEAD `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704` |
 | `docs/reports/quality/backend-strategy-adapter-provider-closeout-2026-05-27.md` | G2.180 human-readable closeout report | Accepted by PR `#333`; superseded for residual next-gate selection by G2.181 |
 | `.planning/codebase/generated/strategy-getter-residual-refresh-decision-2026-05-27.json` | G2.181 residual class refresh and next-gate decision evidence | Current for HEAD `ba929aee2e7fc0de0278f80f30caa185fafa6b5c` |
-| `docs/reports/quality/backend-strategy-getter-residual-refresh-decision-2026-05-27.md` | G2.181 human-readable residual-refresh decision package | Review input until accepted |
+| `docs/reports/quality/backend-strategy-getter-residual-refresh-decision-2026-05-27.md` | G2.181 human-readable residual-refresh decision package | Accepted by PR `#334`; superseded for route/provider fallback classification by G2.182 |
+| `.planning/codebase/generated/strategy-route-provider-fallback-decision-2026-05-27.json` | G2.182 route/provider fallback classification evidence | Current for HEAD `0398eb81259bba5c7d8c8ba6479056554e13d064` |
+| `docs/reports/quality/backend-strategy-route-provider-fallback-decision-2026-05-27.md` | G2.182 human-readable route/provider fallback decision package | Review input until accepted |
 
 ## External State Inputs
 

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-27T17:22:14+08:00",
+  "generated_at": "2026-05-27T17:44:36+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "ba929aee2e7fc0de0278f80f30caa185fafa6b5c",
-  "split_branch": "g2-181-strategy-getter-residual-refresh-decision",
+  "base_head": "0398eb81259bba5c7d8c8ba6479056554e13d064",
+  "split_branch": "g2-182-strategy-route-provider-fallback-decision",
   "scope": "governance_decision_package",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
@@ -170,9 +170,17 @@
     {
       "id": "g2-181-strategy-getter-residual-refresh-decision",
       "type": "decision_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.180 Strategy adapter provider closeout",
+      "github_pr": {
+        "number": 334,
+        "url": "https://github.com/chengjon/mystocks/pull/334",
+        "state_at_closeout": "MERGED",
+        "mergeable_before_merge": "MERGEABLE",
+        "head_ref": "g2-181-strategy-getter-residual-refresh-decision",
+        "merge_commit": "0398eb81259bba5c7d8c8ba6479056554e13d064"
+      },
       "source_edit_authority": false,
       "evidence": [
         ".planning/codebase/generated/strategy-getter-residual-refresh-decision-2026-05-27.json",
@@ -198,10 +206,58 @@
         ]
       },
       "freshness": {
-        "current_head_checked": "ba929aee2e7fc0de0278f80f30caa185fafa6b5c",
+        "source_evidence_head": "ba929aee2e7fc0de0278f80f30caa185fafa6b5c",
+        "current_head_checked": "0398eb81259bba5c7d8c8ba6479056554e13d064",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, prepare G2.182 route/provider fallback decision package before any Strategy getter source edits."
+      "next_gate": "Superseded by G2.182 route/provider fallback decision package."
+    },
+    {
+      "id": "g2-182-strategy-route-provider-fallback-decision",
+      "type": "decision_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.181 Strategy getter residual refresh decision",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/strategy-route-provider-fallback-decision-2026-05-27.json",
+        "docs/reports/quality/backend-strategy-route-provider-fallback-decision-2026-05-27.md",
+        "governance/mainline/task-cards/pr-335.yaml"
+      ],
+      "route_provider_residual": {
+        "target_path": "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+        "get_strategy_service_hits": 6,
+        "import_line": 20,
+        "provider_definition_line": 33,
+        "provider_fallback_call_line": 34,
+        "endpoint_depends_usages": {
+          "query_strategy_results": {
+            "line": 388,
+            "method": "GET",
+            "path": "/results"
+          },
+          "get_matched_stocks": {
+            "line": 454,
+            "method": "GET",
+            "path": "/matched-stocks"
+          },
+          "get_strategy_summary": {
+            "line": 499,
+            "method": "GET",
+            "path": "/stats/summary"
+          }
+        }
+      },
+      "decision": {
+        "classification": "retained route-local provider fallback",
+        "source_lane_recommendation": "do-not-open-from-this-residual",
+        "recommended_next_work_item": "G2.183 Strategy getter remaining residual track closeout / adapter-local decision"
+      },
+      "freshness": {
+        "current_head_checked": "0398eb81259bba5c7d8c8ba6479056554e13d064",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, prepare G2.183 to decide track closeout vs adapter-local lifecycle cleanup authorization."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-27T17:22:14+08:00`
-- Base HEAD checked: `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`
+- Prepared at: `2026-05-27T17:44:36+08:00`
+- Base HEAD checked: `0398eb81259bba5c7d8c8ba6479056554e13d064`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -33,28 +33,29 @@ It proved a repeatable conveyor:
 | G2.177 Strategy canonical adapter provider authorization | Accepted and merged by PR `#330` | Authorized only a constructor-level Strategy service provider seam in canonical `strategy_adapter.py` and focused tests |
 | G2.178 Strategy adapter provider implementation | Merged by PR `#331` | Added the approved optional constructor-level provider seam and reconciled the G2.178 steward update into the split tree |
 | G2.180 Strategy adapter provider closeout | Merged by PR `#333` | Records G2.178 as closed and refreshes residual Strategy getter distribution without source edits |
-| G2.181 Strategy getter residual refresh decision | For review | Rechecks residual classes at HEAD `ba929aee2e7fc0de0278f80f30caa185fafa6b5c` and selects route/provider fallback as the next governance target |
+| G2.181 Strategy getter residual refresh decision | Merged by PR `#334` | Rechecks residual classes and selects route/provider fallback as the next governance target |
+| G2.182 Strategy route/provider fallback decision | For review | Classifies the route/provider fallback as a retained route-local provider seam and does not open a source lane |
 
 ## Current Strategy Getter Residuals
 
 At HEAD `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`, production `.py`
-At HEAD `ba929aee2e7fc0de0278f80f30caa185fafa6b5c`, `get_strategy_service`
+At HEAD `0398eb81259bba5c7d8c8ba6479056554e13d064`, `get_strategy_service`
 hits under `web/backend/app` remain `19`:
 
 | File | Hits | Current decision |
 |---|---:|---|
 | `web/backend/app/services/adapters/strategy_adapter.py` | 10 | Canonical adapter-local residual; defer future adapter-local lifecycle cleanup until a separate decision/authorization package exists |
-| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 6 | Route provider fallback residual; selected as recommended next governance target |
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 6 | Retained route-local provider fallback; no source lane opened by G2.182 |
 | `web/backend/app/tasks/backtest_tasks.py` | 2 | Backtest task helper residual; do not reopen unless current evidence contradicts the closed resolver-seam handling |
 | `web/backend/app/services/strategy_service.py` | 1 | Public getter definition; retain as compatibility entrypoint and do not delete, rename, or privatize here |
 
 ## Next Gates
 
-- Review G2.181 residual-refresh decision.
-- If accepted, prepare G2.182 route/provider fallback decision package before
-  any further Strategy getter source edits.
+- Review G2.182 route/provider fallback decision.
+- If accepted, prepare G2.183 to decide track closeout vs adapter-local
+  lifecycle cleanup authorization.
 - Do not start another Strategy service getter source lane from this
-  residual-refresh decision package.
+  route/provider fallback decision package.
 
 ## Forbidden Scope
 

--- a/docs/reports/quality/backend-strategy-route-provider-fallback-decision-2026-05-27.md
+++ b/docs/reports/quality/backend-strategy-route-provider-fallback-decision-2026-05-27.md
@@ -1,0 +1,108 @@
+# Backend Strategy Route Provider Fallback Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Work item: G2.182
+- State: ready for review
+- Date: 2026-05-27
+- Base HEAD: `0398eb81259bba5c7d8c8ba6479056554e13d064`
+- Parent decision: G2.181, PR `#334`, merge commit `0398eb81259bba5c7d8c8ba6479056554e13d064`
+- Scope: governance decision package only
+
+Boundary note: this report does not authorize backend source edits, frontend
+source edits, tests, generated client updates, docs/API edits, OpenSpec proposal
+creation, issue label changes, PM2 commands, runtime rollout, compatibility
+deletion, adapter-local cleanup implementation, backtest task helper
+implementation, route behavior changes, or OpenAPI exposure changes.
+
+## Purpose
+
+G2.181 selected the Strategy route/provider fallback residual as the next
+governance target. This package checks whether that residual should become a
+source implementation lane or be retained as an intentional route-local provider
+fallback.
+
+## Route Evidence
+
+At HEAD `0398eb81259bba5c7d8c8ba6479056554e13d064`,
+`web/backend/app/api/strategy_management/_strategy_execution_router.py` has
+`6` `get_strategy_service` hits:
+
+| Class | Lines | Current meaning |
+|---|---|---|
+| Import | `20` | Imports `StrategyService` and the public getter fallback. |
+| Route-local provider | `33`, `34` | Defines `get_strategy_service_dependency()` and returns the public fallback. |
+| Endpoint dependency usages | `388`, `454`, `499` | Three handlers receive `StrategyService` through `Depends(get_strategy_service_dependency)`. |
+
+The three endpoint dependency usages are:
+
+| Method | Path | Function |
+|---|---|---|
+| GET | `/results` | `query_strategy_results` |
+| GET | `/matched-stocks` | `get_matched_stocks` |
+| GET | `/stats/summary` | `get_strategy_summary` |
+
+The route handlers do not call `get_strategy_service()` directly. They depend
+on a route-local provider through FastAPI `Depends`.
+
+## Existing Test Evidence
+
+Focused test executed in this branch:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py -q --no-cov --tb=short
+```
+
+Result:
+
+```text
+5 passed in 4.79s
+```
+
+The test file verifies that:
+
+- the route module exposes `get_strategy_service_dependency()`
+- the affected handlers depend on the route-local provider
+- injected fake strategy services are used by the three affected handlers
+
+## Comparison Evidence
+
+A repository scan found `21` backend API files using `Depends(get_*_dependency)`
+style route dependency providers. This means the Strategy execution router is
+not an isolated pattern outlier; the remaining fallback is a route-local
+provider fallback, not a direct handler body call.
+
+## Decision
+
+Retain the current route-local provider fallback. Do not open a source
+implementation lane from this residual.
+
+Rationale:
+
+- The route already has an explicit provider boundary at the handler signature.
+- The only direct getter call is inside the provider helper.
+- Focused tests verify the provider seam and injected-service behavior.
+- Replacing the fallback would be a broader route dependency-provider policy
+  change, not a narrow Strategy getter cleanup.
+
+## Deferred Work
+
+This package does not change the remaining Strategy getter residual classes:
+
+- `strategy_adapter.py`: still a future adapter-local lifecycle cleanup
+  candidate only.
+- `backtest_tasks.py`: no-op unless fresh current-HEAD evidence contradicts the
+  closed resolver-seam handling.
+- `strategy_service.py`: retained public getter definition.
+
+## Next Gate
+
+Review G2.182. If accepted, prepare G2.183 to decide whether the remaining
+Strategy getter work is:
+
+- track closeout with retained residuals, or
+- a separate adapter-local lifecycle cleanup authorization package.
+
+No source lane is opened by G2.182.

--- a/governance/mainline/task-cards/pr-335.yaml
+++ b/governance/mainline/task-cards/pr-335.yaml
@@ -1,0 +1,115 @@
+version: "v0.2"
+
+task:
+  id: "pr-335"
+  title: "Decide Strategy route provider fallback residual"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-strategy-route-provider-fallback-decision"
+  objective: "classify the Strategy route provider fallback residual and decide whether it opens a source lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance decision package only; classifies the Strategy route/provider fallback residual without changing runtime, routes, tests, frontend, OpenAPI, or product behavior."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/strategy-route-provider-fallback-decision-2026-05-27.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-strategy-route-provider-fallback-decision-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-335.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source edits"
+  - "No test edits"
+  - "No route, API, OpenAPI, PM2, frontend, config, script, or issue-label changes"
+  - "No deletion, rename, privatization, or behavior change of get_strategy_service()"
+  - "No route/provider fallback implementation"
+  - "No adapter-local cleanup implementation"
+  - "No backtest task helper implementation"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/strategy-route-provider-fallback-decision-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-335.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-strategy-route-provider-fallback-decision-2026-05-27.md"
+      required: true
+    - id: "focused-route-provider-test"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_strategy_management_route_provider.py -q --no-cov --tb=short"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this decision is read as source authorization, route/provider fallback code could be changed without a separate implementation packet."
+    - "If the retained fallback is later treated as permanent truth, future route dependency-provider policy changes may be missed."
+  rollback_plan: "revert this PR to restore the pre-G2.182 steward state and remove the route/provider fallback decision report, generated JSON, and task card."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "classify the Strategy route/provider fallback residual and decide not to open a source lane from it"
+    modified_scope: "split steward tree files, decision report, generated JSON, and task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no source or compatibility behavior changes"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if the retained-fallback decision is rejected"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T17:44:36+08:00"
+    approval_note: "Human maintainer approved continuing after PR #334 merge; this lane is a route/provider fallback decision package only."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- add G2.182 route/provider fallback decision evidence for `_strategy_execution_router.py`
- classify the remaining route fallback as a retained route-local provider seam, not a new source implementation lane
- update split steward tree files and machine-readable index without source edits

## Boundary
- governance-only package
- no backend/frontend/source/test/OpenAPI/config/script changes
- no authorization for Strategy getter source implementation

## Verification
- JSON parse for `steward-index.json` and generated G2.182 artifact
- YAML parse for `governance/mainline/task-cards/pr-335.yaml`
- Markdown governance gate: 6 checked files, 0 errors
- Focused route provider test: `5 passed in 4.36s`
- `openspec validate migrate-backend-singletons-to-lifecycle-di --strict` valid; PostHog telemetry flush produced existing network noise
- `git diff --check` and `git diff --cached --check`
- GitNexus staged detect changes: low risk, 0 changed symbols, 0 affected processes
- Mainline scope gate: pass=True
- `gitnexus analyze --with-gitignore`: 62,954 nodes / 146,085 edges / 300 flows
EOF 2>&1
