### PR TITLE
docs(governance): authorize data quality route provider

### DIFF
--- a/.planning/codebase/generated/data-quality-route-provider-authorization-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-route-provider-authorization-2026-05-28.json
@@ -1,0 +1,179 @@
+{
+  "schema_version": "2026-05-28.g2-191.authorization.v1",
+  "generated_at": "2026-05-28T01:04:38+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "7154ffbb067dcddc52d80f15342961b51234ac09",
+  "worktree_branch": "g2-191-data-quality-route-provider-authorization",
+  "scope": "data_quality_route_provider_authorization_package",
+  "source_edit_authority": false,
+  "parent": {
+    "id": "G2.190",
+    "description": "data-quality / adapter cross-cutting decision",
+    "github_pr": 343,
+    "merge_commit": "7154ffbb067dcddc52d80f15342961b51234ac09",
+    "merged_at": "2026-05-27T17:02:01Z"
+  },
+  "authorization_decision": {
+    "status": "review_candidate",
+    "authorizes_future_lane": "G2.192 data-quality route provider implementation",
+    "does_not_authorize_current_pr_source_edits": true,
+    "future_source_edit_authority_if_accepted": true,
+    "classification": "route-only-provider-implementation-authorization",
+    "source_lane_recommendation": "start-g2-192-only-after-g2-191-acceptance"
+  },
+  "target_surface": {
+    "route_file": "web/backend/app/api/data_quality.py",
+    "route_count": 9,
+    "routes_touching_monitor_surface": 7,
+    "current_route_get_data_quality_monitor_calls": 6,
+    "current_route_monitor_data_quality_calls": 1,
+    "provider_backing_getter": "get_data_quality_monitor",
+    "provider_backing_helper": "monitor_data_quality",
+    "singleton_wrapper": "web/backend/app/services/_data_quality_monitor_singleton.py",
+    "backing_class": "DataQualityMonitor"
+  },
+  "route_inventory": [
+    {
+      "method": "GET",
+      "path": "/health",
+      "function": "get_sources_health",
+      "getter_calls": 0,
+      "monitor_helper_calls": 0,
+      "authorized_for_future_change": false
+    },
+    {
+      "method": "GET",
+      "path": "/metrics",
+      "function": "get_data_quality_metrics",
+      "getter_calls": 1,
+      "monitor_helper_calls": 0,
+      "authorized_for_future_change": true
+    },
+    {
+      "method": "GET",
+      "path": "/alerts",
+      "function": "get_active_alerts",
+      "getter_calls": 1,
+      "monitor_helper_calls": 0,
+      "authorized_for_future_change": true
+    },
+    {
+      "method": "POST",
+      "path": "/alerts/{alert_id}/acknowledge",
+      "function": "acknowledge_alert",
+      "getter_calls": 1,
+      "monitor_helper_calls": 0,
+      "authorized_for_future_change": true
+    },
+    {
+      "method": "POST",
+      "path": "/alerts/{alert_id}/resolve",
+      "function": "resolve_alert",
+      "getter_calls": 1,
+      "monitor_helper_calls": 0,
+      "authorized_for_future_change": true
+    },
+    {
+      "method": "GET",
+      "path": "/config/mode",
+      "function": "get_data_source_mode",
+      "getter_calls": 0,
+      "monitor_helper_calls": 0,
+      "authorized_for_future_change": false
+    },
+    {
+      "method": "GET",
+      "path": "/status/overview",
+      "function": "get_system_status_overview",
+      "getter_calls": 1,
+      "monitor_helper_calls": 0,
+      "authorized_for_future_change": true
+    },
+    {
+      "method": "POST",
+      "path": "/test/quality",
+      "function": "test_data_quality",
+      "getter_calls": 0,
+      "monitor_helper_calls": 1,
+      "authorized_for_future_change": true
+    },
+    {
+      "method": "GET",
+      "path": "/metrics/trends",
+      "function": "get_quality_trends",
+      "getter_calls": 1,
+      "monitor_helper_calls": 0,
+      "authorized_for_future_change": true
+    }
+  ],
+  "future_g2_192_allowed_scope": {
+    "source_paths": [
+      "web/backend/app/api/data_quality.py"
+    ],
+    "test_paths": [
+      "web/backend/tests/test_data_quality_mock_configuration.py",
+      "web/backend/tests/test_data_quality_route_provider_regressions.py",
+      "tests/unit/contract/test_data_quality_router_runtime_import.py"
+    ],
+    "governance_paths": [
+      ".planning/codebase/generated/data-quality-route-provider-implementation-2026-05-28.json",
+      "docs/reports/quality/backend-data-quality-route-provider-implementation-2026-05-28.md",
+      "governance/mainline/task-cards/pr-345.yaml",
+      ".planning/codebase/steward-tree/current-next-gates.md",
+      ".planning/codebase/steward-tree/steward-index.json",
+      ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+      ".planning/codebase/steward-tree/branch-register.md",
+      ".planning/codebase/steward-tree/evidence-index.md",
+      ".planning/codebase/steward-tree/completed-ledger.md"
+    ],
+    "explicitly_forbidden_paths": [
+      "web/backend/app/services/_data_quality_monitor_singleton.py",
+      "web/backend/app/services/data_quality_monitor.py",
+      "web/backend/app/services/adapters_split/**",
+      "web/backend/app/services/adapters/**",
+      "web/backend/app/services/data_adapters/**",
+      "web/backend/app/services/market_data_adapter.py",
+      "web/frontend/**",
+      "src/**",
+      "docs/api/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ]
+  },
+  "future_g2_192_must_preserve": [
+    "route paths",
+    "HTTP methods",
+    "response models",
+    "OpenAPI examples",
+    "error response contract",
+    "data-source factory behavior",
+    "DataQualityMonitor backing singleton behavior",
+    "direct route test compatibility where existing tests call route functions directly"
+  ],
+  "future_g2_192_required_checks": [
+    "GitNexus impact/context before source edits, with explicit CRITICAL risk acknowledgement",
+    "TDD red/green route-provider regression test",
+    "focused data-quality route/provider regression tests",
+    "OpenAPI dependency leak smoke proving monitor/provider params do not appear in schema",
+    "app.main import / data-quality route registration smoke with required environment available",
+    "ruff check for touched route and test files",
+    "GitNexus staged detect_changes before commit",
+    "mainline scope gate for the implementation PR"
+  ],
+  "current_blockers_or_preconditions": [
+    {
+      "item": "app.openapi smoke from clean G2.191 worktree",
+      "status": "blocked by missing local environment file",
+      "details": "The clean G2.191 worktree has .env.example but no .env. app.main import reports missing POSTGRESQL_HOST, POSTGRESQL_USER, POSTGRESQL_PASSWORD, JWT_SECRET_KEY, BACKEND_PORT, and BACKEND_BACKUP_PORT."
+    }
+  ],
+  "deferred_surfaces": [
+    "adapter constructor migration",
+    "legacy adapter compatibility ownership",
+    "singleton wrapper retention / eventual retirement",
+    "DataQualityMonitor implementation changes",
+    "frontend or docs/api contract changes"
+  ],
+  "next_gate": "If accepted, start G2.192 data-quality route provider implementation lane. Do not edit source from G2.191."
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T00:38:03+08:00`
-- Base HEAD checked: `5565e2b0967958c406a4115dc840a9e90a0b2aab`
+- Prepared at: `2026-05-28T01:04:38+08:00`
+- Base HEAD checked: `7154ffbb067dcddc52d80f15342961b51234ac09`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -27,12 +27,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#340` | `g2-187-risk-stop-loss-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a` | Authorization package for G2.188 stop-loss route provider implementation |
 | `#341` | `g2-188-risk-stop-loss-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `0aac0e16f16480bd99eebb8726e21a7db6566b39` | Path-limited stop-loss route provider implementation closed for G2.189 refresh |
 | `#342` | `g2-189-risk-stop-loss-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `5565e2b0967958c406a4115dc840a9e90a0b2aab` | Governance closeout and candidate refresh selecting data-quality / adapter cross-cutting decision |
+| `#343` | `g2-190-data-quality-adapter-decision` | `wip/root-dirty-20260403` | `MERGED` at `7154ffbb067dcddc52d80f15342961b51234ac09` | Governance decision classifying data-quality / adapter monitor surface as cross-cutting |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-190-data-quality-adapter-decision` | `origin/wip/root-dirty-20260403` at `5565e2b0967958c406a4115dc840a9e90a0b2aab` | Classify the `get_data_quality_monitor` cross-cutting surface and select the next route-only authorization gate | None; governance decision package only |
+| `g2-191-data-quality-route-provider-authorization` | `origin/wip/root-dirty-20260403` at `7154ffbb067dcddc52d80f15342961b51234ac09` | Authorize a future route-only data-quality provider implementation lane without source edits in this PR | None in this PR; future G2.192 source lane only after acceptance |
 
 ## OpenSpec Relationship
 
@@ -48,8 +49,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.190 is a governance-only decision branch after PR `#342` merged G2.189. It
-must not edit backend source, frontend source, tests, OpenSpec changes, or API
-contract files. The next recommended lane is G2.191 data-quality route provider
-authorization only; source implementation remains blocked until a separate
-authorization package is accepted.
+G2.191 is a governance-only authorization branch after PR `#343` merged G2.190.
+It must not edit backend source, frontend source, tests, OpenSpec changes, or
+API contract files. If accepted, it authorizes G2.192 as a route-only
+implementation lane for `web/backend/app/api/data_quality.py` and focused tests.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T00:38:03+08:00`
-- Base HEAD checked: `5565e2b0967958c406a4115dc840a9e90a0b2aab`
+- Prepared at: `2026-05-28T01:04:38+08:00`
+- Base HEAD checked: `7154ffbb067dcddc52d80f15342961b51234ac09`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 is the active governance-only data-quality / adapter cross-cutting decision candidate |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 is the active governance-only data-quality route provider authorization candidate |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T00:38:03+08:00`
-- Base HEAD checked: `5565e2b0967958c406a4115dc840a9e90a0b2aab`
+- Prepared at: `2026-05-28T01:04:38+08:00`
+- Base HEAD checked: `7154ffbb067dcddc52d80f15342961b51234ac09`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.190 data-quality / adapter cross-cutting decision | G/#79 service lifecycle DI | PR `#342` merged at `5565e2b0967958c406a4115dc840a9e90a0b2aab`; `get_data_quality_monitor` is `CRITICAL` with 20 direct callers across route, adapter, legacy adapter, and wrapper surfaces | If accepted, start G2.191 data-quality route provider authorization package only |
+| P0 | Review G2.191 data-quality route provider authorization | G/#79 service lifecycle DI | PR `#343` merged at `7154ffbb067dcddc52d80f15342961b51234ac09`; G2.191 authorizes only a future route-file implementation lane and keeps current PR source authority at none | If accepted, start G2.192 data-quality route provider implementation lane |
+| P0 | Preserve G2.190 data-quality / adapter cross-cutting decision | G/#79 service lifecycle DI | PR `#343` merged; `get_data_quality_monitor` is `CRITICAL` with 20 direct callers across route, adapter, legacy adapter, and wrapper surfaces | Do not batch route, adapter constructor, legacy adapter, and singleton wrapper migration together |
 | P0 | Preserve G2.189 risk stop-loss provider closeout / candidate refresh | G/#79 service lifecycle DI | PR `#342` merged; stop-loss pair is closed for route-body provider migration and retained as provider backing getters | Do not reopen stop-loss or start data-quality source implementation from G2.189 |
 | P0 | Preserve G2.188 risk stop-loss route service provider implementation | G/#79 service lifecycle DI | PR `#341` merged; G2.188 closed the stop-loss route-body provider migration while retaining src-level stop-loss provider backing getters | Do not delete retained getters or expand into alerts, legacy `app.api.risk_management`, or other risk route migrations |
 | P0 | Preserve G2.187 risk stop-loss route service provider authorization | G/#79 service lifecycle DI | PR `#340` merged; G2.187 authorized only `web/backend/app/api/risk/stop_loss.py` plus focused tests for G2.188 | Do not expand G2.188 into alerts resolver, legacy `app.api.risk_management`, or other risk route migrations |
@@ -32,8 +33,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.190 correctly classify `get_data_quality_monitor` as `CRITICAL`, not a low-risk source candidate?
-- Does G2.190 split route, adapter constructor, legacy adapter, and singleton wrapper surfaces instead of batching them?
-- Is G2.191 limited to route-provider authorization only, with no source implementation from G2.190?
-- Are adapter constructor migration and singleton wrapper deletion explicitly deferred?
+- Does G2.191 clearly authorize only a future G2.192 implementation lane, not source edits in PR `#344`?
+- Is the future G2.192 scope limited to `web/backend/app/api/data_quality.py` and focused route/provider tests?
+- Are adapter constructor migration, legacy adapter compatibility, and singleton wrapper deletion explicitly forbidden?
+- Does G2.191 require OpenAPI dependency leak and `app.main` smoke with a valid runtime environment before G2.192 merge?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T00:38:03+08:00`
-- Base HEAD checked: `5565e2b0967958c406a4115dc840a9e90a0b2aab`
+- Prepared at: `2026-05-28T01:04:38+08:00`
+- Base HEAD checked: `7154ffbb067dcddc52d80f15342961b51234ac09`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -43,6 +43,8 @@ state transition.
 | `docs/reports/quality/backend-risk-stop-loss-provider-closeout-refresh-2026-05-28.md` | G2.189 human-readable closeout and candidate-refresh report | Review input until PR `#342` is accepted |
 | `.planning/codebase/generated/data-quality-adapter-cross-cutting-decision-2026-05-28.json` | G2.190 data-quality / adapter cross-cutting decision evidence | Current for HEAD `5565e2b0967958c406a4115dc840a9e90a0b2aab`; review input until PR `#343` is accepted |
 | `docs/reports/quality/backend-data-quality-adapter-cross-cutting-decision-2026-05-28.md` | G2.190 human-readable decision package | Review input until PR `#343` is accepted |
+| `.planning/codebase/generated/data-quality-route-provider-authorization-2026-05-28.json` | G2.191 data-quality route provider authorization evidence | Current for HEAD `7154ffbb067dcddc52d80f15342961b51234ac09`; review input until PR `#344` is accepted |
+| `docs/reports/quality/backend-data-quality-route-provider-authorization-2026-05-28.md` | G2.191 human-readable authorization package | Review input until PR `#344` is accepted |
 
 ## External State Inputs
 
@@ -56,7 +58,8 @@ state transition.
 | GitHub PR `#340` | `MERGED` | G2.187 stop-loss route provider authorization merged by commit `2d3b9c7e3ff30c81a19d51e66c32d2c06c1e1c4a` |
 | GitHub PR `#341` | `MERGED` | G2.188 stop-loss route provider implementation merged by commit `0aac0e16f16480bd99eebb8726e21a7db6566b39` |
 | GitHub PR `#342` | `MERGED` | G2.189 stop-loss provider closeout / candidate refresh merged by commit `5565e2b0967958c406a4115dc840a9e90a0b2aab` |
-| `origin/wip/root-dirty-20260403` | `5565e2b0967958c406a4115dc840a9e90a0b2aab` | Base used for this decision branch |
+| GitHub PR `#343` | `MERGED` | G2.190 data-quality / adapter decision merged by commit `7154ffbb067dcddc52d80f15342961b51234ac09` |
+| `origin/wip/root-dirty-20260403` | `7154ffbb067dcddc52d80f15342961b51234ac09` | Base used for this authorization branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T00:38:03+08:00",
+  "generated_at": "2026-05-28T01:04:38+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "5565e2b0967958c406a4115dc840a9e90a0b2aab",
-  "split_branch": "g2-190-data-quality-adapter-decision",
-  "scope": "data_quality_adapter_cross_cutting_decision_package",
+  "base_head": "7154ffbb067dcddc52d80f15342961b51234ac09",
+  "split_branch": "g2-191-data-quality-route-provider-authorization",
+  "scope": "data_quality_route_provider_authorization_package",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -711,9 +711,17 @@
     {
       "id": "g2-190-data-quality-adapter-decision",
       "type": "decision_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.189 risk stop-loss provider closeout / candidate refresh",
+      "github_pr": {
+        "number": 343,
+        "url": "https://github.com/chengjon/mystocks/pull/343",
+        "state": "MERGED",
+        "merged_at": "2026-05-27T17:02:01Z",
+        "head_ref": "g2-190-data-quality-adapter-decision",
+        "merge_commit": "7154ffbb067dcddc52d80f15342961b51234ac09"
+      },
       "source_edit_authority": false,
       "evidence": [
         ".planning/codebase/generated/data-quality-adapter-cross-cutting-decision-2026-05-28.json",
@@ -767,10 +775,71 @@
         ]
       },
       "freshness": {
-        "current_head_checked": "5565e2b0967958c406a4115dc840a9e90a0b2aab",
+        "current_head_checked": "7154ffbb067dcddc52d80f15342961b51234ac09",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.191 data-quality route provider authorization package only; do not start source implementation from G2.190."
+      "next_gate": "Superseded by G2.191 data-quality route provider authorization."
+    },
+    {
+      "id": "g2-191-data-quality-route-provider-authorization",
+      "type": "authorization_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.190 data-quality / adapter cross-cutting decision",
+      "source_edit_authority": false,
+      "future_source_edit_authority_if_accepted": true,
+      "evidence": [
+        ".planning/codebase/generated/data-quality-route-provider-authorization-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-route-provider-authorization-2026-05-28.md",
+        "governance/mainline/task-cards/pr-344.yaml"
+      ],
+      "authorized_future_lane": {
+        "id": "g2-192-data-quality-route-provider-implementation",
+        "source_paths": [
+          "web/backend/app/api/data_quality.py"
+        ],
+        "test_paths": [
+          "web/backend/tests/test_data_quality_mock_configuration.py",
+          "web/backend/tests/test_data_quality_route_provider_regressions.py",
+          "tests/unit/contract/test_data_quality_router_runtime_import.py"
+        ],
+        "forbidden_paths": [
+          "web/backend/app/services/_data_quality_monitor_singleton.py",
+          "web/backend/app/services/data_quality_monitor.py",
+          "web/backend/app/services/adapters_split/**",
+          "web/backend/app/services/adapters/**",
+          "web/backend/app/services/data_adapters/**",
+          "web/backend/app/services/market_data_adapter.py",
+          "web/frontend/**",
+          "src/**",
+          "docs/api/**",
+          "openspec/changes/**",
+          "openspec/specs/**"
+        ]
+      },
+      "route_surface": {
+        "route_count": 9,
+        "routes_touching_monitor_surface": 7,
+        "current_get_data_quality_monitor_calls": 6,
+        "current_monitor_data_quality_calls": 1
+      },
+      "required_future_checks": [
+        "GitNexus impact/context before source edits with CRITICAL risk acknowledgement",
+        "TDD route-provider regression",
+        "OpenAPI dependency leak smoke",
+        "app.main import / route registration smoke with required environment available",
+        "ruff check touched route and test files",
+        "GitNexus staged detect_changes",
+        "mainline scope gate"
+      ],
+      "preconditions": [
+        "Clean G2.191 worktree app.openapi smoke is blocked by missing local .env; G2.192 needs required environment or approved named equivalent before smoke evidence is valid."
+      ],
+      "freshness": {
+        "current_head_checked": "7154ffbb067dcddc52d80f15342961b51234ac09",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.192 data-quality route provider implementation lane; do not edit source from G2.191."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T00:38:03+08:00`
-- Base HEAD checked: `5565e2b0967958c406a4115dc840a9e90a0b2aab`
+- Prepared at: `2026-05-28T01:04:38+08:00`
+- Base HEAD checked: `7154ffbb067dcddc52d80f15342961b51234ac09`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -42,7 +42,8 @@ It proved a repeatable conveyor:
 | G2.187 risk stop-loss route provider authorization | Merged by PR `#340` | Defines the future G2.188 implementation scope for stop-loss route provider injection without source edits in that PR |
 | G2.188 risk stop-loss route provider implementation | Merged by PR `#341` | Implements the authorized provider injection in `web/backend/app/api/risk/stop_loss.py`; post-merge stop-loss tests and OpenAPI dependency leak smoke pass |
 | G2.189 risk stop-loss provider closeout / candidate refresh | Merged by PR `#342` | Records PR `#341` closeout, marks the stop-loss pair closed for route-body provider migration, and selects data-quality / adapter cross-cutting governance as the next design-only gate |
-| G2.190 data-quality / adapter cross-cutting decision | For review | Classifies `get_data_quality_monitor` as `CRITICAL`, splits the route/adapter/wrapper surfaces, and selects G2.191 route-only authorization as the next gate |
+| G2.190 data-quality / adapter cross-cutting decision | Merged by PR `#343` | Classifies `get_data_quality_monitor` as `CRITICAL`, splits the route/adapter/wrapper surfaces, and selects G2.191 route-only authorization as the next gate |
+| G2.191 data-quality route provider authorization | For review | Authorizes a future G2.192 route-only implementation lane for `web/backend/app/api/data_quality.py` and focused tests, with no source edits in G2.191 |
 
 ## Current Strategy Getter Residuals
 
@@ -119,13 +120,31 @@ At HEAD `5565e2b0967958c406a4115dc840a9e90a0b2aab`, GitNexus classifies
 G2.190 does not authorize source edits. It recommends G2.191 as a
 data-quality route provider authorization package only.
 
+## G2.191 Data-Quality Route Provider Authorization
+
+At HEAD `7154ffbb067dcddc52d80f15342961b51234ac09`,
+`web/backend/app/api/data_quality.py` has 9 route handlers. Seven touch the
+data-quality monitor surface: 6 direct `get_data_quality_monitor()` calls and 1
+`monitor_data_quality()` helper call.
+
+| Future G2.192 surface | Current count | Authorization |
+|---|---:|---|
+| Route file | 1 | `web/backend/app/api/data_quality.py` only |
+| Route handlers touching monitor surface | 7 | Allowed for provider injection |
+| Focused tests | 3 path candidates | Allowed only for route/provider regression, OpenAPI leak, and import smoke coverage |
+| Adapter / legacy adapter / singleton wrapper surfaces | 0 allowed | Explicitly forbidden |
+
+G2.191 does not authorize current-PR source edits. If accepted, it authorizes
+G2.192 as a path-limited source lane. G2.192 must preserve route paths, HTTP
+methods, response models, OpenAPI examples, error response contract, data-source
+factory behavior, and current `DataQualityMonitor` backing singleton behavior.
+
 ## Next Gates
 
-- Review G2.190 data-quality / adapter cross-cutting decision.
-- If accepted, start G2.191 data-quality route provider authorization package
-  only.
-- Do not start data-quality source implementation from G2.190.
-- Do not migrate adapter constructors or delete singleton wrappers from G2.190.
+- Review G2.191 data-quality route provider authorization package.
+- If accepted, start G2.192 data-quality route provider implementation lane.
+- Do not start G2.192 before G2.191 is accepted.
+- Do not migrate adapter constructors or delete singleton wrappers from G2.191.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`
   restoration, or other risk route provider migrations.
 

--- a/docs/reports/quality/backend-data-quality-route-provider-authorization-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-route-provider-authorization-2026-05-28.md
@@ -1,0 +1,137 @@
+# Backend Data Quality Route Provider Authorization
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: review candidate
+- Prepared at: `2026-05-28T01:04:38+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `7154ffbb067dcddc52d80f15342961b51234ac09`
+- Worktree branch: `g2-191-data-quality-route-provider-authorization`
+- Scope: data-quality route provider authorization package
+- Source edit authority in this PR: none
+
+Boundary note: this package authorizes a future route-only implementation lane
+only if reviewed and accepted. It does not itself authorize backend source
+edits, frontend edits, test edits, OpenSpec proposal creation, GitHub issue label
+changes, adapter constructor migration, singleton wrapper deletion, or
+data-quality source implementation inside G2.191.
+
+## Parent State
+
+| Item | State | Evidence |
+|---|---|---|
+| G2.190 data-quality / adapter cross-cutting decision | Merged | PR `#343`, merge commit `7154ffbb067dcddc52d80f15342961b51234ac09` |
+| G2.191 data-quality route provider authorization | For review | This report plus `.planning/codebase/generated/data-quality-route-provider-authorization-2026-05-28.json` |
+
+## Authorization Decision
+
+If accepted, G2.191 authorizes a future `G2.192 data-quality route provider
+implementation` lane. The future lane may only target the route surface in
+`web/backend/app/api/data_quality.py` plus focused route/provider tests and
+governance evidence.
+
+G2.191 does not authorize source edits in this PR.
+
+## Authorized Future Source Surface
+
+| Surface | Future G2.192 authorization |
+|---|---|
+| `web/backend/app/api/data_quality.py` | Allowed |
+| `web/backend/tests/test_data_quality_mock_configuration.py` | Allowed if needed for focused regression coverage |
+| `web/backend/tests/test_data_quality_route_provider_regressions.py` | Allowed as a new focused regression test file |
+| `tests/unit/contract/test_data_quality_router_runtime_import.py` | Allowed as a new focused import / route-registration contract test |
+| `web/backend/app/services/_data_quality_monitor_singleton.py` | Forbidden |
+| `web/backend/app/services/data_quality_monitor.py` | Forbidden |
+| `web/backend/app/services/adapters_split/**` | Forbidden |
+| `web/backend/app/services/adapters/**` | Forbidden |
+| `web/backend/app/services/data_adapters/**` | Forbidden |
+| `web/backend/app/services/market_data_adapter.py` | Forbidden |
+
+## Route Inventory
+
+At HEAD `7154ffbb067dcddc52d80f15342961b51234ac09`,
+`web/backend/app/api/data_quality.py` has 9 route handlers. Seven touch the
+data-quality monitor surface.
+
+| Method | Path | Function | Getter calls | Monitor helper calls | Future G2.192 change allowed |
+|---|---|---|---:|---:|---|
+| `GET` | `/health` | `get_sources_health` | 0 | 0 | No |
+| `GET` | `/metrics` | `get_data_quality_metrics` | 1 | 0 | Yes |
+| `GET` | `/alerts` | `get_active_alerts` | 1 | 0 | Yes |
+| `POST` | `/alerts/{alert_id}/acknowledge` | `acknowledge_alert` | 1 | 0 | Yes |
+| `POST` | `/alerts/{alert_id}/resolve` | `resolve_alert` | 1 | 0 | Yes |
+| `GET` | `/config/mode` | `get_data_source_mode` | 0 | 0 | No |
+| `GET` | `/status/overview` | `get_system_status_overview` | 1 | 0 | Yes |
+| `POST` | `/test/quality` | `test_data_quality` | 0 | 1 | Yes |
+| `GET` | `/metrics/trends` | `get_quality_trends` | 1 | 0 | Yes |
+
+The future implementation should preserve the current backing singleton
+semantics. `get_data_quality_monitor` and `monitor_data_quality` remain retained
+provider/backing helpers until route and adapter consumers are separately
+migrated and current HEAD proves no runtime consumers remain.
+
+## Required Future G2.192 Checks
+
+The future G2.192 implementation lane must run these checks before merge:
+
+- GitNexus impact/context before source edits, with explicit acknowledgement
+  that the broader `get_data_quality_monitor` surface is `CRITICAL`.
+- TDD red/green route-provider regression test.
+- Focused data-quality route/provider regression tests.
+- OpenAPI dependency leak smoke proving monitor/provider params do not appear in
+  the schema.
+- `app.main` import / data-quality route registration smoke with required
+  environment available.
+- `ruff check` for touched route and test files.
+- GitNexus staged `detect_changes` before commit.
+- Mainline scope gate for the implementation PR.
+
+## Current Precondition Note
+
+The clean G2.191 worktree has `.env.example` but no `.env`. A direct
+`app.openapi()` smoke from this clean worktree is blocked by missing required
+environment variables:
+
+- `POSTGRESQL_HOST`
+- `POSTGRESQL_USER`
+- `POSTGRESQL_PASSWORD`
+- `JWT_SECRET_KEY`
+- `BACKEND_PORT`
+- `BACKEND_BACKUP_PORT`
+
+G2.192 should provide the required runtime environment or use an approved named
+equivalent before treating OpenAPI or `app.main` smoke as valid evidence.
+
+## Explicit Non-Goals
+
+- Do not edit backend source from G2.191.
+- Do not edit frontend source from G2.191.
+- Do not edit tests from G2.191.
+- Do not create or change OpenSpec proposals from G2.191.
+- Do not change GitHub issue or PR labels from G2.191.
+- Do not migrate adapter constructors from G2.191.
+- Do not edit legacy adapter compatibility surfaces from G2.191.
+- Do not delete `_data_quality_monitor_singleton.py`.
+- Do not rewrite `DataQualityMonitor`.
+
+## Next Gate
+
+If G2.191 is accepted, start:
+
+`G2.192 data-quality route provider implementation`
+
+G2.192 should be a path-limited implementation lane and must not expand into
+adapter constructors, legacy adapters, singleton wrapper deletion, or
+`DataQualityMonitor` internals.
+
+## Evidence Artifacts
+
+| Artifact | Role |
+|---|---|
+| `.planning/codebase/generated/data-quality-adapter-cross-cutting-decision-2026-05-28.json` | G2.190 cross-cutting decision evidence |
+| `docs/reports/quality/backend-data-quality-adapter-cross-cutting-decision-2026-05-28.md` | G2.190 human-readable decision package |
+| `.planning/codebase/generated/data-quality-route-provider-authorization-2026-05-28.json` | G2.191 machine-readable authorization evidence |
+| `docs/reports/quality/backend-data-quality-route-provider-authorization-2026-05-28.md` | G2.191 human-readable authorization package |
+| `governance/mainline/task-cards/pr-344.yaml` | G2.191 governance-only PR scope card |

--- a/governance/mainline/task-cards/pr-344.yaml
+++ b/governance/mainline/task-cards/pr-344.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-344"
+  title: "Authorize data-quality route provider implementation"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-route-provider-authorization"
+  objective: "authorize the future route-only data-quality provider implementation lane without source edits in this PR"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization package only; no runtime entrypoints, route paths, response models, frontend behavior, PM2 workflows, or public API ownership change"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-route-provider-authorization-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-route-provider-authorization-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-344.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "editing backend source"
+  - "editing frontend source"
+  - "editing tests"
+  - "migrating data-quality route handlers in this PR"
+  - "migrating adapter constructors"
+  - "deleting data-quality singleton wrapper or provider backing getters"
+  - "changing route paths, HTTP methods, response models, or OpenAPI examples"
+  - "creating OpenSpec proposals"
+  - "changing GitHub issue labels"
+  - "starting data-quality source implementation before this authorization is accepted"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-route-provider-authorization-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-344.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-data-quality-route-provider-authorization-2026-05-28.md"
+      required: true
+    - id: "openspec-lifecycle-di"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-344.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 7154ffbb067dcddc52d80f15342961b51234ac09 --head-sha HEAD --report /tmp/pr344-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If this authorization is read as current-PR implementation permission, source could be changed before the future G2.192 implementation lane exists."
+    - "If the route-only scope expands into adapters or singleton wrapper deletion, the CRITICAL cross-cutting surface loses rollback boundaries."
+  rollback_plan: "revert this governance-only PR to remove the future source authorization and restore G2.190 as the active decision point."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize a future route-only data-quality provider implementation lane"
+    modified_scope: "governance tree files, one generated JSON evidence artifact, one quality report, and this task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; singleton wrapper, adapters, route behavior, and tests remain unchanged in this PR"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if the authorization scope is too broad or current-PR source edits are needed"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T01:04:38+08:00"
+    approval_note: "Human maintainer approved continuing after PR #343 merge; this lane is governance-only route provider authorization."
+    secondary_approved: true


### PR DESCRIPTION
## Summary
- authorize future G2.192 data-quality route provider implementation only
- limit the future source surface to web/backend/app/api/data_quality.py plus focused route/provider tests
- explicitly forbid adapter constructor migration, legacy adapter compatibility edits, singleton wrapper deletion, and DataQualityMonitor internals

## Scope
Governance-only. No backend source, frontend source, tests, docs/api, OpenSpec change/spec, config, or scripts edits in this PR.

## Evidence
- G2.190 is merged by PR #343 at 7154ffbb067dcddc52d80f15342961b51234ac09
- route inventory: 9 data-quality routes; 7 touch the monitor surface
- current route calls: 6 get_data_quality_monitor calls and 1 monitor_data_quality helper call
- clean-worktree app.openapi smoke is blocked by missing local .env; future G2.192 must provide required env or approved named equivalent

## Verification
- JSON/YAML parse checks passed
- Markdown governance gate: 6 checked, 0 errors
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: valid (PostHog telemetry ECONNREFUSED noise only)
- git diff --cached --check: passed before commit
- GitNexus staged detect_changes: low risk, 0 changed symbols, 0 affected processes
- mainline_scope_gate pr-344: pass=True

## Next Gate
If accepted, start G2.192 data-quality route provider implementation. Do not edit source from G2.191.