### PR TITLE
docs(governance): close stop loss provider lane

### DIFF
--- a/.planning/codebase/generated/risk-stop-loss-provider-closeout-refresh-2026-05-28.json
+++ b/.planning/codebase/generated/risk-stop-loss-provider-closeout-refresh-2026-05-28.json
@@ -1,0 +1,172 @@
+{
+  "schema_version": "2026-05-28.g2-189.closeout-refresh.v1",
+  "generated_at": "2026-05-28T00:19:16+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "0aac0e16f16480bd99eebb8726e21a7db6566b39",
+  "worktree_branch": "g2-189-risk-stop-loss-provider-closeout-refresh",
+  "scope": "governance_closeout_candidate_refresh_package",
+  "source_edit_authority": false,
+  "parent_chain": [
+    {
+      "id": "G2.187",
+      "description": "risk stop-loss route provider authorization",
+      "github_pr": 340,
+      "merge_commit": "2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a"
+    },
+    {
+      "id": "G2.188",
+      "description": "risk stop-loss route provider implementation",
+      "github_pr": 341,
+      "merge_commit": "0aac0e16f16480bd99eebb8726e21a7db6566b39",
+      "merged_at": "2026-05-27T15:46:26Z"
+    }
+  ],
+  "closed_capability": {
+    "id": "risk-stop-loss-route-provider-migration",
+    "status": "closed_for_route_body_provider_migration",
+    "summary": "G2.188 replaced stop-loss route-body service resolver calls with FastAPI provider-injected service parameters while preserving route paths, HTTP methods, response models, OpenAPI examples, direct-test fallback behavior, and src-level service getters.",
+    "endpoints_with_provider_parameters": 8,
+    "route_body_resolver_calls_after_merge": {
+      "body_resolve_history": 0,
+      "body_resolve_execution": 0
+    },
+    "retained_provider_backing_getters": [
+      "get_stop_loss_history_service",
+      "get_stop_loss_execution_service"
+    ],
+    "retention_reason": "These src-level getters remain provider backing functions and are not deletion candidates in this closeout package."
+  },
+  "post_merge_verification": {
+    "commands": [
+      {
+        "id": "stop-loss-runtime-bootstrap",
+        "result": "5 passed, 5 deselected",
+        "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_risk_runtime_bootstrap_regressions.py -q -k stop_loss --tb=short --disable-warnings --no-cov"
+      },
+      {
+        "id": "stop-loss-route-regressions",
+        "result": "2 passed",
+        "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_stop_loss_route_regressions.py -q --tb=short --disable-warnings --no-cov"
+      },
+      {
+        "id": "app-main-risk-router-contract",
+        "result": "1 passed",
+        "command": "PYTHONPATH=web/backend pytest -o addopts= tests/unit/contract/test_risk_router_runtime_import.py::test_app_main_registers_canonical_risk_router_without_loading_compat_shim -q --tb=short --disable-warnings --no-cov"
+      },
+      {
+        "id": "ruff-touched-risk-files",
+        "result": "passed",
+        "command": "ruff check web/backend/app/api/risk/stop_loss.py web/backend/tests/test_risk_runtime_bootstrap_regressions.py web/backend/tests/test_stop_loss_route_regressions.py tests/unit/contract/test_risk_router_runtime_import.py"
+      }
+    ],
+    "openapi_smoke": {
+      "openapi_paths": 500,
+      "stop_loss_paths": 10,
+      "dependency_params_leaked": 0
+    },
+    "route_body_endpoint_check": {
+      "checked_endpoints": [
+        "add_stop_loss_position",
+        "update_stop_loss_price",
+        "remove_stop_loss_position",
+        "get_stop_loss_status",
+        "get_stop_loss_overview",
+        "batch_update_stop_loss_prices",
+        "get_stop_loss_performance",
+        "get_stop_loss_recommendations"
+      ],
+      "all_have_provider_parameters": true,
+      "body_resolve_history_calls": 0,
+      "body_resolve_execution_calls": 0
+    }
+  },
+  "remaining_candidate_refresh": {
+    "source_inventory": ".planning/codebase/generated/service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.json",
+    "raw_direct_getter_names": 111,
+    "raw_direct_getter_calls": 296,
+    "service_singleton_review": {
+      "names": 10,
+      "calls": 43
+    },
+    "candidate_state_after_g2_188": [
+      {
+        "name": "get_stop_loss_history_service",
+        "previous_g2_186_disposition": "recommended next narrow authorization-package candidate",
+        "g2_189_disposition": "closed for route-body provider migration; retained as provider backing getter"
+      },
+      {
+        "name": "get_stop_loss_execution_service",
+        "previous_g2_186_disposition": "recommended next narrow authorization-package candidate",
+        "g2_189_disposition": "closed for route-body provider migration; retained as provider backing getter"
+      },
+      {
+        "name": "get_data_quality_monitor",
+        "calls": 20,
+        "risk": "HIGH",
+        "g2_189_disposition": "recommended next governance target as data-quality / adapter cross-cutting decision package; design and authorization only"
+      },
+      {
+        "name": "get_execution_tracking_evidence_service",
+        "calls": 2,
+        "risk": "HIGH",
+        "g2_189_disposition": "defer to trade execution evidence authorization package"
+      },
+      {
+        "name": "get_prewarming_strategy",
+        "calls": 3,
+        "risk": "HIGH",
+        "g2_189_disposition": "defer to control-plane cache prewarming governance track"
+      },
+      {
+        "name": "get_integrated_services",
+        "calls": 7,
+        "risk": "MEDIUM",
+        "g2_189_disposition": "retain until root facade compatibility retirement package exists"
+      },
+      {
+        "name": "get_unified_data_service",
+        "calls": 5,
+        "risk": "MEDIUM",
+        "g2_189_disposition": "retain as root facade / service self-wrapper; not a route-body singleton implementation candidate"
+      },
+      {
+        "name": "get_data_service",
+        "calls": 2,
+        "risk": "LOW",
+        "g2_189_disposition": "retain under indicator/data provider governance unless later authorization changes it"
+      },
+      {
+        "name": "get_market_data_service_v2",
+        "calls": 1,
+        "risk": "LOW",
+        "g2_189_disposition": "retain as constructor install fallback"
+      },
+      {
+        "name": "get_tdx_service",
+        "calls": 1,
+        "risk": "LOW",
+        "g2_189_disposition": "retain as constructor install fallback; Dashboard/TDX route work remains separate"
+      }
+    ],
+    "recommended_next_governance_target": "data-quality-and-adapter-cross-cutting-decision-package",
+    "recommended_next_work_item": "G2.190 data-quality / adapter cross-cutting decision package",
+    "source_lane_recommendation": "do-not-start-source-implementation-from-g2-189"
+  },
+  "known_out_of_scope_baselines": [
+    "alerts route resolver baseline failures: _resolve_notification_manager, _resolve_rule_engine, _resolve_runtime_alert_service",
+    "legacy app.api.risk_management compatibility module absence"
+  ],
+  "acceptance_boundary": {
+    "if_g2_189_is_accepted": "Start G2.190 as a design / authorization package for the data-quality and adapter cross-cutting track.",
+    "not_authorized": [
+      "backend source edits",
+      "frontend edits",
+      "test edits",
+      "OpenSpec proposal creation",
+      "GitHub issue label changes",
+      "deleting retained src-level provider backing getters",
+      "starting data-quality source implementation directly"
+    ]
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-27T23:02:44+08:00`
-- Base HEAD checked: `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`
+- Prepared at: `2026-05-28T00:19:16+08:00`
+- Base HEAD checked: `0aac0e16f16480bd99eebb8726e21a7db6566b39`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -25,12 +25,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#338` | `g2-185-route-dependency-provider-governance-decision` | `wip/root-dirty-20260403` | `MERGED` at `720248521d705af067d0a2600710444e439d7605` | Provider governance decision retaining active route contracts |
 | `#339` | `g2-186-remaining-getter-inventory-refresh` | `wip/root-dirty-20260403` | `MERGED` at `a63a6cb9a277195905b046cd31777d95160ee2c6` | Remaining getter inventory refresh selecting stop-loss authorization |
 | `#340` | `g2-187-risk-stop-loss-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a` | Authorization package for G2.188 stop-loss route provider implementation |
+| `#341` | `g2-188-risk-stop-loss-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `0aac0e16f16480bd99eebb8726e21a7db6566b39` | Path-limited stop-loss route provider implementation closed for G2.189 refresh |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-188-risk-stop-loss-provider-implementation` | `origin/wip/root-dirty-20260403` at `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a` | Implement the G2.187-authorized stop-loss route service provider injection in one route file plus focused tests | G2.187 stop-loss route service provider authorization |
+| `g2-189-risk-stop-loss-provider-closeout-refresh` | `origin/wip/root-dirty-20260403` at `0aac0e16f16480bd99eebb8726e21a7db6566b39` | Record PR `#341` closeout, mark the stop-loss pair closed for route-body provider migration, and refresh the next service-lifecycle governance target | None; governance closeout and candidate refresh only |
 
 ## OpenSpec Relationship
 
@@ -46,8 +47,8 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.188 is a path-limited source implementation branch. It starts only after PR
-`#340` merged the G2.187 authorization package, and it must not expand beyond
-`web/backend/app/api/risk/stop_loss.py`, focused stop-loss tests, and governance
-evidence. Alerts resolver failures and the legacy `app.api.risk_management`
-compatibility import failure remain separate lanes.
+G2.189 is a governance-only closeout branch after PR `#341` merged G2.188. It
+must not edit backend source, frontend source, tests, OpenSpec changes, or API
+contract files. The next recommended lane is G2.190 data-quality / adapter
+cross-cutting decision and authorization only; source implementation remains
+blocked until a separate authorization package is accepted.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-27T23:02:44+08:00`
-- Base HEAD checked: `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`
+- Prepared at: `2026-05-28T00:19:16+08:00`
+- Base HEAD checked: `0aac0e16f16480bd99eebb8726e21a7db6566b39`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 is the active path-limited stop-loss implementation review candidate |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 is the active governance-only closeout / candidate-refresh review candidate |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-27T23:02:44+08:00`
-- Base HEAD checked: `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`
+- Prepared at: `2026-05-28T00:19:16+08:00`
+- Base HEAD checked: `0aac0e16f16480bd99eebb8726e21a7db6566b39`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.188 risk stop-loss route service provider implementation | G/#79 service lifecycle DI | PR `#340` merged at `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`; G2.188 implements path-limited stop-loss route provider injection with stop-loss tests green and OpenAPI dependency leak count `0` | If accepted, merge and start a closeout / candidate-refresh governance packet |
+| P0 | Review G2.189 risk stop-loss provider closeout / candidate refresh | G/#79 service lifecycle DI | PR `#341` merged at `0aac0e16f16480bd99eebb8726e21a7db6566b39`; post-merge stop-loss tests pass, OpenAPI dependency leak count is `0`, and route-body stop-loss resolver calls are `0` | If accepted, start G2.190 data-quality / adapter cross-cutting decision package as design / authorization only |
+| P0 | Preserve G2.188 risk stop-loss route service provider implementation | G/#79 service lifecycle DI | PR `#341` merged; G2.188 closed the stop-loss route-body provider migration while retaining src-level stop-loss provider backing getters | Do not delete retained getters or expand into alerts, legacy `app.api.risk_management`, or other risk route migrations |
 | P0 | Preserve G2.187 risk stop-loss route service provider authorization | G/#79 service lifecycle DI | PR `#340` merged; G2.187 authorized only `web/backend/app/api/risk/stop_loss.py` plus focused tests for G2.188 | Do not expand G2.188 into alerts resolver, legacy `app.api.risk_management`, or other risk route migrations |
 | P0 | Preserve G2.186 remaining getter inventory refresh | G/#79 service lifecycle DI | PR `#339` merged; G2.186 refreshed remaining direct getter inventory and selected stop-loss route provider authorization as the next narrow gate | Do not start a backend source lane from G2.186 |
 | P0 | Preserve G2.185 provider governance decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#338` merged; provider residuals are retained active route contracts and excluded from direct implementation-candidate counts | Do not start a backend source lane from G2.185 |
@@ -30,10 +31,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does the split preserve the full historical steward tree in archive?
-- Is the root entrypoint short enough to serve as a daily navigation file?
-- Does `steward-index.json` include enough fields for automated guards?
-- Does G2.188 stay limited to `web/backend/app/api/risk/stop_loss.py` and focused stop-loss tests?
-- Does the G2.188 OpenAPI smoke prove `execution_service` / `history_service` do not leak into schema parameters?
-- Are the unrelated alerts resolver and legacy `app.api.risk_management` failures kept out of this source lane?
-- Are implementation, authorization, decision, and evidence lanes still distinct?
+- Does G2.189 accurately record PR `#341` as merged at `0aac0e16f16480bd99eebb8726e21a7db6566b39`?
+- Does the stop-loss pair move from candidate status to closed route-body provider migration while retaining provider backing getters?
+- Does G2.189 keep alerts resolver and legacy `app.api.risk_management` baselines out of scope?
+- Does G2.189 avoid authorizing data-quality source implementation directly?
+- Is G2.190 correctly framed as a data-quality / adapter cross-cutting decision and authorization package only?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-27T23:02:44+08:00`
-- Base HEAD checked: `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`
+- Prepared at: `2026-05-28T00:19:16+08:00`
+- Base HEAD checked: `0aac0e16f16480bd99eebb8726e21a7db6566b39`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -37,8 +37,10 @@ state transition.
 | `docs/reports/quality/backend-service-lifecycle-remaining-getter-inventory-refresh-2026-05-27.md` | G2.186 human-readable inventory refresh decision package | Accepted by PR `#339`; superseded for stop-loss authorization by G2.187 |
 | `.planning/codebase/generated/risk-stop-loss-route-provider-authorization-2026-05-27.json` | G2.187 risk stop-loss route provider authorization evidence | Accepted by PR `#340`; superseded for implementation review by G2.188 |
 | `docs/reports/quality/backend-risk-stop-loss-route-provider-authorization-2026-05-27.md` | G2.187 human-readable authorization package | Accepted by PR `#340` |
-| `.planning/codebase/generated/risk-stop-loss-route-provider-implementation-2026-05-27.json` | G2.188 risk stop-loss route provider implementation evidence | Current for HEAD `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`; stale if HEAD changes |
-| `docs/reports/quality/backend-risk-stop-loss-route-provider-implementation-2026-05-27.md` | G2.188 human-readable implementation package | Review input until implementation PR is accepted |
+| `.planning/codebase/generated/risk-stop-loss-route-provider-implementation-2026-05-27.json` | G2.188 risk stop-loss route provider implementation evidence | Accepted by PR `#341`; superseded for remaining candidate selection by G2.189 |
+| `docs/reports/quality/backend-risk-stop-loss-route-provider-implementation-2026-05-27.md` | G2.188 human-readable implementation package | Accepted by PR `#341` |
+| `.planning/codebase/generated/risk-stop-loss-provider-closeout-refresh-2026-05-28.json` | G2.189 stop-loss provider closeout and candidate-refresh evidence | Current for HEAD `0aac0e16f16480bd99eebb8726e21a7db6566b39`; review input until PR `#342` is accepted |
+| `docs/reports/quality/backend-risk-stop-loss-provider-closeout-refresh-2026-05-28.md` | G2.189 human-readable closeout and candidate-refresh report | Review input until PR `#342` is accepted |
 
 ## External State Inputs
 
@@ -50,7 +52,8 @@ state transition.
 | GitHub PR `#338` | `MERGED` | G2.185 provider governance decision merged by commit `720248521d705af067d0a2600710444e439d7605` |
 | GitHub PR `#339` | `MERGED` | G2.186 remaining getter inventory refresh merged by commit `a63a6cb9a277195905b046cd31777d95160ee2c6` |
 | GitHub PR `#340` | `MERGED` | G2.187 stop-loss route provider authorization merged by commit `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a` |
-| `origin/wip/root-dirty-20260403` | `a63a6cb9a277195905b046cd31777d95160ee2c6` | Base used for this decision branch |
+| GitHub PR `#341` | `MERGED` | G2.188 stop-loss route provider implementation merged by commit `0aac0e16f16480bd99eebb8726e21a7db6566b39` |
+| `origin/wip/root-dirty-20260403` | `0aac0e16f16480bd99eebb8726e21a7db6566b39` | Base used for this closeout / candidate-refresh branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-27T23:02:44+08:00",
+  "generated_at": "2026-05-28T00:19:16+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a",
-  "split_branch": "g2-188-risk-stop-loss-provider-implementation",
-  "scope": "path_limited_source_implementation_package",
-  "source_edit_authority": true,
+  "base_head": "0aac0e16f16480bd99eebb8726e21a7db6566b39",
+  "split_branch": "g2-189-risk-stop-loss-provider-closeout-refresh",
+  "scope": "governance_closeout_candidate_refresh_package",
+  "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -575,9 +575,17 @@
     {
       "id": "g2-188-risk-stop-loss-provider-implementation",
       "type": "implementation_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.187 risk stop-loss route service provider authorization",
+      "github_pr": {
+        "number": 341,
+        "url": "https://github.com/chengjon/mystocks/pull/341",
+        "state": "MERGED",
+        "merged_at": "2026-05-27T15:46:26Z",
+        "head_ref": "g2-188-risk-stop-loss-provider-implementation",
+        "merge_commit": "0aac0e16f16480bd99eebb8726e21a7db6566b39"
+      },
       "source_edit_authority": true,
       "evidence": [
         ".planning/codebase/generated/risk-stop-loss-route-provider-implementation-2026-05-27.json",
@@ -628,16 +636,69 @@
         "legacy app.api.risk_management compatibility import absence"
       ],
       "decision": {
-        "classification": "path-limited-source-implementation-for-review",
-        "source_lane_recommendation": "review-pr-341-before-merge",
+        "classification": "implementation-accepted",
+        "source_lane_recommendation": "closed-by-g2-189-closeout",
         "selected_next_governance_target": "risk-stop-loss-provider-closeout-or-candidate-refresh",
         "recommended_next_work_item": "G2.189 closeout / remaining candidate refresh after G2.188 acceptance"
       },
       "freshness": {
-        "current_head_checked": "2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a",
+        "current_head_checked": "0aac0e16f16480bd99eebb8726e21a7db6566b39",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, merge and start a closeout / candidate-refresh governance packet; do not expand into alerts, legacy risk_management compat, or other risk route migrations."
+      "next_gate": "Superseded by G2.189 closeout / remaining candidate refresh."
+    },
+    {
+      "id": "g2-189-risk-stop-loss-provider-closeout-refresh",
+      "type": "closeout_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.188 risk stop-loss route service provider implementation",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/risk-stop-loss-provider-closeout-refresh-2026-05-28.json",
+        "docs/reports/quality/backend-risk-stop-loss-provider-closeout-refresh-2026-05-28.md",
+        "governance/mainline/task-cards/pr-342.yaml"
+      ],
+      "closeout_result": {
+        "github_pr": {
+          "number": 341,
+          "url": "https://github.com/chengjon/mystocks/pull/341",
+          "state": "MERGED",
+          "merge_commit": "0aac0e16f16480bd99eebb8726e21a7db6566b39"
+        },
+        "endpoints_with_provider_parameters": 8,
+        "route_body_resolver_calls": {
+          "body_resolve_history": 0,
+          "body_resolve_execution": 0
+        },
+        "openapi_paths": 500,
+        "stop_loss_paths": 10,
+        "dependency_params_leaked": 0,
+        "tests": {
+          "stop_loss_runtime_bootstrap": "5 passed, 5 deselected",
+          "stop_loss_route_regressions": "2 passed",
+          "app_main_risk_router_contract_targeted": "1 passed",
+          "ruff": "passed"
+        }
+      },
+      "candidate_refresh": {
+        "stop_loss_pair": "closed_for_route_body_provider_migration_retained_as_provider_backing_getters",
+        "next_recommended_governance_target": "data-quality-and-adapter-cross-cutting-decision-package",
+        "next_recommended_work_item": "G2.190 data-quality / adapter cross-cutting decision package",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-189",
+        "deferred_tracks": [
+          "trade execution evidence",
+          "control-plane cache prewarming",
+          "root facade compatibility",
+          "indicator/data provider fallback",
+          "constructor install fallbacks"
+        ]
+      },
+      "freshness": {
+        "current_head_checked": "0aac0e16f16480bd99eebb8726e21a7db6566b39",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.190 data-quality / adapter cross-cutting decision and authorization package only; do not start source implementation from G2.189."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-27T23:02:44+08:00`
-- Base HEAD checked: `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`
+- Prepared at: `2026-05-28T00:19:16+08:00`
+- Base HEAD checked: `0aac0e16f16480bd99eebb8726e21a7db6566b39`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -40,7 +40,8 @@ It proved a repeatable conveyor:
 | G2.185 route dependency/provider governance decision | Merged by PR `#338` | Classifies active FastAPI providers as retained route contracts, not singleton getter deletion candidates |
 | G2.186 remaining getter inventory refresh | Merged by PR `#339` | Refreshes direct getter inventory after provider governance and recommends a narrow stop-loss authorization package as the next gate |
 | G2.187 risk stop-loss route provider authorization | Merged by PR `#340` | Defines the future G2.188 implementation scope for stop-loss route provider injection without source edits in that PR |
-| G2.188 risk stop-loss route provider implementation | For review | Implements the authorized provider injection in `web/backend/app/api/risk/stop_loss.py`; stop-loss tests and OpenAPI dependency leak smoke pass |
+| G2.188 risk stop-loss route provider implementation | Merged by PR `#341` | Implements the authorized provider injection in `web/backend/app/api/risk/stop_loss.py`; post-merge stop-loss tests and OpenAPI dependency leak smoke pass |
+| G2.189 risk stop-loss provider closeout / candidate refresh | For review | Records PR `#341` closeout, marks the stop-loss pair closed for route-body provider migration, and selects data-quality / adapter cross-cutting governance as the next design-only gate |
 
 ## Current Strategy Getter Residuals
 
@@ -78,34 +79,38 @@ definitions, imports, FastAPI `Depends(...)` provider references,
 | Realtime / streaming track | 10 | 12 | Already governed by realtime streaming/socket track |
 | Service singleton review | 10 | 43 | Classified by G2.186 generated evidence |
 
-The next recommended authorization-only gate is G2.187 risk stop-loss route
-service provider authorization, limited to the stop-loss route pair. High-risk
-data-quality, root-facade, control-plane cache, trade evidence, and constructor
-fallback getters stay deferred to their owner-specific tracks.
+G2.188 closed the stop-loss route-body provider migration. The stop-loss
+src-level getters now remain retained provider backing functions, not deletion
+candidates. High-risk data-quality, root-facade, control-plane cache, trade
+evidence, and constructor fallback getters stay deferred to their owner-specific
+tracks.
 
 ## G2.187 / G2.188 Stop-Loss Provider Lane
 
-At HEAD `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a`, G2.188 implements the
+At HEAD `0aac0e16f16480bd99eebb8726e21a7db6566b39`, G2.188 implements the
 G2.187-authorized stop-loss route provider seam by replacing route-body resolver
 calls with FastAPI dependency-injected service parameters.
 
 | Implementation surface | Current direct consumers | GitNexus risk | Current decision |
 |---|---:|---|---|
-| `_resolve_history_service` | 2 | LOW | Wrapped by `get_stop_loss_history_service_provider`; direct test fallback preserved |
-| `_resolve_execution_service` | 6 | MEDIUM | Wrapped by `get_stop_loss_execution_service_provider`; direct test fallback preserved |
+| `_resolve_history_service` | 0 route-body calls after G2.188 | LOW | Wrapped by `get_stop_loss_history_service_provider`; direct test fallback preserved |
+| `_resolve_execution_service` | 0 route-body calls after G2.188 | MEDIUM | Wrapped by `get_stop_loss_execution_service_provider`; direct test fallback preserved |
 
-G2.188 touches only `web/backend/app/api/risk/stop_loss.py`, focused stop-loss
-tests, and governance evidence. It preserves route paths, HTTP methods,
+G2.188 touched only `web/backend/app/api/risk/stop_loss.py`, focused stop-loss
+tests, and governance evidence. It preserved route paths, HTTP methods,
 response-model declarations, OpenAPI examples, and src-level service getters.
-OpenAPI smoke records `openapi_paths=500`, `stop_loss_paths=10`, and
+Post-merge smoke records `openapi_paths=500`, `stop_loss_paths=10`, and
 `dependency_params_leaked=0`.
 
 ## Next Gates
 
-- Review G2.188 risk stop-loss route service provider implementation.
-- If accepted, merge and start a closeout / candidate-refresh governance packet.
-- Do not expand this implementation into alerts resolver fixes, legacy
-  `app.api.risk_management` restoration, or other risk route provider migrations.
+- Review G2.189 risk stop-loss provider closeout / candidate refresh.
+- If accepted, start G2.190 data-quality / adapter cross-cutting decision
+  package as design / authorization only.
+- Do not start data-quality source implementation from G2.189.
+- Do not delete retained stop-loss provider backing getters.
+- Do not expand into alerts resolver fixes, legacy `app.api.risk_management`
+  restoration, or other risk route provider migrations.
 
 ## Forbidden Scope
 

--- a/docs/reports/quality/backend-risk-stop-loss-provider-closeout-refresh-2026-05-28.md
+++ b/docs/reports/quality/backend-risk-stop-loss-provider-closeout-refresh-2026-05-28.md
@@ -1,0 +1,126 @@
+# Backend Risk Stop-Loss Provider Closeout Refresh
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: review candidate
+- Prepared at: `2026-05-28T00:19:16+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `0aac0e16f16480bd99eebb8726e21a7db6566b39`
+- Worktree branch: `g2-189-risk-stop-loss-provider-closeout-refresh`
+- Scope: governance closeout and remaining-candidate refresh only
+- Source edit authority: none
+
+Boundary note: this package records the accepted G2.188 outcome and refreshes the
+next service-lifecycle DI gate. It does not authorize backend source edits,
+frontend edits, test edits, OpenSpec proposal creation, GitHub issue label
+changes, PM2 commands, or deletion of retained provider backing getters.
+
+## Parent State
+
+| Item | State | Evidence |
+|---|---|---|
+| G2.187 risk stop-loss route provider authorization | Merged | PR `#340`, merge commit `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a` |
+| G2.188 risk stop-loss route provider implementation | Merged | PR `#341`, merge commit `0aac0e16f16480bd99eebb8726e21a7db6566b39`, merged at `2026-05-27T15:46:26Z` |
+| G2.189 closeout / candidate refresh | For review | This report plus `.planning/codebase/generated/risk-stop-loss-provider-closeout-refresh-2026-05-28.json` |
+
+## Closed Capability
+
+G2.188 is closed as a route-body provider migration for the stop-loss risk route.
+The implementation replaced route-body `_resolve_*_service()` calls with
+FastAPI dependency-injected service parameters while preserving:
+
+- route paths
+- HTTP methods
+- response-model declarations
+- OpenAPI examples
+- direct-test fallback behavior
+- src-level `get_stop_loss_history_service` and `get_stop_loss_execution_service`
+  provider backing getters
+
+The retained src-level getters are still active provider backing functions. They
+are not deletion candidates in this closeout package.
+
+## Post-Merge Verification
+
+| Check | Result |
+|---|---|
+| `web/backend/tests/test_risk_runtime_bootstrap_regressions.py -k stop_loss` | `5 passed, 5 deselected` |
+| `web/backend/tests/test_stop_loss_route_regressions.py` | `2 passed` |
+| `tests/unit/contract/test_risk_router_runtime_import.py::test_app_main_registers_canonical_risk_router_without_loading_compat_shim` | `1 passed` |
+| touched risk files `ruff check` | passed |
+| OpenAPI smoke | `openapi_paths=500`, `stop_loss_paths=10`, `dependency_params_leaked=0` |
+| route body resolver scan | `body_resolve_history=0`, `body_resolve_execution=0` |
+
+The endpoint scan covered these stop-loss endpoints:
+
+- `add_stop_loss_position`
+- `update_stop_loss_price`
+- `remove_stop_loss_position`
+- `get_stop_loss_status`
+- `get_stop_loss_overview`
+- `batch_update_stop_loss_prices`
+- `get_stop_loss_performance`
+- `get_stop_loss_recommendations`
+
+## Remaining Candidate Refresh
+
+G2.186 classified 10 service-singleton review names with 43 calls. G2.188 closes
+the stop-loss pair as a route-body provider migration and leaves the remaining
+names in owner-specific tracks.
+
+| Candidate / group | G2.189 disposition | Next handling |
+|---|---|---|
+| `get_stop_loss_history_service` | Closed for route-body provider migration; retained as provider backing getter | No deletion or source lane from G2.189 |
+| `get_stop_loss_execution_service` | Closed for route-body provider migration; retained as provider backing getter | No deletion or source lane from G2.189 |
+| `get_data_quality_monitor` | High-risk data-quality / adapter cross-cutting candidate | Recommended next governance target: G2.190 decision / authorization package only |
+| `get_execution_tracking_evidence_service` | Trade execution evidence track | Defer to separate trade/evidence authorization package |
+| `get_prewarming_strategy` | Control-plane cache prewarming track | Defer to control-plane cache prewarming governance |
+| `get_integrated_services` | Root facade compatibility | Retain until root facade compatibility retirement package exists |
+| `get_unified_data_service` | Root facade / service self-wrapper | Retain; not a route-body singleton implementation candidate |
+| `get_data_service` | Indicator/data provider fallback | Retain under indicator/data provider governance unless later authorization changes it |
+| `get_market_data_service_v2` | Constructor install fallback | Retain as constructor install fallback |
+| `get_tdx_service` | Constructor install fallback / Dashboard-TDX split | Retain; Dashboard/TDX route work remains separate |
+
+## Recommended Next Gate
+
+If G2.189 is accepted, start `G2.190 data-quality / adapter cross-cutting
+decision package` as a design / authorization package only.
+
+G2.190 should not directly edit source. It should first classify the
+data-quality monitor surface, adapter ownership, route consumers, OpenAPI /
+consumer-contract exposure, test seams, and rollback boundaries. Only after that
+authorization is accepted should a new source implementation lane be opened.
+
+## Explicit Non-Goals
+
+- Do not edit backend source from G2.189.
+- Do not edit frontend source from G2.189.
+- Do not edit tests from G2.189.
+- Do not create or change OpenSpec proposals from G2.189.
+- Do not change GitHub issue or PR labels from G2.189.
+- Do not delete `get_stop_loss_history_service` or
+  `get_stop_loss_execution_service`.
+- Do not expand into alerts resolver fixes.
+- Do not restore or change legacy `app.api.risk_management` compatibility.
+- Do not start data-quality implementation before a separate accepted
+  authorization package exists.
+
+## Known Out-Of-Scope Baselines
+
+- Alerts route resolver baseline failures remain outside this closeout:
+  `_resolve_notification_manager`, `_resolve_rule_engine`, and
+  `_resolve_runtime_alert_service`.
+- Legacy `app.api.risk_management` compatibility module absence remains a
+  separate lane.
+
+## Evidence Artifacts
+
+| Artifact | Role |
+|---|---|
+| `.planning/codebase/generated/risk-stop-loss-route-provider-implementation-2026-05-27.json` | G2.188 implementation evidence |
+| `docs/reports/quality/backend-risk-stop-loss-route-provider-implementation-2026-05-27.md` | G2.188 implementation report |
+| `.planning/codebase/generated/risk-stop-loss-provider-closeout-refresh-2026-05-28.json` | G2.189 machine-readable closeout / candidate refresh |
+| `docs/reports/quality/backend-risk-stop-loss-provider-closeout-refresh-2026-05-28.md` | G2.189 human-readable closeout / candidate refresh |
+| `governance/mainline/task-cards/pr-342.yaml` | G2.189 governance-only PR scope card |

--- a/governance/mainline/task-cards/pr-342.yaml
+++ b/governance/mainline/task-cards/pr-342.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-342"
+  title: "Close risk stop-loss provider lane and refresh remaining candidates"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-risk-stop-loss-provider-closeout-refresh"
+  objective: "record PR #341 stop-loss provider migration closeout and select the next governance-only service-lifecycle DI gate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance closeout and candidate refresh only; no runtime entrypoints, route paths, response models, frontend behavior, PM2 workflows, or public API ownership change"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/risk-stop-loss-provider-closeout-refresh-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-risk-stop-loss-provider-closeout-refresh-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-342.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "editing backend source"
+  - "editing frontend source"
+  - "editing tests"
+  - "deleting retained src-level stop-loss provider backing getters"
+  - "changing route paths, HTTP methods, response models, or OpenAPI examples"
+  - "fixing alerts resolver baseline failures"
+  - "restoring or changing the legacy app.api.risk_management compatibility module"
+  - "creating OpenSpec proposals"
+  - "changing GitHub issue labels"
+  - "starting data-quality source implementation"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/risk-stop-loss-provider-closeout-refresh-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-342.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-risk-stop-loss-provider-closeout-refresh-2026-05-28.md"
+      required: true
+    - id: "openspec-lifecycle-di"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-342.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 0aac0e16f16480bd99eebb8726e21a7db6566b39 --head-sha HEAD --report /tmp/pr342-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this closeout is misread as source authorization, the next service candidate could skip the required design and authorization package."
+    - "If retained stop-loss provider backing getters are treated as deletion candidates, runtime provider behavior can regress."
+  rollback_plan: "revert this governance-only PR to restore the prior steward tree and candidate-refresh state."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close the PR #341 stop-loss provider lane and refresh remaining service-lifecycle candidates"
+    modified_scope: "governance tree files, one generated JSON evidence artifact, one quality report, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; stop-loss src-level provider backing getters remain retained"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if the steward tree misstates PR #341 closeout or next-gate boundaries"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T00:19:16+08:00"
+    approval_note: "Human maintainer approved continuing after PR #341 merge; this lane is governance-only closeout and remaining-candidate refresh."
+    secondary_approved: true


### PR DESCRIPTION
## Summary
- record PR #341 stop-loss route provider implementation as merged and closed
- add G2.189 machine-readable closeout / candidate-refresh evidence and human report
- refresh steward tree next gate to G2.190 data-quality / adapter cross-cutting decision package only

## Scope
Governance-only. No backend source, frontend source, tests, docs/api, OpenSpec change/spec, config, or scripts edits.

## Verification
- JSON/YAML parse checks passed
- Markdown governance gate: 6 checked, 0 errors
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: valid (PostHog telemetry ECONNREFUSED noise only)
- git diff --cached --check: passed before commit
- GitNexus staged detect_changes: low risk, 0 changed symbols, 0 affected processes
- mainline_scope_gate pr-342: pass=True

## Next Gate
If accepted, start G2.190 data-quality / adapter cross-cutting decision package as design / authorization only. Do not start source implementation from G2.189.