### PR TITLE
docs(governance): classify route provider residuals

### DIFF
--- a/.planning/codebase/generated/route-dependency-provider-governance-decision-2026-05-27.json
+++ b/.planning/codebase/generated/route-dependency-provider-governance-decision-2026-05-27.json
@@ -1,0 +1,255 @@
+{
+  "work_item": "G2.185",
+  "title": "Route dependency/provider governance residual decision",
+  "state": "ready_for_review",
+  "recorded_at": "2026-05-27T21:33:48+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba",
+  "branch": "g2-185-route-dependency-provider-governance-decision",
+  "scope": "governance_decision_package_only",
+  "source_edit_authority": false,
+  "parent_item": {
+    "id": "G2.184",
+    "title": "Next non-Strategy service getter candidate decision",
+    "pr": 337,
+    "merge_commit": "b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba",
+    "decision": "Do not open a source lane from token counts; classify route dependency/provider residuals first."
+  },
+  "freshness": {
+    "git_head": "b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba",
+    "gitnexus_repo": "g2-185-route-dependency-provider-governance-decision",
+    "gitnexus_index_refreshed": true,
+    "gitnexus_command": "gitnexus analyze --with-gitignore",
+    "stale_if_head_mismatch": true
+  },
+  "provider_inventory": {
+    "scope": [
+      "web/backend/app/api",
+      "web/backend/app/services",
+      "web/backend/app/core"
+    ],
+    "route_dependency_providers": [
+      {
+        "name": "get_market_data_service_v2_dependency",
+        "tokens": 18,
+        "depends_sites": 14,
+        "definition": "web/backend/app/services/market_data_service_v2.py:678",
+        "consumers": [
+          "web/backend/app/api/market_v2.py",
+          "web/backend/app/api/dashboard_data_source.py"
+        ],
+        "classification": "active service-level FastAPI provider",
+        "decision": "retain"
+      },
+      {
+        "name": "get_market_data_service_dependency",
+        "tokens": 16,
+        "depends_sites": 7,
+        "definition": "web/backend/app/services/market_data_service/get_market_data_service.py:34",
+        "consumers": [
+          "web/backend/app/api/market/market_data_request.py"
+        ],
+        "classification": "active service-level FastAPI provider",
+        "decision": "retain"
+      },
+      {
+        "name": "get_tdx_service_dependency",
+        "tokens": 7,
+        "depends_sites": 5,
+        "definition": "web/backend/app/services/tdx_service.py:295",
+        "consumers": [
+          "web/backend/app/api/tdx.py"
+        ],
+        "classification": "active service-level FastAPI provider",
+        "decision": "retain"
+      },
+      {
+        "name": "get_advanced_analysis_service_dependency",
+        "tokens": 16,
+        "depends_sites": 14,
+        "definition": "web/backend/app/services/advanced_analysis_service.py:497",
+        "consumers": [
+          "web/backend/app/api/advanced_analysis_api.py"
+        ],
+        "classification": "active service-level FastAPI provider",
+        "decision": "retain"
+      },
+      {
+        "name": "get_announcement_service_dependency",
+        "tokens": 13,
+        "depends_sites": 11,
+        "definition": "web/backend/app/services/announcement_service.py:530",
+        "consumers": [
+          "web/backend/app/api/announcement/routes.py"
+        ],
+        "classification": "active service-level FastAPI provider",
+        "decision": "retain"
+      },
+      {
+        "name": "get_email_service_dependency",
+        "tokens": 8,
+        "depends_sites": 6,
+        "definition": "web/backend/app/services/email_service.py:330",
+        "consumers": [
+          "web/backend/app/api/notification.py"
+        ],
+        "classification": "active service-level FastAPI provider",
+        "decision": "retain"
+      },
+      {
+        "name": "get_watchlist_service_dependency",
+        "tokens": 9,
+        "depends_sites": 7,
+        "definition": "web/backend/app/services/watchlist_service.py:617",
+        "consumers": [
+          "web/backend/app/api/watchlist.py"
+        ],
+        "classification": "active service-level FastAPI provider",
+        "decision": "retain"
+      },
+      {
+        "name": "get_stock_search_service_dependency",
+        "tokens": 11,
+        "depends_sites": 6,
+        "definition": "web/backend/app/services/stock_search_service/stock_search_service.py:176",
+        "consumers": [
+          "web/backend/app/api/stock_search/stock_search_result.py",
+          "web/backend/app/api/market/market_data_request.py"
+        ],
+        "classification": "active service-level FastAPI provider",
+        "decision": "retain"
+      },
+      {
+        "name": "get_tradingview_service_dependency",
+        "tokens": 8,
+        "depends_sites": 6,
+        "definition": "web/backend/app/services/tradingview_widget_service.py:331",
+        "consumers": [
+          "web/backend/app/api/tradingview.py"
+        ],
+        "classification": "active service-level FastAPI provider",
+        "decision": "retain"
+      },
+      {
+        "name": "get_indicator_registry_dependency",
+        "tokens": 5,
+        "depends_sites": 2,
+        "definition": "web/backend/app/services/indicator_registry.py:649",
+        "consumers": [
+          "web/backend/app/api/indicators/indicator_cache.py"
+        ],
+        "classification": "active service-level FastAPI provider",
+        "decision": "retain"
+      },
+      {
+        "name": "get_data_source_factory_dependency",
+        "tokens": 30,
+        "depends_sites": 18,
+        "definition": "web/backend/app/services/data_source_factory/data_source_factory.py:314",
+        "consumers": [
+          "web/backend/app/api/data_quality.py",
+          "web/backend/app/api/data/*.py",
+          "web/backend/app/api/market/market_data_request.py"
+        ],
+        "classification": "active cross-domain service-level FastAPI provider",
+        "decision": "retain"
+      }
+    ],
+    "route_local_or_constructor_providers": [
+      {
+        "name": "get_strategy_service_dependency",
+        "tokens": 4,
+        "depends_sites": 3,
+        "location": "web/backend/app/api/strategy_management/_strategy_execution_router.py:33",
+        "classification": "retained route-local provider fallback",
+        "decision": "retain under G2.182/G2.183 closure"
+      },
+      {
+        "name": "get_indicator_data_service",
+        "tokens": 4,
+        "depends_sites": 2,
+        "location": "web/backend/app/api/indicators/indicator_cache.py:48",
+        "classification": "route-local provider fallback over public DataService getter",
+        "decision": "retain"
+      },
+      {
+        "name": "get_strategy_indicator_data_service",
+        "tokens": 3,
+        "depends_sites": 1,
+        "location": "web/backend/app/api/v1/strategy/indicators.py:29",
+        "classification": "route-local provider fallback over public DataService getter",
+        "decision": "retain"
+      },
+      {
+        "name": "get_data_source_dependency",
+        "tokens": 5,
+        "depends_sites": 3,
+        "location": "web/backend/app/api/dashboard.py / dashboard_data_source.py",
+        "classification": "dashboard route-local data-source provider",
+        "decision": "retain"
+      },
+      {
+        "name": "get_streaming_service",
+        "tokens": 25,
+        "location": "web/backend/app/services/realtime_streaming_service.py:428",
+        "classification": "public compatibility getter plus constructor fallback consumers",
+        "decision": "retain; realtime/socket subtrack closed by prior evidence"
+      }
+    ]
+  },
+  "gitnexus_impact_after_refresh": {
+    "note": "GitNexus upstream impact is useful for symbol blast radius, but FastAPI Depends consumer links require static route/provider scanning for this decision.",
+    "providers_checked": {
+      "get_data_source_factory_dependency": "LOW, impacted 0",
+      "get_market_data_service_v2_dependency": "LOW, impacted 0",
+      "get_market_data_service_dependency": "LOW, impacted 0",
+      "get_advanced_analysis_service_dependency": "LOW, impacted 0",
+      "get_tdx_service_dependency": "LOW, impacted 0",
+      "get_strategy_service_dependency": "LOW, impacted 0",
+      "get_indicator_registry_dependency": "LOW, impacted 0",
+      "get_stock_search_service_dependency": "LOW, impacted 0"
+    }
+  },
+  "decision": {
+    "classification": "route-provider-contracts-retained",
+    "source_lane_recommendation": "do-not-open-source-implementation-from-g2-185",
+    "selected_next_governance_target": "service-lifecycle-candidate-refresh-after-provider-governance",
+    "recommended_next_work_item": "G2.186 service lifecycle remaining getter inventory refresh after provider governance",
+    "rules": [
+      "FastAPI dependency/provider functions are active route contracts, not singleton-retirement candidates.",
+      "Public get_*_service compatibility getters remain valid fallback entrypoints unless a later compatibility-retirement package explicitly authorizes changing them.",
+      "Route-local providers may remain route-local when they intentionally encapsulate route-specific fallback behavior.",
+      "Graph impact 0 does not imply deletability for provider functions because static route decorators and Depends sites are the consumer truth.",
+      "Future provider edits require route-level override tests and OpenAPI/route smoke when route signatures or exposure can change."
+    ]
+  },
+  "g2_186_minimum_requirements": [
+    "Rescan all service getter and provider tokens after accepting the G2.185 provider governance decision.",
+    "Exclude retained route dependency providers, route-local provider fallbacks, constructor fallbacks, package exports, public compatibility getter definitions, and test-only references from implementation-candidate counts.",
+    "Report only remaining direct route-body or service-body singleton getter calls that are not provider-governed.",
+    "If no direct implementation candidates remain, prepare a service lifecycle DI closeout or queue-slimming decision package.",
+    "If a candidate remains, require a separate authorization package before source edits."
+  ],
+  "not_authorized": [
+    "backend source edits",
+    "backend test edits",
+    "frontend edits",
+    "route/API/OpenAPI exposure changes",
+    "PM2 commands",
+    "OpenSpec change creation or spec edits",
+    "GitHub issue label changes",
+    "deleting or privatizing provider functions",
+    "deleting or privatizing public compatibility getters",
+    "starting a new implementation lane before G2.186 or a later authorization package is reviewed and approved"
+  ],
+  "updated_steward_files": [
+    ".planning/codebase/steward-tree/current-next-gates.md",
+    ".planning/codebase/steward-tree/steward-index.json",
+    ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+    ".planning/codebase/steward-tree/tracks/route-openapi-governance.md",
+    ".planning/codebase/steward-tree/branch-register.md",
+    ".planning/codebase/steward-tree/evidence-index.md",
+    ".planning/codebase/steward-tree/completed-ledger.md"
+  ],
+  "next_gate": "Review G2.185. If accepted, start G2.186 service lifecycle remaining getter inventory refresh after provider governance; do not start a backend source lane from G2.185."
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-27T20:49:23+08:00`
-- Base HEAD checked: `d454193fdae08ad875c423e0b5aa959d79bedc67`
+- Prepared at: `2026-05-27T21:33:48+08:00`
+- Base HEAD checked: `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -21,12 +21,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#334` | `g2-181-strategy-getter-residual-refresh-decision` | `wip/root-dirty-20260403` | `MERGED` at `0398eb81259bba5c7d8c8ba6479056554e13d064` | Residual refresh and next target selection |
 | `#335` | `g2-182-strategy-route-provider-fallback-decision` | `wip/root-dirty-20260403` | `MERGED` at `597f8186092b4ad3d0704326e292c5e4fa075f15` | Retained route/provider fallback decision |
 | `#336` | `g2-183-strategy-getter-remaining-residual-decision` | `wip/root-dirty-20260403` | `MERGED` at `d454193fdae08ad875c423e0b5aa959d79bedc67` | Strategy getter remaining residual closeout with retained residuals |
+| `#337` | `g2-184-next-nonstrategy-service-getter-candidate-decision` | `wip/root-dirty-20260403` | `MERGED` at `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba` | Next non-Strategy candidate decision selecting provider governance |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-184-next-nonstrategy-service-getter-candidate-decision` | `origin/wip/root-dirty-20260403` at `d454193fdae08ad875c423e0b5aa959d79bedc67` | Select the next non-Strategy service lifecycle governance target after Strategy residual closeout | None |
+| `g2-185-route-dependency-provider-governance-decision` | `origin/wip/root-dirty-20260403` at `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba` | Classify active route dependency/provider residuals and select the next queue-refresh gate | None |
 
 ## OpenSpec Relationship
 
@@ -42,7 +43,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.184 is a candidate-selection decision branch only. It records the merged
-state of PR `#336`, confirms that prior high-risk non-Strategy getter tracks are
-currently provider/compatibility shaped after fresh GitNexus indexing, and must
-not introduce backend source edits or a new implementation lane.
+G2.185 is a provider-governance decision branch only. It records the merged
+state of PR `#337`, classifies active FastAPI dependency providers as retained
+route contracts, and must not introduce backend source edits or a new
+implementation lane.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-27T20:49:23+08:00`
-- Base HEAD checked: `d454193fdae08ad875c423e0b5aa959d79bedc67`
+- Prepared at: `2026-05-27T21:33:48+08:00`
+- Base HEAD checked: `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,6 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 now reviews active FastAPI provider classification before the next inventory refresh |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-27T20:49:23+08:00`
-- Base HEAD checked: `d454193fdae08ad875c423e0b5aa959d79bedc67`
+- Prepared at: `2026-05-27T21:33:48+08:00`
+- Base HEAD checked: `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.184 next non-Strategy service getter candidate decision | G/#79 service lifecycle DI | PR `#336` merged at `d454193fdae08ad875c423e0b5aa959d79bedc67`; G2.184 selects route dependency/provider governance as the next decision target and opens no source lane | If accepted, start G2.185 route dependency/provider governance residual decision package |
+| P0 | Review G2.185 route dependency/provider governance residual decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#337` merged at `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`; G2.185 classifies provider residuals as retained active contracts and opens no source lane | If accepted, start G2.186 service lifecycle remaining getter inventory refresh after provider governance |
+| P0 | Preserve G2.184 next non-Strategy candidate decision | G/#79 service lifecycle DI | PR `#337` merged; G2.184 selected route dependency/provider governance as the next decision target | Do not start a backend source lane from G2.184 |
 | P0 | Preserve G2.183 Strategy getter residual closeout | G/#79 service lifecycle DI | PR `#336` merged; remaining Strategy getter residuals classified as retained and tested | Do not reopen generic Strategy getter implementation unless current HEAD contradicts G2.183 evidence |
 | P0 | Keep steward split structure active | CODEBASE-MAP steward governance | PR `#332` merged at `750fb7c797ff95f27152439ed988a7115252129e` | Future steward updates must use split files and `steward-index.json`, not the archived single-file tree |
 | P1 | Preserve implementation authorization boundary | All lanes | Active | Every source lane still needs its own authorization packet |
@@ -29,6 +30,6 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 - Does the split preserve the full historical steward tree in archive?
 - Is the root entrypoint short enough to serve as a daily navigation file?
 - Does `steward-index.json` include enough fields for automated guards?
-- Does G2.184 correctly avoid opening a source lane when refreshed non-Strategy getter risk is now provider/compatibility shaped?
-- Is G2.185 the right next gate for route dependency/provider governance residual classification?
+- Does G2.185 correctly classify active FastAPI providers as route contracts rather than deletion candidates?
+- Is G2.186 the right next gate for remaining getter inventory refresh after provider governance?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-27T20:49:23+08:00`
-- Base HEAD checked: `d454193fdae08ad875c423e0b5aa959d79bedc67`
+- Prepared at: `2026-05-27T21:33:48+08:00`
+- Base HEAD checked: `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -30,7 +30,9 @@ state transition.
 | `.planning/codebase/generated/strategy-getter-remaining-residual-decision-2026-05-27.json` | G2.183 remaining Strategy getter residual closeout evidence | Current for HEAD `597f8186092b4ad3d0704326e292c5e4fa075f15` |
 | `docs/reports/quality/backend-strategy-getter-remaining-residual-decision-2026-05-27.md` | G2.183 human-readable remaining-residual decision package | Accepted by PR `#336`; superseded for next-gate selection by G2.184 |
 | `.planning/codebase/generated/next-nonstrategy-service-getter-candidate-decision-2026-05-27.json` | G2.184 next non-Strategy service getter candidate decision evidence | Current for HEAD `d454193fdae08ad875c423e0b5aa959d79bedc67`; stale if HEAD changes |
-| `docs/reports/quality/backend-next-nonstrategy-service-getter-candidate-decision-2026-05-27.md` | G2.184 human-readable next-candidate decision package | Review input until accepted |
+| `docs/reports/quality/backend-next-nonstrategy-service-getter-candidate-decision-2026-05-27.md` | G2.184 human-readable next-candidate decision package | Accepted by PR `#337`; superseded for provider classification by G2.185 |
+| `.planning/codebase/generated/route-dependency-provider-governance-decision-2026-05-27.json` | G2.185 route dependency/provider governance decision evidence | Current for HEAD `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`; stale if HEAD changes |
+| `docs/reports/quality/backend-route-dependency-provider-governance-decision-2026-05-27.md` | G2.185 human-readable provider-governance decision package | Review input until accepted |
 
 ## External State Inputs
 
@@ -38,7 +40,8 @@ state transition.
 |---|---|---|
 | GitHub PR `#331` | `MERGED` | G2.178 source implementation lane closed by merge commit `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704` |
 | GitHub PR `#336` | `MERGED` | G2.183 remaining Strategy getter residual closeout merged by commit `d454193fdae08ad875c423e0b5aa959d79bedc67` |
-| `origin/wip/root-dirty-20260403` | `d454193fdae08ad875c423e0b5aa959d79bedc67` | Base used for this decision branch |
+| GitHub PR `#337` | `MERGED` | G2.184 next non-Strategy candidate decision merged by commit `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba` |
+| `origin/wip/root-dirty-20260403` | `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba` | Base used for this decision branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-27T20:49:23+08:00",
+  "generated_at": "2026-05-27T21:33:48+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "d454193fdae08ad875c423e0b5aa959d79bedc67",
-  "split_branch": "g2-184-next-nonstrategy-service-getter-candidate-decision",
+  "base_head": "b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba",
+  "split_branch": "g2-185-route-dependency-provider-governance-decision",
   "scope": "governance_decision_package",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
@@ -303,7 +303,7 @@
     {
       "id": "g2-184-next-nonstrategy-service-getter-candidate-decision",
       "type": "decision_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.183 Strategy getter remaining residual decision",
       "source_edit_authority": false,
@@ -358,10 +358,59 @@
         "recommended_next_work_item": "G2.185 route dependency/provider governance residual decision package"
       },
       "freshness": {
-        "current_head_checked": "d454193fdae08ad875c423e0b5aa959d79bedc67",
+        "current_head_checked": "b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.185 route dependency/provider governance residual decision package. Do not start a backend source lane from G2.184."
+      "next_gate": "Superseded by G2.185 route dependency/provider governance residual decision package."
+    },
+    {
+      "id": "g2-185-route-dependency-provider-governance-decision",
+      "type": "decision_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.184 next non-Strategy service getter candidate decision",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/route-dependency-provider-governance-decision-2026-05-27.json",
+        "docs/reports/quality/backend-route-dependency-provider-governance-decision-2026-05-27.md",
+        "governance/mainline/task-cards/pr-338.yaml"
+      ],
+      "provider_inventory": {
+        "classification": "route-provider-contracts-retained",
+        "service_level_fastapi_providers": [
+          "get_data_source_factory_dependency",
+          "get_market_data_service_v2_dependency",
+          "get_market_data_service_dependency",
+          "get_advanced_analysis_service_dependency",
+          "get_announcement_service_dependency",
+          "get_stock_search_service_dependency",
+          "get_watchlist_service_dependency",
+          "get_email_service_dependency",
+          "get_tradingview_service_dependency",
+          "get_tdx_service_dependency",
+          "get_indicator_registry_dependency"
+        ],
+        "route_local_or_constructor_providers": [
+          "get_strategy_service_dependency",
+          "get_indicator_data_service",
+          "get_strategy_indicator_data_service",
+          "get_data_source_dependency",
+          "get_streaming_service"
+        ],
+        "gitnexus_index_refreshed": true,
+        "gitnexus_note": "FastAPI Depends consumers require static route/provider scan; impacted=0 is not delete evidence."
+      },
+      "decision": {
+        "classification": "route-provider-contracts-retained",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-185",
+        "selected_next_governance_target": "service-lifecycle-candidate-refresh-after-provider-governance",
+        "recommended_next_work_item": "G2.186 service lifecycle remaining getter inventory refresh after provider governance"
+      },
+      "freshness": {
+        "current_head_checked": "b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.186 service lifecycle remaining getter inventory refresh after provider governance. Do not start a backend source lane from G2.185."
     },
     {
       "id": "core-batch2-reconciliation",
@@ -383,7 +432,7 @@
       "evidence": [
         ".planning/codebase/steward-tree/tracks/route-openapi-governance.md"
       ],
-      "next_gate": "Use route/OpenAPI governance for trading, control-plane, compatibility exposure, and duplicate operation ID decisions before route source edits."
+      "next_gate": "Use route/OpenAPI governance for provider ownership, trading, control-plane, compatibility exposure, and duplicate operation ID decisions before route source edits."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/route-openapi-governance.md
+++ b/.planning/codebase/steward-tree/tracks/route-openapi-governance.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-27T15:32:41+08:00`
-- Base HEAD checked: `3b8f95945fcb489316ddfaf919835d372122fa5f`
+- Prepared at: `2026-05-27T21:33:48+08:00`
+- Base HEAD checked: `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`
 
 Boundary note: this track summary does not authorize route source edits,
 OpenAPI exposure changes, compatibility deletion, frontend consumer changes, or
@@ -46,6 +46,9 @@ then indexed from `evidence-index.md` and `steward-index.json` when active.
 
 ## Next Gates
 
+- Review G2.185 route dependency/provider governance residual decision. It
+  classifies active FastAPI providers as route contracts and does not authorize
+  route source edits or OpenAPI exposure changes.
 - Use this track for future trading route, backup route, control-plane, health,
   status, probe, and compatibility exposure decisions.
 - Keep source edits locked until the route owner, OpenAPI exposure policy, and

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-27T20:49:23+08:00`
-- Base HEAD checked: `d454193fdae08ad875c423e0b5aa959d79bedc67`
+- Prepared at: `2026-05-27T21:33:48+08:00`
+- Base HEAD checked: `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -36,7 +36,8 @@ It proved a repeatable conveyor:
 | G2.181 Strategy getter residual refresh decision | Merged by PR `#334` | Rechecks residual classes and selects route/provider fallback as the next governance target |
 | G2.182 Strategy route/provider fallback decision | Merged by PR `#335` | Classifies the route/provider fallback as a retained route-local provider seam and does not open a source lane |
 | G2.183 Strategy getter remaining residual decision | Merged by PR `#336` | Closes the current Strategy getter residual track with retained residuals and focused residual test evidence |
-| G2.184 next non-Strategy candidate decision | For review | Selects route dependency/provider governance as the next decision target and opens no source lane |
+| G2.184 next non-Strategy candidate decision | Merged by PR `#337` | Selects route dependency/provider governance as the next decision target and opens no source lane |
+| G2.185 route dependency/provider governance decision | For review | Classifies active FastAPI providers as retained route contracts, not singleton getter deletion candidates |
 
 ## Current Strategy Getter Residuals
 
@@ -54,12 +55,12 @@ G2.183 classification recorded these `get_strategy_service` hits under
 
 ## Next Gates
 
-- Review G2.184 next non-Strategy candidate decision.
-- If accepted, start G2.185 route dependency/provider governance residual
-  decision package.
-- Do not start another backend source lane directly from G2.184. The current
-  non-Strategy residuals are provider/compatibility shaped after fresh GitNexus
-  indexing and need provider ownership classification first.
+- Review G2.185 route dependency/provider governance residual decision.
+- If accepted, start G2.186 service lifecycle remaining getter inventory refresh
+  after provider governance.
+- Do not start another backend source lane directly from G2.185. The current
+  provider residuals are active route contracts and must be excluded from direct
+  implementation-candidate counts unless a later authorization says otherwise.
 
 ## Forbidden Scope
 

--- a/docs/reports/quality/backend-route-dependency-provider-governance-decision-2026-05-27.md
+++ b/docs/reports/quality/backend-route-dependency-provider-governance-decision-2026-05-27.md
@@ -1,0 +1,195 @@
+# Backend Route Dependency Provider Governance Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Task: G2.185 route dependency/provider governance residual decision
+Branch: `g2-185-route-dependency-provider-governance-decision`
+Base: `wip/root-dirty-20260403`
+Current HEAD: `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`
+Created: 2026-05-27
+
+Boundary: this is a governance decision package only. It does not edit backend
+source, backend tests, route/API behavior, OpenAPI exposure, frontend code, PM2
+workflows, OpenSpec state, GitHub issue labels, or service getter/provider
+implementations. It does not authorize implementation.
+
+## Purpose
+
+G2.184 selected route dependency/provider governance as the next decision target
+after Strategy getter residuals closed by PR `#336` and G2.184 merged by PR
+`#337`.
+
+This package classifies the provider residuals so future agents do not treat
+active FastAPI dependency providers as removable singleton getter debt.
+
+## Parent State
+
+| Input | State |
+|---|---|
+| PR `#337` | merged into `wip/root-dirty-20260403` |
+| Merge commit | `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba` |
+| Parent evidence | `docs/reports/quality/backend-next-nonstrategy-service-getter-candidate-decision-2026-05-27.md` |
+| Parent generated artifact | `.planning/codebase/generated/next-nonstrategy-service-getter-candidate-decision-2026-05-27.json` |
+
+## Evidence Collection
+
+GitNexus was refreshed in this worktree:
+
+```text
+gitnexus analyze --with-gitignore
+Repository indexed successfully
+62,959 nodes | 146,096 edges | 3287 clusters | 300 flows
+```
+
+Important caveat: GitNexus upstream impact is useful for normal symbol blast
+radius. It does not fully model FastAPI `Depends(...)` route consumers as graph
+callers. For provider governance, the static route/provider scan is the consumer
+truth.
+
+## Provider Inventory
+
+Scope: `web/backend/app/api`, `web/backend/app/services`, and
+`web/backend/app/core` at HEAD `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`.
+
+| Provider | Tokens | Depends sites | Owner surface | Classification | Decision |
+|---|---:|---:|---|---|---|
+| `get_data_source_factory_dependency` | 30 | 18 | `web/backend/app/services/data_source_factory/data_source_factory.py` | active cross-domain service-level FastAPI provider | retain |
+| `get_market_data_service_v2_dependency` | 18 | 14 | `web/backend/app/services/market_data_service_v2.py` | active service-level FastAPI provider | retain |
+| `get_market_data_service_dependency` | 16 | 7 | `web/backend/app/services/market_data_service/get_market_data_service.py` | active service-level FastAPI provider | retain |
+| `get_advanced_analysis_service_dependency` | 16 | 14 | `web/backend/app/services/advanced_analysis_service.py` | active service-level FastAPI provider | retain |
+| `get_announcement_service_dependency` | 13 | 11 | `web/backend/app/services/announcement_service.py` | active service-level FastAPI provider | retain |
+| `get_stock_search_service_dependency` | 11 | 6 | `web/backend/app/services/stock_search_service/stock_search_service.py` | active service-level FastAPI provider | retain |
+| `get_watchlist_service_dependency` | 9 | 7 | `web/backend/app/services/watchlist_service.py` | active service-level FastAPI provider | retain |
+| `get_email_service_dependency` | 8 | 6 | `web/backend/app/services/email_service.py` | active service-level FastAPI provider | retain |
+| `get_tradingview_service_dependency` | 8 | 6 | `web/backend/app/services/tradingview_widget_service.py` | active service-level FastAPI provider | retain |
+| `get_tdx_service_dependency` | 7 | 5 | `web/backend/app/services/tdx_service.py` | active service-level FastAPI provider | retain |
+| `get_indicator_registry_dependency` | 5 | 2 | `web/backend/app/services/indicator_registry.py` | active service-level FastAPI provider | retain |
+
+## Route-Local And Constructor Providers
+
+| Provider / getter | Tokens | Depends sites | Surface | Classification | Decision |
+|---|---:|---:|---|---|---|
+| `get_strategy_service_dependency` | 4 | 3 | `web/backend/app/api/strategy_management/_strategy_execution_router.py` | retained route-local provider fallback | retain under G2.182/G2.183 closure |
+| `get_indicator_data_service` | 4 | 2 | `web/backend/app/api/indicators/indicator_cache.py` | route-local provider fallback over public `DataService` getter | retain |
+| `get_strategy_indicator_data_service` | 3 | 1 | `web/backend/app/api/v1/strategy/indicators.py` | route-local provider fallback over public `DataService` getter | retain |
+| `get_data_source_dependency` | 5 | 3 | dashboard routes | dashboard route-local data-source provider | retain |
+| `get_streaming_service` | 25 | n/a | realtime/socket constructor fallback and public getter | public compatibility getter plus constructor fallback consumers | retain; realtime/socket subtrack remains closed |
+
+## GitNexus Impact Cross-Check
+
+The following provider symbols were checked after the G2.185 index refresh:
+
+| Target | GitNexus result | G2.185 interpretation |
+|---|---|---|
+| `get_data_source_factory_dependency` | LOW, impacted `0` | Graph consumer count does not override active static `Depends(...)` sites. |
+| `get_market_data_service_v2_dependency` | LOW, impacted `0` | Retain as active route provider. |
+| `get_market_data_service_dependency` | LOW, impacted `0` | Retain as active route provider. |
+| `get_advanced_analysis_service_dependency` | LOW, impacted `0` | Retain as active route provider. |
+| `get_tdx_service_dependency` | LOW, impacted `0` | Retain as active route provider. |
+| `get_strategy_service_dependency` | LOW, impacted `0` | Retain as route-local provider fallback. |
+| `get_indicator_registry_dependency` | LOW, impacted `0` | Retain as active route provider. |
+| `get_stock_search_service_dependency` | LOW, impacted `0` | Retain as active route provider. |
+
+## Decision
+
+Do not open a backend source implementation lane from G2.185.
+
+Classify the current provider residuals as retained route/provider contracts:
+
+1. FastAPI dependency/provider functions are active route contracts, not
+   singleton-retirement candidates.
+2. Public `get_*_service` compatibility getters remain valid fallback
+   entrypoints unless a later compatibility-retirement package explicitly
+   authorizes changing them.
+3. Route-local providers may remain route-local when they intentionally
+   encapsulate route-specific fallback behavior.
+4. GitNexus impact `0` does not imply deletability for provider functions,
+   because static route decorators and `Depends(...)` sites are the consumer
+   truth.
+5. Future provider edits require route-level override tests and OpenAPI/route
+   smoke when route signatures or exposure can change.
+
+## Next Gate
+
+Select the next work item as:
+
+```text
+G2.186 service lifecycle remaining getter inventory refresh after provider governance
+```
+
+G2.186 should remain governance-only unless it finds a real direct
+route-body/service-body getter candidate and a separate authorization package is
+approved.
+
+Minimum requirements:
+
+1. Rescan all service getter and provider tokens after accepting G2.185.
+2. Exclude retained route dependency providers, route-local provider fallbacks,
+   constructor fallbacks, package exports, public compatibility getter
+   definitions, and test-only references from implementation-candidate counts.
+3. Report only remaining direct route-body or service-body singleton getter calls
+   that are not provider-governed.
+4. If no direct implementation candidates remain, prepare a service lifecycle DI
+   closeout or queue-slimming decision package.
+5. If a candidate remains, require a separate authorization package before
+   source edits.
+
+## Not Authorized
+
+G2.185 does not authorize:
+
+- backend source edits
+- backend test edits
+- frontend edits
+- route/API/OpenAPI exposure changes
+- PM2 commands
+- OpenSpec change creation or spec edits
+- GitHub issue label changes
+- deleting, renaming, moving, or privatizing provider functions
+- deleting, renaming, moving, or privatizing public compatibility getters
+- starting a new implementation lane before G2.186 or a later authorization
+  package is reviewed and approved
+
+## Steward Tree Updates
+
+This package updates the split steward tree, not the archived single-file task
+tree:
+
+- `.planning/codebase/steward-tree/current-next-gates.md`
+- `.planning/codebase/steward-tree/steward-index.json`
+- `.planning/codebase/steward-tree/tracks/service-lifecycle-di.md`
+- `.planning/codebase/steward-tree/tracks/route-openapi-governance.md`
+- `.planning/codebase/steward-tree/branch-register.md`
+- `.planning/codebase/steward-tree/evidence-index.md`
+- `.planning/codebase/steward-tree/completed-ledger.md`
+
+## Verification Plan
+
+Required checks for this governance-only package:
+
+```bash
+python -m json.tool .planning/codebase/generated/route-dependency-provider-governance-decision-2026-05-27.json >/dev/null
+python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null
+python - <<'PY'
+import yaml
+with open("governance/mainline/task-cards/pr-338.yaml", encoding="utf-8") as f:
+    yaml.safe_load(f)
+PY
+python scripts/compliance/markdown_governance_gate.py --root-dir . --format json \
+  .planning/codebase/steward-tree/current-next-gates.md \
+  .planning/codebase/steward-tree/tracks/service-lifecycle-di.md \
+  .planning/codebase/steward-tree/tracks/route-openapi-governance.md \
+  .planning/codebase/steward-tree/branch-register.md \
+  .planning/codebase/steward-tree/evidence-index.md \
+  .planning/codebase/steward-tree/completed-ledger.md \
+  docs/reports/quality/backend-route-dependency-provider-governance-decision-2026-05-27.md
+openspec validate migrate-backend-singletons-to-lifecycle-di --strict
+git diff --check
+```
+
+## Next Gate
+
+Review G2.185. If accepted, start G2.186 as a service lifecycle remaining getter
+inventory refresh after provider governance.
+
+Do not start a backend source lane from G2.185.

--- a/governance/mainline/task-cards/pr-338.yaml
+++ b/governance/mainline/task-cards/pr-338.yaml
@@ -1,0 +1,111 @@
+version: "v0.2"
+
+task:
+  id: "pr-338"
+  title: "Classify route dependency provider residuals"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-route-dependency-provider-governance-decision"
+  objective: "classify active route dependency/provider residuals so they are not misread as singleton getter deletion candidates"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance decision package only; classifies active provider contracts without changing runtime, routes, tests, frontend, OpenAPI, or product behavior."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/route-dependency-provider-governance-decision-2026-05-27.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/tracks/route-openapi-governance.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-route-dependency-provider-governance-decision-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-338.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source edits"
+  - "No test edits"
+  - "No route, API, OpenAPI, PM2, frontend, config, script, or issue-label changes"
+  - "No deletion, rename, move, privatization, or behavior change of provider functions"
+  - "No deletion, rename, move, privatization, or behavior change of public compatibility getters"
+  - "No direct implementation lane selection"
+  - "No OpenSpec proposal creation"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/route-dependency-provider-governance-decision-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-338.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/tracks/route-openapi-governance.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-route-dependency-provider-governance-decision-2026-05-27.md"
+      required: true
+    - id: "openspec-lifecycle-di"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If provider functions are treated as removable singleton getters, active route dependency override contracts can be broken."
+    - "If GitNexus impacted=0 is treated as delete evidence, static FastAPI Depends consumers may be ignored."
+    - "If this decision is read as source authorization, route provider contracts could change without route/OpenAPI/test evidence."
+  rollback_plan: "revert this PR to restore the pre-G2.185 steward state and remove the provider-governance decision report, generated JSON, and task card."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "classify active route dependency providers as retained contracts, not singleton deletion debt"
+    modified_scope: "split steward tree files, decision report, generated JSON, and task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no source or compatibility behavior changes"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if the retained-provider-contract decision is rejected"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T21:33:48+08:00"
+    approval_note: "Human maintainer approved continuing after PR #337 merge; this lane is a route dependency/provider governance decision package only."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- classify residual FastAPI route dependency/provider functions as retained route contracts, not singleton-retirement candidates
- update steward tree, evidence index, completed ledger, and machine-readable steward index for G2.185
- select G2.186 remaining getter inventory refresh as the next gate

## Boundaries
- governance documentation only
- no runtime source edits
- no tests/source/OpenSpec mutation
- no provider deletion, route signature change, or compatibility wrapper retirement authorization

## Verification
- git diff --cached --check
- markdown_governance_gate.py: 7 checked files, 0 errors
- JSON/YAML parse checks passed
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: valid; PostHog telemetry ECONNREFUSED noise only
- gitnexus detect_changes staged: low risk, changed_symbols=0, affected_processes=0
- mainline_scope_gate.py: pass=True
- gitnexus analyze --with-gitignore: indexed 62,957 nodes / 146,106 edges / 300 flows