### PR TITLE
docs(governance): authorize data quality adapter split seam

### DIFF
--- a/.planning/codebase/generated/data-quality-adapter-split-constructor-provider-authorization-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-adapter-split-constructor-provider-authorization-2026-05-28.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "2026-05-28.g2-195.authorization.v1",
+  "generated_at": "2026-05-28T02:31:48+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "e30e16605df6aaa333989a7ac247bab3dcd0dd01",
+  "worktree_branch": "g2-195-data-quality-adapter-split-authorization",
+  "status": "for_review",
+  "source_edit_authority": false,
+  "parent": {
+    "id": "g2-194-data-quality-adapter-seam-design",
+    "github_pr": 347,
+    "merge_commit": "e30e16605df6aaa333989a7ac247bab3dcd0dd01",
+    "decision": "adapter_split constructor seam first; implementation remains blocked until a separate authorization package is accepted"
+  },
+  "authorization": {
+    "classification": "future_source_authorization_package",
+    "authorized_future_lane": "G2.196 data-quality adapter_split constructor provider implementation",
+    "authorized_future_scope": "Introduce injectable data-quality monitor construction for adapter_split only, preserving default runtime behavior and avoiding global getter calls when an injected fake or provider is supplied.",
+    "future_source_edit_authority_if_accepted": true,
+    "future_authorized_source_paths": [
+      "web/backend/app/services/adapters_split/base_adapter.py",
+      "web/backend/app/services/adapters_split/baostock_adapter.py",
+      "web/backend/app/services/adapters_split/tushare_adapter.py",
+      "web/backend/app/services/adapters_split/customer_adapter.py",
+      "web/backend/app/services/adapters_split/byapi_adapter.py",
+      "web/backend/app/services/adapters_split/akshare_adapter.py",
+      "web/backend/app/services/adapters_split/efinance_adapter.py",
+      "web/backend/app/services/adapters_split/tdx_adapter.py"
+    ],
+    "future_authorized_test_paths": [
+      "web/backend/tests/test_adapter_split_data_quality_monitor_provider.py"
+    ],
+    "future_forbidden_paths": [
+      "web/backend/app/services/adapters/**",
+      "web/backend/app/services/data_adapters/**",
+      "web/backend/app/services/market_data_adapter.py",
+      "web/backend/app/services/_data_quality_monitor_singleton.py",
+      "web/backend/app/services/data_quality_monitor.py",
+      "web/backend/app/api/**",
+      "web/frontend/**",
+      "src/**",
+      "docs/api/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ]
+  },
+  "current_inventory_at_authorization": {
+    "files_scanned": 8,
+    "constructors_with_quality_monitor_parameter": 0,
+    "base_adapter": {
+      "path": "web/backend/app/services/adapters_split/base_adapter.py",
+      "constructor_line": 23,
+      "singleton_assignment_line": 27,
+      "log_data_quality_uses_self_quality_monitor_line": 100
+    },
+    "subclass_singleton_assignment_lines": {
+      "web/backend/app/services/adapters_split/baostock_adapter.py": 22,
+      "web/backend/app/services/adapters_split/tushare_adapter.py": 22,
+      "web/backend/app/services/adapters_split/customer_adapter.py": 35,
+      "web/backend/app/services/adapters_split/byapi_adapter.py": 24,
+      "web/backend/app/services/adapters_split/akshare_adapter.py": 22,
+      "web/backend/app/services/adapters_split/efinance_adapter.py": 22,
+      "web/backend/app/services/adapters_split/tdx_adapter.py": 22
+    }
+  },
+  "gitnexus_evidence_at_authorization": {
+    "BaseAdapter": {
+      "risk": "MEDIUM",
+      "impacted_count": 7,
+      "direct_extenders": [
+        "TushareAdapter",
+        "TDXAdapter",
+        "EfinanceAdapter",
+        "CustomerAdapter",
+        "BYAPIAdapter",
+        "BaostockAdapter",
+        "AkshareAdapter"
+      ]
+    },
+    "get_data_quality_monitor": {
+      "risk": "CRITICAL",
+      "impacted_count": 24,
+      "direct_callers": 20,
+      "processes_affected": 7,
+      "modules_affected": 4,
+      "authorization_boundary": "G2.196 may only reduce adapter_split constructor direct calls; all other callers remain out of scope."
+    }
+  },
+  "future_implementation_requirements": {
+    "constructor_policy": [
+      "BaseAdapter may accept an optional injected monitor or provider while defaulting to get_data_quality_monitor() for backward compatibility.",
+      "Adapter subclass constructors may accept an optional keyword-only monitor or provider and pass it to BaseAdapter.",
+      "Subclass constructors must not overwrite an injected monitor with a singleton result.",
+      "CustomerAdapter must preserve ws_url compatibility; any injection parameter should be keyword-only."
+    ],
+    "test_double_contract": {
+      "name": "FakeDataQualityMonitor",
+      "methods": {
+        "check_data_quality": "sync method that records calls and returns a truthy {'is_valid': true-like value}",
+        "evaluate_data_quality": "async method that records calls and returns a truthy result for later runtime-monitoring lanes"
+      }
+    },
+    "required_future_checks": [
+      "TDD red test for injected fake monitor before implementation",
+      "focused pytest for adapter_split constructor provider regression",
+      "import smoke for BaseAdapter and the seven adapter_split subclasses",
+      "ruff check on the eight adapter_split source files and the focused test",
+      "openspec validate migrate-backend-singletons-to-lifecycle-di --strict",
+      "gitnexus_detect_changes(scope=staged) after staging the future implementation batch"
+    ]
+  },
+  "non_goals": [
+    "Do not edit source files in G2.195.",
+    "Do not implement adapter constructor injection in this authorization package.",
+    "Do not touch service adapters, legacy adapters, market_data_adapter.py, singleton wrappers, or DataQualityMonitor internals.",
+    "Do not change routes, OpenAPI schema, frontend consumers, PM2 workflows, or API contracts.",
+    "Do not delete compatibility wrappers or singleton backing APIs."
+  ],
+  "next_gate": "If accepted, start G2.196 data-quality adapter_split constructor provider implementation with the exact future authorized paths and checks above."
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T02:10:15+08:00`
-- Base HEAD checked: `ea659d52903a5e9884d396069526ea08f15109a6`
+- Prepared at: `2026-05-28T02:31:48+08:00`
+- Base HEAD checked: `e30e16605df6aaa333989a7ac247bab3dcd0dd01`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -31,12 +31,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#344` | `g2-191-data-quality-route-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `b899a173909d3818370dddbf35b039832266bd1d` | Authorization package for G2.192 data-quality route provider implementation |
 | `#345` | `g2-192-data-quality-route-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `2b0c3ce373fba38bacd62eff5436822527dccda1` | Path-limited data-quality route provider implementation closed for G2.193 refresh |
 | `#346` | `g2-193-data-quality-route-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `ea659d52903a5e9884d396069526ea08f15109a6` | Governance closeout / remaining surface refresh selecting G2.194 adapter constructor seam design |
+| `#347` | `g2-194-data-quality-adapter-seam-design` | `wip/root-dirty-20260403` | `MERGED` at `e30e16605df6aaa333989a7ac247bab3dcd0dd01` | Governance design decision selecting G2.195 adapter_split constructor provider authorization |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-194-data-quality-adapter-seam-design` | `origin/wip/root-dirty-20260403` at `ea659d52903a5e9884d396069526ea08f15109a6` | Record data-quality adapter constructor seam design and test-double contract before authorizing any adapter source lane | None; governance-only design decision |
+| `g2-195-data-quality-adapter-split-authorization` | `origin/wip/root-dirty-20260403` at `e30e16605df6aaa333989a7ac247bab3dcd0dd01` | Authorize the future G2.196 `adapter_split` constructor provider implementation lane without editing source in this PR | None; governance-only authorization package |
 
 ## OpenSpec Relationship
 
@@ -52,8 +53,8 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.194 is a governance-only design decision branch after PR `#346` merged
-G2.193. It must not edit backend source, frontend source, tests, OpenSpec
-changes, API contract files, config, or scripts. If accepted, it selects G2.195
-as a data-quality `adapter_split` constructor provider authorization package; it
-does not authorize adapter implementation.
+G2.195 is a governance-only authorization branch after PR `#347` merged G2.194.
+It must not edit backend source, frontend source, tests, OpenSpec changes, API
+contract files, config, or scripts. If accepted, it authorizes G2.196 as the
+data-quality `adapter_split` constructor provider implementation lane; it does
+not implement that lane itself.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T02:10:15+08:00`
-- Base HEAD checked: `ea659d52903a5e9884d396069526ea08f15109a6`
+- Prepared at: `2026-05-28T02:31:48+08:00`
+- Base HEAD checked: `e30e16605df6aaa333989a7ac247bab3dcd0dd01`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 is the active governance-only data-quality adapter constructor seam design decision |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 is the active governance-only data-quality `adapter_split` constructor provider authorization package |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T02:10:15+08:00`
-- Base HEAD checked: `ea659d52903a5e9884d396069526ea08f15109a6`
+- Prepared at: `2026-05-28T02:31:48+08:00`
+- Base HEAD checked: `e30e16605df6aaa333989a7ac247bab3dcd0dd01`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,9 +15,10 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.194 data-quality adapter constructor seam design | G/#79 service lifecycle DI | PR `#346` merged at `ea659d52903a5e9884d396069526ea08f15109a6`; G2.194 selects `adapter_split` constructor provider authorization as the next gate and keeps source authority at none | If accepted, start G2.195 data-quality `adapter_split` constructor provider authorization package |
-| P0 | Preserve G2.193 data-quality route provider closeout / remaining candidate refresh | G/#79 service lifecycle DI | PR `#346` merged; route-body migration is closed, remaining adapter surfaces are refreshed, and G2.194 is the current design gate | Do not implement adapter changes from G2.193 or G2.194 |
-| P0 | Preserve G2.192 data-quality route provider implementation | G/#79 service lifecycle DI | PR `#345` merged; route body `get_data_quality_monitor()` and `monitor_data_quality()` calls are both `0` | Do not start adapter constructor implementation from G2.192, G2.193, or G2.194 |
+| P0 | Review G2.195 data-quality `adapter_split` constructor provider authorization | G/#79 service lifecycle DI | PR `#347` merged at `e30e16605df6aaa333989a7ac247bab3dcd0dd01`; G2.195 authorizes a future G2.196 implementation lane but keeps source authority at none in this PR | If accepted, start G2.196 data-quality `adapter_split` constructor provider implementation |
+| P0 | Preserve G2.194 data-quality adapter constructor seam design | G/#79 service lifecycle DI | PR `#347` merged; G2.194 selected `adapter_split` constructor seam as the next authorization target | Do not implement adapter changes from G2.194 or G2.195 |
+| P0 | Preserve G2.193 data-quality route provider closeout / remaining candidate refresh | G/#79 service lifecycle DI | PR `#346` merged; route-body migration is closed, remaining adapter surfaces are refreshed, and G2.194 design has been accepted | Do not reopen route-body provider migration while authorizing `adapter_split` constructor work |
+| P0 | Preserve G2.192 data-quality route provider implementation | G/#79 service lifecycle DI | PR `#345` merged; route body `get_data_quality_monitor()` and `monitor_data_quality()` calls are both `0` | Do not start adapter constructor implementation from G2.192, G2.193, G2.194, or G2.195 |
 | P0 | Preserve G2.191 data-quality route provider authorization | G/#79 service lifecycle DI | PR `#344` merged; authorized only `web/backend/app/api/data_quality.py` plus focused tests for G2.192 | Do not expand into adapters, singleton wrapper, `DataQualityMonitor` internals, or data-source factory behavior |
 | P0 | Preserve G2.190 data-quality / adapter cross-cutting decision | G/#79 service lifecycle DI | PR `#343` merged; `get_data_quality_monitor` is `CRITICAL` with 20 direct callers across route, adapter, legacy adapter, and wrapper surfaces | Do not batch route, adapter constructor, legacy adapter, and singleton wrapper migration together |
 | P0 | Preserve G2.189 risk stop-loss provider closeout / candidate refresh | G/#79 service lifecycle DI | PR `#342` merged; stop-loss pair is closed for route-body provider migration and retained as provider backing getters | Do not reopen stop-loss or start data-quality source implementation from G2.189 |
@@ -36,8 +37,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.194 keep adapter implementation locked behind a separate G2.195 authorization package?
-- Is `adapter_split` separated from service-adapter, legacy-adapter, `market_data_adapter.py`, and singleton-wrapper surfaces?
-- Does the test-double contract cover both `check_data_quality` and `evaluate_data_quality` without changing source code?
-- Is G2.195 an authorization package rather than an implementation lane?
+- Does G2.195 authorize only the future G2.196 `adapter_split` constructor provider implementation lane?
+- Are the eight future source paths and one future test path narrow enough for one source PR?
+- Are service adapters, legacy adapters, `market_data_adapter.py`, singleton wrappers, and `DataQualityMonitor` internals still forbidden?
+- Does G2.195 itself avoid all source and test edits?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T02:10:15+08:00`
-- Base HEAD checked: `ea659d52903a5e9884d396069526ea08f15109a6`
+- Prepared at: `2026-05-28T02:31:48+08:00`
+- Base HEAD checked: `e30e16605df6aaa333989a7ac247bab3dcd0dd01`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -49,8 +49,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-route-provider-implementation-2026-05-28.md` | G2.192 human-readable implementation package | Accepted by PR `#345`; superseded for closeout / remaining candidate refresh by G2.193 |
 | `.planning/codebase/generated/data-quality-route-provider-closeout-refresh-2026-05-28.json` | G2.193 data-quality route provider closeout / refresh evidence | Accepted by PR `#346`; superseded for adapter constructor seam design by G2.194 |
 | `docs/reports/quality/backend-data-quality-route-provider-closeout-refresh-2026-05-28.md` | G2.193 human-readable closeout / refresh report | Accepted by PR `#346`; superseded for adapter constructor seam design by G2.194 |
-| `.planning/codebase/generated/data-quality-adapter-seam-design-decision-2026-05-28.json` | G2.194 data-quality adapter constructor seam design decision evidence | Current for HEAD `ea659d52903a5e9884d396069526ea08f15109a6`; review input until PR `#347` is accepted |
-| `docs/reports/quality/backend-data-quality-adapter-seam-design-decision-2026-05-28.md` | G2.194 human-readable adapter seam design decision report | Review input until PR `#347` is accepted |
+| `.planning/codebase/generated/data-quality-adapter-seam-design-decision-2026-05-28.json` | G2.194 data-quality adapter constructor seam design decision evidence | Accepted by PR `#347`; superseded for implementation authorization by G2.195 |
+| `docs/reports/quality/backend-data-quality-adapter-seam-design-decision-2026-05-28.md` | G2.194 human-readable adapter seam design decision report | Accepted by PR `#347`; superseded for implementation authorization by G2.195 |
+| `.planning/codebase/generated/data-quality-adapter-split-constructor-provider-authorization-2026-05-28.json` | G2.195 data-quality `adapter_split` constructor provider authorization evidence | Current for HEAD `e30e16605df6aaa333989a7ac247bab3dcd0dd01`; review input until PR `#348` is accepted |
+| `docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-authorization-2026-05-28.md` | G2.195 human-readable authorization package | Review input until PR `#348` is accepted |
 
 ## External State Inputs
 
@@ -68,7 +70,8 @@ state transition.
 | GitHub PR `#344` | `MERGED` | G2.191 data-quality route provider authorization merged by commit `b899a173909d3818370dddbf35b039832266bd1d` |
 | GitHub PR `#345` | `MERGED` | G2.192 data-quality route provider implementation merged by commit `2b0c3ce373fba38bacd62eff5436822527dccda1` |
 | GitHub PR `#346` | `MERGED` | G2.193 data-quality route provider closeout / refresh merged by commit `ea659d52903a5e9884d396069526ea08f15109a6` |
-| `origin/wip/root-dirty-20260403` | `ea659d52903a5e9884d396069526ea08f15109a6` | Base used for this adapter seam design branch |
+| GitHub PR `#347` | `MERGED` | G2.194 data-quality adapter constructor seam design merged by commit `e30e16605df6aaa333989a7ac247bab3dcd0dd01` |
+| `origin/wip/root-dirty-20260403` | `e30e16605df6aaa333989a7ac247bab3dcd0dd01` | Base used for this adapter_split constructor provider authorization branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T02:10:15+08:00",
+  "generated_at": "2026-05-28T02:31:48+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "ea659d52903a5e9884d396069526ea08f15109a6",
-  "split_branch": "g2-194-data-quality-adapter-seam-design",
-  "scope": "governance_only_data_quality_adapter_constructor_seam_design",
+  "base_head": "e30e16605df6aaa333989a7ac247bab3dcd0dd01",
+  "split_branch": "g2-195-data-quality-adapter-split-authorization",
+  "scope": "governance_only_data_quality_adapter_split_constructor_provider_authorization",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -987,7 +987,7 @@
     {
       "id": "g2-194-data-quality-adapter-seam-design",
       "type": "decision_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.193 data-quality route provider closeout / remaining candidate refresh",
       "source_edit_authority": false,
@@ -1072,10 +1072,104 @@
         ]
       },
       "freshness": {
-        "current_head_checked": "ea659d52903a5e9884d396069526ea08f15109a6",
+        "current_head_checked": "e30e16605df6aaa333989a7ac247bab3dcd0dd01",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.195 authorization package; do not implement adapter source changes from G2.194."
+      "github_pr": {
+        "number": 347,
+        "url": "https://github.com/chengjon/mystocks/pull/347",
+        "state": "MERGED",
+        "merge_commit": "e30e16605df6aaa333989a7ac247bab3dcd0dd01"
+      },
+      "next_gate": "Superseded by G2.195 data-quality adapter_split constructor provider authorization."
+    },
+    {
+      "id": "g2-195-data-quality-adapter-split-constructor-provider-authorization",
+      "type": "authorization_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.194 data-quality adapter constructor seam design",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/data-quality-adapter-split-constructor-provider-authorization-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-authorization-2026-05-28.md",
+        "governance/mainline/task-cards/pr-348.yaml"
+      ],
+      "future_source_edit_authority_if_accepted": true,
+      "authorized_future_lane": "G2.196 data-quality adapter_split constructor provider implementation",
+      "authorized_future_source_paths": [
+        "web/backend/app/services/adapters_split/base_adapter.py",
+        "web/backend/app/services/adapters_split/baostock_adapter.py",
+        "web/backend/app/services/adapters_split/tushare_adapter.py",
+        "web/backend/app/services/adapters_split/customer_adapter.py",
+        "web/backend/app/services/adapters_split/byapi_adapter.py",
+        "web/backend/app/services/adapters_split/akshare_adapter.py",
+        "web/backend/app/services/adapters_split/efinance_adapter.py",
+        "web/backend/app/services/adapters_split/tdx_adapter.py"
+      ],
+      "authorized_future_test_paths": [
+        "web/backend/tests/test_adapter_split_data_quality_monitor_provider.py"
+      ],
+      "future_forbidden_surfaces": [
+        "web/backend/app/services/adapters/**",
+        "web/backend/app/services/data_adapters/**",
+        "web/backend/app/services/market_data_adapter.py",
+        "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "web/backend/app/services/data_quality_monitor.py",
+        "web/backend/app/api/**",
+        "web/frontend/**",
+        "src/**",
+        "docs/api/**",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "current_inventory": {
+        "adapter_split_files_scanned": 8,
+        "constructors_with_quality_monitor_parameter": 0,
+        "BaseAdapter_singleton_assignment_line": 27,
+        "BaseAdapter_log_data_quality_uses_self_quality_monitor_line": 100,
+        "subclass_singleton_assignment_lines": {
+          "baostock_adapter.py": 22,
+          "tushare_adapter.py": 22,
+          "customer_adapter.py": 35,
+          "byapi_adapter.py": 24,
+          "akshare_adapter.py": 22,
+          "efinance_adapter.py": 22,
+          "tdx_adapter.py": 22
+        }
+      },
+      "gitnexus_evidence": {
+        "BaseAdapter": {
+          "risk": "MEDIUM",
+          "impacted_count": 7,
+          "direct_extenders": 7
+        },
+        "get_data_quality_monitor": {
+          "risk": "CRITICAL",
+          "impacted_count": 24,
+          "direct_callers": 20,
+          "processes_affected": 7,
+          "modules_affected": 4,
+          "authorization_boundary": "G2.196 may only reduce adapter_split constructor calls"
+        }
+      },
+      "future_test_double_contract": {
+        "check_data_quality": "sync fake records calls and returns truthy quality result",
+        "evaluate_data_quality": "async fake records calls and returns truthy result for later runtime-monitoring surfaces"
+      },
+      "future_required_checks": [
+        "focused pytest for web/backend/tests/test_adapter_split_data_quality_monitor_provider.py",
+        "ruff check on eight adapter_split source files plus focused test",
+        "openspec validate migrate-backend-singletons-to-lifecycle-di --strict",
+        "gitnexus_detect_changes(scope=staged)"
+      ],
+      "freshness": {
+        "current_head_checked": "e30e16605df6aaa333989a7ac247bab3dcd0dd01",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.196 implementation on the exact authorized paths; do not implement source changes from G2.195."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T02:10:15+08:00`
-- Base HEAD checked: `ea659d52903a5e9884d396069526ea08f15109a6`
+- Prepared at: `2026-05-28T02:31:48+08:00`
+- Base HEAD checked: `e30e16605df6aaa333989a7ac247bab3dcd0dd01`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -46,7 +46,8 @@ It proved a repeatable conveyor:
 | G2.191 data-quality route provider authorization | Merged by PR `#344` | Authorized a future G2.192 route-only implementation lane for `web/backend/app/api/data_quality.py` and focused tests, with no source edits in G2.191 |
 | G2.192 data-quality route provider implementation | Merged by PR `#345` | Implements authorized provider injection in `web/backend/app/api/data_quality.py`; focused tests and OpenAPI leak smoke pass |
 | G2.193 data-quality route provider closeout / remaining candidate refresh | Merged by PR `#346` | Marks route-body provider migration closed and selects adapter constructor seam design / test-double decision as the next governance gate |
-| G2.194 data-quality adapter constructor seam design | For review | Selects `adapter_split` constructor provider authorization as the next gate, defines test-double contract, and keeps source authority at none |
+| G2.194 data-quality adapter constructor seam design | Merged by PR `#347` | Selects `adapter_split` constructor provider authorization as the next gate, defines test-double contract, and keeps source authority at none |
+| G2.195 data-quality `adapter_split` constructor provider authorization | For review | Authorizes the future G2.196 `adapter_split` constructor provider implementation lane while keeping source authority at none in this PR |
 
 ## Current Strategy Getter Residuals
 
@@ -232,12 +233,59 @@ Required future test-double contract:
 - Future source implementation must prove subclass constructors do not overwrite
   the injected monitor and default runtime behavior remains compatible.
 
+## G2.195 Data-Quality Adapter Split Constructor Provider Authorization
+
+At HEAD `e30e16605df6aaa333989a7ac247bab3dcd0dd01`, PR `#347` is merged and
+the next gate is an authorization package for a future source lane.
+
+G2.195 authorizes G2.196 only after review acceptance. G2.195 itself has no
+source edit authority.
+
+Future authorized implementation lane:
+
+| Future lane | Authorized scope |
+|---|---|
+| G2.196 data-quality `adapter_split` constructor provider implementation | Add injectable data-quality monitor construction for `adapter_split` classes only, preserving default singleton behavior |
+
+Future authorized source paths:
+
+| Path | Future role |
+|---|---|
+| `web/backend/app/services/adapters_split/base_adapter.py` | Add injection seam defaulting to current singleton behavior |
+| `web/backend/app/services/adapters_split/baostock_adapter.py` | Pass injected monitor/provider through constructor |
+| `web/backend/app/services/adapters_split/tushare_adapter.py` | Pass injected monitor/provider through constructor |
+| `web/backend/app/services/adapters_split/customer_adapter.py` | Preserve `ws_url`; use keyword-only injection |
+| `web/backend/app/services/adapters_split/byapi_adapter.py` | Pass injected monitor/provider through constructor |
+| `web/backend/app/services/adapters_split/akshare_adapter.py` | Pass injected monitor/provider through constructor |
+| `web/backend/app/services/adapters_split/efinance_adapter.py` | Pass injected monitor/provider through constructor |
+| `web/backend/app/services/adapters_split/tdx_adapter.py` | Pass injected monitor/provider through constructor |
+
+Future authorized test path:
+
+| Path | Future role |
+|---|---|
+| `web/backend/tests/test_adapter_split_data_quality_monitor_provider.py` | Focused fake-monitor constructor provider regression tests |
+
+Future forbidden surfaces remain:
+
+- service adapters under `web/backend/app/services/adapters/`
+- legacy adapters under `web/backend/app/services/data_adapters/`
+- `web/backend/app/services/market_data_adapter.py`
+- `web/backend/app/services/_data_quality_monitor_singleton.py`
+- `web/backend/app/services/data_quality_monitor.py`
+- route, frontend, OpenAPI contract, config, script, and OpenSpec change files
+
+Required future checks include a focused pytest for the new test path, ruff on
+the eight adapter files plus test, OpenSpec strict validation, and staged
+GitNexus change detection.
+
 ## Next Gates
 
-- Review G2.194 data-quality adapter constructor seam design decision.
-- If accepted, start G2.195 data-quality `adapter_split` constructor provider
-  authorization package.
-- Do not start adapter constructor implementation from G2.194.
+- Review G2.195 data-quality `adapter_split` constructor provider authorization
+  package.
+- If accepted, start G2.196 data-quality `adapter_split` constructor provider
+  implementation.
+- Do not start adapter constructor implementation from G2.195 itself.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-authorization-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-authorization-2026-05-28.md
@@ -1,0 +1,153 @@
+# Backend Data-Quality Adapter Split Constructor Provider Authorization
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: for review
+- Prepared at: `2026-05-28T02:31:48+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD: `e30e16605df6aaa333989a7ac247bab3dcd0dd01`
+- Worktree branch: `g2-195-data-quality-adapter-split-authorization`
+- Parent: G2.194 data-quality adapter constructor seam design, PR `#347`
+- Source edit authority in this package: none
+
+Boundary note: this report authorizes a future implementation lane only after
+review acceptance. It does not edit source, tests, OpenSpec changes, route
+contracts, frontend files, PM2 workflows, or issue labels.
+
+## Decision
+
+G2.195 authorizes the next implementation lane shape, not the implementation
+itself.
+
+If this package is accepted, the next source lane should be:
+
+`G2.196 data-quality adapter_split constructor provider implementation`
+
+The future implementation may only introduce injectable data-quality monitor
+construction for `adapter_split` classes. Runtime defaults must remain
+compatible, and the global singleton path must remain available for callers that
+do not inject a monitor.
+
+## Current Evidence
+
+G2.194 proved that `get_data_quality_monitor` remains cross-cutting and must
+not be migrated in a single broad batch. G2.195 narrows the first source lane to
+the `adapter_split` constructor seam.
+
+| Evidence | Value |
+|---|---:|
+| `adapter_split` files in future source scope | 8 |
+| constructors with a quality monitor parameter | 0 |
+| `BaseAdapter` direct subclass extenders | 7 |
+| `get_data_quality_monitor` impacted symbols | 24 |
+| `get_data_quality_monitor` direct callers | 20 |
+| `get_data_quality_monitor` affected processes | 7 |
+
+GitNexus evidence at authorization time:
+
+| Target | Risk | Meaning for G2.196 |
+|---|---|---|
+| `BaseAdapter` | MEDIUM | Future source lane must update all seven direct subclass extenders or prove they remain compatible |
+| `get_data_quality_monitor` | CRITICAL | Future source lane may only reduce the `adapter_split` constructor calls; all other callers remain forbidden |
+
+## Future Authorized Paths
+
+If accepted, G2.196 may edit only these source files:
+
+| Path | Future use |
+|---|---|
+| `web/backend/app/services/adapters_split/base_adapter.py` | Add injectable monitor/provider defaulting to current singleton behavior |
+| `web/backend/app/services/adapters_split/baostock_adapter.py` | Pass injected monitor/provider through constructor |
+| `web/backend/app/services/adapters_split/tushare_adapter.py` | Pass injected monitor/provider through constructor |
+| `web/backend/app/services/adapters_split/customer_adapter.py` | Preserve `ws_url`; add injection as keyword-only |
+| `web/backend/app/services/adapters_split/byapi_adapter.py` | Pass injected monitor/provider through constructor |
+| `web/backend/app/services/adapters_split/akshare_adapter.py` | Pass injected monitor/provider through constructor |
+| `web/backend/app/services/adapters_split/efinance_adapter.py` | Pass injected monitor/provider through constructor |
+| `web/backend/app/services/adapters_split/tdx_adapter.py` | Pass injected monitor/provider through constructor |
+
+Future authorized test path:
+
+| Path | Future use |
+|---|---|
+| `web/backend/tests/test_adapter_split_data_quality_monitor_provider.py` | Focused regression tests for fake monitor injection, subclass pass-through, and default compatibility |
+
+## Future Forbidden Paths
+
+The future G2.196 source lane must not touch:
+
+- `web/backend/app/services/adapters/**`
+- `web/backend/app/services/data_adapters/**`
+- `web/backend/app/services/market_data_adapter.py`
+- `web/backend/app/services/_data_quality_monitor_singleton.py`
+- `web/backend/app/services/data_quality_monitor.py`
+- `web/backend/app/api/**`
+- `web/frontend/**`
+- `src/**`
+- `docs/api/**`
+- `config/**`
+- `scripts/**`
+- `openspec/changes/**`
+- `openspec/specs/**`
+
+## Constructor Policy
+
+Future G2.196 implementation should follow these constraints:
+
+- `BaseAdapter` may accept an optional injected monitor or provider.
+- The default path must keep current `get_data_quality_monitor()` behavior for
+  callers that do not inject anything.
+- Each `adapter_split` subclass may accept the same injection hook and pass it
+  to `BaseAdapter`.
+- Subclasses must not overwrite an injected monitor with a singleton result.
+- `CustomerAdapter` must preserve existing `ws_url` compatibility; any injection
+  parameter should be keyword-only.
+
+This package intentionally does not choose exact Python type aliases or final
+parameter names. G2.196 must choose them in source context and prove them through
+tests.
+
+## Test-Double Contract
+
+Future G2.196 tests should use a fake monitor with these methods:
+
+| Method | Required behavior |
+|---|---|
+| `check_data_quality(data, source_or_context)` | Synchronous; records calls and returns a truthy quality result |
+| `evaluate_data_quality(...)` | Async; records calls and returns a truthy result for later runtime-monitoring lanes |
+
+Required future assertions:
+
+- `BaseAdapter` can use the fake monitor without calling the global getter.
+- Each subclass can receive the fake monitor/provider through its constructor.
+- Subclass constructors do not replace the injected monitor with a singleton.
+- Default construction still works for existing runtime callers.
+
+## Required Future Checks
+
+Future G2.196 must run at least:
+
+```bash
+pytest -q -n 0 --tb=short --no-cov web/backend/tests/test_adapter_split_data_quality_monitor_provider.py
+ruff check web/backend/app/services/adapters_split/base_adapter.py web/backend/app/services/adapters_split/baostock_adapter.py web/backend/app/services/adapters_split/tushare_adapter.py web/backend/app/services/adapters_split/customer_adapter.py web/backend/app/services/adapters_split/byapi_adapter.py web/backend/app/services/adapters_split/akshare_adapter.py web/backend/app/services/adapters_split/efinance_adapter.py web/backend/app/services/adapters_split/tdx_adapter.py web/backend/tests/test_adapter_split_data_quality_monitor_provider.py
+openspec validate migrate-backend-singletons-to-lifecycle-di --strict
+```
+
+Before committing the future implementation, stage only the authorized paths and
+run `gitnexus_detect_changes(scope=staged)`.
+
+## Review Questions
+
+- Is the future source scope narrow enough for one implementation PR?
+- Does the package keep service adapters, legacy adapters, `market_data_adapter.py`,
+  singleton wrappers, and `DataQualityMonitor` internals out of scope?
+- Does the future test-double contract prove the constructor seam without
+  relying on broad runtime behavior?
+- Is G2.196 clearly an implementation lane that still needs separate review
+  after this authorization package is accepted?
+
+## Next Gate
+
+If accepted, start G2.196 data-quality `adapter_split` constructor provider
+implementation. Do not start source changes from G2.195 itself.

--- a/governance/mainline/task-cards/pr-348.yaml
+++ b/governance/mainline/task-cards/pr-348.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-348"
+  title: "Authorize data-quality adapter_split constructor provider implementation"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-adapter-split-authorization"
+  objective: "authorize the future adapter_split-only constructor provider implementation lane without editing source in this PR"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only future implementation authorization; no route paths, HTTP methods, response models, OpenAPI examples, frontend behavior, PM2 workflows, or public API ownership changes"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-adapter-split-constructor-provider-authorization-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-authorization-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-348.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "editing backend source"
+  - "editing tests"
+  - "implementing adapter constructor injection"
+  - "service adapter migration"
+  - "legacy adapter compatibility edits"
+  - "market_data_adapter.py edits"
+  - "singleton wrapper deletion"
+  - "DataQualityMonitor internals"
+  - "creating OpenSpec proposals"
+  - "changing GitHub issue labels"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-adapter-split-constructor-provider-authorization-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-348.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-authorization-2026-05-28.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-348.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha e30e16605df6aaa333989a7ac247bab3dcd0dd01 --head-sha HEAD --report /tmp/pr348-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "If G2.195 is misread as source authority, adapter constructor edits could start in the authorization PR instead of the future implementation PR."
+    - "If G2.196 expands beyond adapter_split, the CRITICAL get_data_quality_monitor seam loses rollback boundaries."
+  rollback_plan: "revert this PR to remove the authorization package and keep G2.194 as the active adapter seam design gate."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize the future adapter_split-only constructor provider implementation lane"
+    modified_scope: "governance evidence, steward tree state, and PR #348 task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source implementation remains blocked until G2.196"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if it edits source or authorizes non-adapter_split surfaces"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T02:31:48+08:00"
+    approval_note: "Human maintainer requested continuing after PR #347; this lane is authorization-only and does not perform source implementation."
+    secondary_approved: true


### PR DESCRIPTION
## Summary
- Records G2.195 as an authorization-only package for the future data-quality adapter_split constructor provider implementation lane.
- Narrows future G2.196 source authority to eight adapter_split files plus one focused regression test.
- Keeps service adapters, legacy adapters, market_data_adapter.py, singleton wrappers, DataQualityMonitor internals, routes, frontend, and OpenSpec changes out of scope.

## Verification
- JSON/YAML parse passed for steward index, generated evidence, and task card.
- Markdown governance gate: 6 checked files, 0 errors.
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: valid; PostHog network flush noise only.
- mainline_scope_gate for pr-348: pass=True.
- git diff --cached --check: passed.
- GitNexus detect_changes(scope=staged): low risk, changed symbols 0, affected processes 0.

## Boundary
- Governance/documentation only.
- No backend source, frontend, tests, config, scripts, API contract, or OpenSpec change edits.
- G2.195 does not implement adapter constructor injection; it only authorizes the future G2.196 lane after review acceptance.