### PR TITLE
refactor(risk): inject stop loss route providers

### DIFF
--- a/.planning/codebase/generated/risk-stop-loss-route-provider-implementation-2026-05-27.json
+++ b/.planning/codebase/generated/risk-stop-loss-route-provider-implementation-2026-05-27.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": "2026-05-27.risk-stop-loss-provider-implementation.v1",
+  "generated_at": "2026-05-27T23:02:44+08:00",
+  "branch": "g2-188-risk-stop-loss-provider-implementation",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a",
+  "authorization": {
+    "source": "G2.187 risk stop-loss route service provider authorization",
+    "pr": 340,
+    "merged_at": "2026-05-27T14:46:15Z",
+    "merge_commit": "2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a",
+    "scope_status": "accepted_for_g2_188_path_limited_source_implementation"
+  },
+  "changed_paths": [
+    "web/backend/app/api/risk/stop_loss.py",
+    "web/backend/tests/test_risk_runtime_bootstrap_regressions.py",
+    "web/backend/tests/test_stop_loss_route_regressions.py"
+  ],
+  "source_change_summary": {
+    "provider_functions_added": [
+      "get_stop_loss_history_service_provider",
+      "get_stop_loss_execution_service_provider"
+    ],
+    "direct_call_compatibility_helper_added": "_resolve_direct_call_dependency",
+    "injected_execution_service_endpoints": [
+      "add_stop_loss_position",
+      "update_stop_loss_price",
+      "remove_stop_loss_position",
+      "get_stop_loss_status",
+      "get_stop_loss_overview",
+      "batch_update_stop_loss_prices"
+    ],
+    "injected_history_service_endpoints": [
+      "get_stop_loss_performance",
+      "get_stop_loss_recommendations"
+    ],
+    "preserved_boundaries": [
+      "route paths",
+      "HTTP methods",
+      "response_model declarations",
+      "OpenAPI examples",
+      "src-level stop-loss service getters",
+      "route-local BusinessException and ValidationException semantics"
+    ]
+  },
+  "gitnexus_pre_edit_impact": {
+    "get_stop_loss_history_service": {
+      "risk": "LOW",
+      "impacted_count": 3,
+      "direct": 1,
+      "processes_affected": 0
+    },
+    "get_stop_loss_execution_service": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct": 0,
+      "processes_affected": 0
+    },
+    "_resolve_history_service": {
+      "risk": "LOW",
+      "impacted_count": 2,
+      "direct": 2,
+      "processes_affected": 0
+    },
+    "_resolve_execution_service": {
+      "risk": "MEDIUM",
+      "impacted_count": 6,
+      "direct": 6,
+      "processes_affected": 0
+    },
+    "endpoint_symbols": {
+      "risk": "LOW",
+      "impacted_count": 0,
+      "symbols_checked": [
+        "add_stop_loss_position",
+        "update_stop_loss_price",
+        "remove_stop_loss_position",
+        "get_stop_loss_status",
+        "get_stop_loss_overview",
+        "batch_update_stop_loss_prices",
+        "get_stop_loss_performance",
+        "get_stop_loss_recommendations"
+      ]
+    }
+  },
+  "tdd_evidence": {
+    "red": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_risk_runtime_bootstrap_regressions.py -q -k stop_loss --tb=short --disable-warnings --no-cov",
+      "result": "2 failed, 3 passed, 5 deselected",
+      "expected_failures": [
+        "get_stop_loss_performance() got an unexpected keyword argument 'history_service'",
+        "add_stop_loss_position() got an unexpected keyword argument 'execution_service'"
+      ]
+    },
+    "green": [
+      {
+        "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_risk_runtime_bootstrap_regressions.py -q -k stop_loss --tb=short --disable-warnings --no-cov",
+        "result": "5 passed, 5 deselected"
+      },
+      {
+        "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stop_loss_route_regressions.py -q --tb=short --disable-warnings --no-cov",
+        "result": "2 passed"
+      },
+      {
+        "command": "PYTHONPATH=web/backend pytest -o addopts= tests/unit/contract/test_risk_router_runtime_import.py::test_app_main_registers_canonical_risk_router_without_loading_compat_shim -q --tb=short --disable-warnings --no-cov",
+        "result": "1 passed"
+      }
+    ]
+  },
+  "openapi_smoke": {
+    "command": "env PYTHONPATH=web/backend POSTGRESQL_HOST=localhost POSTGRESQL_USER=test POSTGRESQL_PASSWORD=test JWT_SECRET_KEY=testsecret BACKEND_PORT=8020 BACKEND_BACKUP_PORT=8021 python - <<'PY' ...",
+    "openapi_paths": 500,
+    "stop_loss_paths": 10,
+    "dependency_params_leaked": 0
+  },
+  "quality_gates": {
+    "ruff": {
+      "command": "ruff check web/backend/app/api/risk/stop_loss.py web/backend/tests/test_risk_runtime_bootstrap_regressions.py web/backend/tests/test_stop_loss_route_regressions.py tests/unit/contract/test_risk_router_runtime_import.py",
+      "result": "All checks passed"
+    },
+    "git_diff_check": {
+      "command": "git diff --check",
+      "result": "passed"
+    }
+  },
+  "known_out_of_scope_baseline_failures": [
+    {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_risk_runtime_bootstrap_regressions.py -q --tb=short --disable-warnings --no-cov",
+      "result": "4 failed, 6 passed",
+      "reason": "unrelated alerts route resolver baseline failures",
+      "symbols": [
+        "_resolve_notification_manager",
+        "_resolve_rule_engine",
+        "_resolve_runtime_alert_service"
+      ]
+    },
+    {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= tests/unit/contract/test_risk_router_runtime_import.py -q --tb=short --disable-warnings --no-cov",
+      "result": "1 failed, 1 passed when run with stop_loss_route_regressions.py",
+      "reason": "unrelated legacy app.api.risk_management compatibility module import is absent at current HEAD"
+    }
+  ],
+  "next_gate": {
+    "recommended": "review G2.188 implementation PR; if accepted, merge and start a closeout/candidate-refresh governance packet",
+    "do_not_expand_to": [
+      "src-level stop-loss service getter deletion",
+      "other risk route provider migrations",
+      "alerts resolver fixes",
+      "legacy risk_management compatibility router fixes"
+    ]
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-27T22:30:42+08:00`
-- Base HEAD checked: `a63a6cb9a277195905b046cd31777d95160ee2c6`
+- Prepared at: `2026-05-27T23:02:44+08:00`
+- Base HEAD checked: `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -24,12 +24,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#337` | `g2-184-next-nonstrategy-service-getter-candidate-decision` | `wip/root-dirty-20260403` | `MERGED` at `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba` | Next non-Strategy candidate decision selecting provider governance |
 | `#338` | `g2-185-route-dependency-provider-governance-decision` | `wip/root-dirty-20260403` | `MERGED` at `720248521d705af067d0a2600710444e439d7605` | Provider governance decision retaining active route contracts |
 | `#339` | `g2-186-remaining-getter-inventory-refresh` | `wip/root-dirty-20260403` | `MERGED` at `a63a6cb9a277195905b046cd31777d95160ee2c6` | Remaining getter inventory refresh selecting stop-loss authorization |
+| `#340` | `g2-187-risk-stop-loss-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a` | Authorization package for G2.188 stop-loss route provider implementation |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-187-risk-stop-loss-provider-authorization` | `origin/wip/root-dirty-20260403` at `a63a6cb9a277195905b046cd31777d95160ee2c6` | Authorize the future stop-loss route service provider implementation lane without changing source in this PR | G2.186 remaining getter inventory refresh |
+| `g2-188-risk-stop-loss-provider-implementation` | `origin/wip/root-dirty-20260403` at `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a` | Implement the G2.187-authorized stop-loss route service provider injection in one route file plus focused tests | G2.187 stop-loss route service provider authorization |
 
 ## OpenSpec Relationship
 
@@ -45,6 +46,8 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.187 is an authorization branch only. It records the merged state of PR
-`#339`, defines the exact future stop-loss route implementation scope, and must
-not introduce backend source edits in this PR.
+G2.188 is a path-limited source implementation branch. It starts only after PR
+`#340` merged the G2.187 authorization package, and it must not expand beyond
+`web/backend/app/api/risk/stop_loss.py`, focused stop-loss tests, and governance
+evidence. Alerts resolver failures and the legacy `app.api.risk_management`
+compatibility import failure remain separate lanes.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-27T22:30:42+08:00`
-- Base HEAD checked: `a63a6cb9a277195905b046cd31777d95160ee2c6`
+- Prepared at: `2026-05-27T23:02:44+08:00`
+- Base HEAD checked: `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 defines the stop-loss route provider authorization package for review |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 is the active path-limited stop-loss implementation review candidate |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-27T22:30:42+08:00`
-- Base HEAD checked: `a63a6cb9a277195905b046cd31777d95160ee2c6`
+- Prepared at: `2026-05-27T23:02:44+08:00`
+- Base HEAD checked: `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.187 risk stop-loss route service provider authorization | G/#79 service lifecycle DI | PR `#339` merged at `a63a6cb9a277195905b046cd31777d95160ee2c6`; G2.187 defines path-limited future implementation scope and keeps this PR docs-only | If accepted, start G2.188 risk stop-loss route service provider implementation lane |
+| P0 | Review G2.188 risk stop-loss route service provider implementation | G/#79 service lifecycle DI | PR `#340` merged at `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`; G2.188 implements path-limited stop-loss route provider injection with stop-loss tests green and OpenAPI dependency leak count `0` | If accepted, merge and start a closeout / candidate-refresh governance packet |
+| P0 | Preserve G2.187 risk stop-loss route service provider authorization | G/#79 service lifecycle DI | PR `#340` merged; G2.187 authorized only `web/backend/app/api/risk/stop_loss.py` plus focused tests for G2.188 | Do not expand G2.188 into alerts resolver, legacy `app.api.risk_management`, or other risk route migrations |
 | P0 | Preserve G2.186 remaining getter inventory refresh | G/#79 service lifecycle DI | PR `#339` merged; G2.186 refreshed remaining direct getter inventory and selected stop-loss route provider authorization as the next narrow gate | Do not start a backend source lane from G2.186 |
 | P0 | Preserve G2.185 provider governance decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#338` merged; provider residuals are retained active route contracts and excluded from direct implementation-candidate counts | Do not start a backend source lane from G2.185 |
 | P0 | Preserve G2.184 next non-Strategy candidate decision | G/#79 service lifecycle DI | PR `#337` merged; G2.184 selected route dependency/provider governance as the next decision target | Do not start a backend source lane from G2.184 |
@@ -32,6 +33,7 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 - Does the split preserve the full historical steward tree in archive?
 - Is the root entrypoint short enough to serve as a daily navigation file?
 - Does `steward-index.json` include enough fields for automated guards?
-- Does G2.187 correctly limit the future source lane to `web/backend/app/api/risk/stop_loss.py` and focused tests?
-- Is G2.188 allowed to proceed only after this authorization package is reviewed and accepted?
+- Does G2.188 stay limited to `web/backend/app/api/risk/stop_loss.py` and focused stop-loss tests?
+- Does the G2.188 OpenAPI smoke prove `execution_service` / `history_service` do not leak into schema parameters?
+- Are the unrelated alerts resolver and legacy `app.api.risk_management` failures kept out of this source lane?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-27T22:30:42+08:00`
-- Base HEAD checked: `a63a6cb9a277195905b046cd31777d95160ee2c6`
+- Prepared at: `2026-05-27T23:02:44+08:00`
+- Base HEAD checked: `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -35,8 +35,10 @@ state transition.
 | `docs/reports/quality/backend-route-dependency-provider-governance-decision-2026-05-27.md` | G2.185 human-readable provider-governance decision package | Accepted by PR `#338`; superseded for remaining getter queue refresh by G2.186 |
 | `.planning/codebase/generated/service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.json` | G2.186 remaining getter inventory refresh evidence | Current for HEAD `720248521d705af067d0a2600710444e439d7605`; stale if HEAD changes |
 | `docs/reports/quality/backend-service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.md` | G2.186 human-readable inventory refresh decision package | Accepted by PR `#339`; superseded for stop-loss authorization by G2.187 |
-| `.planning/codebase/generated/risk-stop-loss-route-provider-authorization-2026-05-27.json` | G2.187 risk stop-loss route provider authorization evidence | Current for HEAD `a63a6cb9a277195905b046cd31777d95160ee2c6`; stale if HEAD changes |
-| `docs/reports/quality/backend-risk-stop-loss-route-provider-authorization-2026-05-27.md` | G2.187 human-readable authorization package | Review input until accepted |
+| `.planning/codebase/generated/risk-stop-loss-route-provider-authorization-2026-05-27.json` | G2.187 risk stop-loss route provider authorization evidence | Accepted by PR `#340`; superseded for implementation review by G2.188 |
+| `docs/reports/quality/backend-risk-stop-loss-route-provider-authorization-2026-05-27.md` | G2.187 human-readable authorization package | Accepted by PR `#340` |
+| `.planning/codebase/generated/risk-stop-loss-route-provider-implementation-2026-05-27.json` | G2.188 risk stop-loss route provider implementation evidence | Current for HEAD `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`; stale if HEAD changes |
+| `docs/reports/quality/backend-risk-stop-loss-route-provider-implementation-2026-05-27.md` | G2.188 human-readable implementation package | Review input until implementation PR is accepted |
 
 ## External State Inputs
 
@@ -47,6 +49,7 @@ state transition.
 | GitHub PR `#337` | `MERGED` | G2.184 next non-Strategy candidate decision merged by commit `b54e7d043720a8c8bc67ad96f4f7eaad0b23ceba` |
 | GitHub PR `#338` | `MERGED` | G2.185 provider governance decision merged by commit `720248521d705af067d0a2600710444e439d7605` |
 | GitHub PR `#339` | `MERGED` | G2.186 remaining getter inventory refresh merged by commit `a63a6cb9a277195905b046cd31777d95160ee2c6` |
+| GitHub PR `#340` | `MERGED` | G2.187 stop-loss route provider authorization merged by commit `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a` |
 | `origin/wip/root-dirty-20260403` | `a63a6cb9a277195905b046cd31777d95160ee2c6` | Base used for this decision branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-27T22:30:42+08:00",
+  "generated_at": "2026-05-27T23:02:44+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "a63a6cb9a277195905b046cd31777d95160ee2c6",
-  "split_branch": "g2-187-risk-stop-loss-provider-authorization",
-  "scope": "governance_decision_package",
-  "source_edit_authority": false,
+  "base_head": "2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a",
+  "split_branch": "g2-188-risk-stop-loss-provider-implementation",
+  "scope": "path_limited_source_implementation_package",
+  "source_edit_authority": true,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -498,11 +498,17 @@
     {
       "id": "g2-187-risk-stop-loss-provider-authorization",
       "type": "authorization_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.186 remaining getter inventory refresh",
       "source_edit_authority": false,
       "future_source_edit_authority_if_accepted": true,
+      "github_pr": {
+        "number": 340,
+        "url": "https://github.com/chengjon/mystocks/pull/340",
+        "state": "MERGED",
+        "merge_commit": "2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a"
+      },
       "evidence": [
         ".planning/codebase/generated/risk-stop-loss-route-provider-authorization-2026-05-27.json",
         "docs/reports/quality/backend-risk-stop-loss-route-provider-authorization-2026-05-27.md",
@@ -555,16 +561,83 @@
         }
       },
       "decision": {
-        "classification": "authorization-package-for-review",
-        "source_lane_recommendation": "start-g2-188-only-after-human-acceptance",
+        "classification": "authorization-package-accepted",
+        "source_lane_recommendation": "g2-188-started-after-human-acceptance",
         "selected_next_governance_target": "risk-stop-loss-route-service-provider-implementation",
         "recommended_next_work_item": "G2.188 risk stop-loss route service provider implementation lane"
       },
       "freshness": {
-        "current_head_checked": "a63a6cb9a277195905b046cd31777d95160ee2c6",
+        "current_head_checked": "2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.188 risk stop-loss route service provider implementation lane. Do not edit source from G2.187."
+      "next_gate": "Superseded by G2.188 risk stop-loss route service provider implementation."
+    },
+    {
+      "id": "g2-188-risk-stop-loss-provider-implementation",
+      "type": "implementation_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.187 risk stop-loss route service provider authorization",
+      "source_edit_authority": true,
+      "evidence": [
+        ".planning/codebase/generated/risk-stop-loss-route-provider-implementation-2026-05-27.json",
+        "docs/reports/quality/backend-risk-stop-loss-route-provider-implementation-2026-05-27.md",
+        "governance/mainline/task-cards/pr-341.yaml"
+      ],
+      "authorized_scope": {
+        "source_paths": [
+          "web/backend/app/api/risk/stop_loss.py"
+        ],
+        "test_paths": [
+          "web/backend/tests/test_risk_runtime_bootstrap_regressions.py",
+          "web/backend/tests/test_stop_loss_route_regressions.py"
+        ],
+        "governance_paths": [
+          ".planning/codebase/generated/risk-stop-loss-route-provider-implementation-2026-05-27.json",
+          "docs/reports/quality/backend-risk-stop-loss-route-provider-implementation-2026-05-27.md",
+          "governance/mainline/task-cards/pr-341.yaml",
+          ".planning/codebase/steward-tree/current-next-gates.md",
+          ".planning/codebase/steward-tree/steward-index.json",
+          ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+          ".planning/codebase/steward-tree/branch-register.md",
+          ".planning/codebase/steward-tree/evidence-index.md",
+          ".planning/codebase/steward-tree/completed-ledger.md"
+        ],
+        "forbidden_paths": [
+          "src/**",
+          "web/backend/app/api/risk/_shared.py",
+          "other web/backend/app/api/risk/*.py files",
+          "web/frontend/**",
+          "docs/api/**",
+          "openspec/changes/**",
+          "openspec/specs/**"
+        ]
+      },
+      "verification": {
+        "stop_loss_runtime_bootstrap": "5 passed, 5 deselected",
+        "stop_loss_route_regressions": "2 passed",
+        "app_main_risk_router_contract_targeted": "1 passed",
+        "openapi_paths": 500,
+        "stop_loss_paths": 10,
+        "dependency_params_leaked": 0,
+        "ruff": "passed",
+        "git_diff_check": "passed"
+      },
+      "known_out_of_scope_failures": [
+        "alerts route resolver baseline failures",
+        "legacy app.api.risk_management compatibility import absence"
+      ],
+      "decision": {
+        "classification": "path-limited-source-implementation-for-review",
+        "source_lane_recommendation": "review-pr-341-before-merge",
+        "selected_next_governance_target": "risk-stop-loss-provider-closeout-or-candidate-refresh",
+        "recommended_next_work_item": "G2.189 closeout / remaining candidate refresh after G2.188 acceptance"
+      },
+      "freshness": {
+        "current_head_checked": "2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, merge and start a closeout / candidate-refresh governance packet; do not expand into alerts, legacy risk_management compat, or other risk route migrations."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-27T22:30:42+08:00`
-- Base HEAD checked: `a63a6cb9a277195905b046cd31777d95160ee2c6`
+- Prepared at: `2026-05-27T23:02:44+08:00`
+- Base HEAD checked: `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -39,7 +39,8 @@ It proved a repeatable conveyor:
 | G2.184 next non-Strategy candidate decision | Merged by PR `#337` | Selects route dependency/provider governance as the next decision target and opens no source lane |
 | G2.185 route dependency/provider governance decision | Merged by PR `#338` | Classifies active FastAPI providers as retained route contracts, not singleton getter deletion candidates |
 | G2.186 remaining getter inventory refresh | Merged by PR `#339` | Refreshes direct getter inventory after provider governance and recommends a narrow stop-loss authorization package as the next gate |
-| G2.187 risk stop-loss route provider authorization | For review | Defines the future G2.188 implementation scope for stop-loss route provider injection without source edits in this PR |
+| G2.187 risk stop-loss route provider authorization | Merged by PR `#340` | Defines the future G2.188 implementation scope for stop-loss route provider injection without source edits in that PR |
+| G2.188 risk stop-loss route provider implementation | For review | Implements the authorized provider injection in `web/backend/app/api/risk/stop_loss.py`; stop-loss tests and OpenAPI dependency leak smoke pass |
 
 ## Current Strategy Getter Residuals
 
@@ -82,28 +83,29 @@ service provider authorization, limited to the stop-loss route pair. High-risk
 data-quality, root-facade, control-plane cache, trade evidence, and constructor
 fallback getters stay deferred to their owner-specific tracks.
 
-## G2.187 Stop-Loss Authorization
+## G2.187 / G2.188 Stop-Loss Provider Lane
 
-At HEAD `a63a6cb9a277195905b046cd31777d95160ee2c6`, G2.187 authorizes, for a
-future reviewed lane only, replacing stop-loss route-body resolver calls with
-FastAPI dependency-injected service parameters.
+At HEAD `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`, G2.188 implements the
+G2.187-authorized stop-loss route provider seam by replacing route-body resolver
+calls with FastAPI dependency-injected service parameters.
 
-| Future implementation surface | Current direct consumers | GitNexus risk | Current decision |
+| Implementation surface | Current direct consumers | GitNexus risk | Current decision |
 |---|---:|---|---|
-| `_resolve_history_service` | 2 | LOW | May be replaced by `get_stop_loss_history_service_dependency` in G2.188 after acceptance |
-| `_resolve_execution_service` | 6 | MEDIUM | May be replaced by `get_stop_loss_execution_service_dependency` in G2.188 after acceptance |
+| `_resolve_history_service` | 2 | LOW | Wrapped by `get_stop_loss_history_service_provider`; direct test fallback preserved |
+| `_resolve_execution_service` | 6 | MEDIUM | Wrapped by `get_stop_loss_execution_service_provider`; direct test fallback preserved |
 
-G2.187 allows the future source lane to touch only
-`web/backend/app/api/risk/stop_loss.py` and focused tests. It forbids service
-module changes, compatibility getter removal, route path changes, response-model
-changes, and OpenSpec edits.
+G2.188 touches only `web/backend/app/api/risk/stop_loss.py`, focused stop-loss
+tests, and governance evidence. It preserves route paths, HTTP methods,
+response-model declarations, OpenAPI examples, and src-level service getters.
+OpenAPI smoke records `openapi_paths=500`, `stop_loss_paths=10`, and
+`dependency_params_leaked=0`.
 
 ## Next Gates
 
-- Review G2.187 risk stop-loss route service provider authorization.
-- If accepted, start G2.188 risk stop-loss route service provider implementation
-  lane.
-- Do not start G2.188 until this authorization package is accepted.
+- Review G2.188 risk stop-loss route service provider implementation.
+- If accepted, merge and start a closeout / candidate-refresh governance packet.
+- Do not expand this implementation into alerts resolver fixes, legacy
+  `app.api.risk_management` restoration, or other risk route provider migrations.
 
 ## Forbidden Scope
 

--- a/docs/reports/quality/backend-risk-stop-loss-route-provider-implementation-2026-05-27.md
+++ b/docs/reports/quality/backend-risk-stop-loss-route-provider-implementation-2026-05-27.md
@@ -1,0 +1,117 @@
+# Backend Risk Stop-Loss Route Provider Implementation - G2.188
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: implementation PR review candidate
+- Prepared at: `2026-05-27T23:02:44+08:00`
+- Branch: `g2-188-risk-stop-loss-provider-implementation`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD: `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`
+- Parent authorization: G2.187, PR `#340`, merged at `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`
+
+Boundary note: this implementation is limited to the stop-loss route provider
+lane authorized by G2.187. It does not delete or rename src-level stop-loss
+service getters, change other risk routes, alter frontend code, create OpenSpec
+changes, or fix unrelated alerts / legacy compatibility router baselines.
+
+## Implementation
+
+G2.188 moves the stop-loss route pair from route-body service resolver calls to
+route-local FastAPI provider parameters:
+
+| Surface | Before | After |
+|---|---|---|
+| History service routes | `history_service = _resolve_history_service()` inside endpoint body | `history_service: Any = Depends(get_stop_loss_history_service_provider)` |
+| Execution service routes | `execution_service = _resolve_execution_service()` inside endpoint body | `execution_service: Any = Depends(get_stop_loss_execution_service_provider)` |
+| Direct test invocation | endpoint resolved service internally | `_resolve_direct_call_dependency(...)` preserves direct-call fallback |
+
+Injected endpoints:
+
+| Provider | Endpoints |
+|---|---|
+| `get_stop_loss_history_service_provider` | `get_stop_loss_performance`, `get_stop_loss_recommendations` |
+| `get_stop_loss_execution_service_provider` | `add_stop_loss_position`, `update_stop_loss_price`, `remove_stop_loss_position`, `get_stop_loss_status`, `get_stop_loss_overview`, `batch_update_stop_loss_prices` |
+
+Preserved public contract:
+
+- Route paths and HTTP methods remain unchanged.
+- `response_model=Dict[str, Any]` declarations remain unchanged.
+- OpenAPI examples remain unchanged.
+- Dependency parameters do not leak into OpenAPI route parameters.
+- The src-level getters remain canonical compatibility entrypoints.
+- Existing route-local exception behavior is preserved.
+
+## GitNexus Pre-Edit Impact
+
+| Symbol | Risk | Impacted | Direct | Processes |
+|---|---:|---:|---:|---:|
+| `get_stop_loss_history_service` | LOW | 3 | 1 | 0 |
+| `get_stop_loss_execution_service` | LOW | 0 | 0 | 0 |
+| `_resolve_history_service` | LOW | 2 | 2 | 0 |
+| `_resolve_execution_service` | MEDIUM | 6 | 6 | 0 |
+| 8 stop-loss route endpoint symbols | LOW | 0 | 0 | 0 |
+
+The only MEDIUM item is `_resolve_execution_service`, and its direct callers are
+the six stop-loss execution endpoints that this lane explicitly covers.
+
+## TDD Evidence
+
+Red test:
+
+```text
+PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_risk_runtime_bootstrap_regressions.py -q -k stop_loss --tb=short --disable-warnings --no-cov
+2 failed, 3 passed, 5 deselected
+```
+
+Expected red failures:
+
+- `get_stop_loss_performance() got an unexpected keyword argument 'history_service'`
+- `add_stop_loss_position() got an unexpected keyword argument 'execution_service'`
+
+Green tests:
+
+| Command | Result |
+|---|---|
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_risk_runtime_bootstrap_regressions.py -q -k stop_loss --tb=short --disable-warnings --no-cov` | `5 passed, 5 deselected` |
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stop_loss_route_regressions.py -q --tb=short --disable-warnings --no-cov` | `2 passed` |
+| `PYTHONPATH=web/backend pytest -o addopts= tests/unit/contract/test_risk_router_runtime_import.py::test_app_main_registers_canonical_risk_router_without_loading_compat_shim -q --tb=short --disable-warnings --no-cov` | `1 passed` |
+
+## OpenAPI Smoke
+
+Command used minimal local environment values only to import `app.main` and
+generate `app.openapi()`.
+
+| Metric | Value |
+|---|---:|
+| OpenAPI paths | 500 |
+| Stop-loss paths | 10 |
+| Dependency parameters leaked into schema | 0 |
+
+## Quality Gates
+
+| Gate | Result |
+|---|---|
+| `ruff check web/backend/app/api/risk/stop_loss.py web/backend/tests/test_risk_runtime_bootstrap_regressions.py web/backend/tests/test_stop_loss_route_regressions.py tests/unit/contract/test_risk_router_runtime_import.py` | Passed |
+| `git diff --check` | Passed |
+
+## Known Out-Of-Scope Baseline Failures
+
+These failures were observed but are outside the G2.188 authorized stop-loss
+provider scope:
+
+| Command | Observed result | Reason |
+|---|---|---|
+| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_risk_runtime_bootstrap_regressions.py -q --tb=short --disable-warnings --no-cov` | `4 failed, 6 passed` | Alerts route resolver baseline failures on `_resolve_notification_manager`, `_resolve_rule_engine`, and `_resolve_runtime_alert_service` |
+| `PYTHONPATH=web/backend pytest -o addopts= tests/unit/contract/test_risk_router_runtime_import.py -q --tb=short --disable-warnings --no-cov` | One legacy compatibility import test fails when included | `app.api.risk_management` compatibility module is absent at current HEAD |
+
+These are not fixed in this lane because G2.187 authorized only stop-loss route
+service provider injection.
+
+## Next Gate
+
+Review the G2.188 implementation PR. If accepted, merge it and open a
+path-limited closeout / candidate-refresh governance packet. Do not expand this
+PR into alerts resolver fixes, legacy compatibility router restoration, src-level
+getter deletion, or other risk route provider migrations.

--- a/governance/mainline/task-cards/pr-341.yaml
+++ b/governance/mainline/task-cards/pr-341.yaml
@@ -1,0 +1,126 @@
+version: "v0.2"
+
+task:
+  id: "pr-341"
+  title: "Implement risk stop-loss route provider injection"
+  owner: "main"
+  created_at: "2026-05-27"
+
+mainline:
+  id: "L1-risk-stop-loss-provider-implementation"
+  objective: "replace stop-loss route-body service resolver calls with route-local FastAPI provider injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Path-limited risk stop-loss route provider injection; route paths, HTTP methods, response models, OpenAPI examples, frontend behavior, PM2 workflows, and public API ownership remain unchanged"
+
+scope:
+  allowed_paths:
+    - "web/backend/app/api/risk/stop_loss.py"
+    - "web/backend/tests/test_risk_runtime_bootstrap_regressions.py"
+    - "web/backend/tests/test_stop_loss_route_regressions.py"
+    - ".planning/codebase/generated/risk-stop-loss-route-provider-implementation-2026-05-27.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-risk-stop-loss-route-provider-implementation-2026-05-27.md"
+    - "governance/mainline/task-cards/pr-341.yaml"
+  forbidden_paths:
+    - "src/**"
+    - "web/backend/app/api/risk/_shared.py"
+    - "web/backend/app/api/risk/alerts.py"
+    - "web/backend/app/api/risk/metrics.py"
+    - "web/backend/app/api/risk/v31.py"
+    - "web/frontend/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "deleting or renaming src-level stop-loss service getters"
+  - "changing route paths, HTTP methods, response models, or OpenAPI examples"
+  - "migrating other risk routes or generic provider surfaces"
+  - "fixing alerts resolver baseline failures"
+  - "restoring or changing the legacy app.api.risk_management compatibility module"
+  - "creating OpenSpec proposals"
+
+acceptance:
+  checks:
+    - id: "tdd-stop-loss-red"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_risk_runtime_bootstrap_regressions.py -q -k stop_loss --tb=short --disable-warnings --no-cov"
+      required: true
+    - id: "stop-loss-route-regressions"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stop_loss_route_regressions.py -q --tb=short --disable-warnings --no-cov"
+      required: true
+    - id: "app-main-risk-router-contract"
+      command: "PYTHONPATH=web/backend pytest -o addopts= tests/unit/contract/test_risk_router_runtime_import.py::test_app_main_registers_canonical_risk_router_without_loading_compat_shim -q --tb=short --disable-warnings --no-cov"
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/api/risk/stop_loss.py web/backend/tests/test_risk_runtime_bootstrap_regressions.py web/backend/tests/test_stop_loss_route_regressions.py tests/unit/contract/test_risk_router_runtime_import.py"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/risk-stop-loss-route-provider-implementation-2026-05-27.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-341.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-risk-stop-loss-route-provider-implementation-2026-05-27.md"
+      required: true
+    - id: "openspec-lifecycle-di"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If provider parameters leak into OpenAPI, public stop-loss API schema can drift."
+    - "If route-direct test compatibility is lost, existing route unit tests can stop representing current behavior."
+    - "If this lane expands into alerts or legacy risk_management compatibility fixes, it exceeds the G2.187 authorization."
+  rollback_plan: "revert this PR to restore route-body resolver calls and remove the added stop-loss provider tests and governance evidence."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "implement path-limited stop-loss route service provider injection"
+    modified_scope: "one stop-loss route file, focused stop-loss tests, and G2.188 governance evidence"
+    dependency_changes: "adds FastAPI Depends usage in stop_loss.py only"
+    legacy_logic_impact: "src-level getters remain intact; direct route test calls keep resolver fallback"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if route/OpenAPI smoke or stop-loss tests regress"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-27T23:02:44+08:00"
+    approval_note: "Human maintainer approved continuing after PR #340 acceptance; this lane is limited to stop-loss route provider injection."
+    secondary_approved: true

--- a/web/backend/app/api/risk/stop_loss.py
+++ b/web/backend/app/api/risk/stop_loss.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, Body, Path, Query
+from fastapi import APIRouter, Body, Depends, Path, Query
+from fastapi.params import Depends as DependsParam
 
 from app.core.exceptions import BusinessException, NotFoundException, ValidationException
 from app.openapi_config import COMMON_RESPONSES
 from app.api.risk._shared import (
-    ENHANCED_RISK_FEATURES_AVAILABLE,
     RISK_MANAGEMENT_V31_AVAILABLE,
     get_risk_management_core,
     get_stop_loss_execution_service,
@@ -52,6 +52,21 @@ def _resolve_execution_service():
     if not execution_service:
         raise BusinessException(detail="止损执行服务不可用", status_code=503, error_code="STOP_LOSS_EXECUTION_UNAVAILABLE")
     return execution_service
+
+
+def get_stop_loss_history_service_provider():
+    return _resolve_history_service()
+
+
+def get_stop_loss_execution_service_provider():
+    return _resolve_execution_service()
+
+
+def _resolve_direct_call_dependency(service: Any, resolver):
+    if isinstance(service, DependsParam):
+        return resolver()
+    return service
+
 
 STOP_LOSS_ADD_POSITION_EXAMPLES = {
     "monitor_equity_position": {
@@ -319,10 +334,11 @@ STOP_LOSS_TRIGGER_RESPONSES = _success_response_spec(
     responses=STOP_LOSS_ADD_POSITION_RESPONSES,
 )
 async def add_stop_loss_position(
-    request: Dict[str, Any] = Body(..., openapi_examples=STOP_LOSS_ADD_POSITION_EXAMPLES)
+    request: Dict[str, Any] = Body(..., openapi_examples=STOP_LOSS_ADD_POSITION_EXAMPLES),
+    execution_service: Any = Depends(get_stop_loss_execution_service_provider),
 ) -> Dict[str, Any]:
     try:
-        execution_service = _resolve_execution_service()
+        execution_service = _resolve_direct_call_dependency(execution_service, _resolve_execution_service)
 
         result = await execution_service.add_position_monitoring(
             symbol=request["symbol"],
@@ -356,10 +372,11 @@ async def add_stop_loss_position(
     responses=STOP_LOSS_UPDATE_PRICE_RESPONSES,
 )
 async def update_stop_loss_price(
-    request: Dict[str, Any] = Body(..., openapi_examples=STOP_LOSS_UPDATE_PRICE_EXAMPLES)
+    request: Dict[str, Any] = Body(..., openapi_examples=STOP_LOSS_UPDATE_PRICE_EXAMPLES),
+    execution_service: Any = Depends(get_stop_loss_execution_service_provider),
 ) -> Dict[str, Any]:
     try:
-        execution_service = _resolve_execution_service()
+        execution_service = _resolve_direct_call_dependency(execution_service, _resolve_execution_service)
 
         result = await execution_service.update_position_price(
             position_id=request["position_id"],
@@ -385,9 +402,10 @@ async def update_stop_loss_price(
 )
 async def remove_stop_loss_position(
     position_id: str = Path(..., description="需要移除的止损监控持仓ID。"),
+    execution_service: Any = Depends(get_stop_loss_execution_service_provider),
 ) -> Dict[str, Any]:
     try:
-        execution_service = _resolve_execution_service()
+        execution_service = _resolve_direct_call_dependency(execution_service, _resolve_execution_service)
 
         success = await execution_service.remove_position_monitoring(position_id)
         if not success:
@@ -412,9 +430,10 @@ async def remove_stop_loss_position(
 )
 async def get_stop_loss_status(
     position_id: str = Path(..., description="需要查询止损状态的持仓ID。"),
+    execution_service: Any = Depends(get_stop_loss_execution_service_provider),
 ) -> Dict[str, Any]:
     try:
-        execution_service = _resolve_execution_service()
+        execution_service = _resolve_direct_call_dependency(execution_service, _resolve_execution_service)
 
         result = await execution_service.get_monitoring_status(position_id)
         if not result.get("found"):
@@ -437,9 +456,11 @@ async def get_stop_loss_status(
     description="获取当前全部止损监控持仓的总览信息，用于盘中风控看板或批量巡检。",
     responses=STOP_LOSS_OVERVIEW_RESPONSES,
 )
-async def get_stop_loss_overview() -> Dict[str, Any]:
+async def get_stop_loss_overview(
+    execution_service: Any = Depends(get_stop_loss_execution_service_provider),
+) -> Dict[str, Any]:
     try:
-        execution_service = _resolve_execution_service()
+        execution_service = _resolve_direct_call_dependency(execution_service, _resolve_execution_service)
 
         return await execution_service.get_monitoring_status()
 
@@ -460,10 +481,11 @@ async def get_stop_loss_overview() -> Dict[str, Any]:
     responses=STOP_LOSS_BATCH_UPDATE_RESPONSES,
 )
 async def batch_update_stop_loss_prices(
-    request: Dict[str, Any] = Body(..., openapi_examples=STOP_LOSS_BATCH_UPDATE_EXAMPLES)
+    request: Dict[str, Any] = Body(..., openapi_examples=STOP_LOSS_BATCH_UPDATE_EXAMPLES),
+    execution_service: Any = Depends(get_stop_loss_execution_service_provider),
 ) -> Dict[str, Any]:
     try:
-        execution_service = _resolve_execution_service()
+        execution_service = _resolve_direct_call_dependency(execution_service, _resolve_execution_service)
 
         price_updates = request.get("price_updates", {})
         if not price_updates:
@@ -491,9 +513,10 @@ async def get_stop_loss_performance(
     strategy_type: Optional[str] = Query(None, description="可选的止损策略类型，用于筛选指定策略表现。"),
     symbol: Optional[str] = Query(None, description="可选的股票代码，用于筛选单一标的止损表现。"),
     days: int = Query(30, description="回溯统计的天数窗口，默认 30 天。"),
+    history_service: Any = Depends(get_stop_loss_history_service_provider),
 ) -> Dict[str, Any]:
     try:
-        history_service = _resolve_history_service()
+        history_service = _resolve_direct_call_dependency(history_service, _resolve_history_service)
 
         date_from = datetime.now() - timedelta(days=days)
         return await history_service.get_strategy_performance(
@@ -521,9 +544,10 @@ async def get_stop_loss_performance(
 async def get_stop_loss_recommendations(
     strategy_type: str = Query(..., description="用于生成推荐结论的止损策略类型。"),
     symbol: Optional[str] = Query(None, description="可选的股票代码，用于生成单一标的建议。"),
+    history_service: Any = Depends(get_stop_loss_history_service_provider),
 ) -> Dict[str, Any]:
     try:
-        history_service = _resolve_history_service()
+        history_service = _resolve_direct_call_dependency(history_service, _resolve_history_service)
 
         return await history_service.get_strategy_recommendations(strategy_type, symbol)
 

--- a/web/backend/tests/test_risk_runtime_bootstrap_regressions.py
+++ b/web/backend/tests/test_risk_runtime_bootstrap_regressions.py
@@ -130,7 +130,6 @@ def test_v31_stop_loss_history_endpoints_use_runtime_history_service_even_withou
         async def get_strategy_recommendations(self, strategy_type, symbol):
             return {"strategy_type": strategy_type, "symbol": symbol, "recommendations": ["keep"]}
 
-    monkeypatch.setattr(module, "ENHANCED_RISK_FEATURES_AVAILABLE", False)
     monkeypatch.setattr(module, "get_stop_loss_history_service", lambda: FakeHistoryService())
 
     performance = asyncio.run(
@@ -142,6 +141,43 @@ def test_v31_stop_loss_history_endpoints_use_runtime_history_service_even_withou
 
     assert performance["total_trades"] == 2
     assert recommendations["recommendations"] == ["keep"]
+
+
+def test_v31_stop_loss_history_endpoints_accept_injected_service_without_getter_patch(monkeypatch) -> None:
+    from web.backend.app.api.risk import stop_loss as module
+
+    class FakeHistoryService:
+        async def get_strategy_performance(self, **kwargs):
+            return {"total_trades": 3, "filters": kwargs}
+
+        async def get_strategy_recommendations(self, strategy_type, symbol):
+            return {"strategy_type": strategy_type, "symbol": symbol, "recommendations": ["tighten"]}
+
+    def fail_getter():
+        raise AssertionError("route should use the injected stop-loss history service")
+
+    monkeypatch.setattr(module, "get_stop_loss_history_service", fail_getter)
+
+    injected_service = FakeHistoryService()
+    performance = asyncio.run(
+        module.get_stop_loss_performance(
+            strategy_type="volatility_adaptive",
+            symbol="600519.SH",
+            days=15,
+            history_service=injected_service,
+        )
+    )
+    recommendations = asyncio.run(
+        module.get_stop_loss_recommendations(
+            strategy_type="volatility_adaptive",
+            symbol="600519.SH",
+            history_service=injected_service,
+        )
+    )
+
+    assert performance["total_trades"] == 3
+    assert performance["filters"]["symbol"] == "600519.SH"
+    assert recommendations["recommendations"] == ["tighten"]
 
 
 def test_v31_stop_loss_execution_endpoints_use_runtime_execution_service_even_without_feature_flag(monkeypatch) -> None:
@@ -165,7 +201,6 @@ def test_v31_stop_loss_execution_endpoints_use_runtime_execution_service_even_wi
         async def batch_update_prices(self, price_updates):
             return {"total_checked": len(price_updates)}
 
-    monkeypatch.setattr(module, "ENHANCED_RISK_FEATURES_AVAILABLE", False)
     monkeypatch.setattr(module, "get_stop_loss_execution_service", lambda: FakeExecutionService())
 
     added = asyncio.run(
@@ -183,6 +218,63 @@ def test_v31_stop_loss_execution_endpoints_use_runtime_execution_service_even_wi
     assert updated["checked"] is True
     assert status["found"] is True
     assert overview["total_positions"] == 1
+    assert batch["total_checked"] == 1
+    assert removed["success"] is True
+
+
+def test_v31_stop_loss_execution_endpoints_accept_injected_service_without_getter_patch(monkeypatch) -> None:
+    from web.backend.app.api.risk import stop_loss as module
+
+    class FakeExecutionService:
+        async def add_position_monitoring(self, **kwargs):
+            return {"success": True, "position_id": kwargs["position_id"]}
+
+        async def update_position_price(self, **kwargs):
+            return {"checked": True, "position_id": kwargs["position_id"]}
+
+        async def remove_position_monitoring(self, position_id):
+            return True
+
+        async def get_monitoring_status(self, position_id=None):
+            if position_id:
+                return {"found": True, "position_id": position_id}
+            return {"total_positions": 2}
+
+        async def batch_update_prices(self, price_updates):
+            return {"total_checked": len(price_updates)}
+
+    def fail_getter():
+        raise AssertionError("route should use the injected stop-loss execution service")
+
+    monkeypatch.setattr(module, "get_stop_loss_execution_service", fail_getter)
+
+    injected_service = FakeExecutionService()
+    added = asyncio.run(
+        module.add_stop_loss_position(
+            {"symbol": "600519.SH", "position_id": "pos-1", "entry_price": 100.0, "quantity": 10},
+            execution_service=injected_service,
+        )
+    )
+    updated = asyncio.run(
+        module.update_stop_loss_price(
+            {"position_id": "pos-1", "current_price": 95.0},
+            execution_service=injected_service,
+        )
+    )
+    status = asyncio.run(module.get_stop_loss_status("pos-1", execution_service=injected_service))
+    overview = asyncio.run(module.get_stop_loss_overview(execution_service=injected_service))
+    batch = asyncio.run(
+        module.batch_update_stop_loss_prices(
+            {"price_updates": {"600519.SH": 95.0}},
+            execution_service=injected_service,
+        )
+    )
+    removed = asyncio.run(module.remove_stop_loss_position("pos-1", execution_service=injected_service))
+
+    assert added["success"] is True
+    assert updated["checked"] is True
+    assert status["found"] is True
+    assert overview["total_positions"] == 2
     assert batch["total_checked"] == 1
     assert removed["success"] is True
 

--- a/web/backend/tests/test_stop_loss_route_regressions.py
+++ b/web/backend/tests/test_stop_loss_route_regressions.py
@@ -5,6 +5,8 @@ import importlib
 import sys
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[3]
 BACKEND_ROOT = ROOT / "web" / "backend"
@@ -30,13 +32,11 @@ def test_calculate_stop_loss_v31_rejects_missing_symbol(monkeypatch):
     monkeypatch.setattr(module, "RISK_MANAGEMENT_V31_AVAILABLE", True)
     monkeypatch.setattr(module, "get_risk_management_core", lambda: FakeCore())
 
-    try:
+    with pytest.raises(module.ValidationException) as exc_info:
         asyncio.run(module.calculate_stop_loss_v31({"strategy_type": "volatility_adaptive", "entry_price": 1688.0}))
-    except module.ValidationException as exc:
-        assert exc.status_code == 422
-        assert "symbol" in str(exc.detail)
-    else:
-        raise AssertionError("expected ValidationException when symbol is missing")
+
+    assert exc_info.value.status_code == 422
+    assert "symbol" in str(exc_info.value.detail)
 
 
 def test_calculate_stop_loss_v31_rejects_missing_entry_price(monkeypatch):
@@ -52,10 +52,8 @@ def test_calculate_stop_loss_v31_rejects_missing_entry_price(monkeypatch):
     monkeypatch.setattr(module, "RISK_MANAGEMENT_V31_AVAILABLE", True)
     monkeypatch.setattr(module, "get_risk_management_core", lambda: FakeCore())
 
-    try:
+    with pytest.raises(module.ValidationException) as exc_info:
         asyncio.run(module.calculate_stop_loss_v31({"strategy_type": "volatility_adaptive", "symbol": "600519.SH"}))
-    except module.ValidationException as exc:
-        assert exc.status_code == 422
-        assert "entry_price" in str(exc.detail)
-    else:
-        raise AssertionError("expected ValidationException when entry_price is missing")
+
+    assert exc_info.value.status_code == 422
+    assert "entry_price" in str(exc_info.value.detail)


### PR DESCRIPTION
# Backend Risk Stop-Loss Route Provider Implementation - G2.188

> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。

## Status

- Status: implementation PR review candidate
- Prepared at: `2026-05-27T23:02:44+08:00`
- Branch: `g2-188-risk-stop-loss-provider-implementation`
- Base branch: `wip/root-dirty-20260403`
- Base HEAD: `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`
- Parent authorization: G2.187, PR `#340`, merged at `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`

Boundary note: this implementation is limited to the stop-loss route provider
lane authorized by G2.187. It does not delete or rename src-level stop-loss
service getters, change other risk routes, alter frontend code, create OpenSpec
changes, or fix unrelated alerts / legacy compatibility router baselines.

## Implementation

G2.188 moves the stop-loss route pair from route-body service resolver calls to
route-local FastAPI provider parameters:

| Surface | Before | After |
|---|---|---|
| History service routes | `history_service = _resolve_history_service()` inside endpoint body | `history_service: Any = Depends(get_stop_loss_history_service_provider)` |
| Execution service routes | `execution_service = _resolve_execution_service()` inside endpoint body | `execution_service: Any = Depends(get_stop_loss_execution_service_provider)` |
| Direct test invocation | endpoint resolved service internally | `_resolve_direct_call_dependency(...)` preserves direct-call fallback |

Injected endpoints:

| Provider | Endpoints |
|---|---|
| `get_stop_loss_history_service_provider` | `get_stop_loss_performance`, `get_stop_loss_recommendations` |
| `get_stop_loss_execution_service_provider` | `add_stop_loss_position`, `update_stop_loss_price`, `remove_stop_loss_position`, `get_stop_loss_status`, `get_stop_loss_overview`, `batch_update_stop_loss_prices` |

Preserved public contract:

- Route paths and HTTP methods remain unchanged.
- `response_model=Dict[str, Any]` declarations remain unchanged.
- OpenAPI examples remain unchanged.
- Dependency parameters do not leak into OpenAPI route parameters.
- The src-level getters remain canonical compatibility entrypoints.
- Existing route-local exception behavior is preserved.

## GitNexus Pre-Edit Impact

| Symbol | Risk | Impacted | Direct | Processes |
|---|---:|---:|---:|---:|
| `get_stop_loss_history_service` | LOW | 3 | 1 | 0 |
| `get_stop_loss_execution_service` | LOW | 0 | 0 | 0 |
| `_resolve_history_service` | LOW | 2 | 2 | 0 |
| `_resolve_execution_service` | MEDIUM | 6 | 6 | 0 |
| 8 stop-loss route endpoint symbols | LOW | 0 | 0 | 0 |

The only MEDIUM item is `_resolve_execution_service`, and its direct callers are
the six stop-loss execution endpoints that this lane explicitly covers.

## TDD Evidence

Red test:

```text
PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_risk_runtime_bootstrap_regressions.py -q -k stop_loss --tb=short --disable-warnings --no-cov
2 failed, 3 passed, 5 deselected
```

Expected red failures:

- `get_stop_loss_performance() got an unexpected keyword argument 'history_service'`
- `add_stop_loss_position() got an unexpected keyword argument 'execution_service'`

Green tests:

| Command | Result |
|---|---|
| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_risk_runtime_bootstrap_regressions.py -q -k stop_loss --tb=short --disable-warnings --no-cov` | `5 passed, 5 deselected` |
| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stop_loss_route_regressions.py -q --tb=short --disable-warnings --no-cov` | `2 passed` |
| `PYTHONPATH=web/backend pytest -o addopts= tests/unit/contract/test_risk_router_runtime_import.py::test_app_main_registers_canonical_risk_router_without_loading_compat_shim -q --tb=short --disable-warnings --no-cov` | `1 passed` |

## OpenAPI Smoke

Command used minimal local environment values only to import `app.main` and
generate `app.openapi()`.

| Metric | Value |
|---|---:|
| OpenAPI paths | 500 |
| Stop-loss paths | 10 |
| Dependency parameters leaked into schema | 0 |

## Quality Gates

| Gate | Result |
|---|---|
| `ruff check web/backend/app/api/risk/stop_loss.py web/backend/tests/test_risk_runtime_bootstrap_regressions.py web/backend/tests/test_stop_loss_route_regressions.py tests/unit/contract/test_risk_router_runtime_import.py` | Passed |
| `git diff --check` | Passed |

## Known Out-Of-Scope Baseline Failures

These failures were observed but are outside the G2.188 authorized stop-loss
provider scope:

| Command | Observed result | Reason |
|---|---|---|
| `PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_risk_runtime_bootstrap_regressions.py -q --tb=short --disable-warnings --no-cov` | `4 failed, 6 passed` | Alerts route resolver baseline failures on `_resolve_notification_manager`, `_resolve_rule_engine`, and `_resolve_runtime_alert_service` |
| `PYTHONPATH=web/backend pytest -o addopts= tests/unit/contract/test_risk_router_runtime_import.py -q --tb=short --disable-warnings --no-cov` | One legacy compatibility import test fails when included | `app.api.risk_management` compatibility module is absent at current HEAD |

These are not fixed in this lane because G2.187 authorized only stop-loss route
service provider injection.

## Next Gate

Review the G2.188 implementation PR. If accepted, merge it and open a
path-limited closeout / candidate-refresh governance packet. Do not expand this
PR into alerts resolver fixes, legacy compatibility router restoration, src-level
getter deletion, or other risk route provider migrations.
