### PR TITLE
docs(governance): refresh remaining getter inventory

### DIFF
--- a/.planning/codebase/generated/service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.json
+++ b/.planning/codebase/generated/service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.json
@@ -1,0 +1,171 @@
+{
+  "schema_version": 1,
+  "title": "Service lifecycle remaining getter inventory refresh after provider governance",
+  "prepared_at": "2026-05-27T22:01:42+08:00",
+  "base_head_checked": "720248521d705af067d0a2600710444e439d7605",
+  "base_relationship": {
+    "previous_gate": "G2.185 route dependency/provider governance decision",
+    "previous_pr": 338,
+    "previous_merge_commit": "720248521d705af067d0a2600710444e439d7605",
+    "source_edit_authority": false
+  },
+  "scan_scope": {
+    "directories": [
+      "web/backend/app/api",
+      "web/backend/app/services"
+    ],
+    "file_count": 371,
+    "excluded_patterns": [
+      "function definitions",
+      "import statements",
+      "FastAPI Depends(...) provider references",
+      "names ending in _dependency",
+      "method calls through object receivers",
+      "comments and decorators"
+    ]
+  },
+  "raw_direct_getter_scan": {
+    "direct_getter_names": 111,
+    "direct_getter_calls": 296
+  },
+  "bucket_totals": [
+    {
+      "bucket": "infra_control_plane_session_accessors",
+      "names": 18,
+      "calls": 78,
+      "disposition": "not a service lifecycle source candidate"
+    },
+    {
+      "bucket": "factory_adapter_helper_root_facade",
+      "names": 27,
+      "calls": 101,
+      "disposition": "requires separate facade/adapter ownership decisions"
+    },
+    {
+      "bucket": "manual_review",
+      "names": 44,
+      "calls": 50,
+      "disposition": "do not auto-convert into backlog without owner review"
+    },
+    {
+      "bucket": "cache_messaging_accessors",
+      "names": 3,
+      "calls": 12,
+      "disposition": "cache/messaging lifecycle track, not generic service DI"
+    },
+    {
+      "bucket": "realtime_streaming_track",
+      "names": 10,
+      "calls": 12,
+      "disposition": "already governed by realtime streaming/socket track"
+    },
+    {
+      "bucket": "service_singleton_review",
+      "names": 10,
+      "calls": 43,
+      "disposition": "requires candidate-level classification below"
+    }
+  ],
+  "service_singleton_review_candidates": [
+    {
+      "name": "get_data_quality_monitor",
+      "direct_calls": 20,
+      "first_location": "web/backend/app/api/data_quality.py:112",
+      "gitnexus_risk": "HIGH",
+      "gitnexus_direct_impact": 20,
+      "classification": "data-quality and adapter cross-cutting track",
+      "disposition": "do not start source implementation from G2.186; needs separate design/authorization package"
+    },
+    {
+      "name": "get_integrated_services",
+      "direct_calls": 7,
+      "first_location": "web/backend/app/services/__init__.py:259",
+      "gitnexus_risk": "MEDIUM",
+      "gitnexus_direct_impact": 7,
+      "classification": "root facade compatibility",
+      "disposition": "retain until a root facade compatibility retirement package exists"
+    },
+    {
+      "name": "get_unified_data_service",
+      "direct_calls": 5,
+      "first_location": "web/backend/app/services/unified_data_service.py:587",
+      "gitnexus_risk": "MEDIUM",
+      "gitnexus_direct_impact": 5,
+      "classification": "root facade / service self-wrapper",
+      "disposition": "retain; not a route-body singleton implementation candidate"
+    },
+    {
+      "name": "get_prewarming_strategy",
+      "direct_calls": 3,
+      "first_location": "web/backend/app/api/_cache_prewarming_routes.py:118",
+      "gitnexus_risk": "HIGH",
+      "gitnexus_direct_impact": 3,
+      "classification": "control-plane cache prewarming",
+      "disposition": "route/control-plane track; not a generic service lifecycle DI pilot"
+    },
+    {
+      "name": "get_data_service",
+      "direct_calls": 2,
+      "first_location": "web/backend/app/api/v1/strategy/indicators.py:30",
+      "gitnexus_risk": "LOW",
+      "gitnexus_direct_impact": 2,
+      "classification": "indicator/data route-local provider fallback",
+      "disposition": "retain under provider governance unless a later indicator/data authorization package changes it"
+    },
+    {
+      "name": "get_execution_tracking_evidence_service",
+      "direct_calls": 2,
+      "first_location": "web/backend/app/api/trade/execution_tracking_routes.py:364",
+      "gitnexus_risk": "HIGH",
+      "gitnexus_direct_impact": 2,
+      "classification": "trade evidence route track",
+      "disposition": "separate trade/evidence authorization package required before source changes"
+    },
+    {
+      "name": "get_market_data_service_v2",
+      "direct_calls": 1,
+      "first_location": "web/backend/app/services/market_data_service_v2.py:673",
+      "gitnexus_risk": "LOW",
+      "gitnexus_direct_impact": 1,
+      "classification": "constructor install fallback",
+      "disposition": "retain as installation fallback; not a route-body candidate"
+    },
+    {
+      "name": "get_stop_loss_execution_service",
+      "direct_calls": 1,
+      "first_location": "web/backend/app/api/risk/stop_loss.py:51",
+      "gitnexus_risk": "LOW",
+      "gitnexus_direct_impact": 0,
+      "classification": "risk stop-loss route service getter",
+      "disposition": "recommended next narrow authorization-package candidate"
+    },
+    {
+      "name": "get_stop_loss_history_service",
+      "direct_calls": 1,
+      "first_location": "web/backend/app/api/risk/stop_loss.py:44",
+      "gitnexus_risk": "LOW",
+      "gitnexus_direct_impact": 1,
+      "classification": "risk stop-loss route service getter",
+      "disposition": "recommended next narrow authorization-package candidate"
+    },
+    {
+      "name": "get_tdx_service",
+      "direct_calls": 1,
+      "first_location": "web/backend/app/services/tdx_service.py:290",
+      "gitnexus_risk": "LOW",
+      "gitnexus_direct_impact": 1,
+      "classification": "constructor install fallback",
+      "disposition": "retain as installation fallback; Dashboard/TDX route work remains separate"
+    }
+  ],
+  "decision": {
+    "classification": "inventory-refresh-complete-no-source-lane",
+    "source_lane_recommendation": "do-not-start-source-implementation-from-g2-186",
+    "selected_next_governance_target": "risk-stop-loss-route-service-provider-authorization",
+    "recommended_next_work_item": "G2.187 risk stop-loss route service provider authorization package"
+  },
+  "freshness": {
+    "current_head_checked": "720248521d705af067d0a2600710444e439d7605",
+    "stale_if_head_mismatch": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-27T21:33:48+08:00`
-- Base HEAD checked: `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`
+- Prepared at: `2026-05-27T22:01:42+08:00`
+- Base HEAD checked: `720248521d705af067d0a2600710444e439d7605`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -22,12 +22,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#335` | `g2-182-strategy-route-provider-fallback-decision` | `wip/root-dirty-20260403` | `MERGED` at `597f8186092b4ad3d0704326e292c5e4fa075f15` | Retained route/provider fallback decision |
 | `#336` | `g2-183-strategy-getter-remaining-residual-decision` | `wip/root-dirty-20260403` | `MERGED` at `d454193fdae08ad875c423e0b5aa959d79bedc67` | Strategy getter remaining residual closeout with retained residuals |
 | `#337` | `g2-184-next-nonstrategy-service-getter-candidate-decision` | `wip/root-dirty-20260403` | `MERGED` at `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba` | Next non-Strategy candidate decision selecting provider governance |
+| `#338` | `g2-185-route-dependency-provider-governance-decision` | `wip/root-dirty-20260403` | `MERGED` at `720248521d705af067d0a2600710444e439d7605` | Provider governance decision retaining active route contracts |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-185-route-dependency-provider-governance-decision` | `origin/wip/root-dirty-20260403` at `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba` | Classify active route dependency/provider residuals and select the next queue-refresh gate | None |
+| `g2-186-remaining-getter-inventory-refresh` | `origin/wip/root-dirty-20260403` at `720248521d705af067d0a2600710444e439d7605` | Refresh remaining direct getter inventory after provider governance and select the next authorization-only gate | G2.185 provider governance decision |
 
 ## OpenSpec Relationship
 
@@ -43,7 +44,8 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.185 is a provider-governance decision branch only. It records the merged
-state of PR `#337`, classifies active FastAPI dependency providers as retained
-route contracts, and must not introduce backend source edits or a new
-implementation lane.
+G2.186 is an inventory-refresh decision branch only. It records the merged
+state of PR `#338`, excludes retained provider contracts from direct
+implementation-candidate counts, and recommends G2.187 as a stop-loss
+route-service authorization package. It must not introduce backend source edits
+or a new implementation lane.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-27T21:33:48+08:00`
-- Base HEAD checked: `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`
+- Prepared at: `2026-05-27T22:01:42+08:00`
+- Base HEAD checked: `720248521d705af067d0a2600710444e439d7605`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 now reviews active FastAPI provider classification before the next inventory refresh |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 refreshes remaining getter inventory after provider governance and recommends G2.187 stop-loss route service authorization |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-27T21:33:48+08:00`
-- Base HEAD checked: `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`
+- Prepared at: `2026-05-27T22:01:42+08:00`
+- Base HEAD checked: `720248521d705af067d0a2600710444e439d7605`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.185 route dependency/provider governance residual decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#337` merged at `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`; G2.185 classifies provider residuals as retained active contracts and opens no source lane | If accepted, start G2.186 service lifecycle remaining getter inventory refresh after provider governance |
+| P0 | Review G2.186 remaining getter inventory refresh | G/#79 service lifecycle DI | PR `#338` merged at `720248521d705af067d0a2600710444e439d7605`; G2.186 scans remaining direct getter calls after provider governance and opens no source lane | If accepted, start G2.187 risk stop-loss route service provider authorization package |
+| P0 | Preserve G2.185 provider governance decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#338` merged; provider residuals are retained active route contracts and excluded from direct implementation-candidate counts | Do not start a backend source lane from G2.185 |
 | P0 | Preserve G2.184 next non-Strategy candidate decision | G/#79 service lifecycle DI | PR `#337` merged; G2.184 selected route dependency/provider governance as the next decision target | Do not start a backend source lane from G2.184 |
 | P0 | Preserve G2.183 Strategy getter residual closeout | G/#79 service lifecycle DI | PR `#336` merged; remaining Strategy getter residuals classified as retained and tested | Do not reopen generic Strategy getter implementation unless current HEAD contradicts G2.183 evidence |
 | P0 | Keep steward split structure active | CODEBASE-MAP steward governance | PR `#332` merged at `750fb7c797ff95f27152439ed988a7115252129e` | Future steward updates must use split files and `steward-index.json`, not the archived single-file tree |
@@ -30,6 +31,6 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 - Does the split preserve the full historical steward tree in archive?
 - Is the root entrypoint short enough to serve as a daily navigation file?
 - Does `steward-index.json` include enough fields for automated guards?
-- Does G2.185 correctly classify active FastAPI providers as route contracts rather than deletion candidates?
-- Is G2.186 the right next gate for remaining getter inventory refresh after provider governance?
+- Does G2.186 correctly keep provider fallbacks, root facades, constructor fallbacks, and cross-cutting data-quality getters out of direct source candidacy?
+- Is G2.187 risk stop-loss route service provider authorization the right next narrow gate?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-27T21:33:48+08:00`
-- Base HEAD checked: `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`
+- Prepared at: `2026-05-27T22:01:42+08:00`
+- Base HEAD checked: `720248521d705af067d0a2600710444e439d7605`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -31,8 +31,10 @@ state transition.
 | `docs/reports/quality/backend-strategy-getter-remaining-residual-decision-2026-05-27.md` | G2.183 human-readable remaining-residual decision package | Accepted by PR `#336`; superseded for next-gate selection by G2.184 |
 | `.planning/codebase/generated/next-nonstrategy-service-getter-candidate-decision-2026-05-27.json` | G2.184 next non-Strategy service getter candidate decision evidence | Current for HEAD `d454193fdae08ad875c423e0b5aa959d79bedc67`; stale if HEAD changes |
 | `docs/reports/quality/backend-next-nonstrategy-service-getter-candidate-decision-2026-05-27.md` | G2.184 human-readable next-candidate decision package | Accepted by PR `#337`; superseded for provider classification by G2.185 |
-| `.planning/codebase/generated/route-dependency-provider-governance-decision-2026-05-27.json` | G2.185 route dependency/provider governance decision evidence | Current for HEAD `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`; stale if HEAD changes |
-| `docs/reports/quality/backend-route-dependency-provider-governance-decision-2026-05-27.md` | G2.185 human-readable provider-governance decision package | Review input until accepted |
+| `.planning/codebase/generated/route-dependency-provider-governance-decision-2026-05-27.json` | G2.185 route dependency/provider governance decision evidence | Current for HEAD `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`; accepted by PR `#338` |
+| `docs/reports/quality/backend-route-dependency-provider-governance-decision-2026-05-27.md` | G2.185 human-readable provider-governance decision package | Accepted by PR `#338`; superseded for remaining getter queue refresh by G2.186 |
+| `.planning/codebase/generated/service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.json` | G2.186 remaining getter inventory refresh evidence | Current for HEAD `720248521d705af067d0a2600710444e439d7605`; stale if HEAD changes |
+| `docs/reports/quality/backend-service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.md` | G2.186 human-readable inventory refresh decision package | Review input until accepted |
 
 ## External State Inputs
 
@@ -41,7 +43,8 @@ state transition.
 | GitHub PR `#331` | `MERGED` | G2.178 source implementation lane closed by merge commit `8bfb4dc74b06d6bb930e48ebf3d27bb28d908704` |
 | GitHub PR `#336` | `MERGED` | G2.183 remaining Strategy getter residual closeout merged by commit `d454193fdae08ad875c423e0b5aa959d79bedc67` |
 | GitHub PR `#337` | `MERGED` | G2.184 next non-Strategy candidate decision merged by commit `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba` |
-| `origin/wip/root-dirty-20260403` | `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba` | Base used for this decision branch |
+| GitHub PR `#338` | `MERGED` | G2.185 provider governance decision merged by commit `720248521d705af067d0a2600710444e439d7605` |
+| `origin/wip/root-dirty-20260403` | `720248521d705af067d0a2600710444e439d7605` | Base used for this decision branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-27T21:33:48+08:00",
+  "generated_at": "2026-05-27T22:01:42+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba",
-  "split_branch": "g2-185-route-dependency-provider-governance-decision",
+  "base_head": "720248521d705af067d0a2600710444e439d7605",
+  "split_branch": "g2-186-remaining-getter-inventory-refresh",
   "scope": "governance_decision_package",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
@@ -366,9 +366,15 @@
     {
       "id": "g2-185-route-dependency-provider-governance-decision",
       "type": "decision_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.184 next non-Strategy service getter candidate decision",
+      "github_pr": {
+        "number": 338,
+        "url": "https://github.com/chengjon/mystocks/pull/338",
+        "state": "MERGED",
+        "merge_commit": "720248521d705af067d0a2600710444e439d7605"
+      },
       "source_edit_authority": false,
       "evidence": [
         ".planning/codebase/generated/route-dependency-provider-governance-decision-2026-05-27.json",
@@ -410,7 +416,78 @@
         "current_head_checked": "b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.186 service lifecycle remaining getter inventory refresh after provider governance. Do not start a backend source lane from G2.185."
+      "next_gate": "Superseded by G2.186 remaining getter inventory refresh."
+    },
+    {
+      "id": "g2-186-remaining-getter-inventory-refresh",
+      "type": "decision_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.185 route dependency/provider governance decision",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.json",
+        "docs/reports/quality/backend-service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.md",
+        "governance/mainline/task-cards/pr-339.yaml"
+      ],
+      "inventory": {
+        "scan_scope": [
+          "web/backend/app/api",
+          "web/backend/app/services"
+        ],
+        "scanned_files": 371,
+        "direct_getter_names_after_exclusion": 111,
+        "direct_getter_calls_after_exclusion": 296,
+        "bucket_totals": {
+          "infra_control_plane_session_accessors": {
+            "names": 18,
+            "calls": 78
+          },
+          "factory_adapter_helper_root_facade": {
+            "names": 27,
+            "calls": 101
+          },
+          "manual_review": {
+            "names": 44,
+            "calls": 50
+          },
+          "cache_messaging_accessors": {
+            "names": 3,
+            "calls": 12
+          },
+          "realtime_streaming_track": {
+            "names": 10,
+            "calls": 12
+          },
+          "service_singleton_review": {
+            "names": 10,
+            "calls": 43
+          }
+        },
+        "service_singleton_review_names": [
+          "get_data_quality_monitor",
+          "get_integrated_services",
+          "get_unified_data_service",
+          "get_prewarming_strategy",
+          "get_data_service",
+          "get_execution_tracking_evidence_service",
+          "get_market_data_service_v2",
+          "get_stop_loss_execution_service",
+          "get_stop_loss_history_service",
+          "get_tdx_service"
+        ]
+      },
+      "decision": {
+        "classification": "inventory-refresh-complete-no-source-lane",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-186",
+        "selected_next_governance_target": "risk-stop-loss-route-service-provider-authorization",
+        "recommended_next_work_item": "G2.187 risk stop-loss route service provider authorization package"
+      },
+      "freshness": {
+        "current_head_checked": "720248521d705af067d0a2600710444e439d7605",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.187 risk stop-loss route service provider authorization package. Do not start a backend source lane from G2.186."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-27T21:33:48+08:00`
-- Base HEAD checked: `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`
+- Prepared at: `2026-05-27T22:01:42+08:00`
+- Base HEAD checked: `720248521d705af067d0a2600710444e439d7605`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -37,7 +37,8 @@ It proved a repeatable conveyor:
 | G2.182 Strategy route/provider fallback decision | Merged by PR `#335` | Classifies the route/provider fallback as a retained route-local provider seam and does not open a source lane |
 | G2.183 Strategy getter remaining residual decision | Merged by PR `#336` | Closes the current Strategy getter residual track with retained residuals and focused residual test evidence |
 | G2.184 next non-Strategy candidate decision | Merged by PR `#337` | Selects route dependency/provider governance as the next decision target and opens no source lane |
-| G2.185 route dependency/provider governance decision | For review | Classifies active FastAPI providers as retained route contracts, not singleton getter deletion candidates |
+| G2.185 route dependency/provider governance decision | Merged by PR `#338` | Classifies active FastAPI providers as retained route contracts, not singleton getter deletion candidates |
+| G2.186 remaining getter inventory refresh | For review | Refreshes direct getter inventory after provider governance and recommends a narrow stop-loss authorization package as the next gate |
 
 ## Current Strategy Getter Residuals
 
@@ -53,14 +54,41 @@ G2.183 classification recorded these `get_strategy_service` hits under
 | `web/backend/app/tasks/backtest_tasks.py` | 2 | Retained backtest task resolver fallback; do not reopen unless current evidence contradicts focused tests |
 | `web/backend/app/services/strategy_service.py` | 1 | Public getter definition; retain as compatibility entrypoint and do not delete, rename, or privatize here |
 
+## G2.186 Remaining Getter Refresh
+
+At HEAD `720248521d705af067d0a2600710444e439d7605`, G2.186 scanned
+`web/backend/app/api` and `web/backend/app/services` after excluding function
+definitions, imports, FastAPI `Depends(...)` provider references,
+`*_dependency` names, object method calls, comments, and decorators.
+
+| Metric | Count |
+|---|---:|
+| Python files scanned | 371 |
+| Direct `get_*` names after exclusion | 111 |
+| Direct `get_*` calls after exclusion | 296 |
+
+| Candidate class | Names | Calls | Current handling |
+|---|---:|---:|---|
+| Infra / control-plane / session accessors | 18 | 78 | Not service lifecycle source candidates |
+| Factory / adapter / helper / root facade | 27 | 101 | Requires owner-specific decisions |
+| Manual review residue | 44 | 50 | Must not become backlog automatically |
+| Cache / messaging accessors | 3 | 12 | Cache/messaging lifecycle track |
+| Realtime / streaming track | 10 | 12 | Already governed by realtime streaming/socket track |
+| Service singleton review | 10 | 43 | Classified by G2.186 generated evidence |
+
+The next recommended authorization-only gate is G2.187 risk stop-loss route
+service provider authorization, limited to the stop-loss route pair. High-risk
+data-quality, root-facade, control-plane cache, trade evidence, and constructor
+fallback getters stay deferred to their owner-specific tracks.
+
 ## Next Gates
 
-- Review G2.185 route dependency/provider governance residual decision.
-- If accepted, start G2.186 service lifecycle remaining getter inventory refresh
-  after provider governance.
-- Do not start another backend source lane directly from G2.185. The current
-  provider residuals are active route contracts and must be excluded from direct
-  implementation-candidate counts unless a later authorization says otherwise.
+- Review G2.186 remaining getter inventory refresh.
+- If accepted, start G2.187 risk stop-loss route service provider authorization
+  package.
+- Do not start another backend source lane directly from G2.186. The current
+  report is an inventory refresh and next-gate recommendation, not source
+  authorization.
 
 ## Forbidden Scope
 

--- a/docs/reports/quality/backend-service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.md
+++ b/docs/reports/quality/backend-service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.md
@@ -1,0 +1,140 @@
+# Backend Service Lifecycle Remaining Getter Inventory Refresh
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: decision package for review
+- Prepared at: `2026-05-27T22:01:42+08:00`
+- Base HEAD checked: `720248521d705af067d0a2600710444e439d7605`
+- Previous gate: G2.185 route dependency/provider governance decision
+- Previous PR: `#338`, merged at `720248521d705af067d0a2600710444e439d7605`
+- OpenSpec lane: `migrate-backend-singletons-to-lifecycle-di`
+
+Boundary note: this report is evidence and scheduling guidance only. It does not
+authorize backend source edits, route signature changes, test edits, OpenSpec
+proposal creation, issue label changes, provider deletion, or compatibility
+getter retirement.
+
+## Purpose
+
+G2.185 closed the provider-governance ambiguity by classifying active FastAPI
+dependency providers as retained route contracts. G2.186 refreshes the remaining
+getter inventory after that decision so that provider functions, route-local
+fallbacks, constructor fallbacks, package exports, public getter definitions,
+and test-only references do not inflate the next implementation backlog.
+
+## Scan Method
+
+The scan covered:
+
+- `web/backend/app/api`
+- `web/backend/app/services`
+
+The scanner counted direct `get_*(` calls and excluded:
+
+- function definitions
+- import statements
+- FastAPI `Depends(...)` provider references
+- names ending in `_dependency`
+- method calls through object receivers
+- comments and decorators
+
+This keeps the result focused on route-body and service-body direct getter
+usage. It is still an inventory, not an implementation authorization.
+
+## Inventory Summary
+
+| Metric | Count |
+|---|---:|
+| Python files scanned | 371 |
+| Direct `get_*` names after exclusion | 111 |
+| Direct `get_*` calls after exclusion | 296 |
+
+| Bucket | Names | Calls | Disposition |
+|---|---:|---:|---|
+| Infra / control-plane / session accessors | 18 | 78 | Not service lifecycle source candidates |
+| Factory / adapter / helper / root facade | 27 | 101 | Requires owner-specific facade or adapter decisions |
+| Manual review residue | 44 | 50 | Must not become backlog automatically |
+| Cache / messaging accessors | 3 | 12 | Cache/messaging lifecycle track, not generic service DI |
+| Realtime / streaming track | 10 | 12 | Already governed by realtime streaming/socket track |
+| Service singleton review | 10 | 43 | Candidate-level classification below |
+
+## Service Singleton Review Candidates
+
+| Getter | Direct calls | First location | GitNexus risk | Direct impact | Classification | Disposition |
+|---|---:|---|---|---:|---|---|
+| `get_data_quality_monitor` | 20 | `web/backend/app/api/data_quality.py:112` | HIGH | 20 | Data-quality and adapter cross-cutting track | Separate design/authorization package required; no G2.186 source lane |
+| `get_integrated_services` | 7 | `web/backend/app/services/__init__.py:259` | MEDIUM | 7 | Root facade compatibility | Retain until a root facade compatibility retirement package exists |
+| `get_unified_data_service` | 5 | `web/backend/app/services/unified_data_service.py:587` | MEDIUM | 5 | Root facade / service self-wrapper | Retain; not a route-body singleton implementation candidate |
+| `get_prewarming_strategy` | 3 | `web/backend/app/api/_cache_prewarming_routes.py:118` | HIGH | 3 | Control-plane cache prewarming | Route/control-plane track; not a generic service lifecycle pilot |
+| `get_data_service` | 2 | `web/backend/app/api/v1/strategy/indicators.py:30` | LOW | 2 | Indicator/data route-local provider fallback | Retain under provider governance unless later authorization changes it |
+| `get_execution_tracking_evidence_service` | 2 | `web/backend/app/api/trade/execution_tracking_routes.py:364` | HIGH | 2 | Trade evidence route track | Separate trade/evidence authorization package required |
+| `get_market_data_service_v2` | 1 | `web/backend/app/services/market_data_service_v2.py:673` | LOW | 1 | Constructor install fallback | Retain as installation fallback |
+| `get_stop_loss_execution_service` | 1 | `web/backend/app/api/risk/stop_loss.py:51` | LOW | 0 | Risk stop-loss route service getter | Recommended next narrow authorization-package candidate |
+| `get_stop_loss_history_service` | 1 | `web/backend/app/api/risk/stop_loss.py:44` | LOW | 1 | Risk stop-loss route service getter | Recommended next narrow authorization-package candidate |
+| `get_tdx_service` | 1 | `web/backend/app/services/tdx_service.py:290` | LOW | 1 | Constructor install fallback | Retain; Dashboard/TDX route work remains separate |
+
+## Decision
+
+G2.186 does not open a backend source implementation lane.
+
+The refreshed inventory shows that the largest remaining direct getter surfaces
+are either cross-cutting, root-facade shaped, provider fallback shaped, or owned
+by a different governance track. The only narrow next candidate is the stop-loss
+risk route pair:
+
+- `get_stop_loss_history_service`
+- `get_stop_loss_execution_service`
+
+The recommended next work item is:
+
+`G2.187 risk stop-loss route service provider authorization package`
+
+That package should remain design/authorization only until reviewed. It should
+define the exact route file scope, tests, rollback plan, GitNexus pre-edit
+checks, and route contract checks before any source edit is allowed.
+
+## Blocked Actions
+
+This package explicitly forbids:
+
+- editing `web/backend/**`
+- editing `src/**`
+- editing tests
+- deleting or renaming any getter
+- treating `get_data_quality_monitor` as a quick source lane
+- treating root facade getters as unused
+- changing FastAPI provider behavior
+- opening G2.187 source implementation before its authorization package is accepted
+
+## Verification
+
+- `gitnexus analyze --with-gitignore`
+  - `62,963 nodes`
+  - `146,095 edges`
+  - `300 flows`
+- Direct getter scanner:
+  - files=`371`
+  - direct names=`111`
+  - direct calls=`296`
+- GitNexus impact samples:
+  - `get_data_quality_monitor`: HIGH, direct=`20`, processes=`2`
+  - `get_integrated_services`: MEDIUM, direct=`7`
+  - `get_unified_data_service`: MEDIUM, direct=`5`
+  - `get_prewarming_strategy`: HIGH, direct=`3`, processes=`3`
+  - `get_data_service`: LOW, direct=`2`
+  - `get_execution_tracking_evidence_service`: HIGH, direct=`2`, processes=`3`
+  - `get_stop_loss_history_service`: LOW, direct=`1`
+  - `get_stop_loss_execution_service`: LOW, direct=`0`
+  - `get_market_data_service_v2`: LOW, direct=`1`
+  - `get_tdx_service`: LOW, direct=`1`
+
+## Review Questions
+
+- Should G2.187 focus on the stop-loss route pair as the next narrow
+  authorization package?
+- Should `get_data_quality_monitor` be deferred to a larger data-quality and
+  adapter governance package?
+- Should root facade compatibility retirement remain blocked behind a separate
+  root-facade decision package?

--- a/governance/mainline/task-cards/pr-339.yaml
+++ b/governance/mainline/task-cards/pr-339.yaml
@@ -1,0 +1,100 @@
+version: "v0.2"
+
+task:
+  id: "pr-339"
+  title: "Refresh remaining service getter inventory after provider governance"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-service-lifecycle-remaining-getter-refresh"
+  objective: "refresh remaining direct getter inventory after provider governance and select the next authorization-only gate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-339.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits"
+  - "test edits"
+  - "OpenSpec proposal creation"
+  - "provider deletion or compatibility getter retirement"
+  - "route signature or OpenAPI schema changes"
+  - "starting the G2.187 source implementation lane"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-339.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.md"
+      required: true
+    - id: "openspec-lifecycle-di"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If raw direct getter counts are treated as implementation backlog, provider fallbacks and root facades can be migrated without owner-specific authorization."
+    - "If high-risk data-quality/root-facade getters are selected as a quick lane, the next implementation batch can become too broad."
+    - "If G2.187 is treated as source authorization, stop-loss route behavior can change before the package defines tests and rollback."
+  rollback_plan: "revert this PR to restore the pre-G2.186 steward state and remove the inventory refresh report, generated JSON, and task card."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "refresh remaining getter inventory after G2.185 provider governance"
+    modified_scope: "split steward tree files, decision report, generated JSON, and task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no source or compatibility behavior changes"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if the G2.186 classification or G2.187 recommendation is rejected"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T22:01:42+08:00"
+    approval_note: "Human maintainer approved continuing after PR #338 merge; this lane is a remaining getter inventory refresh decision package only."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records PR #338 as merged and refreshes the remaining direct getter inventory after provider governance
- classifies remaining getter surfaces into infra/session, facade/adapter/helper, cache/messaging, realtime, manual review, and service-singleton review buckets
- recommends G2.187 risk stop-loss route service provider authorization as the next narrow gate

## Boundaries
- governance documentation only
- no backend source edits
- no test edits
- no route signature, OpenAPI schema, provider behavior, or compatibility getter changes
- no G2.187 source implementation authorization

## Key Evidence
- scanned 371 Python files under web/backend/app/api and web/backend/app/services
- direct get_* names after exclusion: 111
- direct get_* calls after exclusion: 296
- service singleton review: 10 names / 43 calls
- high-risk surfaces deferred: get_data_quality_monitor, get_prewarming_strategy, get_execution_tracking_evidence_service
- recommended narrow next gate: get_stop_loss_history_service + get_stop_loss_execution_service authorization package

## Verification
- markdown_governance_gate.py: 6 checked files, 0 errors
- JSON/YAML parse checks passed
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: valid; PostHog telemetry ECONNREFUSED noise only
- mainline_scope_gate.py: pass=True
- git diff --check: clean
- gitnexus detect_changes compare: low risk, affected_processes=0
- gitnexus analyze --with-gitignore: indexed 62,974 nodes / 146,108 edges / 300 flows