### PR TITLE
docs(governance): close strategy getter residual track

### DIFF
--- a/.planning/codebase/generated/strategy-getter-remaining-residual-decision-2026-05-27.json
+++ b/.planning/codebase/generated/strategy-getter-remaining-residual-decision-2026-05-27.json
@@ -1,0 +1,93 @@
+{
+  "work_item": "G2.183",
+  "title": "Strategy getter remaining residual decision",
+  "state": "ready-for-review",
+  "recorded_at": "2026-05-27T18:06:02+08:00",
+  "base_head": "597f8186092b4ad3d0704326e292c5e4fa075f15",
+  "scope": {
+    "type": "governance-decision-package",
+    "source_edit_authority": false,
+    "route_behavior_changed": false,
+    "openapi_exposure_changed": false,
+    "compatibility_deleted": false,
+    "issue_label_changed": false,
+    "openspec_change_created": false
+  },
+  "parent_item": {
+    "work_item": "G2.182",
+    "github_pr": 335,
+    "merge_commit": "597f8186092b4ad3d0704326e292c5e4fa075f15",
+    "title": "Strategy route provider fallback decision"
+  },
+  "residual_scan": {
+    "pattern": "get_strategy_service",
+    "root": "web/backend/app",
+    "total_hits": 19,
+    "files": {
+      "web/backend/app/tasks/backtest_tasks.py": {
+        "hits": 2,
+        "lines": [19, 21],
+        "classification": "backtest task resolver fallback",
+        "decision": "retained; do not reopen unless fresh current-HEAD evidence contradicts the resolver-seam tests"
+      },
+      "web/backend/app/services/adapters/strategy_adapter.py": {
+        "hits": 10,
+        "lines": [40, 47, 49, 106, 120, 136, 153, 183, 332, 344],
+        "classification": "adapter-local helper/provider seam",
+        "decision": "retained; no adapter-local cleanup authorization from this package"
+      },
+      "web/backend/app/services/strategy_service.py": {
+        "hits": 1,
+        "lines": [455],
+        "classification": "public compatibility getter definition",
+        "decision": "retained; not a deletion, rename, or privatization candidate"
+      },
+      "web/backend/app/api/strategy_management/_strategy_execution_router.py": {
+        "hits": 6,
+        "lines": [20, 33, 34, 388, 454, 499],
+        "classification": "route-local provider fallback",
+        "decision": "retained by G2.182"
+      }
+    }
+  },
+  "focused_test_evidence": {
+    "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_adapter_mock_fallback_controls.py web/backend/tests/test_backtest_tasks_regressions.py web/backend/tests/test_strategy_management_route_provider.py -q --no-cov --tb=short",
+    "result": "16 passed in 4.52s",
+    "covered_surfaces": [
+      "StrategyDataSourceAdapter provider/fallback controls",
+      "backtest task resolver fallback",
+      "strategy route provider fallback"
+    ]
+  },
+  "decision": {
+    "classification": "strategy-getter-track-closeout-with-retained-residuals",
+    "source_lane_recommendation": "do-not-open-adapter-local-cleanup-now",
+    "rationale": [
+      "The remaining route/provider fallback was retained by G2.182.",
+      "The adapter-local residuals are internal helper/provider seam calls after the approved constructor provider seam.",
+      "The backtest task residual is a resolver fallback covered by focused regression tests.",
+      "The public get_strategy_service definition remains the compatibility entrypoint.",
+      "Focused tests covering adapter, backtest, and route residual surfaces passed."
+    ],
+    "closed_strategy_getter_track": true,
+    "recommended_next_work_item": "return to service lifecycle DI queue for next non-Strategy getter candidate selection"
+  },
+  "not_authorized": [
+    "backend source edits",
+    "test edits",
+    "route behavior changes",
+    "OpenAPI exposure changes",
+    "public get_strategy_service deletion or privatization",
+    "adapter-local cleanup implementation",
+    "backtest task helper implementation"
+  ],
+  "updated_steward_files": [
+    ".planning/codebase/steward-tree/current-next-gates.md",
+    ".planning/codebase/steward-tree/steward-index.json",
+    ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+    ".planning/codebase/steward-tree/branch-register.md",
+    ".planning/codebase/steward-tree/evidence-index.md",
+    ".planning/codebase/steward-tree/completed-ledger.md"
+  ],
+  "next_gate": "review G2.183; if accepted, use a separate decision package to select the next non-Strategy service lifecycle DI candidate"
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-27T17:44:36+08:00`
-- Base HEAD checked: `0398eb81259bba5c7d8c8ba6479056554e13d064`
+- Prepared at: `2026-05-27T18:06:02+08:00`
+- Base HEAD checked: `597f8186092b4ad3d0704326e292c5e4fa075f15`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -19,12 +19,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#332` | `g2-179-steward-tree-governance-split` | `wip/root-dirty-20260403` | `MERGED` at `750fb7c797ff95f27152439ed988a7115252129e` | Steward tree split and machine-readable index |
 | `#333` | `g2-180-strategy-adapter-provider-closeout` | `wip/root-dirty-20260403` | `MERGED` at `ba929aee2e7fc0de0278f80f30caa185fafa6b5c` | Governance closeout for G2.178 and residual scan handoff |
 | `#334` | `g2-181-strategy-getter-residual-refresh-decision` | `wip/root-dirty-20260403` | `MERGED` at `0398eb81259bba5c7d8c8ba6479056554e13d064` | Residual refresh and next target selection |
+| `#335` | `g2-182-strategy-route-provider-fallback-decision` | `wip/root-dirty-20260403` | `MERGED` at `597f8186092b4ad3d0704326e292c5e4fa075f15` | Retained route/provider fallback decision |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-182-strategy-route-provider-fallback-decision` | `origin/wip/root-dirty-20260403` at `0398eb81259bba5c7d8c8ba6479056554e13d064` | Decide whether the Strategy route/provider fallback opens a source lane | None |
+| `g2-183-strategy-getter-remaining-residual-decision` | `origin/wip/root-dirty-20260403` at `597f8186092b4ad3d0704326e292c5e4fa075f15` | Decide whether remaining Strategy getter residuals close the track or require adapter-local cleanup authorization | None |
 
 ## OpenSpec Relationship
 
@@ -40,7 +41,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.182 is a route/provider fallback decision branch only. It records the already
-merged state of PR `#334`, classifies the fallback as a retained route-local
-provider seam, and must not introduce another Strategy service getter
-implementation.
+G2.183 is a remaining-residual decision branch only. It records the already
+merged state of PR `#335`, closes the current Strategy getter residual track
+with retained residuals if accepted, and must not introduce another Strategy
+service getter implementation.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-27T17:44:36+08:00`
-- Base HEAD checked: `0398eb81259bba5c7d8c8ba6479056554e13d064`
+- Prepared at: `2026-05-27T18:06:02+08:00`
+- Base HEAD checked: `597f8186092b4ad3d0704326e292c5e4fa075f15`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -20,7 +20,7 @@ exact verification output.
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
-| Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 now reviews retaining route/provider fallback |
+| Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 now reviews final Strategy getter residual closeout |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-27T17:44:36+08:00`
-- Base HEAD checked: `0398eb81259bba5c7d8c8ba6479056554e13d064`
+- Prepared at: `2026-05-27T18:06:02+08:00`
+- Base HEAD checked: `597f8186092b4ad3d0704326e292c5e4fa075f15`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,7 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.182 Strategy route/provider fallback decision | G/#79 service lifecycle DI | PR `#334` merged at `0398eb81259bba5c7d8c8ba6479056554e13d064`; route/provider fallback classified as retained route-local provider seam | If accepted, prepare G2.183 to decide track closeout vs adapter-local lifecycle cleanup authorization |
+| P0 | Review G2.183 Strategy getter remaining residual decision | G/#79 service lifecycle DI | PR `#335` merged at `597f8186092b4ad3d0704326e292c5e4fa075f15`; remaining Strategy getter residuals classified as retained and tested | If accepted, return to service lifecycle DI queue for next non-Strategy getter candidate selection |
 | P0 | Keep steward split structure active | CODEBASE-MAP steward governance | PR `#332` merged at `750fb7c797ff95f27152439ed988a7115252129e` | Future steward updates must use split files and `steward-index.json`, not the archived single-file tree |
 | P1 | Preserve implementation authorization boundary | All lanes | Active | Every source lane still needs its own authorization packet |
 | P1 | Keep Core Batch 2 blocked | Core split / compatibility wrappers | Blocked | Resolve Task 3.2 and shared evidence gate disposition before selecting Batch 2 |
@@ -28,6 +28,6 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 - Does the split preserve the full historical steward tree in archive?
 - Is the root entrypoint short enough to serve as a daily navigation file?
 - Does `steward-index.json` include enough fields for automated guards?
-- Does G2.182 correctly retain the route-local provider fallback without opening a source lane?
-- Is G2.183 the right next gate for track closeout vs adapter-local lifecycle cleanup authorization?
+- Does G2.183 correctly close the Strategy getter residual track without authorizing deletion or adapter-local cleanup?
+- Is the next gate now a non-Strategy service lifecycle DI candidate selection?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-27T17:44:36+08:00`
-- Base HEAD checked: `0398eb81259bba5c7d8c8ba6479056554e13d064`
+- Prepared at: `2026-05-27T18:06:02+08:00`
+- Base HEAD checked: `597f8186092b4ad3d0704326e292c5e4fa075f15`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -26,7 +26,9 @@ state transition.
 | `.planning/codebase/generated/strategy-getter-residual-refresh-decision-2026-05-27.json` | G2.181 residual class refresh and next-gate decision evidence | Current for HEAD `ba929aee2e7fc0de0278f80f30caa185fafa6b5c` |
 | `docs/reports/quality/backend-strategy-getter-residual-refresh-decision-2026-05-27.md` | G2.181 human-readable residual-refresh decision package | Accepted by PR `#334`; superseded for route/provider fallback classification by G2.182 |
 | `.planning/codebase/generated/strategy-route-provider-fallback-decision-2026-05-27.json` | G2.182 route/provider fallback classification evidence | Current for HEAD `0398eb81259bba5c7d8c8ba6479056554e13d064` |
-| `docs/reports/quality/backend-strategy-route-provider-fallback-decision-2026-05-27.md` | G2.182 human-readable route/provider fallback decision package | Review input until accepted |
+| `docs/reports/quality/backend-strategy-route-provider-fallback-decision-2026-05-27.md` | G2.182 human-readable route/provider fallback decision package | Accepted by PR `#335`; superseded for remaining-residual closeout by G2.183 |
+| `.planning/codebase/generated/strategy-getter-remaining-residual-decision-2026-05-27.json` | G2.183 remaining Strategy getter residual closeout evidence | Current for HEAD `597f8186092b4ad3d0704326e292c5e4fa075f15` |
+| `docs/reports/quality/backend-strategy-getter-remaining-residual-decision-2026-05-27.md` | G2.183 human-readable remaining-residual decision package | Review input until accepted |
 
 ## External State Inputs
 

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-27T17:44:36+08:00",
+  "generated_at": "2026-05-27T18:06:02+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "0398eb81259bba5c7d8c8ba6479056554e13d064",
-  "split_branch": "g2-182-strategy-route-provider-fallback-decision",
+  "base_head": "597f8186092b4ad3d0704326e292c5e4fa075f15",
+  "split_branch": "g2-183-strategy-getter-remaining-residual-decision",
   "scope": "governance_decision_package",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
@@ -215,9 +215,17 @@
     {
       "id": "g2-182-strategy-route-provider-fallback-decision",
       "type": "decision_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.181 Strategy getter residual refresh decision",
+      "github_pr": {
+        "number": 335,
+        "url": "https://github.com/chengjon/mystocks/pull/335",
+        "state_at_closeout": "MERGED",
+        "mergeable_before_merge": "MERGEABLE",
+        "head_ref": "g2-182-strategy-route-provider-fallback-decision",
+        "merge_commit": "597f8186092b4ad3d0704326e292c5e4fa075f15"
+      },
       "source_edit_authority": false,
       "evidence": [
         ".planning/codebase/generated/strategy-route-provider-fallback-decision-2026-05-27.json",
@@ -254,10 +262,43 @@
         "recommended_next_work_item": "G2.183 Strategy getter remaining residual track closeout / adapter-local decision"
       },
       "freshness": {
-        "current_head_checked": "0398eb81259bba5c7d8c8ba6479056554e13d064",
+        "source_evidence_head": "0398eb81259bba5c7d8c8ba6479056554e13d064",
+        "current_head_checked": "597f8186092b4ad3d0704326e292c5e4fa075f15",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, prepare G2.183 to decide track closeout vs adapter-local lifecycle cleanup authorization."
+      "next_gate": "Superseded by G2.183 remaining residual decision package."
+    },
+    {
+      "id": "g2-183-strategy-getter-remaining-residual-decision",
+      "type": "decision_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.182 Strategy route/provider fallback decision",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/strategy-getter-remaining-residual-decision-2026-05-27.json",
+        "docs/reports/quality/backend-strategy-getter-remaining-residual-decision-2026-05-27.md",
+        "governance/mainline/task-cards/pr-336.yaml"
+      ],
+      "residual": {
+        "get_strategy_service_hits": 19,
+        "files": {
+          "web/backend/app/tasks/backtest_tasks.py": 2,
+          "web/backend/app/services/adapters/strategy_adapter.py": 10,
+          "web/backend/app/services/strategy_service.py": 1,
+          "web/backend/app/api/strategy_management/_strategy_execution_router.py": 6
+        }
+      },
+      "decision": {
+        "classification": "strategy-getter-track-closeout-with-retained-residuals",
+        "source_lane_recommendation": "do-not-open-adapter-local-cleanup-now",
+        "recommended_next_work_item": "select next non-Strategy service lifecycle DI candidate"
+      },
+      "freshness": {
+        "current_head_checked": "597f8186092b4ad3d0704326e292c5e4fa075f15",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, use a separate decision package to select the next non-Strategy service lifecycle DI candidate."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-27T17:44:36+08:00`
-- Base HEAD checked: `0398eb81259bba5c7d8c8ba6479056554e13d064`
+- Prepared at: `2026-05-27T18:06:02+08:00`
+- Base HEAD checked: `597f8186092b4ad3d0704326e292c5e4fa075f15`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -34,28 +34,30 @@ It proved a repeatable conveyor:
 | G2.178 Strategy adapter provider implementation | Merged by PR `#331` | Added the approved optional constructor-level provider seam and reconciled the G2.178 steward update into the split tree |
 | G2.180 Strategy adapter provider closeout | Merged by PR `#333` | Records G2.178 as closed and refreshes residual Strategy getter distribution without source edits |
 | G2.181 Strategy getter residual refresh decision | Merged by PR `#334` | Rechecks residual classes and selects route/provider fallback as the next governance target |
-| G2.182 Strategy route/provider fallback decision | For review | Classifies the route/provider fallback as a retained route-local provider seam and does not open a source lane |
+| G2.182 Strategy route/provider fallback decision | Merged by PR `#335` | Classifies the route/provider fallback as a retained route-local provider seam and does not open a source lane |
+| G2.183 Strategy getter remaining residual decision | For review | Closes the current Strategy getter residual track with retained residuals and focused residual test evidence |
 
 ## Current Strategy Getter Residuals
 
 At HEAD `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`, production `.py`
-At HEAD `0398eb81259bba5c7d8c8ba6479056554e13d064`, `get_strategy_service`
+At HEAD `597f8186092b4ad3d0704326e292c5e4fa075f15`, `get_strategy_service`
 hits under `web/backend/app` remain `19`:
 
 | File | Hits | Current decision |
 |---|---:|---|
-| `web/backend/app/services/adapters/strategy_adapter.py` | 10 | Canonical adapter-local residual; defer future adapter-local lifecycle cleanup until a separate decision/authorization package exists |
+| `web/backend/app/services/adapters/strategy_adapter.py` | 10 | Retained adapter-local helper/provider seam; no adapter-local cleanup authorization opened by G2.183 |
 | `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 6 | Retained route-local provider fallback; no source lane opened by G2.182 |
-| `web/backend/app/tasks/backtest_tasks.py` | 2 | Backtest task helper residual; do not reopen unless current evidence contradicts the closed resolver-seam handling |
+| `web/backend/app/tasks/backtest_tasks.py` | 2 | Retained backtest task resolver fallback; do not reopen unless current evidence contradicts focused tests |
 | `web/backend/app/services/strategy_service.py` | 1 | Public getter definition; retain as compatibility entrypoint and do not delete, rename, or privatize here |
 
 ## Next Gates
 
-- Review G2.182 route/provider fallback decision.
-- If accepted, prepare G2.183 to decide track closeout vs adapter-local
-  lifecycle cleanup authorization.
+- Review G2.183 remaining residual decision.
+- If accepted, close the current Strategy getter residual track with retained
+  residuals and select the next non-Strategy service lifecycle DI candidate in a
+  separate decision package.
 - Do not start another Strategy service getter source lane from this
-  route/provider fallback decision package.
+  remaining-residual decision package.
 
 ## Forbidden Scope
 

--- a/docs/reports/quality/backend-strategy-getter-remaining-residual-decision-2026-05-27.md
+++ b/docs/reports/quality/backend-strategy-getter-remaining-residual-decision-2026-05-27.md
@@ -1,0 +1,90 @@
+# Backend Strategy Getter Remaining Residual Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Work item: G2.183
+- State: ready for review
+- Date: 2026-05-27
+- Base HEAD: `597f8186092b4ad3d0704326e292c5e4fa075f15`
+- Parent decision: G2.182, PR `#335`, merge commit `597f8186092b4ad3d0704326e292c5e4fa075f15`
+- Scope: governance decision package only
+
+Boundary note: this report does not authorize backend source edits, frontend
+source edits, tests, generated client updates, docs/API edits, OpenSpec proposal
+creation, issue label changes, PM2 commands, runtime rollout, compatibility
+deletion, adapter-local cleanup implementation, backtest task helper
+implementation, route behavior changes, or OpenAPI exposure changes.
+
+## Purpose
+
+G2.182 retained the Strategy route/provider fallback as an intentional
+route-local provider seam. This package decides whether the remaining Strategy
+getter residuals justify a new adapter-local lifecycle cleanup authorization
+package or whether the Strategy getter track can close with retained residuals.
+
+## Residual Scan
+
+At HEAD `597f8186092b4ad3d0704326e292c5e4fa075f15`, production `.py`
+`get_strategy_service` hits under `web/backend/app` remain `19`:
+
+| File | Hits | Lines | Decision |
+|---|---:|---|---|
+| `web/backend/app/services/adapters/strategy_adapter.py` | 10 | `40`, `47`, `49`, `106`, `120`, `136`, `153`, `183`, `332`, `344` | Retain as adapter-local helper/provider seam. Do not open adapter-local cleanup authorization from this package. |
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 6 | `20`, `33`, `34`, `388`, `454`, `499` | Retained by G2.182 as route-local provider fallback. |
+| `web/backend/app/tasks/backtest_tasks.py` | 2 | `19`, `21` | Retain as backtest task resolver fallback unless fresh current-HEAD evidence contradicts resolver-seam tests. |
+| `web/backend/app/services/strategy_service.py` | 1 | `455` | Retain as public compatibility getter definition. |
+
+## Focused Test Evidence
+
+Focused residual tests executed in this branch:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_adapter_mock_fallback_controls.py web/backend/tests/test_backtest_tasks_regressions.py web/backend/tests/test_strategy_management_route_provider.py -q --no-cov --tb=short
+```
+
+Result:
+
+```text
+16 passed in 4.52s
+```
+
+The test set covers:
+
+- `StrategyDataSourceAdapter` provider/fallback controls
+- backtest task resolver fallback
+- Strategy route provider fallback
+
+## Decision
+
+Close the current Strategy getter residual track with retained residuals. Do
+not open an adapter-local lifecycle cleanup authorization package from this
+decision.
+
+Rationale:
+
+- The route/provider fallback is already retained by G2.182.
+- The adapter-local residuals are internal helper/provider seam calls after the
+  approved constructor provider seam.
+- The backtest residual is a resolver fallback covered by focused regression
+  tests.
+- The public getter definition remains the compatibility entrypoint.
+- Focused tests covering all remaining Strategy residual surfaces passed.
+
+## Closure Boundary
+
+This closeout is not a statement that every `get_strategy_service` token should
+disappear. It means the remaining tokens have classified ownership and should
+not be used to reopen a generic Strategy getter source lane.
+
+Future changes may still propose a broader service dependency-provider policy,
+but that must be a separate proposal or authorization package with fresh
+evidence, impact analysis, tests, and review.
+
+## Next Gate
+
+Review G2.183. If accepted, return the service lifecycle DI queue to selecting
+the next non-Strategy getter candidate through a separate decision package.
+
+No source lane is opened by G2.183.

--- a/governance/mainline/task-cards/pr-336.yaml
+++ b/governance/mainline/task-cards/pr-336.yaml
@@ -1,0 +1,115 @@
+version: "v0.2"
+
+task:
+  id: "pr-336"
+  title: "Close Strategy getter remaining residual track"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-strategy-getter-remaining-residual-decision"
+  objective: "decide whether remaining Strategy getter residuals close the track or require adapter-local cleanup authorization"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance decision package only; classifies remaining Strategy getter residuals and closes the Strategy getter track without changing runtime, routes, tests, frontend, OpenAPI, or product behavior."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/strategy-getter-remaining-residual-decision-2026-05-27.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-strategy-getter-remaining-residual-decision-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-336.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source edits"
+  - "No test edits"
+  - "No route, API, OpenAPI, PM2, frontend, config, script, or issue-label changes"
+  - "No deletion, rename, privatization, or behavior change of get_strategy_service()"
+  - "No route/provider fallback implementation"
+  - "No adapter-local cleanup implementation"
+  - "No backtest task helper implementation"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/strategy-getter-remaining-residual-decision-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-336.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-strategy-getter-remaining-residual-decision-2026-05-27.md"
+      required: true
+    - id: "focused-residual-tests"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_adapter_mock_fallback_controls.py web/backend/tests/test_backtest_tasks_regressions.py web/backend/tests/test_strategy_management_route_provider.py -q --no-cov --tb=short"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this decision is read as permission to delete remaining getter tokens, public compatibility or route/provider seams could be broken."
+    - "If retained residuals are treated as permanent truth, future broader dependency-provider policy changes may be missed."
+  rollback_plan: "revert this PR to restore the pre-G2.183 steward state and remove the remaining-residual decision report, generated JSON, and task card."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close the Strategy getter residual track with retained, classified residuals"
+    modified_scope: "split steward tree files, decision report, generated JSON, and task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no source or compatibility behavior changes"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if the closeout-with-retained-residuals decision is rejected"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T18:06:02+08:00"
+    approval_note: "Human maintainer approved continuing after PR #335 merge; this lane is a remaining-residual decision package only."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- add G2.183 remaining Strategy getter residual decision evidence at `597f8186092b4ad3d0704326e292c5e4fa075f15`
- close the current Strategy getter residual track with retained, classified residuals
- update split steward tree files and machine-readable index without source edits

## Boundary
- governance-only package
- no backend/frontend/source/test/OpenAPI/config/script changes
- no authorization for Strategy getter source implementation or adapter-local cleanup

## Verification
- JSON parse for `steward-index.json` and generated G2.183 artifact
- YAML parse for `governance/mainline/task-cards/pr-336.yaml`
- Markdown governance gate: 6 checked files, 0 errors
- Focused residual tests: `16 passed in 4.55s`
- `openspec validate migrate-backend-singletons-to-lifecycle-di --strict` valid; PostHog telemetry flush produced existing network noise
- `git diff --check` and `git diff --cached --check`
- GitNexus staged detect changes: low risk, 0 changed symbols, 0 affected processes
- Mainline scope gate: pass=True
- `gitnexus analyze --with-gitignore`: 62,961 nodes / 146,087 edges / 300 flows
EOF 2>&1
