### PR TITLE
docs(governance): decide data quality adapter path

### DIFF
--- a/.planning/codebase/generated/data-quality-adapter-cross-cutting-decision-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-adapter-cross-cutting-decision-2026-05-28.json
@@ -1,0 +1,231 @@
+{
+  "schema_version": "2026-05-28.g2-190.decision.v1",
+  "generated_at": "2026-05-28T00:38:03+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "5565e2b0967958c406a4115dc840a9e90a0b2aab",
+  "worktree_branch": "g2-190-data-quality-adapter-decision",
+  "scope": "data_quality_adapter_cross_cutting_decision_package",
+  "source_edit_authority": false,
+  "parent": {
+    "id": "G2.189",
+    "description": "risk stop-loss provider closeout / candidate refresh",
+    "github_pr": 342,
+    "merge_commit": "5565e2b0967958c406a4115dc840a9e90a0b2aab",
+    "merged_at": "2026-05-27T16:32:36Z"
+  },
+  "target_surface": {
+    "primary_getter": "get_data_quality_monitor",
+    "definition": "web/backend/app/services/_data_quality_monitor_singleton.py",
+    "backing_class": "DataQualityMonitor",
+    "backing_class_file": "web/backend/app/services/data_quality_monitor.py",
+    "current_global_state": "_global_monitor",
+    "current_export_path": "web/backend/app/services/data_quality_monitor.py"
+  },
+  "gitnexus_evidence": {
+    "target": "Function:web/backend/app/services/_data_quality_monitor_singleton.py:get_data_quality_monitor",
+    "risk": "CRITICAL",
+    "impacted_count": 24,
+    "direct_callers": 20,
+    "processes_affected": 7,
+    "modules_affected": 4,
+    "affected_modules": [
+      "Services",
+      "Data_adapters",
+      "Api",
+      "Adapters"
+    ]
+  },
+  "static_inventory": {
+    "files_with_data_quality_monitor_surface": 16,
+    "get_data_quality_monitor_calls": 21,
+    "monitor_data_quality_calls": 2,
+    "buckets": {
+      "route": {
+        "files": 1,
+        "get_calls": 6,
+        "monitor_calls": 1,
+        "paths": [
+          "web/backend/app/api/data_quality.py"
+        ]
+      },
+      "adapter_split": {
+        "files": 8,
+        "get_calls": 8,
+        "monitor_calls": 0,
+        "paths": [
+          "web/backend/app/services/adapters_split/base_adapter.py",
+          "web/backend/app/services/adapters_split/baostock_adapter.py",
+          "web/backend/app/services/adapters_split/tushare_adapter.py",
+          "web/backend/app/services/adapters_split/customer_adapter.py",
+          "web/backend/app/services/adapters_split/byapi_adapter.py",
+          "web/backend/app/services/adapters_split/akshare_adapter.py",
+          "web/backend/app/services/adapters_split/efinance_adapter.py",
+          "web/backend/app/services/adapters_split/tdx_adapter.py"
+        ]
+      },
+      "legacy_adapter": {
+        "files": 5,
+        "get_calls": 5,
+        "monitor_calls": 0,
+        "paths": [
+          "web/backend/app/services/adapters/dashboard_adapter.py",
+          "web/backend/app/services/adapters/data_adapter.py",
+          "web/backend/app/services/data_adapters/data_source.py",
+          "web/backend/app/services/data_adapters/dashboard.py",
+          "web/backend/app/services/market_data_adapter.py"
+        ]
+      },
+      "service_wrapper": {
+        "files": 2,
+        "get_calls": 2,
+        "monitor_calls": 1,
+        "paths": [
+          "web/backend/app/services/data_quality_monitor.py",
+          "web/backend/app/services/_data_quality_monitor_singleton.py"
+        ]
+      }
+    }
+  },
+  "route_surface": {
+    "file": "web/backend/app/api/data_quality.py",
+    "route_count": 9,
+    "routes_with_getter_or_monitor_calls": 7,
+    "routes": [
+      {
+        "method": "GET",
+        "path": "/health",
+        "function": "get_sources_health",
+        "get_calls": 0,
+        "monitor_calls": 0
+      },
+      {
+        "method": "GET",
+        "path": "/metrics",
+        "function": "get_data_quality_metrics",
+        "get_calls": 1,
+        "monitor_calls": 0
+      },
+      {
+        "method": "GET",
+        "path": "/alerts",
+        "function": "get_active_alerts",
+        "get_calls": 1,
+        "monitor_calls": 0
+      },
+      {
+        "method": "POST",
+        "path": "/alerts/{alert_id}/acknowledge",
+        "function": "acknowledge_alert",
+        "get_calls": 1,
+        "monitor_calls": 0
+      },
+      {
+        "method": "POST",
+        "path": "/alerts/{alert_id}/resolve",
+        "function": "resolve_alert",
+        "get_calls": 1,
+        "monitor_calls": 0
+      },
+      {
+        "method": "GET",
+        "path": "/config/mode",
+        "function": "get_data_source_mode",
+        "get_calls": 0,
+        "monitor_calls": 0
+      },
+      {
+        "method": "GET",
+        "path": "/status/overview",
+        "function": "get_system_status_overview",
+        "get_calls": 1,
+        "monitor_calls": 0
+      },
+      {
+        "method": "POST",
+        "path": "/test/quality",
+        "function": "test_data_quality",
+        "get_calls": 0,
+        "monitor_calls": 1
+      },
+      {
+        "method": "GET",
+        "path": "/metrics/trends",
+        "function": "get_quality_trends",
+        "get_calls": 1,
+        "monitor_calls": 0
+      }
+    ]
+  },
+  "decision": {
+    "classification": "critical-cross-cutting-surface-do-not-implement-as-single-batch",
+    "selected_next_governance_target": "data-quality-route-provider-authorization",
+    "recommended_next_work_item": "G2.191 data-quality route provider authorization package",
+    "source_lane_recommendation": "do-not-start-source-implementation-from-g2-190",
+    "strategy": [
+      {
+        "track": "route_provider",
+        "surface": "web/backend/app/api/data_quality.py",
+        "recommended_sequence": 1,
+        "next_gate": "Prepare G2.191 authorization package for route-only provider injection. No source edits in G2.190."
+      },
+      {
+        "track": "adapter_split_constructor",
+        "surface": "web/backend/app/services/adapters_split/*.py",
+        "recommended_sequence": 2,
+        "next_gate": "Require interface/test-double design before adapter constructor changes."
+      },
+      {
+        "track": "legacy_adapter_compatibility",
+        "surface": "web/backend/app/services/adapters/*.py and data_adapters/*.py",
+        "recommended_sequence": 3,
+        "next_gate": "Separate compatibility ownership decision before source edits."
+      },
+      {
+        "track": "singleton_wrapper_retention",
+        "surface": "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "recommended_sequence": 4,
+        "next_gate": "Retain wrapper until route and adapter consumers are migrated and current HEAD proves no runtime consumers remain."
+      }
+    ]
+  },
+  "g2_191_authorization_shape": {
+    "type": "authorization_package_only",
+    "suggested_future_source_surface": [
+      "web/backend/app/api/data_quality.py"
+    ],
+    "suggested_future_test_surface": [
+      "focused data-quality route/provider regression tests",
+      "OpenAPI dependency leak smoke",
+      "app.main import / data-quality route registration smoke"
+    ],
+    "must_preserve": [
+      "route paths",
+      "HTTP methods",
+      "response models",
+      "OpenAPI examples",
+      "error response contract",
+      "data-source factory behavior",
+      "DataQualityMonitor backing singleton behavior"
+    ],
+    "must_not_include": [
+      "adapter constructor migration",
+      "legacy adapter compatibility cleanup",
+      "DataQualityMonitor implementation rewrite",
+      "singleton wrapper deletion"
+    ]
+  },
+  "acceptance_boundary": {
+    "if_g2_190_is_accepted": "Start G2.191 as a route-only authorization package for data-quality route provider injection.",
+    "not_authorized": [
+      "backend source edits",
+      "frontend edits",
+      "test edits",
+      "OpenSpec proposal creation",
+      "GitHub issue label changes",
+      "adapter constructor migration",
+      "singleton wrapper deletion",
+      "data-quality source implementation"
+    ]
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T00:19:16+08:00`
-- Base HEAD checked: `0aac0e16f16480bd99eebb8726e21a7db6566b39`
+- Prepared at: `2026-05-28T00:38:03+08:00`
+- Base HEAD checked: `5565e2b0967958c406a4115dc840a9e90a0b2aab`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -26,12 +26,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#339` | `g2-186-remaining-getter-inventory-refresh` | `wip/root-dirty-20260403` | `MERGED` at `a63a6cb9a277195905b046cd31777d95160ee2c6` | Remaining getter inventory refresh selecting stop-loss authorization |
 | `#340` | `g2-187-risk-stop-loss-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a` | Authorization package for G2.188 stop-loss route provider implementation |
 | `#341` | `g2-188-risk-stop-loss-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `0aac0e16f16480bd99eebb8726e21a7db6566b39` | Path-limited stop-loss route provider implementation closed for G2.189 refresh |
+| `#342` | `g2-189-risk-stop-loss-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `5565e2b0967958c406a4115dc840a9e90a0b2aab` | Governance closeout and candidate refresh selecting data-quality / adapter cross-cutting decision |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-189-risk-stop-loss-provider-closeout-refresh` | `origin/wip/root-dirty-20260403` at `0aac0e16f16480bd99eebb8726e21a7db6566b39` | Record PR `#341` closeout, mark the stop-loss pair closed for route-body provider migration, and refresh the next service-lifecycle governance target | None; governance closeout and candidate refresh only |
+| `g2-190-data-quality-adapter-decision` | `origin/wip/root-dirty-20260403` at `5565e2b0967958c406a4115dc840a9e90a0b2aab` | Classify the `get_data_quality_monitor` cross-cutting surface and select the next route-only authorization gate | None; governance decision package only |
 
 ## OpenSpec Relationship
 
@@ -47,8 +48,8 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.189 is a governance-only closeout branch after PR `#341` merged G2.188. It
+G2.190 is a governance-only decision branch after PR `#342` merged G2.189. It
 must not edit backend source, frontend source, tests, OpenSpec changes, or API
-contract files. The next recommended lane is G2.190 data-quality / adapter
-cross-cutting decision and authorization only; source implementation remains
-blocked until a separate authorization package is accepted.
+contract files. The next recommended lane is G2.191 data-quality route provider
+authorization only; source implementation remains blocked until a separate
+authorization package is accepted.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T00:19:16+08:00`
-- Base HEAD checked: `0aac0e16f16480bd99eebb8726e21a7db6566b39`
+- Prepared at: `2026-05-28T00:38:03+08:00`
+- Base HEAD checked: `5565e2b0967958c406a4115dc840a9e90a0b2aab`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 is the active governance-only closeout / candidate-refresh review candidate |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 is the active governance-only data-quality / adapter cross-cutting decision candidate |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T00:19:16+08:00`
-- Base HEAD checked: `0aac0e16f16480bd99eebb8726e21a7db6566b39`
+- Prepared at: `2026-05-28T00:38:03+08:00`
+- Base HEAD checked: `5565e2b0967958c406a4115dc840a9e90a0b2aab`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.189 risk stop-loss provider closeout / candidate refresh | G/#79 service lifecycle DI | PR `#341` merged at `0aac0e16f16480bd99eebb8726e21a7db6566b39`; post-merge stop-loss tests pass, OpenAPI dependency leak count is `0`, and route-body stop-loss resolver calls are `0` | If accepted, start G2.190 data-quality / adapter cross-cutting decision package as design / authorization only |
+| P0 | Review G2.190 data-quality / adapter cross-cutting decision | G/#79 service lifecycle DI | PR `#342` merged at `5565e2b0967958c406a4115dc840a9e90a0b2aab`; `get_data_quality_monitor` is `CRITICAL` with 20 direct callers across route, adapter, legacy adapter, and wrapper surfaces | If accepted, start G2.191 data-quality route provider authorization package only |
+| P0 | Preserve G2.189 risk stop-loss provider closeout / candidate refresh | G/#79 service lifecycle DI | PR `#342` merged; stop-loss pair is closed for route-body provider migration and retained as provider backing getters | Do not reopen stop-loss or start data-quality source implementation from G2.189 |
 | P0 | Preserve G2.188 risk stop-loss route service provider implementation | G/#79 service lifecycle DI | PR `#341` merged; G2.188 closed the stop-loss route-body provider migration while retaining src-level stop-loss provider backing getters | Do not delete retained getters or expand into alerts, legacy `app.api.risk_management`, or other risk route migrations |
 | P0 | Preserve G2.187 risk stop-loss route service provider authorization | G/#79 service lifecycle DI | PR `#340` merged; G2.187 authorized only `web/backend/app/api/risk/stop_loss.py` plus focused tests for G2.188 | Do not expand G2.188 into alerts resolver, legacy `app.api.risk_management`, or other risk route migrations |
 | P0 | Preserve G2.186 remaining getter inventory refresh | G/#79 service lifecycle DI | PR `#339` merged; G2.186 refreshed remaining direct getter inventory and selected stop-loss route provider authorization as the next narrow gate | Do not start a backend source lane from G2.186 |
@@ -31,8 +32,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.189 accurately record PR `#341` as merged at `0aac0e16f16480bd99eebb8726e21a7db6566b39`?
-- Does the stop-loss pair move from candidate status to closed route-body provider migration while retaining provider backing getters?
-- Does G2.189 keep alerts resolver and legacy `app.api.risk_management` baselines out of scope?
-- Does G2.189 avoid authorizing data-quality source implementation directly?
-- Is G2.190 correctly framed as a data-quality / adapter cross-cutting decision and authorization package only?
+- Does G2.190 correctly classify `get_data_quality_monitor` as `CRITICAL`, not a low-risk source candidate?
+- Does G2.190 split route, adapter constructor, legacy adapter, and singleton wrapper surfaces instead of batching them?
+- Is G2.191 limited to route-provider authorization only, with no source implementation from G2.190?
+- Are adapter constructor migration and singleton wrapper deletion explicitly deferred?
+- Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T00:19:16+08:00`
-- Base HEAD checked: `0aac0e16f16480bd99eebb8726e21a7db6566b39`
+- Prepared at: `2026-05-28T00:38:03+08:00`
+- Base HEAD checked: `5565e2b0967958c406a4115dc840a9e90a0b2aab`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -41,6 +41,8 @@ state transition.
 | `docs/reports/quality/backend-risk-stop-loss-route-provider-implementation-2026-05-27.md` | G2.188 human-readable implementation package | Accepted by PR `#341` |
 | `.planning/codebase/generated/risk-stop-loss-provider-closeout-refresh-2026-05-28.json` | G2.189 stop-loss provider closeout and candidate-refresh evidence | Current for HEAD `0aac0e16f16480bd99eebb8726e21a7db6566b39`; review input until PR `#342` is accepted |
 | `docs/reports/quality/backend-risk-stop-loss-provider-closeout-refresh-2026-05-28.md` | G2.189 human-readable closeout and candidate-refresh report | Review input until PR `#342` is accepted |
+| `.planning/codebase/generated/data-quality-adapter-cross-cutting-decision-2026-05-28.json` | G2.190 data-quality / adapter cross-cutting decision evidence | Current for HEAD `5565e2b0967958c406a4115dc840a9e90a0b2aab`; review input until PR `#343` is accepted |
+| `docs/reports/quality/backend-data-quality-adapter-cross-cutting-decision-2026-05-28.md` | G2.190 human-readable decision package | Review input until PR `#343` is accepted |
 
 ## External State Inputs
 
@@ -53,7 +55,8 @@ state transition.
 | GitHub PR `#339` | `MERGED` | G2.186 remaining getter inventory refresh merged by commit `a63a6cb9a277195905b046cd31777d95160ee2c6` |
 | GitHub PR `#340` | `MERGED` | G2.187 stop-loss route provider authorization merged by commit `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a` |
 | GitHub PR `#341` | `MERGED` | G2.188 stop-loss route provider implementation merged by commit `0aac0e16f16480bd99eebb8726e21a7db6566b39` |
-| `origin/wip/root-dirty-20260403` | `0aac0e16f16480bd99eebb8726e21a7db6566b39` | Base used for this closeout / candidate-refresh branch |
+| GitHub PR `#342` | `MERGED` | G2.189 stop-loss provider closeout / candidate refresh merged by commit `5565e2b0967958c406a4115dc840a9e90a0b2aab` |
+| `origin/wip/root-dirty-20260403` | `5565e2b0967958c406a4115dc840a9e90a0b2aab` | Base used for this decision branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T00:19:16+08:00",
+  "generated_at": "2026-05-28T00:38:03+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "0aac0e16f16480bd99eebb8726e21a7db6566b39",
-  "split_branch": "g2-189-risk-stop-loss-provider-closeout-refresh",
-  "scope": "governance_closeout_candidate_refresh_package",
+  "base_head": "5565e2b0967958c406a4115dc840a9e90a0b2aab",
+  "split_branch": "g2-190-data-quality-adapter-decision",
+  "scope": "data_quality_adapter_cross_cutting_decision_package",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -650,9 +650,17 @@
     {
       "id": "g2-189-risk-stop-loss-provider-closeout-refresh",
       "type": "closeout_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.188 risk stop-loss route service provider implementation",
+      "github_pr": {
+        "number": 342,
+        "url": "https://github.com/chengjon/mystocks/pull/342",
+        "state": "MERGED",
+        "merged_at": "2026-05-27T16:32:36Z",
+        "head_ref": "g2-189-risk-stop-loss-provider-closeout-refresh",
+        "merge_commit": "5565e2b0967958c406a4115dc840a9e90a0b2aab"
+      },
       "source_edit_authority": false,
       "evidence": [
         ".planning/codebase/generated/risk-stop-loss-provider-closeout-refresh-2026-05-28.json",
@@ -695,10 +703,74 @@
         ]
       },
       "freshness": {
-        "current_head_checked": "0aac0e16f16480bd99eebb8726e21a7db6566b39",
+        "current_head_checked": "5565e2b0967958c406a4115dc840a9e90a0b2aab",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.190 data-quality / adapter cross-cutting decision and authorization package only; do not start source implementation from G2.189."
+      "next_gate": "Superseded by G2.190 data-quality / adapter cross-cutting decision."
+    },
+    {
+      "id": "g2-190-data-quality-adapter-decision",
+      "type": "decision_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.189 risk stop-loss provider closeout / candidate refresh",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/data-quality-adapter-cross-cutting-decision-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-adapter-cross-cutting-decision-2026-05-28.md",
+        "governance/mainline/task-cards/pr-343.yaml"
+      ],
+      "analysis": {
+        "target": "get_data_quality_monitor",
+        "definition": "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "gitnexus_risk": "CRITICAL",
+        "impacted_count": 24,
+        "direct_callers": 20,
+        "processes_affected": 7,
+        "modules_affected": 4,
+        "static_inventory": {
+          "files": 16,
+          "get_data_quality_monitor_calls": 21,
+          "monitor_data_quality_calls": 2
+        },
+        "surface_buckets": {
+          "route": {
+            "files": 1,
+            "get_calls": 6,
+            "monitor_calls": 1
+          },
+          "adapter_split": {
+            "files": 8,
+            "get_calls": 8
+          },
+          "legacy_adapter": {
+            "files": 5,
+            "get_calls": 5
+          },
+          "service_wrapper": {
+            "files": 2,
+            "get_calls": 2,
+            "monitor_calls": 1
+          }
+        }
+      },
+      "decision": {
+        "classification": "critical-cross-cutting-surface-do-not-implement-as-single-batch",
+        "selected_next_governance_target": "data-quality-route-provider-authorization",
+        "recommended_next_work_item": "G2.191 data-quality route provider authorization package",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-190",
+        "deferred_tracks": [
+          "adapter constructor migration after interface/test-double design",
+          "legacy adapter compatibility ownership",
+          "singleton wrapper retention / eventual retirement",
+          "DataQualityMonitor implementation changes"
+        ]
+      },
+      "freshness": {
+        "current_head_checked": "5565e2b0967958c406a4115dc840a9e90a0b2aab",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.191 data-quality route provider authorization package only; do not start source implementation from G2.190."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T00:19:16+08:00`
-- Base HEAD checked: `0aac0e16f16480bd99eebb8726e21a7db6566b39`
+- Prepared at: `2026-05-28T00:38:03+08:00`
+- Base HEAD checked: `5565e2b0967958c406a4115dc840a9e90a0b2aab`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -41,7 +41,8 @@ It proved a repeatable conveyor:
 | G2.186 remaining getter inventory refresh | Merged by PR `#339` | Refreshes direct getter inventory after provider governance and recommends a narrow stop-loss authorization package as the next gate |
 | G2.187 risk stop-loss route provider authorization | Merged by PR `#340` | Defines the future G2.188 implementation scope for stop-loss route provider injection without source edits in that PR |
 | G2.188 risk stop-loss route provider implementation | Merged by PR `#341` | Implements the authorized provider injection in `web/backend/app/api/risk/stop_loss.py`; post-merge stop-loss tests and OpenAPI dependency leak smoke pass |
-| G2.189 risk stop-loss provider closeout / candidate refresh | For review | Records PR `#341` closeout, marks the stop-loss pair closed for route-body provider migration, and selects data-quality / adapter cross-cutting governance as the next design-only gate |
+| G2.189 risk stop-loss provider closeout / candidate refresh | Merged by PR `#342` | Records PR `#341` closeout, marks the stop-loss pair closed for route-body provider migration, and selects data-quality / adapter cross-cutting governance as the next design-only gate |
+| G2.190 data-quality / adapter cross-cutting decision | For review | Classifies `get_data_quality_monitor` as `CRITICAL`, splits the route/adapter/wrapper surfaces, and selects G2.191 route-only authorization as the next gate |
 
 ## Current Strategy Getter Residuals
 
@@ -102,13 +103,29 @@ response-model declarations, OpenAPI examples, and src-level service getters.
 Post-merge smoke records `openapi_paths=500`, `stop_loss_paths=10`, and
 `dependency_params_leaked=0`.
 
+## G2.190 Data-Quality / Adapter Cross-Cutting Lane
+
+At HEAD `5565e2b0967958c406a4115dc840a9e90a0b2aab`, GitNexus classifies
+`get_data_quality_monitor` as `CRITICAL`: 20 direct callers, 24 impacted symbols,
+7 affected processes, and 4 affected modules.
+
+| Surface | Files | Getter calls | Current decision |
+|---|---:|---:|---|
+| Data-quality route | 1 | 6 | Select as the next route-only authorization package, not source implementation |
+| Split adapter constructors | 8 | 8 | Defer until interface / test-double design exists |
+| Legacy adapter compatibility | 5 | 5 | Defer to separate compatibility ownership decision |
+| Service wrapper / export | 2 | 2 | Retain until route and adapter consumers are migrated and verified |
+
+G2.190 does not authorize source edits. It recommends G2.191 as a
+data-quality route provider authorization package only.
+
 ## Next Gates
 
-- Review G2.189 risk stop-loss provider closeout / candidate refresh.
-- If accepted, start G2.190 data-quality / adapter cross-cutting decision
-  package as design / authorization only.
-- Do not start data-quality source implementation from G2.189.
-- Do not delete retained stop-loss provider backing getters.
+- Review G2.190 data-quality / adapter cross-cutting decision.
+- If accepted, start G2.191 data-quality route provider authorization package
+  only.
+- Do not start data-quality source implementation from G2.190.
+- Do not migrate adapter constructors or delete singleton wrappers from G2.190.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`
   restoration, or other risk route provider migrations.
 

--- a/docs/reports/quality/backend-data-quality-adapter-cross-cutting-decision-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-adapter-cross-cutting-decision-2026-05-28.md
@@ -1,0 +1,145 @@
+# Backend Data Quality / Adapter Cross-Cutting Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: review candidate
+- Prepared at: `2026-05-28T00:38:03+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `5565e2b0967958c406a4115dc840a9e90a0b2aab`
+- Worktree branch: `g2-190-data-quality-adapter-decision`
+- Scope: data-quality / adapter cross-cutting decision package
+- Source edit authority: none
+
+Boundary note: this package is a design and authorization input only. It does
+not authorize backend source edits, frontend edits, test edits, OpenSpec
+proposal creation, GitHub issue label changes, adapter constructor migration,
+singleton wrapper deletion, or data-quality source implementation.
+
+## Parent State
+
+| Item | State | Evidence |
+|---|---|---|
+| G2.189 stop-loss provider closeout / candidate refresh | Merged | PR `#342`, merge commit `5565e2b0967958c406a4115dc840a9e90a0b2aab` |
+| G2.190 data-quality / adapter cross-cutting decision | For review | This report plus `.planning/codebase/generated/data-quality-adapter-cross-cutting-decision-2026-05-28.json` |
+
+## Why This Is Not A Direct Implementation Lane
+
+`get_data_quality_monitor` is a cross-cutting service singleton surface, not a
+small route-local getter.
+
+GitNexus impact for
+`web/backend/app/services/_data_quality_monitor_singleton.py:get_data_quality_monitor`
+records:
+
+| Metric | Value |
+|---|---:|
+| Risk | `CRITICAL` |
+| Impacted symbols | 24 |
+| Direct callers | 20 |
+| Affected processes | 7 |
+| Affected modules | 4 |
+
+The affected modules span Services, Data_adapters, Api, and Adapters. That means
+this surface must be split into owner-specific lanes before source
+implementation. G2.190 therefore does not open a source lane.
+
+## Static Inventory
+
+Static inventory at HEAD `5565e2b0967958c406a4115dc840a9e90a0b2aab` found 16
+files touching the data-quality monitor surface, with 21
+`get_data_quality_monitor()` calls and 2 `monitor_data_quality()` calls.
+
+| Bucket | Files | Getter calls | Monitor calls | Handling |
+|---|---:|---:|---:|---|
+| Route surface | 1 | 6 | 1 | Candidate for the next route-only authorization package |
+| Split adapter constructors | 8 | 8 | 0 | Requires interface / test-double design before source edits |
+| Legacy adapter compatibility | 5 | 5 | 0 | Requires separate compatibility ownership decision |
+| Service wrapper / export | 2 | 2 | 1 | Retain until consumers are migrated and current HEAD proves no runtime consumers remain |
+
+## Route Surface
+
+`web/backend/app/api/data_quality.py` has 9 routes. Seven route handlers touch
+the monitor surface directly or through `monitor_data_quality()`.
+
+| Method | Path | Function | Getter calls | Monitor calls |
+|---|---|---|---:|---:|
+| `GET` | `/health` | `get_sources_health` | 0 | 0 |
+| `GET` | `/metrics` | `get_data_quality_metrics` | 1 | 0 |
+| `GET` | `/alerts` | `get_active_alerts` | 1 | 0 |
+| `POST` | `/alerts/{alert_id}/acknowledge` | `acknowledge_alert` | 1 | 0 |
+| `POST` | `/alerts/{alert_id}/resolve` | `resolve_alert` | 1 | 0 |
+| `GET` | `/config/mode` | `get_data_source_mode` | 0 | 0 |
+| `GET` | `/status/overview` | `get_system_status_overview` | 1 | 0 |
+| `POST` | `/test/quality` | `test_data_quality` | 0 | 1 |
+| `GET` | `/metrics/trends` | `get_quality_trends` | 1 | 0 |
+
+## Decision
+
+G2.190 classifies the data-quality monitor surface as a critical cross-cutting
+surface and rejects a single-batch implementation.
+
+The next gate should be:
+
+`G2.191 data-quality route provider authorization package`
+
+G2.191 should remain authorization-only. It should define the exact future
+source/test surface for a route-only provider migration before any backend source
+changes happen.
+
+## Track Split
+
+| Track | Surface | Sequence | Next gate |
+|---|---|---:|---|
+| Route provider | `web/backend/app/api/data_quality.py` | 1 | Prepare G2.191 route-only authorization package |
+| Split adapter constructor | `web/backend/app/services/adapters_split/*.py` | 2 | Interface / test-double design before adapter constructor source edits |
+| Legacy adapter compatibility | `web/backend/app/services/adapters/*.py`, `web/backend/app/services/data_adapters/*.py`, `web/backend/app/services/market_data_adapter.py` | 3 | Compatibility ownership decision before source edits |
+| Singleton wrapper retention | `web/backend/app/services/_data_quality_monitor_singleton.py` | 4 | Retain until route and adapter consumers are migrated and verified |
+
+## G2.191 Suggested Authorization Shape
+
+G2.191 may authorize a future source lane only after review. The suggested future
+implementation surface should be limited to:
+
+- `web/backend/app/api/data_quality.py`
+- focused data-quality route/provider regression tests
+- OpenAPI dependency leak smoke
+- `app.main` import / data-quality route registration smoke
+
+G2.191 must preserve:
+
+- route paths
+- HTTP methods
+- response models
+- OpenAPI examples
+- error response contract
+- data-source factory behavior
+- `DataQualityMonitor` backing singleton behavior
+
+G2.191 must not include:
+
+- adapter constructor migration
+- legacy adapter compatibility cleanup
+- `DataQualityMonitor` implementation rewrite
+- singleton wrapper deletion
+
+## Explicit Non-Goals
+
+- Do not edit backend source from G2.190.
+- Do not edit frontend source from G2.190.
+- Do not edit tests from G2.190.
+- Do not create or change OpenSpec proposals from G2.190.
+- Do not change GitHub issue or PR labels from G2.190.
+- Do not migrate adapter constructors from G2.190.
+- Do not delete `_data_quality_monitor_singleton.py`.
+- Do not start data-quality source implementation before a separate accepted
+  authorization package exists.
+
+## Evidence Artifacts
+
+| Artifact | Role |
+|---|---|
+| `.planning/codebase/generated/data-quality-adapter-cross-cutting-decision-2026-05-28.json` | G2.190 machine-readable decision evidence |
+| `docs/reports/quality/backend-data-quality-adapter-cross-cutting-decision-2026-05-28.md` | G2.190 human-readable decision package |
+| `governance/mainline/task-cards/pr-343.yaml` | G2.190 governance-only PR scope card |

--- a/governance/mainline/task-cards/pr-343.yaml
+++ b/governance/mainline/task-cards/pr-343.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-343"
+  title: "Decide data-quality adapter cross-cutting lifecycle path"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-adapter-cross-cutting-decision"
+  objective: "classify the get_data_quality_monitor cross-cutting surface and select the next governance-only route authorization gate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance decision package only; no runtime entrypoints, route paths, response models, frontend behavior, PM2 workflows, or public API ownership change"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-adapter-cross-cutting-decision-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-adapter-cross-cutting-decision-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-343.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "editing backend source"
+  - "editing frontend source"
+  - "editing tests"
+  - "migrating data-quality route handlers"
+  - "migrating adapter constructors"
+  - "deleting data-quality singleton wrapper or provider backing getters"
+  - "changing route paths, HTTP methods, response models, or OpenAPI examples"
+  - "creating OpenSpec proposals"
+  - "changing GitHub issue labels"
+  - "starting data-quality source implementation"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-adapter-cross-cutting-decision-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-343.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-data-quality-adapter-cross-cutting-decision-2026-05-28.md"
+      required: true
+    - id: "openspec-lifecycle-di"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-343.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 5565e2b0967958c406a4115dc840a9e90a0b2aab --head-sha HEAD --report /tmp/pr343-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this CRITICAL surface is misread as implementation authorization, adapter and route behavior could be changed without the required split plan."
+    - "If adapter constructor work is batched with route-provider work, the lifecycle migration can lose owner-specific rollback boundaries."
+  rollback_plan: "revert this governance-only PR to restore the prior steward tree and candidate-refresh state."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "classify get_data_quality_monitor as a critical cross-cutting surface and select a route-only authorization gate"
+    modified_scope: "governance tree files, one generated JSON evidence artifact, one quality report, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; singleton wrapper and adapter consumers remain unchanged"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if the steward tree misstates the CRITICAL risk or next-gate boundaries"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T00:38:03+08:00"
+    approval_note: "Human maintainer approved continuing after PR #342 merge; this lane is governance-only data-quality / adapter cross-cutting decision."
+    secondary_approved: true


### PR DESCRIPTION
## Summary
- classify get_data_quality_monitor as a CRITICAL cross-cutting lifecycle surface
- split the data-quality route, split adapter constructor, legacy adapter compatibility, and singleton wrapper tracks
- select G2.191 as the next data-quality route provider authorization package only

## Scope
Governance-only. No backend source, frontend source, tests, docs/api, OpenSpec change/spec, config, or scripts edits.

## Evidence
- GitNexus impact: CRITICAL, 24 impacted symbols, 20 direct callers, 7 affected processes, 4 affected modules
- static inventory: 16 files, 21 get_data_quality_monitor calls, 2 monitor_data_quality calls
- route surface: 9 data-quality routes, 7 routes touch the monitor surface

## Verification
- JSON/YAML parse checks passed
- Markdown governance gate: 6 checked, 0 errors
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: valid (PostHog telemetry ECONNREFUSED noise only)
- git diff --cached --check: passed before commit
- GitNexus staged detect_changes: low risk, 0 changed symbols, 0 affected processes
- mainline_scope_gate pr-343: pass=True

## Next Gate
If accepted, start G2.191 data-quality route provider authorization package only. Do not start source implementation from G2.190.