### PR TITLE
docs(governance): select next non-strategy candidate

### DIFF
--- a/.planning/codebase/generated/next-nonstrategy-service-getter-candidate-decision-2026-05-27.json
+++ b/.planning/codebase/generated/next-nonstrategy-service-getter-candidate-decision-2026-05-27.json
@@ -1,0 +1,233 @@
+{
+  "work_item": "G2.184",
+  "title": "Next non-Strategy service getter candidate decision",
+  "state": "ready_for_review",
+  "recorded_at": "2026-05-27T20:49:23+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "d454193fdae08ad875c423e0b5aa959d79bedc67",
+  "branch": "g2-184-next-nonstrategy-service-getter-candidate-decision",
+  "scope": "governance_decision_package_only",
+  "source_edit_authority": false,
+  "parent_item": {
+    "id": "G2.183",
+    "title": "Strategy getter remaining residual decision",
+    "pr": 336,
+    "merge_commit": "d454193fdae08ad875c423e0b5aa959d79bedc67",
+    "decision": "Strategy getter residual track closed with retained residuals; select next non-Strategy candidate through a separate decision package."
+  },
+  "freshness": {
+    "git_head": "d454193fdae08ad875c423e0b5aa959d79bedc67",
+    "gitnexus_repo": "g2-184-next-nonstrategy-service-getter-candidate-decision",
+    "gitnexus_index_refreshed": true,
+    "gitnexus_command": "gitnexus analyze --with-gitignore",
+    "stale_if_head_mismatch": true
+  },
+  "current_static_scan": {
+    "scope": [
+      "web/backend/app",
+      "web/backend/tests"
+    ],
+    "getters": {
+      "get_tdx_service": {
+        "token_count": 6,
+        "files": 4,
+        "category_counts": {
+          "definition": 1,
+          "import": 1,
+          "provider_dependency": 0,
+          "call": 1,
+          "other": 3
+        }
+      },
+      "get_data_service": {
+        "token_count": 9,
+        "files": 4,
+        "category_counts": {
+          "definition": 1,
+          "import": 4,
+          "provider_dependency": 0,
+          "call": 4,
+          "other": 0
+        }
+      },
+      "get_streaming_service": {
+        "token_count": 25,
+        "files": 6,
+        "category_counts": {
+          "definition": 1,
+          "import": 0,
+          "provider_dependency": 0,
+          "call": 18,
+          "other": 6
+        },
+        "interpretation": "app references are constructor fallback/import/service definition surfaces; most call tokens are focused tests"
+      },
+      "get_market_data_service": {
+        "token_count": 19,
+        "files": 8,
+        "category_counts": {
+          "definition": 1,
+          "import": 1,
+          "provider_dependency": 0,
+          "call": 1,
+          "other": 16
+        }
+      },
+      "get_market_data_service_v2_dependency": {
+        "token_count": 18,
+        "files": 4,
+        "category_counts": {
+          "definition": 1,
+          "import": 1,
+          "provider_dependency": 14,
+          "call": 1,
+          "other": 1
+        },
+        "interpretation": "active route dependency/provider surface, not a getter-retirement source lane"
+      },
+      "get_indicator_data_service": {
+        "token_count": 4,
+        "files": 2,
+        "category_counts": {
+          "definition": 1,
+          "import": 0,
+          "provider_dependency": 2,
+          "call": 0,
+          "other": 1
+        }
+      },
+      "get_strategy_indicator_data_service": {
+        "token_count": 3,
+        "files": 2,
+        "category_counts": {
+          "definition": 1,
+          "import": 0,
+          "provider_dependency": 1,
+          "call": 0,
+          "other": 1
+        }
+      },
+      "get_indicator_registry_dependency": {
+        "token_count": 5,
+        "files": 3,
+        "category_counts": {
+          "definition": 1,
+          "import": 1,
+          "provider_dependency": 2,
+          "call": 0,
+          "other": 1
+        }
+      },
+      "get_strategy_service": {
+        "token_count": 13,
+        "files": 6,
+        "category_counts": {
+          "definition": 1,
+          "import": 3,
+          "provider_dependency": 0,
+          "call": 3,
+          "other": 6
+        },
+        "interpretation": "closed by G2.183 as retained residuals; included here only as a freshness check"
+      }
+    }
+  },
+  "gitnexus_impact_after_refresh": {
+    "get_tdx_service": {
+      "risk": "LOW",
+      "impacted": 1,
+      "direct": 1,
+      "processes": 0,
+      "d1": [
+        "web/backend/app/services/tdx_service.py::install_tdx_service"
+      ]
+    },
+    "get_data_service": {
+      "risk": "LOW",
+      "impacted": 2,
+      "direct": 2,
+      "processes": 0,
+      "d1": [
+        "web/backend/app/api/indicators/indicator_cache.py::get_indicator_data_service",
+        "web/backend/app/api/v1/strategy/indicators.py::get_strategy_indicator_data_service"
+      ]
+    },
+    "get_streaming_service": {
+      "risk": "LOW",
+      "impacted": 2,
+      "direct": 2,
+      "processes": 0,
+      "d1": [
+        "web/backend/app/services/aggregation_streaming_bridge.py::__init__",
+        "web/backend/app/core/socketio_manager.py::__init__"
+      ]
+    },
+    "get_market_data_service": {
+      "risk": "LOW",
+      "impacted": 0,
+      "direct": 0,
+      "processes": 0
+    },
+    "get_market_data_service_v2_dependency": {
+      "risk": "not_indexed_by_gitnexus_symbol_lookup",
+      "static_interpretation": "active FastAPI route dependency/provider function with 14 provider sites in market_v2.py"
+    }
+  },
+  "prior_closure_inputs": {
+    "realtime_socket": {
+      "evidence": "docs/reports/quality/backend-realtime-socket-subtrack-closeout-2026-05-26.md",
+      "decision": "closed for now; remaining getter references are import plus constructor fallback"
+    },
+    "dashboard_tdx": {
+      "evidence": "docs/reports/quality/backend-dashboard-tdx-verification-closeout-2026-05-26.md",
+      "decision": "closed without implementation; direct dashboard helper getter debt is 0"
+    },
+    "indicator_data": {
+      "evidence": "docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.md",
+      "decision": "direct route/helper body debt closed; remaining hits are provider-governed runtime seam"
+    },
+    "strategy": {
+      "evidence": "docs/reports/quality/backend-strategy-getter-remaining-residual-decision-2026-05-27.md",
+      "decision": "closed with retained residuals"
+    }
+  },
+  "decision": {
+    "classification": "no-new-nonstrategy-getter-source-lane",
+    "selected_next_governance_target": "route-dependency-provider-governance-residual-decision",
+    "source_lane_recommendation": "do-not-start-source-implementation-from-g2-184",
+    "rationale": [
+      "The previously high-risk non-Strategy tracks now have accepted or review-ready closeout evidence and no current fresh GitNexus HIGH/CRITICAL risk after the G2.184 index refresh.",
+      "Current static surfaces are mainly route dependency/provider functions, constructor fallbacks, public compatibility definitions, package exports, and focused tests.",
+      "The remaining material question is whether cross-route provider functions have consistent ownership, naming, compatibility retention, and OpenAPI/test evidence boundaries.",
+      "That question is a governance/provider-contract decision, not a path-limited service getter implementation lane."
+    ],
+    "recommended_next_work_item": "G2.185 route dependency/provider governance residual decision package"
+  },
+  "g2_185_minimum_requirements": [
+    "Inventory active provider dependency functions, including get_market_data_service_v2_dependency, get_indicator_data_service, get_strategy_indicator_data_service, get_indicator_registry_dependency, route-local Strategy dependency, TDX provider fallbacks, and realtime constructor/provider fallbacks.",
+    "Classify each provider as active route dependency, constructor fallback, public compatibility getter, package export, test-only helper, or retirement candidate.",
+    "Define ownership rules for route-local providers versus service-level public getters.",
+    "Decide whether any future source lane is warranted, and if so produce a separate authorization package with exact allowed files, focused tests, rollback rules, and GitNexus impact.",
+    "Do not delete, rename, privatize, or move provider functions from the G2.185 decision package."
+  ],
+  "not_authorized": [
+    "backend source edits",
+    "backend test edits",
+    "frontend edits",
+    "route/API/OpenAPI exposure changes",
+    "PM2 commands",
+    "OpenSpec change creation or spec edits",
+    "GitHub issue label changes",
+    "deleting or privatizing compatibility getters",
+    "starting a new implementation lane before G2.185 is reviewed and approved"
+  ],
+  "updated_steward_files": [
+    ".planning/codebase/steward-tree/current-next-gates.md",
+    ".planning/codebase/steward-tree/steward-index.json",
+    ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+    ".planning/codebase/steward-tree/branch-register.md",
+    ".planning/codebase/steward-tree/evidence-index.md",
+    ".planning/codebase/steward-tree/completed-ledger.md"
+  ],
+  "next_gate": "Review G2.184. If accepted, start G2.185 route dependency/provider governance residual decision package; do not start a backend source lane from G2.184."
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-27T18:06:02+08:00`
-- Base HEAD checked: `597f8186092b4ad3d0704326e292c5e4fa075f15`
+- Prepared at: `2026-05-27T20:49:23+08:00`
+- Base HEAD checked: `d454193fdae08ad875c423e0b5aa959d79bedc67`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -20,12 +20,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#333` | `g2-180-strategy-adapter-provider-closeout` | `wip/root-dirty-20260403` | `MERGED` at `ba929aee2e7fc0de0278f80f30caa185fafa6b5c` | Governance closeout for G2.178 and residual scan handoff |
 | `#334` | `g2-181-strategy-getter-residual-refresh-decision` | `wip/root-dirty-20260403` | `MERGED` at `0398eb81259bba5c7d8c8ba6479056554e13d064` | Residual refresh and next target selection |
 | `#335` | `g2-182-strategy-route-provider-fallback-decision` | `wip/root-dirty-20260403` | `MERGED` at `597f8186092b4ad3d0704326e292c5e4fa075f15` | Retained route/provider fallback decision |
+| `#336` | `g2-183-strategy-getter-remaining-residual-decision` | `wip/root-dirty-20260403` | `MERGED` at `d454193fdae08ad875c423e0b5aa959d79bedc67` | Strategy getter remaining residual closeout with retained residuals |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-183-strategy-getter-remaining-residual-decision` | `origin/wip/root-dirty-20260403` at `597f8186092b4ad3d0704326e292c5e4fa075f15` | Decide whether remaining Strategy getter residuals close the track or require adapter-local cleanup authorization | None |
+| `g2-184-next-nonstrategy-service-getter-candidate-decision` | `origin/wip/root-dirty-20260403` at `d454193fdae08ad875c423e0b5aa959d79bedc67` | Select the next non-Strategy service lifecycle governance target after Strategy residual closeout | None |
 
 ## OpenSpec Relationship
 
@@ -41,7 +42,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.183 is a remaining-residual decision branch only. It records the already
-merged state of PR `#335`, closes the current Strategy getter residual track
-with retained residuals if accepted, and must not introduce another Strategy
-service getter implementation.
+G2.184 is a candidate-selection decision branch only. It records the merged
+state of PR `#336`, confirms that prior high-risk non-Strategy getter tracks are
+currently provider/compatibility shaped after fresh GitNexus indexing, and must
+not introduce backend source edits or a new implementation lane.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-27T18:06:02+08:00`
-- Base HEAD checked: `597f8186092b4ad3d0704326e292c5e4fa075f15`
+- Prepared at: `2026-05-27T20:49:23+08:00`
+- Base HEAD checked: `d454193fdae08ad875c423e0b5aa959d79bedc67`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -20,7 +20,7 @@ exact verification output.
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
-| Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 now reviews final Strategy getter residual closeout |
+| Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-27T18:06:02+08:00`
-- Base HEAD checked: `597f8186092b4ad3d0704326e292c5e4fa075f15`
+- Prepared at: `2026-05-27T20:49:23+08:00`
+- Base HEAD checked: `d454193fdae08ad875c423e0b5aa959d79bedc67`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.183 Strategy getter remaining residual decision | G/#79 service lifecycle DI | PR `#335` merged at `597f8186092b4ad3d0704326e292c5e4fa075f15`; remaining Strategy getter residuals classified as retained and tested | If accepted, return to service lifecycle DI queue for next non-Strategy getter candidate selection |
+| P0 | Review G2.184 next non-Strategy service getter candidate decision | G/#79 service lifecycle DI | PR `#336` merged at `d454193fdae08ad875c423e0b5aa959d79bedc67`; G2.184 selects route dependency/provider governance as the next decision target and opens no source lane | If accepted, start G2.185 route dependency/provider governance residual decision package |
+| P0 | Preserve G2.183 Strategy getter residual closeout | G/#79 service lifecycle DI | PR `#336` merged; remaining Strategy getter residuals classified as retained and tested | Do not reopen generic Strategy getter implementation unless current HEAD contradicts G2.183 evidence |
 | P0 | Keep steward split structure active | CODEBASE-MAP steward governance | PR `#332` merged at `750fb7c797ff95f27152439ed988a7115252129e` | Future steward updates must use split files and `steward-index.json`, not the archived single-file tree |
 | P1 | Preserve implementation authorization boundary | All lanes | Active | Every source lane still needs its own authorization packet |
 | P1 | Keep Core Batch 2 blocked | Core split / compatibility wrappers | Blocked | Resolve Task 3.2 and shared evidence gate disposition before selecting Batch 2 |
@@ -28,6 +29,6 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 - Does the split preserve the full historical steward tree in archive?
 - Is the root entrypoint short enough to serve as a daily navigation file?
 - Does `steward-index.json` include enough fields for automated guards?
-- Does G2.183 correctly close the Strategy getter residual track without authorizing deletion or adapter-local cleanup?
-- Is the next gate now a non-Strategy service lifecycle DI candidate selection?
+- Does G2.184 correctly avoid opening a source lane when refreshed non-Strategy getter risk is now provider/compatibility shaped?
+- Is G2.185 the right next gate for route dependency/provider governance residual classification?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-27T18:06:02+08:00`
-- Base HEAD checked: `597f8186092b4ad3d0704326e292c5e4fa075f15`
+- Prepared at: `2026-05-27T20:49:23+08:00`
+- Base HEAD checked: `d454193fdae08ad875c423e0b5aa959d79bedc67`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -28,14 +28,17 @@ state transition.
 | `.planning/codebase/generated/strategy-route-provider-fallback-decision-2026-05-27.json` | G2.182 route/provider fallback classification evidence | Current for HEAD `0398eb81259bba5c7d8c8ba6479056554e13d064` |
 | `docs/reports/quality/backend-strategy-route-provider-fallback-decision-2026-05-27.md` | G2.182 human-readable route/provider fallback decision package | Accepted by PR `#335`; superseded for remaining-residual closeout by G2.183 |
 | `.planning/codebase/generated/strategy-getter-remaining-residual-decision-2026-05-27.json` | G2.183 remaining Strategy getter residual closeout evidence | Current for HEAD `597f8186092b4ad3d0704326e292c5e4fa075f15` |
-| `docs/reports/quality/backend-strategy-getter-remaining-residual-decision-2026-05-27.md` | G2.183 human-readable remaining-residual decision package | Review input until accepted |
+| `docs/reports/quality/backend-strategy-getter-remaining-residual-decision-2026-05-27.md` | G2.183 human-readable remaining-residual decision package | Accepted by PR `#336`; superseded for next-gate selection by G2.184 |
+| `.planning/codebase/generated/next-nonstrategy-service-getter-candidate-decision-2026-05-27.json` | G2.184 next non-Strategy service getter candidate decision evidence | Current for HEAD `d454193fdae08ad875c423e0b5aa959d79bedc67`; stale if HEAD changes |
+| `docs/reports/quality/backend-next-nonstrategy-service-getter-candidate-decision-2026-05-27.md` | G2.184 human-readable next-candidate decision package | Review input until accepted |
 
 ## External State Inputs
 
 | Input | Current state at split | Notes |
 |---|---|---|
 | GitHub PR `#331` | `MERGED` | G2.178 source implementation lane closed by merge commit `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704` |
-| `origin/wip/root-dirty-20260403` | `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704` | Base used for this closeout branch |
+| GitHub PR `#336` | `MERGED` | G2.183 remaining Strategy getter residual closeout merged by commit `d454193fdae08ad875c423e0b5aa959d79bedc67` |
+| `origin/wip/root-dirty-20260403` | `d454193fdae08ad875c423e0b5aa959d79bedc67` | Base used for this decision branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-27T18:06:02+08:00",
+  "generated_at": "2026-05-27T20:49:23+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "597f8186092b4ad3d0704326e292c5e4fa075f15",
-  "split_branch": "g2-183-strategy-getter-remaining-residual-decision",
+  "base_head": "d454193fdae08ad875c423e0b5aa959d79bedc67",
+  "split_branch": "g2-184-next-nonstrategy-service-getter-candidate-decision",
   "scope": "governance_decision_package",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
@@ -271,7 +271,7 @@
     {
       "id": "g2-183-strategy-getter-remaining-residual-decision",
       "type": "decision_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.182 Strategy route/provider fallback decision",
       "source_edit_authority": false,
@@ -295,10 +295,73 @@
         "recommended_next_work_item": "select next non-Strategy service lifecycle DI candidate"
       },
       "freshness": {
-        "current_head_checked": "597f8186092b4ad3d0704326e292c5e4fa075f15",
+        "current_head_checked": "d454193fdae08ad875c423e0b5aa959d79bedc67",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, use a separate decision package to select the next non-Strategy service lifecycle DI candidate."
+      "next_gate": "Superseded by G2.184 next non-Strategy service getter candidate decision."
+    },
+    {
+      "id": "g2-184-next-nonstrategy-service-getter-candidate-decision",
+      "type": "decision_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.183 Strategy getter remaining residual decision",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/next-nonstrategy-service-getter-candidate-decision-2026-05-27.json",
+        "docs/reports/quality/backend-next-nonstrategy-service-getter-candidate-decision-2026-05-27.md",
+        "governance/mainline/task-cards/pr-337.yaml"
+      ],
+      "refreshed_candidates": {
+        "gitnexus_repo": "g2-184-next-nonstrategy-service-getter-candidate-decision",
+        "gitnexus_index_refreshed": true,
+        "impact_after_refresh": {
+          "get_tdx_service": {
+            "risk": "LOW",
+            "impacted": 1,
+            "direct": 1,
+            "processes": 0
+          },
+          "get_data_service": {
+            "risk": "LOW",
+            "impacted": 2,
+            "direct": 2,
+            "processes": 0
+          },
+          "get_streaming_service": {
+            "risk": "LOW",
+            "impacted": 2,
+            "direct": 2,
+            "processes": 0
+          },
+          "get_market_data_service": {
+            "risk": "LOW",
+            "impacted": 0,
+            "direct": 0,
+            "processes": 0
+          }
+        },
+        "static_provider_surfaces": [
+          "get_market_data_service_v2_dependency",
+          "get_indicator_data_service",
+          "get_strategy_indicator_data_service",
+          "get_indicator_registry_dependency",
+          "route-local Strategy dependency",
+          "TDX provider fallback",
+          "Realtime constructor/provider fallback"
+        ]
+      },
+      "decision": {
+        "classification": "no-new-nonstrategy-getter-source-lane",
+        "selected_next_governance_target": "route-dependency-provider-governance-residual-decision",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-184",
+        "recommended_next_work_item": "G2.185 route dependency/provider governance residual decision package"
+      },
+      "freshness": {
+        "current_head_checked": "d454193fdae08ad875c423e0b5aa959d79bedc67",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.185 route dependency/provider governance residual decision package. Do not start a backend source lane from G2.184."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-27T18:06:02+08:00`
-- Base HEAD checked: `597f8186092b4ad3d0704326e292c5e4fa075f15`
+- Prepared at: `2026-05-27T20:49:23+08:00`
+- Base HEAD checked: `d454193fdae08ad875c423e0b5aa959d79bedc67`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -35,13 +35,15 @@ It proved a repeatable conveyor:
 | G2.180 Strategy adapter provider closeout | Merged by PR `#333` | Records G2.178 as closed and refreshes residual Strategy getter distribution without source edits |
 | G2.181 Strategy getter residual refresh decision | Merged by PR `#334` | Rechecks residual classes and selects route/provider fallback as the next governance target |
 | G2.182 Strategy route/provider fallback decision | Merged by PR `#335` | Classifies the route/provider fallback as a retained route-local provider seam and does not open a source lane |
-| G2.183 Strategy getter remaining residual decision | For review | Closes the current Strategy getter residual track with retained residuals and focused residual test evidence |
+| G2.183 Strategy getter remaining residual decision | Merged by PR `#336` | Closes the current Strategy getter residual track with retained residuals and focused residual test evidence |
+| G2.184 next non-Strategy candidate decision | For review | Selects route dependency/provider governance as the next decision target and opens no source lane |
 
 ## Current Strategy Getter Residuals
 
-At HEAD `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704`, production `.py`
-At HEAD `597f8186092b4ad3d0704326e292c5e4fa075f15`, `get_strategy_service`
-hits under `web/backend/app` remain `19`:
+At HEAD `d454193fdae08ad875c423e0b5aa959d79bedc67`, the current Strategy
+getter residual track is closed with retained residuals. The latest accepted
+G2.183 classification recorded these `get_strategy_service` hits under
+`web/backend/app`:
 
 | File | Hits | Current decision |
 |---|---:|---|
@@ -52,12 +54,12 @@ hits under `web/backend/app` remain `19`:
 
 ## Next Gates
 
-- Review G2.183 remaining residual decision.
-- If accepted, close the current Strategy getter residual track with retained
-  residuals and select the next non-Strategy service lifecycle DI candidate in a
-  separate decision package.
-- Do not start another Strategy service getter source lane from this
-  remaining-residual decision package.
+- Review G2.184 next non-Strategy candidate decision.
+- If accepted, start G2.185 route dependency/provider governance residual
+  decision package.
+- Do not start another backend source lane directly from G2.184. The current
+  non-Strategy residuals are provider/compatibility shaped after fresh GitNexus
+  indexing and need provider ownership classification first.
 
 ## Forbidden Scope
 

--- a/docs/reports/quality/backend-next-nonstrategy-service-getter-candidate-decision-2026-05-27.md
+++ b/docs/reports/quality/backend-next-nonstrategy-service-getter-candidate-decision-2026-05-27.md
@@ -1,0 +1,189 @@
+# Backend Next Non-Strategy Service Getter Candidate Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Task: G2.184 next non-Strategy service getter candidate decision
+Branch: `g2-184-next-nonstrategy-service-getter-candidate-decision`
+Base: `wip/root-dirty-20260403`
+Current HEAD: `d454193fdae08ad875c423e0b5aa959d79bedc67`
+Created: 2026-05-27
+
+Boundary: this is a governance decision package only. It does not edit backend
+source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2
+workflows, OpenSpec state, GitHub issue labels, or service getter
+implementations. It does not authorize implementation.
+
+## Purpose
+
+G2.183 closed the current Strategy getter residual track with retained residuals
+after PR `#336` merged. This package refreshes the remaining non-Strategy getter
+queue and decides what the next gate should be before any new source lane starts.
+
+## Parent State
+
+| Input | State |
+|---|---|
+| PR `#336` | merged into `wip/root-dirty-20260403` |
+| Merge commit | `d454193fdae08ad875c423e0b5aa959d79bedc67` |
+| Parent evidence | `docs/reports/quality/backend-strategy-getter-remaining-residual-decision-2026-05-27.md` |
+| Parent generated artifact | `.planning/codebase/generated/strategy-getter-remaining-residual-decision-2026-05-27.json` |
+
+G2.183 does not mean every `get_strategy_service` token disappeared. It means
+the remaining Strategy residuals have classified ownership and must not be used
+to reopen a generic Strategy getter implementation lane.
+
+## Freshness Work
+
+GitNexus was refreshed in this worktree before making the G2.184 decision:
+
+```text
+gitnexus analyze --with-gitignore
+Repository indexed successfully
+62,988 nodes | 147,144 edges | 3319 clusters | 300 flows
+```
+
+The refreshed GitNexus repository is:
+`g2-184-next-nonstrategy-service-getter-candidate-decision`.
+
+## Current Static Surface
+
+Scope: `web/backend/app` and `web/backend/tests` at HEAD
+`d454193fdae08ad875c423e0b5aa959d79bedc67`.
+
+| Getter / provider | Tokens | Files | Definition / import / provider / call / other | Current interpretation |
+|---|---:|---:|---|---|
+| `get_tdx_service` | 6 | 4 | `1/1/0/1/3` | Dashboard/TDX helper debt remains closed; current app use is provider/fallback shape. |
+| `get_data_service` | 9 | 4 | `1/4/0/4/0` | Indicator/Data direct route/helper debt remains closed; active app calls are provider fallbacks in route-local dependency helpers. |
+| `get_streaming_service` | 25 | 6 | `1/0/0/18/6` | Realtime/socket subtrack is closed; app references are constructor fallback/import/service definition surfaces, while most call tokens are tests. |
+| `get_market_data_service` | 19 | 8 | `1/1/0/1/16` | Mostly package export/test compatibility surface; not a new route-body getter lane. |
+| `get_market_data_service_v2_dependency` | 18 | 4 | `1/1/14/1/1` | Active FastAPI route dependency/provider surface; should be governed as provider ownership, not getter retirement. |
+| `get_indicator_data_service` | 4 | 2 | `1/0/2/0/1` | Active provider helper in Indicator/Data route surface. |
+| `get_strategy_indicator_data_service` | 3 | 2 | `1/0/1/0/1` | Active provider helper in Strategy indicator route surface. |
+| `get_indicator_registry_dependency` | 5 | 3 | `1/1/2/0/1` | Active provider helper in Indicator/Data route surface. |
+| `get_strategy_service` | 13 | 6 | `1/3/0/3/6` | Closed by G2.183 as retained residuals; included here only as a freshness check. |
+
+## Refreshed GitNexus Impact
+
+After the worktree index refresh:
+
+| Target | Risk | Impacted | Direct | Processes | Interpretation |
+|---|---:|---:|---:|---:|---|
+| `get_tdx_service` | LOW | 1 | 1 | 0 | Only `install_tdx_service` remains as direct graph caller. |
+| `get_data_service` | LOW | 2 | 2 | 0 | Direct graph callers are route-local provider helpers: `get_indicator_data_service` and `get_strategy_indicator_data_service`. |
+| `get_streaming_service` | LOW | 2 | 2 | 0 | Direct graph callers are constructor/provider fallback sites in streaming bridge and socket manager. |
+| `get_market_data_service` | LOW | 0 | 0 | 0 | No direct graph callers. |
+| `get_market_data_service_v2_dependency` | not indexed as a GitNexus symbol | n/a | n/a | n/a | Static scan shows an active route dependency/provider function with 14 provider sites in `market_v2.py`. |
+
+This matters because older reports correctly showed HIGH/CRITICAL graph risk
+before their corresponding source lanes closed. G2.184 should use the refreshed
+G2.184 graph plus the current static scan, not stale earlier graph impact.
+
+## Prior Closure Inputs
+
+| Track | Current closure evidence | G2.184 handling |
+|---|---|---|
+| Realtime/socket | `docs/reports/quality/backend-realtime-socket-subtrack-closeout-2026-05-26.md` | Closed for now; do not reopen from token count alone. |
+| Dashboard/TDX | `docs/reports/quality/backend-dashboard-tdx-verification-closeout-2026-05-26.md` | Closed without implementation; direct dashboard helper getter debt is `0`. |
+| Indicator/Data | `docs/reports/quality/backend-service-lifecycle-candidate-refresh-after-indicator-data-2026-05-27.md` | Direct route/helper body debt closed; remaining provider seams are expected runtime flow. |
+| Strategy | `docs/reports/quality/backend-strategy-getter-remaining-residual-decision-2026-05-27.md` | Closed with retained residuals by PR `#336`. |
+
+## Decision
+
+Do not select a new backend source implementation lane from G2.184.
+
+Select the next governance target as:
+
+```text
+G2.185 route dependency/provider governance residual decision package
+```
+
+Rationale:
+
+1. Previously high-risk non-Strategy tracks now have closure evidence and fresh
+   GitNexus impact no longer shows HIGH/CRITICAL risk for the refreshed
+   candidate getters.
+2. Current meaningful residuals are route dependency/provider functions,
+   constructor fallbacks, public compatibility getters, package exports, and
+   tests.
+3. Those surfaces need ownership and compatibility classification before any
+   implementation authorization can be honest.
+4. Starting a new source lane directly from token count would conflate active
+   provider contracts with removable getter debt.
+
+## G2.185 Minimum Requirements
+
+G2.185 should remain a decision package. It should not edit source or tests.
+
+Minimum required content:
+
+1. Inventory active provider dependency functions, including
+   `get_market_data_service_v2_dependency`, `get_indicator_data_service`,
+   `get_strategy_indicator_data_service`, `get_indicator_registry_dependency`,
+   route-local Strategy dependency, TDX provider fallbacks, and realtime
+   constructor/provider fallbacks.
+2. Classify each provider as active route dependency, constructor fallback,
+   public compatibility getter, package export, test-only helper, or retirement
+   candidate.
+3. Define ownership rules for route-local providers versus service-level public
+   getters.
+4. Decide whether any future source lane is warranted, and if so require a
+   separate authorization package with exact allowed files, focused tests,
+   rollback rules, and GitNexus impact.
+5. Preserve public compatibility getters unless a later compatibility-retirement
+   package explicitly authorizes changing them.
+
+## Not Authorized
+
+G2.184 does not authorize:
+
+- backend source edits
+- backend test edits
+- frontend edits
+- route/API/OpenAPI exposure changes
+- PM2 commands
+- OpenSpec change creation or spec edits
+- GitHub issue label changes
+- deleting, renaming, moving, or privatizing compatibility getters
+- starting a new implementation lane before G2.185 is reviewed and approved
+
+## Steward Tree Updates
+
+This package updates the split steward tree, not the archived single-file task
+tree:
+
+- `.planning/codebase/steward-tree/current-next-gates.md`
+- `.planning/codebase/steward-tree/steward-index.json`
+- `.planning/codebase/steward-tree/tracks/service-lifecycle-di.md`
+- `.planning/codebase/steward-tree/branch-register.md`
+- `.planning/codebase/steward-tree/evidence-index.md`
+- `.planning/codebase/steward-tree/completed-ledger.md`
+
+## Verification Plan
+
+Required checks for this governance-only package:
+
+```bash
+python -m json.tool .planning/codebase/generated/next-nonstrategy-service-getter-candidate-decision-2026-05-27.json >/dev/null
+python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null
+python - <<'PY'
+import yaml
+with open("governance/mainline/task-cards/pr-337.yaml", encoding="utf-8") as f:
+    yaml.safe_load(f)
+PY
+python scripts/compliance/markdown_governance_gate.py --root-dir . --format json \
+  .planning/codebase/steward-tree/current-next-gates.md \
+  .planning/codebase/steward-tree/tracks/service-lifecycle-di.md \
+  .planning/codebase/steward-tree/branch-register.md \
+  .planning/codebase/steward-tree/evidence-index.md \
+  .planning/codebase/steward-tree/completed-ledger.md \
+  docs/reports/quality/backend-next-nonstrategy-service-getter-candidate-decision-2026-05-27.md
+openspec validate migrate-backend-singletons-to-lifecycle-di --strict
+git diff --check
+```
+
+## Next Gate
+
+Review G2.184. If accepted, start G2.185 as a route dependency/provider
+governance residual decision package.
+
+Do not start a backend source lane from G2.184.

--- a/governance/mainline/task-cards/pr-337.yaml
+++ b/governance/mainline/task-cards/pr-337.yaml
@@ -1,0 +1,110 @@
+version: "v0.2"
+
+task:
+  id: "pr-337"
+  title: "Select next non-Strategy service lifecycle governance target"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-next-nonstrategy-service-getter-candidate-decision"
+  objective: "select the next non-Strategy service lifecycle DI governance target after Strategy residual closeout"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance decision package only; selects route dependency/provider governance as the next decision target without changing runtime, routes, tests, frontend, OpenAPI, or product behavior."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/next-nonstrategy-service-getter-candidate-decision-2026-05-27.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-next-nonstrategy-service-getter-candidate-decision-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-337.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source edits"
+  - "No test edits"
+  - "No route, API, OpenAPI, PM2, frontend, config, script, or issue-label changes"
+  - "No deletion, rename, move, privatization, or behavior change of service getter functions"
+  - "No direct implementation lane selection"
+  - "No OpenSpec proposal creation"
+  - "No compatibility wrapper retirement"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/next-nonstrategy-service-getter-candidate-decision-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-337.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-next-nonstrategy-service-getter-candidate-decision-2026-05-27.md"
+      required: true
+    - id: "openspec-lifecycle-di"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this decision is read as source authorization, provider functions or compatibility getters could be changed without a path-limited authorization package."
+    - "If refreshed LOW GitNexus impact is treated as permanent truth, future provider-governance drift may be missed after later route changes."
+    - "If token counts are used as deletion evidence, active route dependency/provider surfaces could be broken."
+  rollback_plan: "revert this PR to restore the pre-G2.184 steward state and remove the next-candidate decision report, generated JSON, and task card."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "select route dependency/provider governance as the next non-Strategy service lifecycle decision target"
+    modified_scope: "split steward tree files, decision report, generated JSON, and task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no source or compatibility behavior changes"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if the no-new-source-lane decision is rejected"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T20:49:23+08:00"
+    approval_note: "Human maintainer approved continuing after PR #336 merge; this lane is a next-candidate decision package only."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records G2.184 next non-Strategy service getter candidate decision
- selects G2.185 route dependency/provider governance residual decision as the next gate
- keeps backend source/test/OpenSpec/runtime changes out of scope

## Verification
- json/yaml parse: pass
- markdown governance: 6 checked, 0 errors
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: valid (PostHog telemetry noise only)
- git diff --cached --check: pass
- mainline_scope_gate: pass=True
- GitNexus detect_changes staged: low risk, 0 changed symbols/affected flows
- gitnexus analyze --with-gitignore: refreshed after commit

## Boundary
This PR does not authorize backend source edits. If accepted, the next work item is G2.185 route dependency/provider governance residual decision package.