### PR TITLE
docs(governance): decide data quality adapter seam

### DIFF
--- a/.planning/codebase/generated/data-quality-adapter-seam-design-decision-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-adapter-seam-design-decision-2026-05-28.json
@@ -1,0 +1,148 @@
+{
+  "schema_version": "2026-05-28.g2-194.decision.v1",
+  "generated_at": "2026-05-28T02:10:15+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "ea659d52903a5e9884d396069526ea08f15109a6",
+  "worktree_branch": "g2-194-data-quality-adapter-seam-design",
+  "scope": "governance_only_data_quality_adapter_constructor_seam_design",
+  "source_edit_authority": false,
+  "parent": {
+    "id": "G2.193",
+    "description": "data-quality route provider closeout / remaining candidate refresh",
+    "github_pr": 346,
+    "merge_commit": "ea659d52903a5e9884d396069526ea08f15109a6",
+    "merged_at": "2026-05-27T18:07:58Z"
+  },
+  "current_inventory": {
+    "head": "ea659d52903a5e9884d396069526ea08f15109a6",
+    "files_scanned": 14,
+    "get_data_quality_monitor_calls": 15,
+    "monitor_data_quality_calls": 1,
+    "constructor_count": 15,
+    "constructors_with_quality_monitor_param": 0,
+    "quality_monitor_methods_used": [
+      "check_data_quality",
+      "evaluate_data_quality"
+    ],
+    "existing_test_hit_files": [
+      "web/backend/tests/test_logging_noise_regressions.py",
+      "web/backend/tests/_test_data_source_factory_management.py",
+      "web/backend/tests/_test_data_source_factory_support.py",
+      "web/backend/tests/test_market_data_service_getter_retirement.py",
+      "tests/backend/test_data_adapter_regression.py"
+    ]
+  },
+  "surface_buckets": {
+    "adapter_split_constructor": {
+      "files": 8,
+      "get_data_quality_monitor_calls": 8,
+      "constructor_shape": "BaseAdapter plus seven subclasses call get_data_quality_monitor during __init__",
+      "classification": "next recommended governance target"
+    },
+    "service_adapter_trigger_monitoring": {
+      "files": 2,
+      "get_data_quality_monitor_calls": 2,
+      "constructor_shape": "config constructors plus async _trigger_quality_monitoring runtime getter",
+      "classification": "defer until adapter_split pattern is proven"
+    },
+    "legacy_adapter_trigger_monitoring": {
+      "files": 2,
+      "get_data_quality_monitor_calls": 2,
+      "constructor_shape": "config constructors plus async _trigger_quality_monitoring runtime getter",
+      "classification": "defer to compatibility ownership decision"
+    },
+    "market_data_adapter_compatibility": {
+      "files": 1,
+      "get_data_quality_monitor_calls": 1,
+      "constructor_shape": "config constructor plus async _trigger_quality_monitoring runtime getter",
+      "classification": "defer to market-data compatibility decision"
+    },
+    "service_wrapper": {
+      "files": 1,
+      "get_data_quality_monitor_calls": 2,
+      "monitor_data_quality_calls": 1,
+      "classification": "retained backing API; not a deletion candidate"
+    }
+  },
+  "gitnexus_evidence": {
+    "get_data_quality_monitor": {
+      "risk": "CRITICAL",
+      "impacted_count": 24,
+      "direct_callers": 20,
+      "processes_affected": 7,
+      "modules_affected": 4
+    },
+    "BaseAdapter": {
+      "risk": "MEDIUM",
+      "impacted_count": 7,
+      "direct": 7,
+      "processes_affected": 0,
+      "d1_extenders": [
+        "TushareAdapter",
+        "TDXAdapter",
+        "EfinanceAdapter",
+        "CustomerAdapter",
+        "BYAPIAdapter",
+        "BaostockAdapter",
+        "AkshareAdapter"
+      ]
+    }
+  },
+  "decision": {
+    "classification": "adapter_split_constructor_seam_first_design",
+    "source_lane_recommendation": "do-not-start-source-implementation-from-g2-194",
+    "selected_next_governance_target": "data-quality-adapter-split-constructor-provider-authorization",
+    "recommended_next_work_item": "G2.195 data-quality adapter_split constructor provider authorization package",
+    "future_authorization_shape": {
+      "future_lane": "G2.196 data-quality adapter_split constructor provider implementation after G2.195 acceptance",
+      "candidate_source_paths": [
+        "web/backend/app/services/adapters_split/base_adapter.py",
+        "web/backend/app/services/adapters_split/baostock_adapter.py",
+        "web/backend/app/services/adapters_split/tushare_adapter.py",
+        "web/backend/app/services/adapters_split/customer_adapter.py",
+        "web/backend/app/services/adapters_split/byapi_adapter.py",
+        "web/backend/app/services/adapters_split/akshare_adapter.py",
+        "web/backend/app/services/adapters_split/efinance_adapter.py",
+        "web/backend/app/services/adapters_split/tdx_adapter.py"
+      ],
+      "candidate_test_paths": [
+        "new focused adapter_split constructor provider regression test",
+        "existing adapter_split import / construction smoke if present"
+      ],
+      "forbidden_future_paths_until_separate_decision": [
+        "web/backend/app/services/adapters/**",
+        "web/backend/app/services/data_adapters/**",
+        "web/backend/app/services/market_data_adapter.py",
+        "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "web/backend/app/services/data_quality_monitor.py"
+      ]
+    }
+  },
+  "test_double_contract": {
+    "name": "FakeDataQualityMonitor",
+    "required_methods": {
+      "check_data_quality": "sync method returning {'is_valid': true-like value} and recording calls",
+      "evaluate_data_quality": "async method returning true-like value and recording calls for later runtime-monitoring tracks"
+    },
+    "required_assertions_for_future_implementation": [
+      "adapter constructors can receive the fake monitor or provider without calling the global getter",
+      "BaseAdapter._log_data_quality uses the injected monitor",
+      "subclass constructors do not overwrite the injected monitor with the singleton",
+      "existing constructor defaults still preserve current runtime behavior"
+    ]
+  },
+  "explicit_non_goals": [
+    "backend source edits",
+    "test edits",
+    "adapter constructor implementation",
+    "legacy adapter compatibility edits",
+    "singleton wrapper deletion",
+    "DataQualityMonitor internals",
+    "frontend edits",
+    "src edits",
+    "docs/api edits",
+    "OpenSpec change/spec edits"
+  ],
+  "next_gate": "If accepted, start G2.195 data-quality adapter_split constructor provider authorization package; do not implement adapter changes from G2.194."
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T01:52:33+08:00`
-- Base HEAD checked: `2b0c3ce373fba38bacd62eff5436822527dccda1`
+- Prepared at: `2026-05-28T02:10:15+08:00`
+- Base HEAD checked: `ea659d52903a5e9884d396069526ea08f15109a6`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -30,12 +30,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#343` | `g2-190-data-quality-adapter-decision` | `wip/root-dirty-20260403` | `MERGED` at `7154ffbb067dcddc52d80f15342961b51234ac09` | Governance decision classifying data-quality / adapter monitor surface as cross-cutting |
 | `#344` | `g2-191-data-quality-route-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `b899a173909d3818370dddbf35b039832266bd1d` | Authorization package for G2.192 data-quality route provider implementation |
 | `#345` | `g2-192-data-quality-route-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `2b0c3ce373fba38bacd62eff5436822527dccda1` | Path-limited data-quality route provider implementation closed for G2.193 refresh |
+| `#346` | `g2-193-data-quality-route-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `ea659d52903a5e9884d396069526ea08f15109a6` | Governance closeout / remaining surface refresh selecting G2.194 adapter constructor seam design |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-193-data-quality-route-provider-closeout-refresh` | `origin/wip/root-dirty-20260403` at `2b0c3ce373fba38bacd62eff5436822527dccda1` | Record G2.192 closeout and refresh remaining data-quality monitor surfaces before selecting the next governance gate | None; governance-only closeout / refresh |
+| `g2-194-data-quality-adapter-seam-design` | `origin/wip/root-dirty-20260403` at `ea659d52903a5e9884d396069526ea08f15109a6` | Record data-quality adapter constructor seam design and test-double contract before authorizing any adapter source lane | None; governance-only design decision |
 
 ## OpenSpec Relationship
 
@@ -51,8 +52,8 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.193 is a governance-only closeout and candidate refresh branch after PR
-`#345` merged G2.192. It must not edit backend source, frontend source, tests,
-OpenSpec changes, API contract files, config, or scripts. If accepted, it
-selects G2.194 as a design / test-double decision package for the data-quality
-adapter constructor seam; it does not authorize adapter implementation.
+G2.194 is a governance-only design decision branch after PR `#346` merged
+G2.193. It must not edit backend source, frontend source, tests, OpenSpec
+changes, API contract files, config, or scripts. If accepted, it selects G2.195
+as a data-quality `adapter_split` constructor provider authorization package; it
+does not authorize adapter implementation.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T01:52:33+08:00`
-- Base HEAD checked: `2b0c3ce373fba38bacd62eff5436822527dccda1`
+- Prepared at: `2026-05-28T02:10:15+08:00`
+- Base HEAD checked: `ea659d52903a5e9884d396069526ea08f15109a6`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 is the active governance-only data-quality route provider closeout / remaining candidate refresh |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 is the active governance-only data-quality adapter constructor seam design decision |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T01:52:33+08:00`
-- Base HEAD checked: `2b0c3ce373fba38bacd62eff5436822527dccda1`
+- Prepared at: `2026-05-28T02:10:15+08:00`
+- Base HEAD checked: `ea659d52903a5e9884d396069526ea08f15109a6`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,8 +15,9 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.193 data-quality route provider closeout / remaining candidate refresh | G/#79 service lifecycle DI | PR `#345` merged at `2b0c3ce373fba38bacd62eff5436822527dccda1`; route-body migration is closed with 7 focused tests green and OpenAPI dependency leak count `0` | If accepted, start G2.194 data-quality adapter constructor seam design / test-double decision package |
-| P0 | Preserve G2.192 data-quality route provider implementation | G/#79 service lifecycle DI | PR `#345` merged; route body `get_data_quality_monitor()` and `monitor_data_quality()` calls are both `0` | Do not start adapter constructor implementation from G2.192 or G2.193 |
+| P0 | Review G2.194 data-quality adapter constructor seam design | G/#79 service lifecycle DI | PR `#346` merged at `ea659d52903a5e9884d396069526ea08f15109a6`; G2.194 selects `adapter_split` constructor provider authorization as the next gate and keeps source authority at none | If accepted, start G2.195 data-quality `adapter_split` constructor provider authorization package |
+| P0 | Preserve G2.193 data-quality route provider closeout / remaining candidate refresh | G/#79 service lifecycle DI | PR `#346` merged; route-body migration is closed, remaining adapter surfaces are refreshed, and G2.194 is the current design gate | Do not implement adapter changes from G2.193 or G2.194 |
+| P0 | Preserve G2.192 data-quality route provider implementation | G/#79 service lifecycle DI | PR `#345` merged; route body `get_data_quality_monitor()` and `monitor_data_quality()` calls are both `0` | Do not start adapter constructor implementation from G2.192, G2.193, or G2.194 |
 | P0 | Preserve G2.191 data-quality route provider authorization | G/#79 service lifecycle DI | PR `#344` merged; authorized only `web/backend/app/api/data_quality.py` plus focused tests for G2.192 | Do not expand into adapters, singleton wrapper, `DataQualityMonitor` internals, or data-source factory behavior |
 | P0 | Preserve G2.190 data-quality / adapter cross-cutting decision | G/#79 service lifecycle DI | PR `#343` merged; `get_data_quality_monitor` is `CRITICAL` with 20 direct callers across route, adapter, legacy adapter, and wrapper surfaces | Do not batch route, adapter constructor, legacy adapter, and singleton wrapper migration together |
 | P0 | Preserve G2.189 risk stop-loss provider closeout / candidate refresh | G/#79 service lifecycle DI | PR `#342` merged; stop-loss pair is closed for route-body provider migration and retained as provider backing getters | Do not reopen stop-loss or start data-quality source implementation from G2.189 |
@@ -35,8 +36,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.193 correctly mark the data-quality route-body provider migration closed after PR `#345`?
-- Does the remaining surface refresh keep adapter constructors, legacy adapters, singleton wrapper, and `DataQualityMonitor` internals out of scope?
-- Is G2.194 a design / test-double decision package rather than an adapter implementation lane?
-- Does the retained route provider backing getter stay distinct from route-body singleton calls?
+- Does G2.194 keep adapter implementation locked behind a separate G2.195 authorization package?
+- Is `adapter_split` separated from service-adapter, legacy-adapter, `market_data_adapter.py`, and singleton-wrapper surfaces?
+- Does the test-double contract cover both `check_data_quality` and `evaluate_data_quality` without changing source code?
+- Is G2.195 an authorization package rather than an implementation lane?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T01:52:33+08:00`
-- Base HEAD checked: `2b0c3ce373fba38bacd62eff5436822527dccda1`
+- Prepared at: `2026-05-28T02:10:15+08:00`
+- Base HEAD checked: `ea659d52903a5e9884d396069526ea08f15109a6`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -47,8 +47,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-route-provider-authorization-2026-05-28.md` | G2.191 human-readable authorization package | Accepted by PR `#344`; superseded for implementation review by G2.192 |
 | `.planning/codebase/generated/data-quality-route-provider-implementation-2026-05-28.json` | G2.192 data-quality route provider implementation evidence | Accepted by PR `#345`; superseded for closeout / remaining candidate refresh by G2.193 |
 | `docs/reports/quality/backend-data-quality-route-provider-implementation-2026-05-28.md` | G2.192 human-readable implementation package | Accepted by PR `#345`; superseded for closeout / remaining candidate refresh by G2.193 |
-| `.planning/codebase/generated/data-quality-route-provider-closeout-refresh-2026-05-28.json` | G2.193 data-quality route provider closeout / refresh evidence | Current for HEAD `2b0c3ce373fba38bacd62eff5436822527dccda1`; review input until PR `#346` is accepted |
-| `docs/reports/quality/backend-data-quality-route-provider-closeout-refresh-2026-05-28.md` | G2.193 human-readable closeout / refresh report | Review input until PR `#346` is accepted |
+| `.planning/codebase/generated/data-quality-route-provider-closeout-refresh-2026-05-28.json` | G2.193 data-quality route provider closeout / refresh evidence | Accepted by PR `#346`; superseded for adapter constructor seam design by G2.194 |
+| `docs/reports/quality/backend-data-quality-route-provider-closeout-refresh-2026-05-28.md` | G2.193 human-readable closeout / refresh report | Accepted by PR `#346`; superseded for adapter constructor seam design by G2.194 |
+| `.planning/codebase/generated/data-quality-adapter-seam-design-decision-2026-05-28.json` | G2.194 data-quality adapter constructor seam design decision evidence | Current for HEAD `ea659d52903a5e9884d396069526ea08f15109a6`; review input until PR `#347` is accepted |
+| `docs/reports/quality/backend-data-quality-adapter-seam-design-decision-2026-05-28.md` | G2.194 human-readable adapter seam design decision report | Review input until PR `#347` is accepted |
 
 ## External State Inputs
 
@@ -65,7 +67,8 @@ state transition.
 | GitHub PR `#343` | `MERGED` | G2.190 data-quality / adapter decision merged by commit `7154ffbb067dcddc52d80f15342961b51234ac09` |
 | GitHub PR `#344` | `MERGED` | G2.191 data-quality route provider authorization merged by commit `b899a173909d3818370dddbf35b039832266bd1d` |
 | GitHub PR `#345` | `MERGED` | G2.192 data-quality route provider implementation merged by commit `2b0c3ce373fba38bacd62eff5436822527dccda1` |
-| `origin/wip/root-dirty-20260403` | `2b0c3ce373fba38bacd62eff5436822527dccda1` | Base used for this closeout / refresh branch |
+| GitHub PR `#346` | `MERGED` | G2.193 data-quality route provider closeout / refresh merged by commit `ea659d52903a5e9884d396069526ea08f15109a6` |
+| `origin/wip/root-dirty-20260403` | `ea659d52903a5e9884d396069526ea08f15109a6` | Base used for this adapter seam design branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T01:52:33+08:00",
+  "generated_at": "2026-05-28T02:10:15+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "2b0c3ce373fba38bacd62eff5436822527dccda1",
-  "split_branch": "g2-193-data-quality-route-provider-closeout-refresh",
-  "scope": "governance_only_data_quality_route_provider_closeout_refresh",
+  "base_head": "ea659d52903a5e9884d396069526ea08f15109a6",
+  "split_branch": "g2-194-data-quality-adapter-seam-design",
+  "scope": "governance_only_data_quality_adapter_constructor_seam_design",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -916,7 +916,7 @@
     {
       "id": "g2-193-data-quality-route-provider-closeout-refresh",
       "type": "closeout_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.192 data-quality route provider implementation",
       "source_edit_authority": false,
@@ -973,10 +973,109 @@
         "source_lane_recommendation": "do-not-start-source-implementation-from-g2-193"
       },
       "freshness": {
-        "current_head_checked": "2b0c3ce373fba38bacd62eff5436822527dccda1",
+        "current_head_checked": "ea659d52903a5e9884d396069526ea08f15109a6",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.194 data-quality adapter constructor seam design / test-double decision package; do not implement adapter changes from G2.193."
+      "github_pr": {
+        "number": 346,
+        "url": "https://github.com/chengjon/mystocks/pull/346",
+        "state": "MERGED",
+        "merge_commit": "ea659d52903a5e9884d396069526ea08f15109a6"
+      },
+      "next_gate": "Superseded by G2.194 data-quality adapter constructor seam design."
+    },
+    {
+      "id": "g2-194-data-quality-adapter-seam-design",
+      "type": "decision_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.193 data-quality route provider closeout / remaining candidate refresh",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/data-quality-adapter-seam-design-decision-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-adapter-seam-design-decision-2026-05-28.md",
+        "governance/mainline/task-cards/pr-347.yaml"
+      ],
+      "current_inventory": {
+        "files_scanned": 14,
+        "get_data_quality_monitor_calls": 15,
+        "monitor_data_quality_calls": 1,
+        "init_definitions": 15,
+        "constructors_with_quality_monitor_parameter": 0,
+        "methods_required_by_remaining_surfaces": [
+          "check_data_quality",
+          "evaluate_data_quality"
+        ]
+      },
+      "surface_buckets": {
+        "adapter_split": {
+          "files": 8,
+          "getter_calls": 8,
+          "decision": "next_authorization_target"
+        },
+        "service_adapter": {
+          "files": 2,
+          "getter_calls": 2,
+          "decision": "defer_async_runtime_monitoring_surface"
+        },
+        "legacy_adapter": {
+          "files": 2,
+          "getter_calls": 2,
+          "decision": "defer_owner_specific_compatibility_surface"
+        },
+        "market_data_adapter": {
+          "files": 1,
+          "getter_calls": 1,
+          "decision": "defer_compatibility_surface"
+        },
+        "service_wrapper": {
+          "files": 1,
+          "getter_calls": 2,
+          "monitor_helper_calls": 1,
+          "decision": "retain_backing_api_until_consumers_migrate"
+        }
+      },
+      "gitnexus_evidence": {
+        "get_data_quality_monitor": {
+          "risk": "CRITICAL",
+          "impacted_count": 24,
+          "direct_callers": 20,
+          "processes": 7,
+          "modules": 4
+        },
+        "BaseAdapter": {
+          "risk": "MEDIUM",
+          "direct_extenders": 7,
+          "decision_use": "adapter_split_constructor_seam_first"
+        }
+      },
+      "decision": {
+        "classification": "adapter_split_constructor_seam_first_design",
+        "selected_next_governance_target": "data-quality-adapter-split-constructor-provider-authorization",
+        "recommended_next_work_item": "G2.195 data-quality adapter_split constructor provider authorization package",
+        "future_implementation_lane_after_authorization": "G2.196 data-quality adapter_split constructor provider implementation",
+        "deferred_surfaces": [
+          "service_adapter",
+          "legacy_adapter",
+          "market_data_adapter",
+          "service_wrapper",
+          "DataQualityMonitor internals"
+        ]
+      },
+      "test_double_contract": {
+        "check_data_quality": "sync fake records calls and returns truthy quality result",
+        "evaluate_data_quality": "async fake records calls and returns truthy result for later runtime-monitoring surfaces",
+        "future_source_requirements": [
+          "BaseAdapter and subclasses can receive fake monitor/provider without global getter",
+          "subclass constructors do not overwrite injected monitor",
+          "default runtime behavior remains compatible"
+        ]
+      },
+      "freshness": {
+        "current_head_checked": "ea659d52903a5e9884d396069526ea08f15109a6",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.195 authorization package; do not implement adapter source changes from G2.194."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T01:52:33+08:00`
-- Base HEAD checked: `2b0c3ce373fba38bacd62eff5436822527dccda1`
+- Prepared at: `2026-05-28T02:10:15+08:00`
+- Base HEAD checked: `ea659d52903a5e9884d396069526ea08f15109a6`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -45,7 +45,8 @@ It proved a repeatable conveyor:
 | G2.190 data-quality / adapter cross-cutting decision | Merged by PR `#343` | Classifies `get_data_quality_monitor` as `CRITICAL`, splits the route/adapter/wrapper surfaces, and selects G2.191 route-only authorization as the next gate |
 | G2.191 data-quality route provider authorization | Merged by PR `#344` | Authorized a future G2.192 route-only implementation lane for `web/backend/app/api/data_quality.py` and focused tests, with no source edits in G2.191 |
 | G2.192 data-quality route provider implementation | Merged by PR `#345` | Implements authorized provider injection in `web/backend/app/api/data_quality.py`; focused tests and OpenAPI leak smoke pass |
-| G2.193 data-quality route provider closeout / remaining candidate refresh | For review | Marks route-body provider migration closed and selects adapter constructor seam design / test-double decision as the next governance gate |
+| G2.193 data-quality route provider closeout / remaining candidate refresh | Merged by PR `#346` | Marks route-body provider migration closed and selects adapter constructor seam design / test-double decision as the next governance gate |
+| G2.194 data-quality adapter constructor seam design | For review | Selects `adapter_split` constructor provider authorization as the next gate, defines test-double contract, and keeps source authority at none |
 
 ## Current Strategy Getter Residuals
 
@@ -188,14 +189,57 @@ Remaining `get_data_quality_monitor` surface after route closeout:
 | other | 1 | 1 | `market_data_adapter.py` compatibility surface |
 | service_wrapper | 1 | 2 | Retain singleton wrapper / backing API until consumers are migrated and verified |
 
+## G2.194 Data-Quality Adapter Constructor Seam Design
+
+At HEAD `ea659d52903a5e9884d396069526ea08f15109a6`, PR `#346` is merged and the
+remaining data-quality adapter seam is classified as constructor-level
+dependency ownership, not route-body provider debt.
+
+| Inventory item | Value |
+|---|---:|
+| Adapter-related files scanned | 14 |
+| `get_data_quality_monitor()` calls | 15 |
+| `monitor_data_quality()` helper calls | 1 |
+| `__init__` definitions | 15 |
+| Constructors with quality monitor parameter | 0 |
+
+Surface classification:
+
+| Surface | Files | Getter calls | G2.194 decision |
+|---|---:|---:|---|
+| `adapter_split` | 8 | 8 | Next governance target: constructor provider authorization |
+| service adapters | 2 | 2 | Defer; async runtime monitoring surface, not constructor migration |
+| legacy adapters | 2 | 2 | Defer to owner-specific compatibility decision |
+| `market_data_adapter.py` | 1 | 1 | Defer as compatibility surface |
+| singleton wrapper | 1 | 2 plus 1 helper | Retain backing API until consumers are migrated and verified |
+
+GitNexus design evidence:
+
+| Target | Risk | Impact summary | Decision use |
+|---|---|---|---|
+| `get_data_quality_monitor` | CRITICAL | 24 impacted symbols, 20 direct callers, 7 processes, 4 modules | Do not migrate all surfaces in one source lane |
+| `BaseAdapter` | MEDIUM | 7 direct subclass extenders | Use `adapter_split` constructor seam as the first authorization candidate |
+
+Required future test-double contract:
+
+- `FakeDataQualityMonitor.check_data_quality(data, source_or_context)` records
+  calls and returns a truthy quality result.
+- `FakeDataQualityMonitor.evaluate_data_quality(...)` records calls and returns
+  a truthy result for later async runtime-monitoring surfaces.
+- Future source implementation must prove `BaseAdapter` and subclass
+  constructors can accept the fake monitor/provider without calling the global
+  getter.
+- Future source implementation must prove subclass constructors do not overwrite
+  the injected monitor and default runtime behavior remains compatible.
+
 ## Next Gates
 
-- Review G2.193 data-quality route provider closeout / remaining candidate
-  refresh.
-- If accepted, start G2.194 data-quality adapter constructor seam design /
-  test-double decision package.
-- Do not start adapter constructor implementation from G2.193.
-- Do not migrate adapter constructors or delete singleton wrappers from G2.193.
+- Review G2.194 data-quality adapter constructor seam design decision.
+- If accepted, start G2.195 data-quality `adapter_split` constructor provider
+  authorization package.
+- Do not start adapter constructor implementation from G2.194.
+- Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
+  singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`
   restoration, or other risk route provider migrations.
 

--- a/docs/reports/quality/backend-data-quality-adapter-seam-design-decision-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-adapter-seam-design-decision-2026-05-28.md
@@ -1,0 +1,167 @@
+# Backend Data Quality Adapter Seam Design Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: governance design decision review candidate
+- Prepared at: `2026-05-28T02:10:15+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `ea659d52903a5e9884d396069526ea08f15109a6`
+- Worktree branch: `g2-194-data-quality-adapter-seam-design`
+- Scope: data-quality adapter constructor seam design / test-double decision
+- Source edit authority: none
+
+Boundary note: this package selects the next governance gate. It does not
+authorize adapter constructor implementation, legacy adapter edits, singleton
+wrapper deletion, `DataQualityMonitor` internals, frontend edits, `src` edits,
+`docs/api` edits, or OpenSpec change/spec edits.
+
+## Parent State
+
+| Item | State | Evidence |
+|---|---|---|
+| G2.193 data-quality route provider closeout / refresh | Merged | PR `#346`, merge commit `ea659d52903a5e9884d396069526ea08f15109a6` |
+| G2.194 data-quality adapter seam design | For review | This report plus `.planning/codebase/generated/data-quality-adapter-seam-design-decision-2026-05-28.json` |
+
+## Current Inventory
+
+At HEAD `ea659d52903a5e9884d396069526ea08f15109a6`, the remaining data-quality
+monitor surface is no longer a route-body migration. It is an adapter and
+compatibility seam.
+
+| Metric | Count |
+|---|---:|
+| Files scanned | 14 |
+| `get_data_quality_monitor()` calls | 15 |
+| `monitor_data_quality()` calls | 1 |
+| `__init__` definitions in scanned files | 15 |
+| Constructors already accepting a quality monitor parameter | 0 |
+
+Quality monitor methods used by the remaining surfaces:
+
+- `check_data_quality`
+- `evaluate_data_quality`
+
+Existing test files that already touch related adapter names:
+
+- `web/backend/tests/test_logging_noise_regressions.py`
+- `web/backend/tests/_test_data_source_factory_management.py`
+- `web/backend/tests/_test_data_source_factory_support.py`
+- `web/backend/tests/test_market_data_service_getter_retirement.py`
+- `tests/backend/test_data_adapter_regression.py`
+
+## Surface Classification
+
+| Surface | Files | Getter calls | Current shape | Decision |
+|---|---:|---:|---|---|
+| `adapters_split` constructor surface | 8 | 8 | `BaseAdapter` plus seven subclasses call `get_data_quality_monitor()` during `__init__` | Select as next governance target |
+| service adapter runtime monitoring | 2 | 2 | config constructors plus async `_trigger_quality_monitoring()` runtime getter | Defer until `adapters_split` pattern is proven |
+| legacy adapter runtime monitoring | 2 | 2 | compatibility package with async `_trigger_quality_monitoring()` runtime getter | Defer to compatibility ownership decision |
+| `market_data_adapter.py` compatibility surface | 1 | 1 | market-data adapter runtime monitoring getter | Defer to market-data compatibility decision |
+| singleton wrapper / backing API | 1 | 2 + 1 helper | retained `get_data_quality_monitor` / `monitor_data_quality` backing API | Retain; not a deletion candidate |
+
+The `adapters_split` target is cohesive because all eight files share the same
+constructor-time dependency pattern:
+
+- `web/backend/app/services/adapters_split/base_adapter.py`
+- `web/backend/app/services/adapters_split/baostock_adapter.py`
+- `web/backend/app/services/adapters_split/tushare_adapter.py`
+- `web/backend/app/services/adapters_split/customer_adapter.py`
+- `web/backend/app/services/adapters_split/byapi_adapter.py`
+- `web/backend/app/services/adapters_split/akshare_adapter.py`
+- `web/backend/app/services/adapters_split/efinance_adapter.py`
+- `web/backend/app/services/adapters_split/tdx_adapter.py`
+
+## GitNexus Evidence
+
+| Target | Risk | Summary |
+|---|---|---|
+| `get_data_quality_monitor` | CRITICAL | 24 impacted symbols, 20 direct callers, 7 affected processes, 4 affected modules |
+| `BaseAdapter` | MEDIUM | 7 impacted subclasses, 0 affected processes |
+
+The `get_data_quality_monitor` risk remains cross-cutting. G2.194 therefore
+does not authorize source edits. It only selects the next authorization package.
+
+## Design Decision
+
+G2.194 selects:
+
+`G2.195 data-quality adapter_split constructor provider authorization package`
+
+G2.195 should authorize, but still not implement, a future implementation lane
+for the `adapters_split` constructor seam. The likely future implementation lane
+should be G2.196 after G2.195 acceptance.
+
+The future authorization candidate should be limited to:
+
+- `web/backend/app/services/adapters_split/base_adapter.py`
+- `web/backend/app/services/adapters_split/baostock_adapter.py`
+- `web/backend/app/services/adapters_split/tushare_adapter.py`
+- `web/backend/app/services/adapters_split/customer_adapter.py`
+- `web/backend/app/services/adapters_split/byapi_adapter.py`
+- `web/backend/app/services/adapters_split/akshare_adapter.py`
+- `web/backend/app/services/adapters_split/efinance_adapter.py`
+- `web/backend/app/services/adapters_split/tdx_adapter.py`
+- focused adapter constructor/provider tests
+- G2.195/G2.196 governance evidence
+
+The future authorization candidate must continue to forbid:
+
+- `web/backend/app/services/adapters/**`
+- `web/backend/app/services/data_adapters/**`
+- `web/backend/app/services/market_data_adapter.py`
+- `web/backend/app/services/_data_quality_monitor_singleton.py`
+- `web/backend/app/services/data_quality_monitor.py`
+- frontend, `src`, `docs/api`, config, scripts, and OpenSpec change/spec edits
+
+## Test-Double Contract
+
+Future implementation should define focused test evidence around a fake monitor
+contract before changing adapter constructors.
+
+Proposed fake:
+
+- `FakeDataQualityMonitor.check_data_quality(data, source_or_context)` records
+  calls and returns a truthy `{"is_valid": True}` style result.
+- `FakeDataQualityMonitor.evaluate_data_quality(...)` is async, records calls,
+  and returns a truthy result for later runtime-monitoring tracks.
+
+Future implementation must prove:
+
+- adapter constructors can receive the fake monitor or provider without calling
+  the global getter
+- `BaseAdapter._log_data_quality` uses the injected monitor
+- subclass constructors do not overwrite the injected monitor with the singleton
+- default constructor behavior still preserves current runtime behavior
+
+## Explicit Non-Goals
+
+- No backend source edits.
+- No test edits.
+- No adapter constructor implementation.
+- No legacy adapter compatibility edits.
+- No singleton wrapper deletion.
+- No `DataQualityMonitor` implementation rewrite.
+- No frontend edits.
+- No `src` edits.
+- No `docs/api` edits.
+- No OpenSpec change/spec edits.
+
+## Next Gate
+
+If accepted, start:
+
+`G2.195 data-quality adapter_split constructor provider authorization package`
+
+Do not implement adapter changes from G2.194.
+
+## Evidence Artifacts
+
+| Artifact | Role |
+|---|---|
+| `.planning/codebase/generated/data-quality-route-provider-closeout-refresh-2026-05-28.json` | G2.193 closeout / refresh evidence |
+| `docs/reports/quality/backend-data-quality-route-provider-closeout-refresh-2026-05-28.md` | G2.193 closeout / refresh report |
+| `.planning/codebase/generated/data-quality-adapter-seam-design-decision-2026-05-28.json` | G2.194 machine-readable design decision evidence |
+| `docs/reports/quality/backend-data-quality-adapter-seam-design-decision-2026-05-28.md` | G2.194 design decision report |
+| `governance/mainline/task-cards/pr-347.yaml` | G2.194 governance PR scope card |

--- a/governance/mainline/task-cards/pr-347.yaml
+++ b/governance/mainline/task-cards/pr-347.yaml
@@ -1,0 +1,116 @@
+version: "v0.2"
+
+task:
+  id: "pr-347"
+  title: "Decide data-quality adapter constructor seam"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-adapter-seam-design"
+  objective: "select the next governance gate for the data-quality adapter constructor seam without authorizing source implementation"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only adapter seam design; no route paths, HTTP methods, response models, OpenAPI examples, frontend behavior, PM2 workflows, or public API ownership changes"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-adapter-seam-design-decision-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-adapter-seam-design-decision-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-347.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "editing backend source"
+  - "editing tests"
+  - "adapter constructor implementation"
+  - "legacy adapter compatibility edits"
+  - "singleton wrapper deletion"
+  - "DataQualityMonitor internals"
+  - "creating OpenSpec proposals"
+  - "changing GitHub issue labels"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-adapter-seam-design-decision-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-347.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-data-quality-adapter-seam-design-decision-2026-05-28.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-347.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha ea659d52903a5e9884d396069526ea08f15109a6 --head-sha HEAD --report /tmp/pr347-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If G2.194 is misread as source authority, adapter constructor edits could start before an explicit authorization package exists."
+    - "If service_adapter, legacy_adapter, and market_data_adapter are batched with adapters_split, the seam loses rollback boundaries."
+  rollback_plan: "revert this PR to remove the governance-only design decision and restore the previous G2.193 next gate."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "select the next data-quality adapter constructor seam governance gate"
+    modified_scope: "governance evidence, steward tree state, and PR #347 task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; adapter and singleton surfaces remain untouched"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if it authorizes source implementation or conflates adapter surfaces"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T02:10:15+08:00"
+    approval_note: "Human maintainer approved continuing after PR #346 acceptance; this lane is governance-only design / test-double decision."
+    secondary_approved: true


### PR DESCRIPTION
## Summary
- Records G2.194 as a governance-only data-quality adapter constructor seam design decision.
- Updates steward tree split files and machine-readable index after PR #346 merged.
- Selects G2.195 as the next authorization package for adapter_split constructor provider work; no backend source edits are authorized here.

## Verification
- JSON/YAML parse passed for steward index, generated evidence, and task card.
- Markdown governance gate: 6 checked files, 0 errors.
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: valid; PostHog network flush noise only.
- mainline_scope_gate for pr-347: pass=True.
- git diff --cached --check: passed.
- GitNexus detect_changes(scope=staged): low risk, changed symbols 0, affected processes 0.

## Boundary
- Governance/documentation only.
- No web/backend, web/frontend, tests, OpenSpec change, config, script, or API contract edits.
- G2.194 does not authorize adapter implementation; it only prepares the G2.195 authorization gate.