### PR TITLE
docs(governance): close data quality route provider lane

### DIFF
--- a/.planning/codebase/generated/data-quality-route-provider-closeout-refresh-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-route-provider-closeout-refresh-2026-05-28.json
@@ -1,0 +1,124 @@
+{
+  "schema_version": "2026-05-28.g2-193.closeout-refresh.v1",
+  "generated_at": "2026-05-28T01:52:33+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "2b0c3ce373fba38bacd62eff5436822527dccda1",
+  "worktree_branch": "g2-193-data-quality-route-provider-closeout-refresh",
+  "scope": "governance_only_data_quality_route_provider_closeout_refresh",
+  "source_edit_authority": false,
+  "parent": {
+    "id": "G2.192",
+    "description": "data-quality route provider implementation",
+    "github_pr": 345,
+    "merge_commit": "2b0c3ce373fba38bacd62eff5436822527dccda1",
+    "merged_at": "2026-05-27T17:49:25Z"
+  },
+  "closeout_result": {
+    "route_provider_surface": "closed_for_route_body_provider_migration",
+    "route_file": "web/backend/app/api/data_quality.py",
+    "provider_definitions": {
+      "get_data_quality_monitor_provider": 1,
+      "_resolve_direct_call_dependency": 1
+    },
+    "route_body_get_data_quality_monitor_calls": 0,
+    "route_body_monitor_data_quality_calls": 0,
+    "route_file_get_data_quality_monitor_calls": 1,
+    "route_file_monitor_data_quality_calls": 0,
+    "depends_provider_params": 7,
+    "direct_call_fallbacks": 7
+  },
+  "verification": {
+    "focused_tests": {
+      "command": "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_route_provider_regressions.py web/backend/tests/test_data_quality_mock_configuration.py tests/unit/contract/test_data_quality_router_runtime_import.py -q --tb=short --disable-warnings --no-cov",
+      "result": "7 passed"
+    },
+    "openapi_smoke": {
+      "environment": "approved dummy local environment variables for required settings only; repository root and web/backend on PYTHONPATH",
+      "openapi_paths": 500,
+      "data_quality_paths": 9,
+      "dependency_params_leaked": 0
+    },
+    "github_pr_345": {
+      "state": "MERGED",
+      "checks": "all observed checks passed or skipped before merge"
+    }
+  },
+  "remaining_surface_refresh": {
+    "scan_scope": [
+      "web/backend/app/api",
+      "web/backend/app/services"
+    ],
+    "totals_by_bucket": {
+      "route": {
+        "files": 1,
+        "get_data_quality_monitor_calls": 1,
+        "monitor_data_quality_calls": 0,
+        "classification": "provider backing getter retained, route-body migration closed"
+      },
+      "adapter_split": {
+        "files": 8,
+        "get_data_quality_monitor_calls": 8,
+        "monitor_data_quality_calls": 0,
+        "classification": "remaining adapter constructor seam"
+      },
+      "service_adapter": {
+        "files": 2,
+        "get_data_quality_monitor_calls": 2,
+        "monitor_data_quality_calls": 0,
+        "classification": "remaining adapter compatibility seam"
+      },
+      "legacy_adapter": {
+        "files": 2,
+        "get_data_quality_monitor_calls": 2,
+        "monitor_data_quality_calls": 0,
+        "classification": "remaining legacy adapter compatibility seam"
+      },
+      "other": {
+        "files": 1,
+        "get_data_quality_monitor_calls": 1,
+        "monitor_data_quality_calls": 0,
+        "classification": "market_data_adapter compatibility surface"
+      },
+      "service_wrapper": {
+        "files": 1,
+        "get_data_quality_monitor_calls": 2,
+        "monitor_data_quality_calls": 1,
+        "classification": "retained singleton wrapper / backing API"
+      }
+    },
+    "remaining_rows": [
+      "web/backend/app/services/adapters_split/base_adapter.py",
+      "web/backend/app/services/adapters_split/baostock_adapter.py",
+      "web/backend/app/services/adapters_split/tushare_adapter.py",
+      "web/backend/app/services/adapters_split/customer_adapter.py",
+      "web/backend/app/services/adapters_split/byapi_adapter.py",
+      "web/backend/app/services/adapters_split/akshare_adapter.py",
+      "web/backend/app/services/adapters_split/efinance_adapter.py",
+      "web/backend/app/services/adapters_split/tdx_adapter.py",
+      "web/backend/app/services/adapters/dashboard_adapter.py",
+      "web/backend/app/services/adapters/data_adapter.py",
+      "web/backend/app/services/data_adapters/data_source.py",
+      "web/backend/app/services/data_adapters/dashboard.py",
+      "web/backend/app/services/market_data_adapter.py",
+      "web/backend/app/services/_data_quality_monitor_singleton.py"
+    ]
+  },
+  "decision": {
+    "classification": "route-provider-closeout-complete-remaining-adapter-seams-deferred",
+    "source_lane_recommendation": "do-not-start-source-implementation-from-g2-193",
+    "selected_next_governance_target": "data-quality-adapter-constructor-seam-design",
+    "recommended_next_work_item": "G2.194 data-quality adapter constructor seam design / test-double decision package"
+  },
+  "explicit_non_goals": [
+    "adapter constructor implementation",
+    "legacy adapter compatibility edits",
+    "singleton wrapper deletion",
+    "DataQualityMonitor internals",
+    "frontend edits",
+    "src edits",
+    "docs/api edits",
+    "OpenSpec change/spec edits"
+  ],
+  "next_gate": "If accepted, start G2.194 data-quality adapter constructor seam design / test-double decision package; do not implement adapter changes from G2.193."
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T01:22:05+08:00`
-- Base HEAD checked: `b899a173909d3818370dddbf35b039832266bd1d`
+- Prepared at: `2026-05-28T01:52:33+08:00`
+- Base HEAD checked: `2b0c3ce373fba38bacd62eff5436822527dccda1`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -29,12 +29,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#342` | `g2-189-risk-stop-loss-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `5565e2b0967958c406a4115dc840a9e90a0b2aab` | Governance closeout and candidate refresh selecting data-quality / adapter cross-cutting decision |
 | `#343` | `g2-190-data-quality-adapter-decision` | `wip/root-dirty-20260403` | `MERGED` at `7154ffbb067dcddc52d80f15342961b51234ac09` | Governance decision classifying data-quality / adapter monitor surface as cross-cutting |
 | `#344` | `g2-191-data-quality-route-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `b899a173909d3818370dddbf35b039832266bd1d` | Authorization package for G2.192 data-quality route provider implementation |
+| `#345` | `g2-192-data-quality-route-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `2b0c3ce373fba38bacd62eff5436822527dccda1` | Path-limited data-quality route provider implementation closed for G2.193 refresh |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-192-data-quality-route-provider-implementation` | `origin/wip/root-dirty-20260403` at `b899a173909d3818370dddbf35b039832266bd1d` | Implement G2.191-authorized data-quality route provider injection in one route file plus focused tests | G2.191 data-quality route provider authorization |
+| `g2-193-data-quality-route-provider-closeout-refresh` | `origin/wip/root-dirty-20260403` at `2b0c3ce373fba38bacd62eff5436822527dccda1` | Record G2.192 closeout and refresh remaining data-quality monitor surfaces before selecting the next governance gate | None; governance-only closeout / refresh |
 
 ## OpenSpec Relationship
 
@@ -50,8 +51,8 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.192 is a path-limited source implementation branch after PR `#344` merged
-G2.191. It must not expand beyond `web/backend/app/api/data_quality.py`,
-focused route/provider tests, and governance evidence. Adapter constructor
-migration, legacy adapter compatibility, singleton wrapper deletion, and
-`DataQualityMonitor` internals remain separate lanes.
+G2.193 is a governance-only closeout and candidate refresh branch after PR
+`#345` merged G2.192. It must not edit backend source, frontend source, tests,
+OpenSpec changes, API contract files, config, or scripts. If accepted, it
+selects G2.194 as a design / test-double decision package for the data-quality
+adapter constructor seam; it does not authorize adapter implementation.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T01:22:05+08:00`
-- Base HEAD checked: `b899a173909d3818370dddbf35b039832266bd1d`
+- Prepared at: `2026-05-28T01:52:33+08:00`
+- Base HEAD checked: `2b0c3ce373fba38bacd62eff5436822527dccda1`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 is the active path-limited data-quality route provider implementation review candidate |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 is the active governance-only data-quality route provider closeout / remaining candidate refresh |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T01:22:05+08:00`
-- Base HEAD checked: `b899a173909d3818370dddbf35b039832266bd1d`
+- Prepared at: `2026-05-28T01:52:33+08:00`
+- Base HEAD checked: `2b0c3ce373fba38bacd62eff5436822527dccda1`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.192 data-quality route provider implementation | G/#79 service lifecycle DI | PR `#344` merged at `b899a173909d3818370dddbf35b039832266bd1d`; G2.192 implements the authorized route-file provider injection with 7 focused tests green and OpenAPI dependency leak count `0` | If accepted, merge PR `#345` and start G2.193 data-quality route provider closeout / remaining candidate refresh |
+| P0 | Review G2.193 data-quality route provider closeout / remaining candidate refresh | G/#79 service lifecycle DI | PR `#345` merged at `2b0c3ce373fba38bacd62eff5436822527dccda1`; route-body migration is closed with 7 focused tests green and OpenAPI dependency leak count `0` | If accepted, start G2.194 data-quality adapter constructor seam design / test-double decision package |
+| P0 | Preserve G2.192 data-quality route provider implementation | G/#79 service lifecycle DI | PR `#345` merged; route body `get_data_quality_monitor()` and `monitor_data_quality()` calls are both `0` | Do not start adapter constructor implementation from G2.192 or G2.193 |
 | P0 | Preserve G2.191 data-quality route provider authorization | G/#79 service lifecycle DI | PR `#344` merged; authorized only `web/backend/app/api/data_quality.py` plus focused tests for G2.192 | Do not expand into adapters, singleton wrapper, `DataQualityMonitor` internals, or data-source factory behavior |
 | P0 | Preserve G2.190 data-quality / adapter cross-cutting decision | G/#79 service lifecycle DI | PR `#343` merged; `get_data_quality_monitor` is `CRITICAL` with 20 direct callers across route, adapter, legacy adapter, and wrapper surfaces | Do not batch route, adapter constructor, legacy adapter, and singleton wrapper migration together |
 | P0 | Preserve G2.189 risk stop-loss provider closeout / candidate refresh | G/#79 service lifecycle DI | PR `#342` merged; stop-loss pair is closed for route-body provider migration and retained as provider backing getters | Do not reopen stop-loss or start data-quality source implementation from G2.189 |
@@ -34,9 +35,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.192 stay limited to `web/backend/app/api/data_quality.py` and focused route/provider tests?
-- Does the TDD red/green evidence prove the provider migration rather than only documenting the target state?
-- Does the OpenAPI smoke prove monitor provider parameters do not leak into the schema?
-- Are adapter constructor migration, legacy adapter compatibility, singleton wrapper deletion, and `DataQualityMonitor` internals untouched?
-- Is the next gate G2.193 governance closeout / remaining candidate refresh only?
+- Does G2.193 correctly mark the data-quality route-body provider migration closed after PR `#345`?
+- Does the remaining surface refresh keep adapter constructors, legacy adapters, singleton wrapper, and `DataQualityMonitor` internals out of scope?
+- Is G2.194 a design / test-double decision package rather than an adapter implementation lane?
+- Does the retained route provider backing getter stay distinct from route-body singleton calls?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T01:22:05+08:00`
-- Base HEAD checked: `b899a173909d3818370dddbf35b039832266bd1d`
+- Prepared at: `2026-05-28T01:52:33+08:00`
+- Base HEAD checked: `2b0c3ce373fba38bacd62eff5436822527dccda1`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -45,8 +45,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-adapter-cross-cutting-decision-2026-05-28.md` | G2.190 human-readable decision package | Accepted by PR `#343`; superseded for route authorization by G2.191 |
 | `.planning/codebase/generated/data-quality-route-provider-authorization-2026-05-28.json` | G2.191 data-quality route provider authorization evidence | Accepted by PR `#344`; superseded for implementation review by G2.192 |
 | `docs/reports/quality/backend-data-quality-route-provider-authorization-2026-05-28.md` | G2.191 human-readable authorization package | Accepted by PR `#344`; superseded for implementation review by G2.192 |
-| `.planning/codebase/generated/data-quality-route-provider-implementation-2026-05-28.json` | G2.192 data-quality route provider implementation evidence | Current for HEAD `b899a173909d3818370dddbf35b039832266bd1d`; review input until PR `#345` is accepted |
-| `docs/reports/quality/backend-data-quality-route-provider-implementation-2026-05-28.md` | G2.192 human-readable implementation package | Review input until PR `#345` is accepted |
+| `.planning/codebase/generated/data-quality-route-provider-implementation-2026-05-28.json` | G2.192 data-quality route provider implementation evidence | Accepted by PR `#345`; superseded for closeout / remaining candidate refresh by G2.193 |
+| `docs/reports/quality/backend-data-quality-route-provider-implementation-2026-05-28.md` | G2.192 human-readable implementation package | Accepted by PR `#345`; superseded for closeout / remaining candidate refresh by G2.193 |
+| `.planning/codebase/generated/data-quality-route-provider-closeout-refresh-2026-05-28.json` | G2.193 data-quality route provider closeout / refresh evidence | Current for HEAD `2b0c3ce373fba38bacd62eff5436822527dccda1`; review input until PR `#346` is accepted |
+| `docs/reports/quality/backend-data-quality-route-provider-closeout-refresh-2026-05-28.md` | G2.193 human-readable closeout / refresh report | Review input until PR `#346` is accepted |
 
 ## External State Inputs
 
@@ -62,7 +64,8 @@ state transition.
 | GitHub PR `#342` | `MERGED` | G2.189 stop-loss provider closeout / candidate refresh merged by commit `5565e2b0967958c406a4115dc840a9e90a0b2aab` |
 | GitHub PR `#343` | `MERGED` | G2.190 data-quality / adapter decision merged by commit `7154ffbb067dcddc52d80f15342961b51234ac09` |
 | GitHub PR `#344` | `MERGED` | G2.191 data-quality route provider authorization merged by commit `b899a173909d3818370dddbf35b039832266bd1d` |
-| `origin/wip/root-dirty-20260403` | `b899a173909d3818370dddbf35b039832266bd1d` | Base used for this implementation branch |
+| GitHub PR `#345` | `MERGED` | G2.192 data-quality route provider implementation merged by commit `2b0c3ce373fba38bacd62eff5436822527dccda1` |
+| `origin/wip/root-dirty-20260403` | `2b0c3ce373fba38bacd62eff5436822527dccda1` | Base used for this closeout / refresh branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T01:22:05+08:00",
+  "generated_at": "2026-05-28T01:52:33+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "b899a173909d3818370dddbf35b039832266bd1d",
-  "split_branch": "g2-192-data-quality-route-provider-implementation",
-  "scope": "path_limited_data_quality_route_provider_implementation",
-  "source_edit_authority": true,
+  "base_head": "2b0c3ce373fba38bacd62eff5436822527dccda1",
+  "split_branch": "g2-193-data-quality-route-provider-closeout-refresh",
+  "scope": "governance_only_data_quality_route_provider_closeout_refresh",
+  "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -852,9 +852,17 @@
     {
       "id": "g2-192-data-quality-route-provider-implementation",
       "type": "implementation_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.191 data-quality route provider authorization",
+      "github_pr": {
+        "number": 345,
+        "url": "https://github.com/chengjon/mystocks/pull/345",
+        "state": "MERGED",
+        "merged_at": "2026-05-27T17:49:25Z",
+        "head_ref": "g2-192-data-quality-route-provider-implementation",
+        "merge_commit": "2b0c3ce373fba38bacd62eff5436822527dccda1"
+      },
       "source_edit_authority": true,
       "evidence": [
         ".planning/codebase/generated/data-quality-route-provider-implementation-2026-05-28.json",
@@ -900,10 +908,75 @@
         "openspec/specs/**"
       ],
       "freshness": {
-        "current_head_checked": "b899a173909d3818370dddbf35b039832266bd1d",
+        "current_head_checked": "2b0c3ce373fba38bacd62eff5436822527dccda1",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, merge and start G2.193 data-quality route provider closeout / remaining candidate refresh; do not start adapter implementation from G2.192."
+      "next_gate": "Superseded by G2.193 data-quality route provider closeout / remaining candidate refresh."
+    },
+    {
+      "id": "g2-193-data-quality-route-provider-closeout-refresh",
+      "type": "closeout_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.192 data-quality route provider implementation",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/data-quality-route-provider-closeout-refresh-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-route-provider-closeout-refresh-2026-05-28.md",
+        "governance/mainline/task-cards/pr-346.yaml"
+      ],
+      "closeout_result": {
+        "github_pr": {
+          "number": 345,
+          "url": "https://github.com/chengjon/mystocks/pull/345",
+          "state": "MERGED",
+          "merge_commit": "2b0c3ce373fba38bacd62eff5436822527dccda1"
+        },
+        "route_provider_surface": "closed_for_route_body_provider_migration",
+        "route_body_get_data_quality_monitor_calls": 0,
+        "route_body_monitor_data_quality_calls": 0,
+        "route_file_provider_backing_get_data_quality_monitor_calls": 1,
+        "depends_provider_params": 7,
+        "direct_call_fallbacks": 7,
+        "focused_tests": "7 passed",
+        "openapi_paths": 500,
+        "data_quality_paths": 9,
+        "dependency_params_leaked": 0
+      },
+      "candidate_refresh": {
+        "route_surface": "closed_for_route_body_provider_migration_retained_as_provider_backing_getter",
+        "remaining_buckets": {
+          "adapter_split": {
+            "files": 8,
+            "getter_calls": 8
+          },
+          "service_adapter": {
+            "files": 2,
+            "getter_calls": 2
+          },
+          "legacy_adapter": {
+            "files": 2,
+            "getter_calls": 2
+          },
+          "market_data_adapter_compatibility": {
+            "files": 1,
+            "getter_calls": 1
+          },
+          "service_wrapper": {
+            "files": 1,
+            "getter_calls": 2,
+            "monitor_helper_calls": 1
+          }
+        },
+        "next_recommended_governance_target": "data-quality-adapter-constructor-seam-design",
+        "next_recommended_work_item": "G2.194 data-quality adapter constructor seam design / test-double decision package",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-193"
+      },
+      "freshness": {
+        "current_head_checked": "2b0c3ce373fba38bacd62eff5436822527dccda1",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.194 data-quality adapter constructor seam design / test-double decision package; do not implement adapter changes from G2.193."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T01:22:05+08:00`
-- Base HEAD checked: `b899a173909d3818370dddbf35b039832266bd1d`
+- Prepared at: `2026-05-28T01:52:33+08:00`
+- Base HEAD checked: `2b0c3ce373fba38bacd62eff5436822527dccda1`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -44,7 +44,8 @@ It proved a repeatable conveyor:
 | G2.189 risk stop-loss provider closeout / candidate refresh | Merged by PR `#342` | Records PR `#341` closeout, marks the stop-loss pair closed for route-body provider migration, and selects data-quality / adapter cross-cutting governance as the next design-only gate |
 | G2.190 data-quality / adapter cross-cutting decision | Merged by PR `#343` | Classifies `get_data_quality_monitor` as `CRITICAL`, splits the route/adapter/wrapper surfaces, and selects G2.191 route-only authorization as the next gate |
 | G2.191 data-quality route provider authorization | Merged by PR `#344` | Authorized a future G2.192 route-only implementation lane for `web/backend/app/api/data_quality.py` and focused tests, with no source edits in G2.191 |
-| G2.192 data-quality route provider implementation | For review | Implements authorized provider injection in `web/backend/app/api/data_quality.py`; focused tests and OpenAPI leak smoke pass |
+| G2.192 data-quality route provider implementation | Merged by PR `#345` | Implements authorized provider injection in `web/backend/app/api/data_quality.py`; focused tests and OpenAPI leak smoke pass |
+| G2.193 data-quality route provider closeout / remaining candidate refresh | For review | Marks route-body provider migration closed and selects adapter constructor seam design / test-double decision as the next governance gate |
 
 ## Current Strategy Getter Residuals
 
@@ -159,13 +160,42 @@ authorization to the route file only.
 G2.192 does not change adapter constructors, legacy adapter compatibility,
 singleton wrappers, or `DataQualityMonitor` internals.
 
+## G2.193 Data-Quality Route Provider Closeout / Refresh
+
+At HEAD `2b0c3ce373fba38bacd62eff5436822527dccda1`, PR `#345` is merged and
+the data-quality route-body provider migration is closed.
+
+| Closeout result | Value |
+|---|---:|
+| Route body `get_data_quality_monitor()` calls | 0 |
+| Route body `monitor_data_quality()` helper calls | 0 |
+| Retained provider backing `get_data_quality_monitor()` calls in route file | 1 |
+| Route handlers using `Depends(get_data_quality_monitor_provider)` | 7 |
+| Direct-call fallback resolver uses | 7 |
+| Focused tests | 7 passed |
+| OpenAPI paths | 500 |
+| Data-quality OpenAPI paths | 9 |
+| Dependency parameters leaked into OpenAPI | 0 |
+
+Remaining `get_data_quality_monitor` surface after route closeout:
+
+| Bucket | Files | Getter calls | Current decision |
+|---|---:|---:|---|
+| route | 1 | 1 | Retained provider backing getter, not route-body debt |
+| adapter_split | 8 | 8 | Next governance target: adapter constructor seam design / test-double decision |
+| service_adapter | 2 | 2 | Compatibility surface, defer until adapter seam design is explicit |
+| legacy_adapter | 2 | 2 | Compatibility surface, defer to owner-specific decision |
+| other | 1 | 1 | `market_data_adapter.py` compatibility surface |
+| service_wrapper | 1 | 2 | Retain singleton wrapper / backing API until consumers are migrated and verified |
+
 ## Next Gates
 
-- Review G2.192 data-quality route provider implementation package.
-- If accepted, merge PR `#345` and start G2.193 closeout / remaining candidate
+- Review G2.193 data-quality route provider closeout / remaining candidate
   refresh.
-- Do not start adapter constructor implementation from G2.192.
-- Do not migrate adapter constructors or delete singleton wrappers from G2.192.
+- If accepted, start G2.194 data-quality adapter constructor seam design /
+  test-double decision package.
+- Do not start adapter constructor implementation from G2.193.
+- Do not migrate adapter constructors or delete singleton wrappers from G2.193.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`
   restoration, or other risk route provider migrations.
 

--- a/docs/reports/quality/backend-data-quality-route-provider-closeout-refresh-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-route-provider-closeout-refresh-2026-05-28.md
@@ -1,0 +1,117 @@
+# Backend Data Quality Route Provider Closeout Refresh
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: governance closeout / remaining candidate refresh review candidate
+- Prepared at: `2026-05-28T01:52:33+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `2b0c3ce373fba38bacd62eff5436822527dccda1`
+- Worktree branch: `g2-193-data-quality-route-provider-closeout-refresh`
+- Scope: governance-only closeout and remaining surface refresh
+- Source edit authority: none
+
+Boundary note: this package records the G2.192 closeout and selects the next
+governance gate. It does not authorize adapter constructor implementation,
+legacy adapter edits, singleton wrapper deletion, `DataQualityMonitor` internals,
+frontend edits, `src` edits, `docs/api` edits, or OpenSpec change/spec edits.
+
+## Parent State
+
+| Item | State | Evidence |
+|---|---|---|
+| G2.192 data-quality route provider implementation | Merged | PR `#345`, merge commit `2b0c3ce373fba38bacd62eff5436822527dccda1` |
+| G2.193 closeout / remaining candidate refresh | For review | This report plus `.planning/codebase/generated/data-quality-route-provider-closeout-refresh-2026-05-28.json` |
+
+## Closeout Result
+
+The data-quality route-body provider migration is closed.
+
+| Metric | Count |
+|---|---:|
+| `get_data_quality_monitor_provider` definitions | 1 |
+| `_resolve_direct_call_dependency` definitions | 1 |
+| `get_data_quality_monitor()` calls inside affected route bodies | 0 |
+| `monitor_data_quality()` calls inside affected route bodies | 0 |
+| `Depends(get_data_quality_monitor_provider)` route parameters | 7 |
+| `_resolve_direct_call_dependency(...)` route fallbacks | 7 |
+
+The route file still has one `get_data_quality_monitor()` call in
+`get_data_quality_monitor_provider`. That is the retained provider backing
+getter, not a route-body singleton call.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| PR `#345` state | `MERGED` |
+| PR `#345` merge commit | `2b0c3ce373fba38bacd62eff5436822527dccda1` |
+| Focused pytest | `7 passed` |
+| OpenAPI smoke | `openapi_paths=500`, `data_quality_paths=9`, `dependency_params_leaked=0` |
+
+The OpenAPI smoke used local dummy environment variables only for required
+settings, with repository root and `web/backend` on `PYTHONPATH`. It did not
+write `.env`, start PM2, or modify runtime configuration.
+
+## Remaining Surface Refresh
+
+Current scan scope: `web/backend/app/api` and `web/backend/app/services`.
+
+| Bucket | Files | `get_data_quality_monitor()` | `monitor_data_quality()` | Classification |
+|---|---:|---:|---:|---|
+| route | 1 | 1 | 0 | provider backing getter retained; route-body migration closed |
+| adapter_split | 8 | 8 | 0 | remaining adapter constructor seam |
+| service_adapter | 2 | 2 | 0 | remaining adapter compatibility seam |
+| legacy_adapter | 2 | 2 | 0 | remaining legacy adapter compatibility seam |
+| other | 1 | 1 | 0 | `market_data_adapter.py` compatibility surface |
+| service_wrapper | 1 | 2 | 1 | retained singleton wrapper / backing API |
+
+Remaining adapter-surface files:
+
+- `web/backend/app/services/adapters_split/base_adapter.py`
+- `web/backend/app/services/adapters_split/baostock_adapter.py`
+- `web/backend/app/services/adapters_split/tushare_adapter.py`
+- `web/backend/app/services/adapters_split/customer_adapter.py`
+- `web/backend/app/services/adapters_split/byapi_adapter.py`
+- `web/backend/app/services/adapters_split/akshare_adapter.py`
+- `web/backend/app/services/adapters_split/efinance_adapter.py`
+- `web/backend/app/services/adapters_split/tdx_adapter.py`
+- `web/backend/app/services/adapters/dashboard_adapter.py`
+- `web/backend/app/services/adapters/data_adapter.py`
+- `web/backend/app/services/data_adapters/data_source.py`
+- `web/backend/app/services/data_adapters/dashboard.py`
+- `web/backend/app/services/market_data_adapter.py`
+- `web/backend/app/services/_data_quality_monitor_singleton.py`
+
+## Decision
+
+G2.193 marks the route provider migration closed and does not start source
+implementation. The next governance gate should be:
+
+`G2.194 data-quality adapter constructor seam design / test-double decision package`
+
+This next package should decide interface shape, test-double strategy, adapter
+grouping, compatibility handling, and rollback boundaries before any adapter
+constructor source edit is allowed.
+
+## Explicit Non-Goals
+
+- No adapter constructor implementation.
+- No legacy adapter compatibility edits.
+- No singleton wrapper deletion.
+- No `DataQualityMonitor` implementation rewrite.
+- No frontend edits.
+- No `src` edits.
+- No `docs/api` edits.
+- No OpenSpec change/spec edits.
+
+## Evidence Artifacts
+
+| Artifact | Role |
+|---|---|
+| `.planning/codebase/generated/data-quality-route-provider-implementation-2026-05-28.json` | G2.192 implementation evidence |
+| `docs/reports/quality/backend-data-quality-route-provider-implementation-2026-05-28.md` | G2.192 implementation report |
+| `.planning/codebase/generated/data-quality-route-provider-closeout-refresh-2026-05-28.json` | G2.193 machine-readable closeout / refresh evidence |
+| `docs/reports/quality/backend-data-quality-route-provider-closeout-refresh-2026-05-28.md` | G2.193 closeout / refresh report |
+| `governance/mainline/task-cards/pr-346.yaml` | G2.193 governance PR scope card |

--- a/governance/mainline/task-cards/pr-346.yaml
+++ b/governance/mainline/task-cards/pr-346.yaml
@@ -1,0 +1,119 @@
+version: "v0.2"
+
+task:
+  id: "pr-346"
+  title: "Close out data-quality route provider implementation"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-route-provider-closeout-refresh"
+  objective: "record PR #345 closeout and refresh remaining data-quality monitor surfaces before selecting the next governance gate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only closeout and candidate refresh; no route paths, HTTP methods, response models, OpenAPI examples, frontend behavior, PM2 workflows, or public API ownership changes"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-route-provider-closeout-refresh-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-route-provider-closeout-refresh-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-346.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "editing backend source"
+  - "editing tests"
+  - "adapter constructor implementation"
+  - "legacy adapter compatibility edits"
+  - "singleton wrapper deletion"
+  - "DataQualityMonitor internals"
+  - "creating OpenSpec proposals"
+  - "changing GitHub issue labels"
+
+acceptance:
+  checks:
+    - id: "focused-tests-observed"
+      command: "PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_route_provider_regressions.py web/backend/tests/test_data_quality_mock_configuration.py tests/unit/contract/test_data_quality_router_runtime_import.py -q --tb=short --disable-warnings --no-cov"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-route-provider-closeout-refresh-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-346.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-data-quality-route-provider-closeout-refresh-2026-05-28.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-346.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 2b0c3ce373fba38bacd62eff5436822527dccda1 --head-sha HEAD --report /tmp/pr346-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If G2.193 is misread as implementation authority, adapter source edits could start before seam design is approved."
+    - "If remaining surfaces are not separated, route closeout could be conflated with adapter constructor migration."
+  rollback_plan: "revert this PR to remove the governance-only closeout / refresh evidence and restore the previous steward tree next gate."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out data-quality route provider implementation and refresh remaining monitor surfaces"
+    modified_scope: "governance evidence, steward tree state, and PR #346 task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; adapter and singleton surfaces remain untouched"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if it misstates PR #345 closeout or authorizes source implementation"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T01:52:33+08:00"
+    approval_note: "Human maintainer approved continuing after PR #345 acceptance; this lane is governance-only closeout and remaining candidate refresh."
+    secondary_approved: true


### PR DESCRIPTION
## Summary
- record PR #345 as merged and close the data-quality route-body provider migration
- refresh remaining `get_data_quality_monitor` surfaces after the route closeout
- update steward tree, machine-readable evidence, closeout report, and PR #346 task card

## Scope
Governance-only. No backend source, tests, frontend, src, docs/api, config, scripts, or OpenSpec change/spec edits.

## Evidence
- Parent implementation: PR #345 merged at `2b0c3ce373fba38bacd62eff5436822527dccda1`
- Commit: `76d94c4eb docs(governance): close data quality route provider lane`
- Route-body `get_data_quality_monitor()` calls: `0`
- Route-body `monitor_data_quality()` calls: `0`
- Retained route provider backing getter call: `1`
- Route handlers using `Depends(get_data_quality_monitor_provider)`: `7`
- OpenAPI smoke: `openapi_paths=500`, `data_quality_paths=9`, `dependency_params_leaked=0`

## Remaining Surface Refresh
- `adapter_split`: 8 files / 8 getter calls
- `service_adapter`: 2 files / 2 getter calls
- `legacy_adapter`: 2 files / 2 getter calls
- `market_data_adapter.py` compatibility surface: 1 getter call
- singleton wrapper / backing API: retained

## Verification
- Focused pytest: `7 passed`
- JSON/YAML parse: passed
- Markdown governance gate: 6 checked, 0 errors
- OpenSpec strict validate: valid; PostHog telemetry ECONNREFUSED remains non-blocking telemetry noise
- git diff --check: passed
- git diff --cached --check: passed
- GitNexus staged detect_changes: LOW, 0 changed symbols, 0 affected processes
- Mainline scope gate: `pass=True`

## Next Gate
If accepted, start G2.194 data-quality adapter constructor seam design / test-double decision package. Do not start adapter source implementation from G2.193.
