### PR TITLE
docs(governance): authorize stop-loss provider lane

### DIFF
--- a/.planning/codebase/generated/risk-stop-loss-route-provider-authorization-2026-05-27.json
+++ b/.planning/codebase/generated/risk-stop-loss-route-provider-authorization-2026-05-27.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": 1,
+  "title": "Risk stop-loss route service provider authorization package",
+  "prepared_at": "2026-05-27T22:30:42+08:00",
+  "base_head_checked": "a63a6cb9a277195905b046cd31777d95160ee2c6",
+  "base_relationship": {
+    "previous_gate": "G2.186 remaining getter inventory refresh",
+    "previous_pr": 339,
+    "previous_merge_commit": "a63a6cb9a277195905b046cd31777d95160ee2c6",
+    "source_edit_authority_for_this_pr": false
+  },
+  "authorization_target": {
+    "next_lane": "G2.188 risk stop-loss route service provider implementation",
+    "authorization_type": "path-limited source implementation after human acceptance",
+    "source_edit_authority_for_next_lane_if_accepted": true
+  },
+  "current_shape": {
+    "route_file": "web/backend/app/api/risk/stop_loss.py",
+    "history_resolver": {
+      "function": "_resolve_history_service",
+      "line": 43,
+      "direct_getter": "get_stop_loss_history_service",
+      "route_consumers": [
+        "get_stop_loss_performance",
+        "get_stop_loss_recommendations"
+      ]
+    },
+    "execution_resolver": {
+      "function": "_resolve_execution_service",
+      "line": 50,
+      "direct_getter": "get_stop_loss_execution_service",
+      "route_consumers": [
+        "add_stop_loss_position",
+        "update_stop_loss_price",
+        "remove_stop_loss_position",
+        "get_stop_loss_status",
+        "get_stop_loss_overview",
+        "batch_update_stop_loss_prices"
+      ]
+    }
+  },
+  "gitnexus_pre_authorization_evidence": [
+    {
+      "target": "get_stop_loss_history_service",
+      "risk": "LOW",
+      "impacted_count": 3,
+      "direct": 1,
+      "processes": 0,
+      "d1": [
+        "_resolve_history_service"
+      ],
+      "d2": [
+        "get_stop_loss_performance",
+        "get_stop_loss_recommendations"
+      ]
+    },
+    {
+      "target": "get_stop_loss_execution_service",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct": 0,
+      "processes": 0
+    },
+    {
+      "target": "_resolve_history_service",
+      "risk": "LOW",
+      "impacted_count": 2,
+      "direct": 2,
+      "processes": 0
+    },
+    {
+      "target": "_resolve_execution_service",
+      "risk": "MEDIUM",
+      "impacted_count": 6,
+      "direct": 6,
+      "processes": 0
+    }
+  ],
+  "authorized_next_lane_scope": {
+    "source_paths": [
+      "web/backend/app/api/risk/stop_loss.py"
+    ],
+    "test_paths": [
+      "web/backend/tests/test_risk_runtime_bootstrap_regressions.py",
+      "web/backend/tests/test_stop_loss_route_regressions.py",
+      "tests/unit/contract/test_risk_router_runtime_import.py"
+    ],
+    "forbidden_paths": [
+      "src/**",
+      "web/backend/app/api/risk/_shared.py",
+      "web/backend/app/api/risk/*.py except stop_loss.py",
+      "web/frontend/**",
+      "docs/api/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ]
+  },
+  "authorized_next_lane_design": {
+    "add_fastapi_dependency_import": "from fastapi import APIRouter, Body, Depends, Path, Query",
+    "add_provider_functions": [
+      "get_stop_loss_history_service_dependency",
+      "get_stop_loss_execution_service_dependency"
+    ],
+    "route_body_change": "inject services through FastAPI Depends parameters and replace route-body _resolve_* calls with injected parameters",
+    "contract_boundary": "no route path, HTTP method, response_model, OpenAPI examples, error code, or service behavior change",
+    "compatibility_boundary": "do not delete, rename, or privatize src-level get_stop_loss_* service getters"
+  },
+  "required_next_lane_verification": [
+    "GitNexus impact before editing stop_loss.py symbols in the implementation worktree",
+    "TDD red test proving endpoint functions accept injected fake history/execution services without monkeypatching module-level getters",
+    "pytest -o addopts= web/backend/tests/test_risk_runtime_bootstrap_regressions.py web/backend/tests/test_stop_loss_route_regressions.py tests/unit/contract/test_risk_router_runtime_import.py -q --no-cov",
+    "ruff check web/backend/app/api/risk/stop_loss.py web/backend/tests/test_risk_runtime_bootstrap_regressions.py web/backend/tests/test_stop_loss_route_regressions.py tests/unit/contract/test_risk_router_runtime_import.py",
+    "route/OpenAPI smoke if any route signature or OpenAPI exposure can drift",
+    "gitnexus detect_changes with staged scope before commit"
+  ],
+  "decision": {
+    "classification": "authorization-package-for-review",
+    "source_lane_recommendation": "start-g2-188-only-after-human-acceptance",
+    "selected_next_governance_target": "risk-stop-loss-route-service-provider-implementation",
+    "recommended_next_work_item": "G2.188 risk stop-loss route service provider implementation lane"
+  },
+  "freshness": {
+    "current_head_checked": "a63a6cb9a277195905b046cd31777d95160ee2c6",
+    "stale_if_head_mismatch": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-27T22:01:42+08:00`
-- Base HEAD checked: `720248521d705af067d0a2600710444e439d7605`
+- Prepared at: `2026-05-27T22:30:42+08:00`
+- Base HEAD checked: `a63a6cb9a277195905b046cd31777d95160ee2c6`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -23,12 +23,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#336` | `g2-183-strategy-getter-remaining-residual-decision` | `wip/root-dirty-20260403` | `MERGED` at `d454193fdae08ad875c423e0b5aa959d79bedc67` | Strategy getter remaining residual closeout with retained residuals |
 | `#337` | `g2-184-next-nonstrategy-service-getter-candidate-decision` | `wip/root-dirty-20260403` | `MERGED` at `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba` | Next non-Strategy candidate decision selecting provider governance |
 | `#338` | `g2-185-route-dependency-provider-governance-decision` | `wip/root-dirty-20260403` | `MERGED` at `720248521d705af067d0a2600710444e439d7605` | Provider governance decision retaining active route contracts |
+| `#339` | `g2-186-remaining-getter-inventory-refresh` | `wip/root-dirty-20260403` | `MERGED` at `a63a6cb9a277195905b046cd31777d95160ee2c6` | Remaining getter inventory refresh selecting stop-loss authorization |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-186-remaining-getter-inventory-refresh` | `origin/wip/root-dirty-20260403` at `720248521d705af067d0a2600710444e439d7605` | Refresh remaining direct getter inventory after provider governance and select the next authorization-only gate | G2.185 provider governance decision |
+| `g2-187-risk-stop-loss-provider-authorization` | `origin/wip/root-dirty-20260403` at `a63a6cb9a277195905b046cd31777d95160ee2c6` | Authorize the future stop-loss route service provider implementation lane without changing source in this PR | G2.186 remaining getter inventory refresh |
 
 ## OpenSpec Relationship
 
@@ -44,8 +45,6 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.186 is an inventory-refresh decision branch only. It records the merged
-state of PR `#338`, excludes retained provider contracts from direct
-implementation-candidate counts, and recommends G2.187 as a stop-loss
-route-service authorization package. It must not introduce backend source edits
-or a new implementation lane.
+G2.187 is an authorization branch only. It records the merged state of PR
+`#339`, defines the exact future stop-loss route implementation scope, and must
+not introduce backend source edits in this PR.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-27T22:01:42+08:00`
-- Base HEAD checked: `720248521d705af067d0a2600710444e439d7605`
+- Prepared at: `2026-05-27T22:30:42+08:00`
+- Base HEAD checked: `a63a6cb9a277195905b046cd31777d95160ee2c6`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 refreshes remaining getter inventory after provider governance and recommends G2.187 stop-loss route service authorization |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 defines the stop-loss route provider authorization package for review |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-27T22:01:42+08:00`
-- Base HEAD checked: `720248521d705af067d0a2600710444e439d7605`
+- Prepared at: `2026-05-27T22:30:42+08:00`
+- Base HEAD checked: `a63a6cb9a277195905b046cd31777d95160ee2c6`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.186 remaining getter inventory refresh | G/#79 service lifecycle DI | PR `#338` merged at `720248521d705af067d0a2600710444e439d7605`; G2.186 scans remaining direct getter calls after provider governance and opens no source lane | If accepted, start G2.187 risk stop-loss route service provider authorization package |
+| P0 | Review G2.187 risk stop-loss route service provider authorization | G/#79 service lifecycle DI | PR `#339` merged at `a63a6cb9a277195905b046cd31777d95160ee2c6`; G2.187 defines path-limited future implementation scope and keeps this PR docs-only | If accepted, start G2.188 risk stop-loss route service provider implementation lane |
+| P0 | Preserve G2.186 remaining getter inventory refresh | G/#79 service lifecycle DI | PR `#339` merged; G2.186 refreshed remaining direct getter inventory and selected stop-loss route provider authorization as the next narrow gate | Do not start a backend source lane from G2.186 |
 | P0 | Preserve G2.185 provider governance decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#338` merged; provider residuals are retained active route contracts and excluded from direct implementation-candidate counts | Do not start a backend source lane from G2.185 |
 | P0 | Preserve G2.184 next non-Strategy candidate decision | G/#79 service lifecycle DI | PR `#337` merged; G2.184 selected route dependency/provider governance as the next decision target | Do not start a backend source lane from G2.184 |
 | P0 | Preserve G2.183 Strategy getter residual closeout | G/#79 service lifecycle DI | PR `#336` merged; remaining Strategy getter residuals classified as retained and tested | Do not reopen generic Strategy getter implementation unless current HEAD contradicts G2.183 evidence |
@@ -31,6 +32,6 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 - Does the split preserve the full historical steward tree in archive?
 - Is the root entrypoint short enough to serve as a daily navigation file?
 - Does `steward-index.json` include enough fields for automated guards?
-- Does G2.186 correctly keep provider fallbacks, root facades, constructor fallbacks, and cross-cutting data-quality getters out of direct source candidacy?
-- Is G2.187 risk stop-loss route service provider authorization the right next narrow gate?
+- Does G2.187 correctly limit the future source lane to `web/backend/app/api/risk/stop_loss.py` and focused tests?
+- Is G2.188 allowed to proceed only after this authorization package is reviewed and accepted?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-27T22:01:42+08:00`
-- Base HEAD checked: `720248521d705af067d0a2600710444e439d7605`
+- Prepared at: `2026-05-27T22:30:42+08:00`
+- Base HEAD checked: `a63a6cb9a277195905b046cd31777d95160ee2c6`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -34,7 +34,9 @@ state transition.
 | `.planning/codebase/generated/route-dependency-provider-governance-decision-2026-05-27.json` | G2.185 route dependency/provider governance decision evidence | Current for HEAD `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba`; accepted by PR `#338` |
 | `docs/reports/quality/backend-route-dependency-provider-governance-decision-2026-05-27.md` | G2.185 human-readable provider-governance decision package | Accepted by PR `#338`; superseded for remaining getter queue refresh by G2.186 |
 | `.planning/codebase/generated/service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.json` | G2.186 remaining getter inventory refresh evidence | Current for HEAD `720248521d705af067d0a2600710444e439d7605`; stale if HEAD changes |
-| `docs/reports/quality/backend-service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.md` | G2.186 human-readable inventory refresh decision package | Review input until accepted |
+| `docs/reports/quality/backend-service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.md` | G2.186 human-readable inventory refresh decision package | Accepted by PR `#339`; superseded for stop-loss authorization by G2.187 |
+| `.planning/codebase/generated/risk-stop-loss-route-provider-authorization-2026-05-27.json` | G2.187 risk stop-loss route provider authorization evidence | Current for HEAD `a63a6cb9a277195905b046cd31777d95160ee2c6`; stale if HEAD changes |
+| `docs/reports/quality/backend-risk-stop-loss-route-provider-authorization-2026-05-27.md` | G2.187 human-readable authorization package | Review input until accepted |
 
 ## External State Inputs
 
@@ -44,7 +46,8 @@ state transition.
 | GitHub PR `#336` | `MERGED` | G2.183 remaining Strategy getter residual closeout merged by commit `d454193fdae08ad875c423e0b5aa959d79bedc67` |
 | GitHub PR `#337` | `MERGED` | G2.184 next non-Strategy candidate decision merged by commit `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba` |
 | GitHub PR `#338` | `MERGED` | G2.185 provider governance decision merged by commit `720248521d705af067d0a2600710444e439d7605` |
-| `origin/wip/root-dirty-20260403` | `720248521d705af067d0a2600710444e439d7605` | Base used for this decision branch |
+| GitHub PR `#339` | `MERGED` | G2.186 remaining getter inventory refresh merged by commit `a63a6cb9a277195905b046cd31777d95160ee2c6` |
+| `origin/wip/root-dirty-20260403` | `a63a6cb9a277195905b046cd31777d95160ee2c6` | Base used for this decision branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-27T22:01:42+08:00",
+  "generated_at": "2026-05-27T22:30:42+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "720248521d705af067d0a2600710444e439d7605",
-  "split_branch": "g2-186-remaining-getter-inventory-refresh",
+  "base_head": "a63a6cb9a277195905b046cd31777d95160ee2c6",
+  "split_branch": "g2-187-risk-stop-loss-provider-authorization",
   "scope": "governance_decision_package",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
@@ -421,9 +421,15 @@
     {
       "id": "g2-186-remaining-getter-inventory-refresh",
       "type": "decision_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.185 route dependency/provider governance decision",
+      "github_pr": {
+        "number": 339,
+        "url": "https://github.com/chengjon/mystocks/pull/339",
+        "state": "MERGED",
+        "merge_commit": "a63a6cb9a277195905b046cd31777d95160ee2c6"
+      },
       "source_edit_authority": false,
       "evidence": [
         ".planning/codebase/generated/service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.json",
@@ -487,7 +493,78 @@
         "current_head_checked": "720248521d705af067d0a2600710444e439d7605",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.187 risk stop-loss route service provider authorization package. Do not start a backend source lane from G2.186."
+      "next_gate": "Superseded by G2.187 risk stop-loss route service provider authorization."
+    },
+    {
+      "id": "g2-187-risk-stop-loss-provider-authorization",
+      "type": "authorization_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.186 remaining getter inventory refresh",
+      "source_edit_authority": false,
+      "future_source_edit_authority_if_accepted": true,
+      "evidence": [
+        ".planning/codebase/generated/risk-stop-loss-route-provider-authorization-2026-05-27.json",
+        "docs/reports/quality/backend-risk-stop-loss-route-provider-authorization-2026-05-27.md",
+        "governance/mainline/task-cards/pr-340.yaml"
+      ],
+      "authorization_scope": {
+        "future_lane": "G2.188 risk stop-loss route service provider implementation",
+        "allowed_source_paths": [
+          "web/backend/app/api/risk/stop_loss.py"
+        ],
+        "allowed_test_paths": [
+          "web/backend/tests/test_risk_runtime_bootstrap_regressions.py",
+          "web/backend/tests/test_stop_loss_route_regressions.py",
+          "tests/unit/contract/test_risk_router_runtime_import.py"
+        ],
+        "forbidden_paths": [
+          "src/**",
+          "web/backend/app/api/risk/_shared.py",
+          "other web/backend/app/api/risk/*.py files",
+          "web/frontend/**",
+          "docs/api/**",
+          "openspec/changes/**",
+          "openspec/specs/**"
+        ]
+      },
+      "gitnexus_evidence": {
+        "get_stop_loss_history_service": {
+          "risk": "LOW",
+          "impacted": 3,
+          "direct": 1,
+          "processes": 0
+        },
+        "get_stop_loss_execution_service": {
+          "risk": "LOW",
+          "impacted": 0,
+          "direct": 0,
+          "processes": 0
+        },
+        "_resolve_history_service": {
+          "risk": "LOW",
+          "impacted": 2,
+          "direct": 2,
+          "processes": 0
+        },
+        "_resolve_execution_service": {
+          "risk": "MEDIUM",
+          "impacted": 6,
+          "direct": 6,
+          "processes": 0
+        }
+      },
+      "decision": {
+        "classification": "authorization-package-for-review",
+        "source_lane_recommendation": "start-g2-188-only-after-human-acceptance",
+        "selected_next_governance_target": "risk-stop-loss-route-service-provider-implementation",
+        "recommended_next_work_item": "G2.188 risk stop-loss route service provider implementation lane"
+      },
+      "freshness": {
+        "current_head_checked": "a63a6cb9a277195905b046cd31777d95160ee2c6",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.188 risk stop-loss route service provider implementation lane. Do not edit source from G2.187."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-27T22:01:42+08:00`
-- Base HEAD checked: `720248521d705af067d0a2600710444e439d7605`
+- Prepared at: `2026-05-27T22:30:42+08:00`
+- Base HEAD checked: `a63a6cb9a277195905b046cd31777d95160ee2c6`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -38,7 +38,8 @@ It proved a repeatable conveyor:
 | G2.183 Strategy getter remaining residual decision | Merged by PR `#336` | Closes the current Strategy getter residual track with retained residuals and focused residual test evidence |
 | G2.184 next non-Strategy candidate decision | Merged by PR `#337` | Selects route dependency/provider governance as the next decision target and opens no source lane |
 | G2.185 route dependency/provider governance decision | Merged by PR `#338` | Classifies active FastAPI providers as retained route contracts, not singleton getter deletion candidates |
-| G2.186 remaining getter inventory refresh | For review | Refreshes direct getter inventory after provider governance and recommends a narrow stop-loss authorization package as the next gate |
+| G2.186 remaining getter inventory refresh | Merged by PR `#339` | Refreshes direct getter inventory after provider governance and recommends a narrow stop-loss authorization package as the next gate |
+| G2.187 risk stop-loss route provider authorization | For review | Defines the future G2.188 implementation scope for stop-loss route provider injection without source edits in this PR |
 
 ## Current Strategy Getter Residuals
 
@@ -81,14 +82,28 @@ service provider authorization, limited to the stop-loss route pair. High-risk
 data-quality, root-facade, control-plane cache, trade evidence, and constructor
 fallback getters stay deferred to their owner-specific tracks.
 
+## G2.187 Stop-Loss Authorization
+
+At HEAD `a63a6cb9a277195905b046cd31777d95160ee2c6`, G2.187 authorizes, for a
+future reviewed lane only, replacing stop-loss route-body resolver calls with
+FastAPI dependency-injected service parameters.
+
+| Future implementation surface | Current direct consumers | GitNexus risk | Current decision |
+|---|---:|---|---|
+| `_resolve_history_service` | 2 | LOW | May be replaced by `get_stop_loss_history_service_dependency` in G2.188 after acceptance |
+| `_resolve_execution_service` | 6 | MEDIUM | May be replaced by `get_stop_loss_execution_service_dependency` in G2.188 after acceptance |
+
+G2.187 allows the future source lane to touch only
+`web/backend/app/api/risk/stop_loss.py` and focused tests. It forbids service
+module changes, compatibility getter removal, route path changes, response-model
+changes, and OpenSpec edits.
+
 ## Next Gates
 
-- Review G2.186 remaining getter inventory refresh.
-- If accepted, start G2.187 risk stop-loss route service provider authorization
-  package.
-- Do not start another backend source lane directly from G2.186. The current
-  report is an inventory refresh and next-gate recommendation, not source
-  authorization.
+- Review G2.187 risk stop-loss route service provider authorization.
+- If accepted, start G2.188 risk stop-loss route service provider implementation
+  lane.
+- Do not start G2.188 until this authorization package is accepted.
 
 ## Forbidden Scope
 

--- a/docs/reports/quality/backend-risk-stop-loss-route-provider-authorization-2026-05-27.md
+++ b/docs/reports/quality/backend-risk-stop-loss-route-provider-authorization-2026-05-27.md
@@ -1,0 +1,158 @@
+# Backend Risk Stop-Loss Route Provider Authorization
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: authorization package for review
+- Prepared at: `2026-05-27T22:30:42+08:00`
+- Base HEAD checked: `a63a6cb9a277195905b046cd31777d95160ee2c6`
+- Previous gate: G2.186 remaining getter inventory refresh
+- Previous PR: `#339`, merged at `a63a6cb9a277195905b046cd31777d95160ee2c6`
+- OpenSpec lane: `migrate-backend-singletons-to-lifecycle-di`
+
+Boundary note: this PR is governance and authorization documentation only. It
+does not edit backend source, tests, OpenSpec specs, route definitions, OpenAPI
+schemas, or runtime behavior. If accepted, it authorizes a separate G2.188
+source implementation lane with the scope and verification below.
+
+## Why This Candidate
+
+G2.186 classified the remaining getter surfaces after provider governance. The
+largest remaining items are high-risk or cross-track surfaces:
+
+- `get_data_quality_monitor`: data-quality and adapter cross-cutting track
+- `get_integrated_services` / `get_unified_data_service`: root facade compatibility
+- `get_prewarming_strategy`: control-plane cache prewarming
+- `get_execution_tracking_evidence_service`: trade evidence route track
+
+The stop-loss route pair is the narrowest low/medium-risk candidate left in the
+service lifecycle DI queue. It is route-local, has existing regression tests, and
+does not require changing service implementation modules.
+
+## Current Shape
+
+`web/backend/app/api/risk/stop_loss.py` imports the service getters from
+`app.api.risk._shared` and wraps them with route-local resolvers:
+
+| Resolver | Direct getter | Route consumers |
+|---|---|---|
+| `_resolve_history_service` | `get_stop_loss_history_service` | `get_stop_loss_performance`, `get_stop_loss_recommendations` |
+| `_resolve_execution_service` | `get_stop_loss_execution_service` | `add_stop_loss_position`, `update_stop_loss_price`, `remove_stop_loss_position`, `get_stop_loss_status`, `get_stop_loss_overview`, `batch_update_stop_loss_prices` |
+
+The source service getters remain canonical compatibility entrypoints and must
+not be deleted, renamed, or privatized by this lane.
+
+## GitNexus Evidence
+
+| Target | Risk | Impacted | Direct | Processes | Interpretation |
+|---|---|---:|---:|---:|---|
+| `get_stop_loss_history_service` | LOW | 3 | 1 | 0 | Two route consumers through `_resolve_history_service` |
+| `get_stop_loss_execution_service` | LOW | 0 | 0 | 0 | Graph undercounts the route-local wrapper; static route scan remains required |
+| `_resolve_history_service` | LOW | 2 | 2 | 0 | Narrow history route seam |
+| `_resolve_execution_service` | MEDIUM | 6 | 6 | 0 | Wider but still single-route-file execution seam |
+
+The medium risk on `_resolve_execution_service` is acceptable for an
+authorization package because all direct consumers live in the same route file.
+The later implementation lane must rerun GitNexus impact before editing.
+
+## Authorized Next Lane
+
+If this package is accepted, it authorizes opening:
+
+`G2.188 risk stop-loss route service provider implementation`
+
+Allowed implementation scope:
+
+- `web/backend/app/api/risk/stop_loss.py`
+
+Allowed test scope:
+
+- `web/backend/tests/test_risk_runtime_bootstrap_regressions.py`
+- `web/backend/tests/test_stop_loss_route_regressions.py`
+- `tests/unit/contract/test_risk_router_runtime_import.py`
+
+Forbidden scope:
+
+- `src/**`
+- `web/backend/app/api/risk/_shared.py`
+- other `web/backend/app/api/risk/*.py` files
+- `web/frontend/**`
+- `docs/api/**`
+- `openspec/changes/**`
+- `openspec/specs/**`
+
+## Authorized Design
+
+The implementation lane may:
+
+1. Import FastAPI `Depends` in `web/backend/app/api/risk/stop_loss.py`.
+2. Add route-local provider functions:
+   - `get_stop_loss_history_service_dependency`
+   - `get_stop_loss_execution_service_dependency`
+3. Inject those providers into the eight stop-loss route functions.
+4. Replace route-body calls to `_resolve_history_service()` and
+   `_resolve_execution_service()` with injected service parameters.
+5. Keep existing error handling semantics for unavailable services.
+
+The implementation lane must not change:
+
+- route paths
+- HTTP methods
+- response models
+- OpenAPI examples
+- request/response shape
+- service module behavior
+- source-level compatibility getters
+
+## Required G2.188 Verification
+
+Before editing:
+
+- Rerun GitNexus impact on `get_stop_loss_history_service`,
+  `get_stop_loss_execution_service`, `_resolve_history_service`, and
+  `_resolve_execution_service`.
+- Stop and return to review if risk increases to HIGH or CRITICAL.
+
+TDD requirement:
+
+- Add or update a focused red test proving stop-loss endpoint functions can use
+  injected fake history/execution services without monkeypatching module-level
+  getters.
+
+Required checks:
+
+```bash
+pytest -o addopts= \
+  web/backend/tests/test_risk_runtime_bootstrap_regressions.py \
+  web/backend/tests/test_stop_loss_route_regressions.py \
+  tests/unit/contract/test_risk_router_runtime_import.py \
+  -q --no-cov
+
+ruff check \
+  web/backend/app/api/risk/stop_loss.py \
+  web/backend/tests/test_risk_runtime_bootstrap_regressions.py \
+  web/backend/tests/test_stop_loss_route_regressions.py \
+  tests/unit/contract/test_risk_router_runtime_import.py
+```
+
+If route signatures or OpenAPI exposure can drift, the implementation lane must
+also run a route/OpenAPI smoke and record the path/operationId result.
+
+## Rollback Plan
+
+For G2.187 itself, rollback is a governance-only revert.
+
+For the future G2.188 source lane, rollback must be path-limited to:
+
+- `web/backend/app/api/risk/stop_loss.py`
+- the focused test files changed by the implementation lane
+
+Rollback must restore route-body resolver calls and remove only the newly added
+provider injection test expectations.
+
+## Decision
+
+G2.187 recommends accepting this authorization package and then starting G2.188
+as a source implementation lane. G2.187 does not itself authorize code changes
+inside this PR.

--- a/governance/mainline/task-cards/pr-340.yaml
+++ b/governance/mainline/task-cards/pr-340.yaml
@@ -1,0 +1,100 @@
+version: "v0.2"
+
+task:
+  id: "pr-340"
+  title: "Authorize risk stop-loss route provider implementation"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-risk-stop-loss-provider-authorization"
+  objective: "authorize a path-limited future implementation lane for stop-loss route service provider injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/risk-stop-loss-route-provider-authorization-2026-05-27.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-risk-stop-loss-route-provider-authorization-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-340.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits in this PR"
+  - "test edits in this PR"
+  - "OpenSpec proposal creation"
+  - "route signature or OpenAPI schema changes in this PR"
+  - "provider implementation before human acceptance"
+  - "deleting or renaming src-level stop-loss service getters"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/risk-stop-loss-route-provider-authorization-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-340.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-risk-stop-loss-route-provider-authorization-2026-05-27.md"
+      required: true
+    - id: "openspec-lifecycle-di"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this authorization is read as immediate source permission, stop-loss route code can change before review."
+    - "If the future implementation exceeds the route file, it can affect broader risk-management behavior."
+    - "If route/OpenAPI drift is not checked when signatures change, dependency injection may alter public route contracts."
+  rollback_plan: "revert this governance-only PR to remove the G2.187 authorization package and restore the pre-G2.187 steward state."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize a future stop-loss route service provider implementation lane"
+    modified_scope: "split steward tree files, authorization report, generated JSON, and task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no source or compatibility behavior changes"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this governance-only PR if the G2.187 authorization package is rejected"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: false
+    approved_by: "main"
+    approved_at: "2026-05-27T22:30:42+08:00"
+    approval_note: "Human maintainer approved continuing after PR #339 merge; this lane is a stop-loss route provider authorization package only."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records PR #339 as merged and opens G2.187 as an authorization package only
- authorizes a future G2.188 stop-loss route service provider implementation lane if this package is accepted
- limits future source scope to web/backend/app/api/risk/stop_loss.py and focused tests

## Boundaries
- governance documentation only in this PR
- no backend source edits
- no test edits
- no route signature, OpenAPI schema, service module, or compatibility getter changes
- no G2.188 implementation until this authorization package is accepted

## Authorized future lane if accepted
- add route-local FastAPI dependency providers for stop-loss history/execution services
- inject providers into the eight stop-loss route functions
- keep route paths, methods, response models, OpenAPI examples, error semantics, and src-level service getters unchanged

## Evidence
- get_stop_loss_history_service: LOW, impacted=3, direct=1, processes=0
- get_stop_loss_execution_service: LOW, impacted=0, direct=0, processes=0
- _resolve_history_service: LOW, impacted=2, direct=2, processes=0
- _resolve_execution_service: MEDIUM, impacted=6, direct=6, processes=0

## Verification
- JSON/YAML parse checks passed
- markdown_governance_gate.py: 6 checked files, 0 errors
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: valid; PostHog telemetry ECONNREFUSED noise only
- git diff --check: clean
- gitnexus detect_changes staged: low risk, changed_symbols=0, affected_processes=0
- mainline_scope_gate.py: pass=True
- gitnexus analyze --with-gitignore: indexed 62,969 nodes / 146,114 edges / 300 flows