### PR TITLE
refactor(services): inject adapter split quality monitor

### DIFF
--- a/.planning/codebase/generated/data-quality-adapter-split-constructor-provider-implementation-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-adapter-split-constructor-provider-implementation-2026-05-28.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": "2026-05-28.g2-196.implementation.v1",
+  "generated_at": "2026-05-28T07:45:53+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "fabd674e8a748cdd2c51a80eebb5ad20b52bc737",
+  "worktree_branch": "g2-196-data-quality-adapter-split-implementation",
+  "status": "for_review",
+  "source_edit_authority": true,
+  "parent": {
+    "id": "g2-195-data-quality-adapter-split-constructor-provider-authorization",
+    "github_pr": 348,
+    "merge_commit": "fabd674e8a748cdd2c51a80eebb5ad20b52bc737",
+    "authorization": "adapter_split-only constructor provider implementation"
+  },
+  "implemented_scope": {
+    "source_paths": [
+      "web/backend/app/services/adapters_split/base_adapter.py",
+      "web/backend/app/services/adapters_split/baostock_adapter.py",
+      "web/backend/app/services/adapters_split/tushare_adapter.py",
+      "web/backend/app/services/adapters_split/customer_adapter.py",
+      "web/backend/app/services/adapters_split/byapi_adapter.py",
+      "web/backend/app/services/adapters_split/akshare_adapter.py",
+      "web/backend/app/services/adapters_split/efinance_adapter.py",
+      "web/backend/app/services/adapters_split/tdx_adapter.py"
+    ],
+    "test_paths": [
+      "web/backend/tests/test_adapter_split_data_quality_monitor_provider.py"
+    ],
+    "governance_paths": [
+      ".planning/codebase/generated/data-quality-adapter-split-constructor-provider-implementation-2026-05-28.json",
+      "docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-implementation-2026-05-28.md",
+      "governance/mainline/task-cards/pr-349.yaml",
+      ".planning/codebase/steward-tree/current-next-gates.md",
+      ".planning/codebase/steward-tree/branch-register.md",
+      ".planning/codebase/steward-tree/evidence-index.md",
+      ".planning/codebase/steward-tree/completed-ledger.md",
+      ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+      ".planning/codebase/steward-tree/steward-index.json",
+      "governance/function-tree/catalog.yaml"
+    ]
+  },
+  "implementation_summary": {
+    "base_adapter": "BaseAdapter now accepts an optional quality_monitor and defaults to get_data_quality_monitor() when not injected.",
+    "subclasses": "Seven adapter_split subclasses accept keyword-only quality_monitor and pass it to BaseAdapter without overwriting injected monitor.",
+    "compatibility": "Default construction remains compatible because BaseAdapter still owns the singleton fallback.",
+    "incidental_authorized_fixes": [
+      "tushare_adapter.py now imports os for existing os.getenv usage.",
+      "byapi_adapter.py now imports os for existing os.getenv usage.",
+      "tdx_adapter.py constructor logger now uses self.name instead of undefined TDX."
+    ]
+  },
+  "post_implementation_inventory": {
+    "adapter_split_files_scanned": 8,
+    "base_adapter_get_data_quality_monitor_calls": 1,
+    "subclass_get_data_quality_monitor_calls": 0,
+    "subclass_get_data_quality_monitor_imports": 0,
+    "constructors_accepting_quality_monitor": 8,
+    "focused_test_count": 1
+  },
+  "gitnexus_pre_edit_evidence": {
+    "BaseAdapter": {
+      "risk": "MEDIUM",
+      "impacted_count": 7,
+      "direct_extenders": 7
+    },
+    "get_data_quality_monitor": {
+      "risk": "CRITICAL",
+      "impacted_count": 24,
+      "direct_callers": 20,
+      "processes_affected": 7,
+      "authorization_boundary": "only adapter_split constructor calls were migrated"
+    }
+  },
+  "tdd_evidence": {
+    "red": {
+      "command": "env PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov web/backend/tests/test_adapter_split_data_quality_monitor_provider.py",
+      "result": "failed as expected",
+      "failure": "BaostockAdapter.__init__() got an unexpected keyword argument 'quality_monitor'"
+    },
+    "green": {
+      "command": "env PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov web/backend/tests/test_adapter_split_data_quality_monitor_provider.py",
+      "result": "1 passed"
+    }
+  },
+  "verification": {
+    "focused_pytest": "1 passed",
+    "ruff_authorized_files": "All checks passed",
+    "import_smoke": "passed with minimal dummy required env; no service startup",
+    "openspec_validate": "migrate-backend-singletons-to-lifecycle-di valid; PostHog network flush noise only",
+    "git_diff_check": "passed",
+    "mainline_scope_gate": "passed after task-card schema alignment to feature/domain-01/domain-01-node-03 and Function Tree catalog coverage for adapters_split",
+    "gitnexus_detect_changes_staged": {
+      "risk": "low",
+      "changed_files": 18,
+      "changed_symbols": 84,
+      "affected_processes": 0
+    }
+  },
+  "forbidden_scope_preserved": [
+    "web/backend/app/services/adapters/**",
+    "web/backend/app/services/data_adapters/**",
+    "web/backend/app/services/market_data_adapter.py",
+    "web/backend/app/services/_data_quality_monitor_singleton.py",
+    "web/backend/app/services/data_quality_monitor.py",
+    "web/backend/app/api/**",
+    "web/frontend/**",
+    "src/**",
+    "docs/api/**",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**"
+  ],
+  "next_gate": "If accepted, run a G2.197 closeout / remaining candidate refresh before selecting any further data-quality monitor migration lane."
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T02:31:48+08:00`
-- Base HEAD checked: `e30e16605df6aaa333989a7ac247bab3dcd0dd01`
+- Prepared at: `2026-05-28T07:45:53+08:00`
+- Base HEAD checked: `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -32,12 +32,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#345` | `g2-192-data-quality-route-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `2b0c3ce373fba38bacd62eff5436822527dccda1` | Path-limited data-quality route provider implementation closed for G2.193 refresh |
 | `#346` | `g2-193-data-quality-route-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `ea659d52903a5e9884d396069526ea08f15109a6` | Governance closeout / remaining surface refresh selecting G2.194 adapter constructor seam design |
 | `#347` | `g2-194-data-quality-adapter-seam-design` | `wip/root-dirty-20260403` | `MERGED` at `e30e16605df6aaa333989a7ac247bab3dcd0dd01` | Governance design decision selecting G2.195 adapter_split constructor provider authorization |
+| `#348` | `g2-195-data-quality-adapter-split-authorization` | `wip/root-dirty-20260403` | `MERGED` at `fabd674e8a748cdd2c51a80eebb5ad20b52bc737` | Authorization package for G2.196 adapter_split constructor provider implementation |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-195-data-quality-adapter-split-authorization` | `origin/wip/root-dirty-20260403` at `e30e16605df6aaa333989a7ac247bab3dcd0dd01` | Authorize the future G2.196 `adapter_split` constructor provider implementation lane without editing source in this PR | None; governance-only authorization package |
+| `g2-196-data-quality-adapter-split-implementation` | `origin/wip/root-dirty-20260403` at `fabd674e8a748cdd2c51a80eebb5ad20b52bc737` | Implement the authorized `adapter_split` constructor provider seam with focused TDD evidence | Yes; limited to eight `adapter_split` source files plus one focused test |
 
 ## OpenSpec Relationship
 
@@ -53,8 +54,8 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.195 is a governance-only authorization branch after PR `#347` merged G2.194.
-It must not edit backend source, frontend source, tests, OpenSpec changes, API
-contract files, config, or scripts. If accepted, it authorizes G2.196 as the
-data-quality `adapter_split` constructor provider implementation lane; it does
-not implement that lane itself.
+G2.196 is a path-limited source implementation branch after PR `#348` merged
+G2.195. It may edit only the eight authorized `adapter_split` source files plus
+one focused test, alongside governance evidence and steward updates. If
+accepted, it should be followed by G2.197 closeout / remaining candidate refresh
+before any further data-quality monitor migration lane is selected.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T02:31:48+08:00`
-- Base HEAD checked: `e30e16605df6aaa333989a7ac247bab3dcd0dd01`
+- Prepared at: `2026-05-28T07:45:53+08:00`
+- Base HEAD checked: `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 is the active governance-only data-quality `adapter_split` constructor provider authorization package |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 is the active path-limited data-quality `adapter_split` constructor provider implementation |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T02:31:48+08:00`
-- Base HEAD checked: `e30e16605df6aaa333989a7ac247bab3dcd0dd01`
+- Prepared at: `2026-05-28T07:45:53+08:00`
+- Base HEAD checked: `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,8 +15,9 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.195 data-quality `adapter_split` constructor provider authorization | G/#79 service lifecycle DI | PR `#347` merged at `e30e16605df6aaa333989a7ac247bab3dcd0dd01`; G2.195 authorizes a future G2.196 implementation lane but keeps source authority at none in this PR | If accepted, start G2.196 data-quality `adapter_split` constructor provider implementation |
-| P0 | Preserve G2.194 data-quality adapter constructor seam design | G/#79 service lifecycle DI | PR `#347` merged; G2.194 selected `adapter_split` constructor seam as the next authorization target | Do not implement adapter changes from G2.194 or G2.195 |
+| P0 | Review G2.196 data-quality `adapter_split` constructor provider implementation | G/#79 service lifecycle DI | PR `#348` merged at `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`; G2.196 implements the authorized `adapter_split` constructor injection seam with focused TDD evidence | If accepted, start G2.197 data-quality monitor closeout / remaining candidate refresh |
+| P0 | Preserve G2.195 data-quality `adapter_split` constructor provider authorization | G/#79 service lifecycle DI | PR `#348` merged; G2.195 authorized only eight `adapter_split` source paths plus one focused test path | Do not expand G2.196 into service adapters, legacy adapters, singleton wrappers, routes, or frontend |
+| P0 | Preserve G2.194 data-quality adapter constructor seam design | G/#79 service lifecycle DI | PR `#347` merged; G2.194 selected `adapter_split` constructor seam as the next authorization target | Do not implement adapter changes outside the accepted G2.195/G2.196 scope |
 | P0 | Preserve G2.193 data-quality route provider closeout / remaining candidate refresh | G/#79 service lifecycle DI | PR `#346` merged; route-body migration is closed, remaining adapter surfaces are refreshed, and G2.194 design has been accepted | Do not reopen route-body provider migration while authorizing `adapter_split` constructor work |
 | P0 | Preserve G2.192 data-quality route provider implementation | G/#79 service lifecycle DI | PR `#345` merged; route body `get_data_quality_monitor()` and `monitor_data_quality()` calls are both `0` | Do not start adapter constructor implementation from G2.192, G2.193, G2.194, or G2.195 |
 | P0 | Preserve G2.191 data-quality route provider authorization | G/#79 service lifecycle DI | PR `#344` merged; authorized only `web/backend/app/api/data_quality.py` plus focused tests for G2.192 | Do not expand into adapters, singleton wrapper, `DataQualityMonitor` internals, or data-source factory behavior |
@@ -37,8 +38,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.195 authorize only the future G2.196 `adapter_split` constructor provider implementation lane?
-- Are the eight future source paths and one future test path narrow enough for one source PR?
-- Are service adapters, legacy adapters, `market_data_adapter.py`, singleton wrappers, and `DataQualityMonitor` internals still forbidden?
-- Does G2.195 itself avoid all source and test edits?
+- Does G2.196 modify only the eight authorized `adapter_split` source files and one focused test?
+- Does default singleton fallback remain in `BaseAdapter` for existing callers?
+- Are subclass-level `get_data_quality_monitor()` calls and imports retired without touching forbidden surfaces?
+- Is G2.197 correctly positioned as closeout / remaining candidate refresh rather than another direct source lane?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T02:31:48+08:00`
-- Base HEAD checked: `e30e16605df6aaa333989a7ac247bab3dcd0dd01`
+- Prepared at: `2026-05-28T07:45:53+08:00`
+- Base HEAD checked: `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -51,8 +51,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-route-provider-closeout-refresh-2026-05-28.md` | G2.193 human-readable closeout / refresh report | Accepted by PR `#346`; superseded for adapter constructor seam design by G2.194 |
 | `.planning/codebase/generated/data-quality-adapter-seam-design-decision-2026-05-28.json` | G2.194 data-quality adapter constructor seam design decision evidence | Accepted by PR `#347`; superseded for implementation authorization by G2.195 |
 | `docs/reports/quality/backend-data-quality-adapter-seam-design-decision-2026-05-28.md` | G2.194 human-readable adapter seam design decision report | Accepted by PR `#347`; superseded for implementation authorization by G2.195 |
-| `.planning/codebase/generated/data-quality-adapter-split-constructor-provider-authorization-2026-05-28.json` | G2.195 data-quality `adapter_split` constructor provider authorization evidence | Current for HEAD `e30e16605df6aaa333989a7ac247bab3dcd0dd01`; review input until PR `#348` is accepted |
-| `docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-authorization-2026-05-28.md` | G2.195 human-readable authorization package | Review input until PR `#348` is accepted |
+| `.planning/codebase/generated/data-quality-adapter-split-constructor-provider-authorization-2026-05-28.json` | G2.195 data-quality `adapter_split` constructor provider authorization evidence | Accepted by PR `#348`; superseded for implementation evidence by G2.196 |
+| `docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-authorization-2026-05-28.md` | G2.195 human-readable authorization package | Accepted by PR `#348`; superseded for implementation evidence by G2.196 |
+| `.planning/codebase/generated/data-quality-adapter-split-constructor-provider-implementation-2026-05-28.json` | G2.196 data-quality `adapter_split` constructor provider implementation evidence | Current for HEAD `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`; review input until PR `#349` is accepted |
+| `docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-implementation-2026-05-28.md` | G2.196 human-readable implementation report | Review input until PR `#349` is accepted |
 
 ## External State Inputs
 
@@ -71,7 +73,8 @@ state transition.
 | GitHub PR `#345` | `MERGED` | G2.192 data-quality route provider implementation merged by commit `2b0c3ce373fba38bacd62eff5436822527dccda1` |
 | GitHub PR `#346` | `MERGED` | G2.193 data-quality route provider closeout / refresh merged by commit `ea659d52903a5e9884d396069526ea08f15109a6` |
 | GitHub PR `#347` | `MERGED` | G2.194 data-quality adapter constructor seam design merged by commit `e30e16605df6aaa333989a7ac247bab3dcd0dd01` |
-| `origin/wip/root-dirty-20260403` | `e30e16605df6aaa333989a7ac247bab3dcd0dd01` | Base used for this adapter_split constructor provider authorization branch |
+| GitHub PR `#348` | `MERGED` | G2.195 data-quality adapter_split constructor provider authorization merged by commit `fabd674e8a748cdd2c51a80eebb5ad20b52bc737` |
+| `origin/wip/root-dirty-20260403` | `fabd674e8a748cdd2c51a80eebb5ad20b52bc737` | Base used for this adapter_split constructor provider implementation branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T02:31:48+08:00",
+  "generated_at": "2026-05-28T07:45:53+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "e30e16605df6aaa333989a7ac247bab3dcd0dd01",
-  "split_branch": "g2-195-data-quality-adapter-split-authorization",
-  "scope": "governance_only_data_quality_adapter_split_constructor_provider_authorization",
-  "source_edit_authority": false,
+  "base_head": "fabd674e8a748cdd2c51a80eebb5ad20b52bc737",
+  "split_branch": "g2-196-data-quality-adapter-split-implementation",
+  "scope": "data_quality_adapter_split_constructor_provider_implementation",
+  "source_edit_authority": true,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -1086,7 +1086,7 @@
     {
       "id": "g2-195-data-quality-adapter-split-constructor-provider-authorization",
       "type": "authorization_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.194 data-quality adapter constructor seam design",
       "source_edit_authority": false,
@@ -1166,10 +1166,69 @@
         "gitnexus_detect_changes(scope=staged)"
       ],
       "freshness": {
-        "current_head_checked": "e30e16605df6aaa333989a7ac247bab3dcd0dd01",
+        "current_head_checked": "fabd674e8a748cdd2c51a80eebb5ad20b52bc737",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.196 implementation on the exact authorized paths; do not implement source changes from G2.195."
+      "github_pr": {
+        "number": 348,
+        "url": "https://github.com/chengjon/mystocks/pull/348",
+        "state": "MERGED",
+        "merge_commit": "fabd674e8a748cdd2c51a80eebb5ad20b52bc737"
+      },
+      "next_gate": "Superseded by G2.196 data-quality adapter_split constructor provider implementation."
+    },
+    {
+      "id": "g2-196-data-quality-adapter-split-constructor-provider-implementation",
+      "type": "implementation_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.195 data-quality adapter_split constructor provider authorization",
+      "source_edit_authority": true,
+      "evidence": [
+        ".planning/codebase/generated/data-quality-adapter-split-constructor-provider-implementation-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-implementation-2026-05-28.md",
+        "governance/mainline/task-cards/pr-349.yaml"
+      ],
+      "source_paths": [
+        "web/backend/app/services/adapters_split/base_adapter.py",
+        "web/backend/app/services/adapters_split/baostock_adapter.py",
+        "web/backend/app/services/adapters_split/tushare_adapter.py",
+        "web/backend/app/services/adapters_split/customer_adapter.py",
+        "web/backend/app/services/adapters_split/byapi_adapter.py",
+        "web/backend/app/services/adapters_split/akshare_adapter.py",
+        "web/backend/app/services/adapters_split/efinance_adapter.py",
+        "web/backend/app/services/adapters_split/tdx_adapter.py"
+      ],
+      "test_paths": [
+        "web/backend/tests/test_adapter_split_data_quality_monitor_provider.py"
+      ],
+      "implementation_result": {
+        "base_adapter_singleton_fallback_calls": 1,
+        "subclass_get_data_quality_monitor_calls": 0,
+        "subclass_get_data_quality_monitor_imports": 0,
+        "constructors_accepting_quality_monitor": 8,
+        "focused_tests": "1 passed",
+        "ruff_authorized_files": "All checks passed"
+      },
+      "incidental_authorized_fixes": [
+        "tushare_adapter.py imports os for existing os.getenv usage",
+        "byapi_adapter.py imports os for existing os.getenv usage",
+        "tdx_adapter.py logs self.name instead of undefined TDX"
+      ],
+      "verification": {
+        "tdd_red": "failed on missing quality_monitor constructor parameter",
+        "focused_pytest": "1 passed",
+      "ruff": "All checks passed",
+      "import_smoke": "passed with minimal dummy required env",
+      "openspec_validate": "valid; PostHog network flush noise only",
+      "mainline_scope_gate": "passed",
+      "gitnexus_detect_changes_staged": "low risk; 18 changed files, 84 changed symbols, 0 affected processes"
+    },
+      "freshness": {
+        "current_head_checked": "fabd674e8a748cdd2c51a80eebb5ad20b52bc737",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.197 closeout / remaining candidate refresh before selecting another data-quality monitor migration lane."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T02:31:48+08:00`
-- Base HEAD checked: `e30e16605df6aaa333989a7ac247bab3dcd0dd01`
+- Prepared at: `2026-05-28T07:45:53+08:00`
+- Base HEAD checked: `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -47,7 +47,8 @@ It proved a repeatable conveyor:
 | G2.192 data-quality route provider implementation | Merged by PR `#345` | Implements authorized provider injection in `web/backend/app/api/data_quality.py`; focused tests and OpenAPI leak smoke pass |
 | G2.193 data-quality route provider closeout / remaining candidate refresh | Merged by PR `#346` | Marks route-body provider migration closed and selects adapter constructor seam design / test-double decision as the next governance gate |
 | G2.194 data-quality adapter constructor seam design | Merged by PR `#347` | Selects `adapter_split` constructor provider authorization as the next gate, defines test-double contract, and keeps source authority at none |
-| G2.195 data-quality `adapter_split` constructor provider authorization | For review | Authorizes the future G2.196 `adapter_split` constructor provider implementation lane while keeping source authority at none in this PR |
+| G2.195 data-quality `adapter_split` constructor provider authorization | Merged by PR `#348` | Authorizes the future G2.196 `adapter_split` constructor provider implementation lane while keeping source authority at none in that PR |
+| G2.196 data-quality `adapter_split` constructor provider implementation | For review | Implements optional constructor monitor injection in `adapter_split` only, with focused TDD evidence |
 
 ## Current Strategy Getter Residuals
 
@@ -279,13 +280,48 @@ Required future checks include a focused pytest for the new test path, ruff on
 the eight adapter files plus test, OpenSpec strict validation, and staged
 GitNexus change detection.
 
+## G2.196 Data-Quality Adapter Split Constructor Provider Implementation
+
+At HEAD `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`, PR `#348` is merged and
+the G2.195 authorization package is accepted.
+
+G2.196 implements the authorized `adapter_split` constructor provider seam:
+
+| Item | Before | After |
+|---|---:|---:|
+| `adapter_split` subclass `get_data_quality_monitor()` calls | 7 | 0 |
+| `adapter_split` subclass `get_data_quality_monitor` imports | 7 | 0 |
+| `BaseAdapter` singleton fallback calls | 1 | 1 |
+| Constructors accepting `quality_monitor` | 0 | 8 |
+| Focused regression tests | 0 | 1 |
+
+Implementation evidence:
+
+- `BaseAdapter` accepts optional `quality_monitor` and falls back to the current
+  singleton getter for default construction.
+- Seven `adapter_split` subclasses accept keyword-only `quality_monitor` and
+  pass it through to `BaseAdapter`.
+- `CustomerAdapter` preserves `ws_url` compatibility.
+- `tushare_adapter.py` and `byapi_adapter.py` import `os` for existing
+  `os.getenv` usage reached by constructor smoke.
+- `tdx_adapter.py` logs `self.name` instead of undefined `TDX`.
+
+Focused verification:
+
+| Check | Result |
+|---|---|
+| TDD red | Failed on missing `quality_monitor` constructor parameter |
+| Focused pytest | `1 passed` |
+| Ruff authorized files | `All checks passed` |
+| Import smoke | Passed with minimal dummy required env |
+| OpenSpec strict validate | Valid; PostHog network flush noise only |
+
 ## Next Gates
 
-- Review G2.195 data-quality `adapter_split` constructor provider authorization
-  package.
-- If accepted, start G2.196 data-quality `adapter_split` constructor provider
-  implementation.
-- Do not start adapter constructor implementation from G2.195 itself.
+- Review G2.196 data-quality `adapter_split` constructor provider implementation.
+- If accepted, start G2.197 data-quality monitor closeout / remaining candidate
+  refresh.
+- Do not start another data-quality source implementation directly from G2.196.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`
@@ -295,7 +331,7 @@ GitNexus change detection.
 
 This track summary forbids:
 
-- backend source edits
+- unauthorized backend source edits
 - frontend edits
 - test edits
 - OpenSpec proposal creation

--- a/docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-implementation-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-implementation-2026-05-28.md
@@ -1,0 +1,123 @@
+# Backend Data-Quality Adapter Split Constructor Provider Implementation
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: for review
+- Prepared at: `2026-05-28T07:45:53+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD: `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`
+- Worktree branch: `g2-196-data-quality-adapter-split-implementation`
+- Parent: G2.195 data-quality `adapter_split` constructor provider authorization, PR `#348`
+
+Boundary note: this implementation uses the G2.195 authorized source lane only.
+It does not edit service adapters, legacy adapters, `market_data_adapter.py`,
+singleton wrappers, `DataQualityMonitor` internals, routes, frontend files,
+OpenSpec changes, API contracts, config, or scripts.
+
+## Change Summary
+
+G2.196 implements the `adapter_split` constructor provider seam authorized by
+G2.195.
+
+The implementation:
+
+- Adds optional `quality_monitor` injection to `BaseAdapter`.
+- Preserves default singleton fallback in `BaseAdapter` for existing callers.
+- Updates seven `adapter_split` subclasses to accept keyword-only
+  `quality_monitor` and pass it through to `BaseAdapter`.
+- Removes subclass-level `get_data_quality_monitor()` imports and assignments.
+- Adds one focused regression test proving injected monitors bypass the global
+  getter and are used by `_log_data_quality`.
+
+Incidental fixes within authorized files:
+
+- `tushare_adapter.py` imports `os` for existing `os.getenv` usage.
+- `byapi_adapter.py` imports `os` for existing `os.getenv` usage.
+- `tdx_adapter.py` logs `self.name` instead of undefined `TDX`.
+
+## Implemented Paths
+
+| Path | Change |
+|---|---|
+| `web/backend/app/services/adapters_split/base_adapter.py` | Optional injected `quality_monitor`, singleton fallback retained |
+| `web/backend/app/services/adapters_split/baostock_adapter.py` | Keyword-only `quality_monitor` pass-through |
+| `web/backend/app/services/adapters_split/tushare_adapter.py` | Keyword-only `quality_monitor` pass-through; `os` import |
+| `web/backend/app/services/adapters_split/customer_adapter.py` | Preserves `ws_url`; keyword-only `quality_monitor` pass-through |
+| `web/backend/app/services/adapters_split/byapi_adapter.py` | Keyword-only `quality_monitor` pass-through; `os` import |
+| `web/backend/app/services/adapters_split/akshare_adapter.py` | Keyword-only `quality_monitor` pass-through |
+| `web/backend/app/services/adapters_split/efinance_adapter.py` | Keyword-only `quality_monitor` pass-through |
+| `web/backend/app/services/adapters_split/tdx_adapter.py` | Keyword-only `quality_monitor` pass-through; logger fix |
+| `web/backend/tests/test_adapter_split_data_quality_monitor_provider.py` | Focused fake monitor constructor provider regression |
+
+## Inventory Delta
+
+| Item | Before G2.196 | After G2.196 |
+|---|---:|---:|
+| `adapter_split` subclass `get_data_quality_monitor()` calls | 7 | 0 |
+| `adapter_split` subclass `get_data_quality_monitor` imports | 7 | 0 |
+| `BaseAdapter` singleton fallback calls | 1 | 1 |
+| Constructors accepting `quality_monitor` | 0 | 8 |
+| Focused regression tests | 0 | 1 |
+
+## TDD Evidence
+
+Red test:
+
+```bash
+env PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov web/backend/tests/test_adapter_split_data_quality_monitor_provider.py
+```
+
+Expected failure observed:
+
+```text
+TypeError: BaostockAdapter.__init__() got an unexpected keyword argument 'quality_monitor'
+```
+
+Green test:
+
+```bash
+env PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov web/backend/tests/test_adapter_split_data_quality_monitor_provider.py
+```
+
+Result:
+
+```text
+1 passed
+```
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Focused pytest | `1 passed` |
+| Ruff on eight adapter files plus focused test | `All checks passed` |
+| Import smoke | Passed with minimal dummy required env; no service startup |
+| `openspec validate migrate-backend-singletons-to-lifecycle-di --strict` | Valid; PostHog network flush noise only |
+| `git diff --check` | Passed |
+| Mainline scope gate | Passed after task-card schema alignment to `feature`, `domain-01`, `domain-01-node-03`, plus Function Tree catalog coverage for `adapters_split` |
+| GitNexus staged detect changes | Low risk; 18 source/governance files checked before the catalog coverage amendment, 84 changed symbols, 0 affected processes |
+
+## Preserved Boundaries
+
+G2.196 does not touch:
+
+- `web/backend/app/services/adapters/**`
+- `web/backend/app/services/data_adapters/**`
+- `web/backend/app/services/market_data_adapter.py`
+- `web/backend/app/services/_data_quality_monitor_singleton.py`
+- `web/backend/app/services/data_quality_monitor.py`
+- `web/backend/app/api/**`
+- `web/frontend/**`
+- `src/**`
+- `docs/api/**`
+- `config/**`
+- `scripts/**`
+- `openspec/changes/**`
+- `openspec/specs/**`
+
+## Next Gate
+
+If accepted, run G2.197 closeout / remaining candidate refresh before selecting
+any further data-quality monitor migration lane.

--- a/governance/function-tree/catalog.yaml
+++ b/governance/function-tree/catalog.yaml
@@ -54,6 +54,8 @@ domains:
         label: "1.3 多数据源集成"
         coverage_paths:
           - "src/adapters/**"
+          - "web/backend/app/services/adapters_split/**"
+          - "web/backend/tests/test_adapter_split_data_quality_monitor_provider.py"
           - "config/data_sources*"
         entrypoints:
           governance:

--- a/governance/mainline/task-cards/pr-349.yaml
+++ b/governance/mainline/task-cards/pr-349.yaml
@@ -1,0 +1,139 @@
+version: "v0.2"
+
+task:
+  id: "pr-349"
+  title: "Implement data-quality adapter_split constructor provider seam"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-adapter-split-implementation"
+  objective: "implement the authorized adapter_split-only constructor provider seam for data-quality monitor injection"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "feature"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "domain-01"
+  node_id: "domain-01-node-03"
+  affected_entrypoints:
+    - "governance"
+    - "core"
+    - "tests"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Internal service constructor injection seam; no route paths, HTTP methods, response models, OpenAPI examples, frontend behavior, PM2 workflows, or public API ownership changes"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-adapter-split-constructor-provider-implementation-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-implementation-2026-05-28.md"
+    - "governance/function-tree/catalog.yaml"
+    - "governance/mainline/task-cards/pr-349.yaml"
+    - "web/backend/app/services/adapters_split/base_adapter.py"
+    - "web/backend/app/services/adapters_split/baostock_adapter.py"
+    - "web/backend/app/services/adapters_split/tushare_adapter.py"
+    - "web/backend/app/services/adapters_split/customer_adapter.py"
+    - "web/backend/app/services/adapters_split/byapi_adapter.py"
+    - "web/backend/app/services/adapters_split/akshare_adapter.py"
+    - "web/backend/app/services/adapters_split/efinance_adapter.py"
+    - "web/backend/app/services/adapters_split/tdx_adapter.py"
+    - "web/backend/tests/test_adapter_split_data_quality_monitor_provider.py"
+  forbidden_paths:
+    - "web/backend/app/services/adapters/**"
+    - "web/backend/app/services/data_adapters/**"
+    - "web/backend/app/services/market_data_adapter.py"
+    - "web/backend/app/services/_data_quality_monitor_singleton.py"
+    - "web/backend/app/services/data_quality_monitor.py"
+    - "web/backend/app/api/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "service adapter migration"
+  - "legacy adapter compatibility edits"
+  - "market_data_adapter.py edits"
+  - "singleton wrapper deletion"
+  - "DataQualityMonitor internals"
+  - "route changes"
+  - "frontend changes"
+  - "OpenSpec proposal creation"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov web/backend/tests/test_adapter_split_data_quality_monitor_provider.py"
+      required: true
+    - id: "ruff-authorized-files"
+      command: "ruff check web/backend/app/services/adapters_split/base_adapter.py web/backend/app/services/adapters_split/baostock_adapter.py web/backend/app/services/adapters_split/tushare_adapter.py web/backend/app/services/adapters_split/customer_adapter.py web/backend/app/services/adapters_split/byapi_adapter.py web/backend/app/services/adapters_split/akshare_adapter.py web/backend/app/services/adapters_split/efinance_adapter.py web/backend/app/services/adapters_split/tdx_adapter.py web/backend/tests/test_adapter_split_data_quality_monitor_provider.py"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-adapter-split-constructor-provider-implementation-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-349.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-implementation-2026-05-28.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-349.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha fabd674e8a748cdd2c51a80eebb5ad20b52bc737 --head-sha HEAD --report /tmp/pr349-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "BaseAdapter is inherited by seven adapter_split subclasses; all subclass constructors must preserve default compatibility."
+    - "get_data_quality_monitor remains CRITICAL globally; this PR must only reduce adapter_split constructor calls."
+  rollback_plan: "revert this PR to restore the pre-G2.196 adapter_split constructor behavior and return to the accepted G2.195 authorization state."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "implement adapter_split constructor monitor injection"
+    modified_scope: "eight adapter_split source files, one focused test, and governance evidence only"
+    dependency_changes: "none"
+    legacy_logic_impact: "default singleton fallback remains in BaseAdapter"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if constructor compatibility or scoped checks regress"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T07:45:53+08:00"
+    approval_note: "Human maintainer approved continuing after PR #348 acceptance; this lane is the authorized adapter_split-only source implementation."
+    secondary_approved: true

--- a/web/backend/app/services/adapters_split/akshare_adapter.py
+++ b/web/backend/app/services/adapters_split/akshare_adapter.py
@@ -8,7 +8,6 @@ from typing import Dict, List, Optional
 
 from .base_adapter import BaseAdapter
 from app.core.database import db_service
-from app.services.data_quality_monitor import get_data_quality_monitor
 
 logger = __import__("logging").getLogger(__name__)
 
@@ -16,10 +15,9 @@ logger = __import__("logging").getLogger(__name__)
 class AkshareAdapter(BaseAdapter):
     """Akshare数据源适配器"""
 
-    def __init__(self):
-        super().__init__(name="Akshare", source_type="akshare")
+    def __init__(self, *, quality_monitor=None):
+        super().__init__(name="Akshare", source_type="akshare", quality_monitor=quality_monitor)
         self.db_service = db_service
-        self.quality_monitor = get_data_quality_monitor()
 
         logger.info(f"初始化{self.name}适配器")
 

--- a/web/backend/app/services/adapters_split/baostock_adapter.py
+++ b/web/backend/app/services/adapters_split/baostock_adapter.py
@@ -8,7 +8,6 @@ from typing import Dict, List, Optional
 
 from .base_adapter import BaseAdapter
 from app.core.database import db_service
-from app.services.data_quality_monitor import get_data_quality_monitor
 
 logger = __import__("logging").getLogger(__name__)
 
@@ -16,10 +15,9 @@ logger = __import__("logging").getLogger(__name__)
 class BaostockAdapter(BaseAdapter):
     """Baostock东方财富数据源适配器"""
 
-    def __init__(self):
-        super().__init__(name="Baostock", source_type="baostock")
+    def __init__(self, *, quality_monitor=None):
+        super().__init__(name="Baostock", source_type="baostock", quality_monitor=quality_monitor)
         self.db_service = db_service
-        self.quality_monitor = get_data_quality_monitor()
 
         logger.info(f"初始化{self.name}适配器")
 

--- a/web/backend/app/services/adapters_split/base_adapter.py
+++ b/web/backend/app/services/adapters_split/base_adapter.py
@@ -20,11 +20,11 @@ logger = __import__("logging").getLogger(__name__)
 class BaseAdapter(ABC):
     """数据源适配器基类"""
 
-    def __init__(self, name: str, source_type: str):
+    def __init__(self, name: str, source_type: str, quality_monitor: Optional[Any] = None):
         self.name = name
         self.source_type = source_type
         self.metrics = DataSourceMetrics()
-        self.quality_monitor = get_data_quality_monitor()
+        self.quality_monitor = quality_monitor or get_data_quality_monitor()
         self.db_service = db_service
 
         logger.info(f"初始化{self.name}适配器")

--- a/web/backend/app/services/adapters_split/byapi_adapter.py
+++ b/web/backend/app/services/adapters_split/byapi_adapter.py
@@ -5,12 +5,12 @@ BYAPI数据源适配器
 """
 
 from typing import Any, Dict, List, Optional
+import os
 import httpx
 import asyncio
 
 from .base_adapter import BaseAdapter
 from app.core.database import db_service
-from app.services.data_quality_monitor import get_data_quality_monitor
 
 logger = __import__("logging").getLogger(__name__)
 
@@ -18,10 +18,9 @@ logger = __import__("logging").getLogger(__name__)
 class BYAPIAdapter(BaseAdapter):
     """BYAPI数据源适配器"""
 
-    def __init__(self):
-        super().__init__(name="BYAPI", source_type="byapi")
+    def __init__(self, *, quality_monitor=None):
+        super().__init__(name="BYAPI", source_type="byapi", quality_monitor=quality_monitor)
         self.db_service = db_service
-        self.quality_monitor = get_data_quality_monitor()
         self.api_key = os.getenv("BYAPI_API_KEY", "")
         self.base_url = "https://api.byapi.com"
         self.max_retries = 3

--- a/web/backend/app/services/adapters_split/customer_adapter.py
+++ b/web/backend/app/services/adapters_split/customer_adapter.py
@@ -12,7 +12,6 @@ import websockets
 
 from .base_adapter import BaseAdapter
 from app.core.database import db_service
-from app.services.data_quality_monitor import get_data_quality_monitor
 
 logger = __import__("logging").getLogger(__name__)
 
@@ -20,8 +19,8 @@ logger = __import__("logging").getLogger(__name__)
 class CustomerAdapter(BaseAdapter):
     """客户端数据源适配器"""
 
-    def __init__(self, ws_url: Optional[str] = None):
-        super().__init__(name="Customer", source_type="customer")
+    def __init__(self, ws_url: Optional[str] = None, *, quality_monitor=None):
+        super().__init__(name="Customer", source_type="customer", quality_monitor=quality_monitor)
         if ws_url is None:
             ws_url = os.getenv("BACKEND_WS_URL", "").strip()
         if not ws_url:
@@ -32,7 +31,6 @@ class CustomerAdapter(BaseAdapter):
         self.ws_url = ws_url
 
         self.db_service = db_service
-        self.quality_monitor = get_data_quality_monitor()
         self.websocket = None
         self.subscriptions = set()
         self.max_retries = 3

--- a/web/backend/app/services/adapters_split/efinance_adapter.py
+++ b/web/backend/app/services/adapters_split/efinance_adapter.py
@@ -8,7 +8,6 @@ from typing import Dict, List, Optional
 
 from .base_adapter import BaseAdapter
 from app.core.database import db_service
-from app.services.data_quality_monitor import get_data_quality_monitor
 
 logger = __import__("logging").getLogger(__name__)
 
@@ -16,10 +15,9 @@ logger = __import__("logging").getLogger(__name__)
 class EfinanceAdapter(BaseAdapter):
     """Efinance数据源适配器"""
 
-    def __init__(self):
-        super().__init__(name="Efinance", source_type="efinance")
+    def __init__(self, *, quality_monitor=None):
+        super().__init__(name="Efinance", source_type="efinance", quality_monitor=quality_monitor)
         self.db_service = db_service
-        self.quality_monitor = get_data_quality_monitor()
 
         logger.info(f"初始化{self.name}适配器")
 

--- a/web/backend/app/services/adapters_split/tdx_adapter.py
+++ b/web/backend/app/services/adapters_split/tdx_adapter.py
@@ -8,7 +8,6 @@ from typing import Dict, List, Optional
 
 from .base_adapter import BaseAdapter
 from app.core.database import db_service
-from app.services.data_quality_monitor import get_data_quality_monitor
 
 logger = __import__("logging").getLogger(__name__)
 
@@ -16,14 +15,13 @@ logger = __import__("logging").getLogger(__name__)
 class TDXAdapter(BaseAdapter):
     """TDX通达信数据源适配器"""
 
-    def __init__(self):
-        super().__init__(name="TDX", source_type="tdx")
+    def __init__(self, *, quality_monitor=None):
+        super().__init__(name="TDX", source_type="tdx", quality_monitor=quality_monitor)
         self.db_service = db_service
-        self.quality_monitor = get_data_quality_monitor()
         self.connection_pool = None
         self.max_connections = 5
 
-        logger.info(f"初始化{TDX}适配器")
+        logger.info(f"初始化{self.name}适配器")
 
     async def get_stock_basic(self, stock_code: str) -> Optional[Dict]:
         """获取股票基本信息"""

--- a/web/backend/app/services/adapters_split/tushare_adapter.py
+++ b/web/backend/app/services/adapters_split/tushare_adapter.py
@@ -4,11 +4,11 @@ Tushare专业数据源适配器
 提供Tushare专业金融数据获取功能，支持股票、基金、期货、期权等高级金融数据
 """
 
+import os
 from typing import Dict, List, Optional
 
 from .base_adapter import BaseAdapter
 from app.core.database import db_service
-from app.services.data_quality_monitor import get_data_quality_monitor
 
 logger = __import__("logging").getLogger(__name__)
 
@@ -16,10 +16,9 @@ logger = __import__("logging").getLogger(__name__)
 class TushareAdapter(BaseAdapter):
     """Tushare专业数据源适配器"""
 
-    def __init__(self):
-        super().__init__(name="Tushare", source_type="tushare")
+    def __init__(self, *, quality_monitor=None):
+        super().__init__(name="Tushare", source_type="tushare", quality_monitor=quality_monitor)
         self.db_service = db_service
-        self.quality_monitor = get_data_quality_monitor()
         self.token = None
         self.account_type = "pro"
 

--- a/web/backend/tests/test_adapter_split_data_quality_monitor_provider.py
+++ b/web/backend/tests/test_adapter_split_data_quality_monitor_provider.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib
+
+
+class FakeDataQualityMonitor:
+    def __init__(self) -> None:
+        self.check_calls = []
+        self.evaluate_calls = []
+
+    def check_data_quality(self, data, source_or_context):
+        self.check_calls.append((data, source_or_context))
+        return {"is_valid": True}
+
+    async def evaluate_data_quality(self, *args, **kwargs):
+        self.evaluate_calls.append((args, kwargs))
+        return {"is_valid": True}
+
+
+def _fail_global_getter():
+    raise AssertionError("global get_data_quality_monitor() should not be called when a monitor is injected")
+
+
+def test_adapter_split_constructors_accept_injected_quality_monitor(monkeypatch):
+    base_module = importlib.import_module("app.services.adapters_split.base_adapter")
+    adapter_modules = [
+        importlib.import_module("app.services.adapters_split.baostock_adapter"),
+        importlib.import_module("app.services.adapters_split.tushare_adapter"),
+        importlib.import_module("app.services.adapters_split.customer_adapter"),
+        importlib.import_module("app.services.adapters_split.byapi_adapter"),
+        importlib.import_module("app.services.adapters_split.akshare_adapter"),
+        importlib.import_module("app.services.adapters_split.efinance_adapter"),
+        importlib.import_module("app.services.adapters_split.tdx_adapter"),
+    ]
+
+    monkeypatch.setattr(base_module, "get_data_quality_monitor", _fail_global_getter)
+    for module in adapter_modules:
+        monkeypatch.setattr(module, "get_data_quality_monitor", _fail_global_getter, raising=False)
+
+    customer_module = adapter_modules[2]
+    monkeypatch.setattr(customer_module.asyncio, "create_task", lambda coro: coro.close() or object())
+
+    fake = FakeDataQualityMonitor()
+    adapter_specs = [
+        (adapter_modules[0].BaostockAdapter, {}),
+        (adapter_modules[1].TushareAdapter, {}),
+        (adapter_modules[2].CustomerAdapter, {"ws_url": "ws://localhost:8020/ws"}),
+        (adapter_modules[3].BYAPIAdapter, {}),
+        (adapter_modules[4].AkshareAdapter, {}),
+        (adapter_modules[5].EfinanceAdapter, {}),
+        (adapter_modules[6].TDXAdapter, {}),
+    ]
+    for adapter_cls, _ in adapter_specs:
+        monkeypatch.setattr(adapter_cls, "__abstractmethods__", frozenset())
+
+    adapters = [adapter_cls(quality_monitor=fake, **kwargs) for adapter_cls, kwargs in adapter_specs]
+
+    assert all(adapter.quality_monitor is fake for adapter in adapters)
+
+    adapters[0]._log_data_quality([{"symbol": "000001"}], "probe")
+
+    assert fake.check_calls == [([{"symbol": "000001"}], "Baostock.probe")]


### PR DESCRIPTION
## Summary

Implements the G2.196 authorized adapter_split-only data-quality monitor constructor provider seam after PR #348 / G2.195 authorization.

- Adds optional `quality_monitor` injection to `BaseAdapter` while preserving the default `get_data_quality_monitor()` fallback.
- Threads keyword-only `quality_monitor` through the seven `web/backend/app/services/adapters_split/*_adapter.py` subclasses.
- Removes subclass-level `get_data_quality_monitor` imports/calls so the fallback is centralized in `BaseAdapter`.
- Adds a focused regression test proving injected monitor usage and subclass no-global-getter construction.
- Records implementation evidence, task card, steward-tree state, and Function Tree catalog coverage for `adapters_split`.

## Scope Boundaries

This PR does not touch:

- `web/backend/app/services/adapters/**`
- `web/backend/app/services/data_adapters/**`
- `web/backend/app/services/market_data_adapter.py`
- `web/backend/app/services/_data_quality_monitor_singleton.py`
- `web/backend/app/services/data_quality_monitor.py`
- `web/backend/app/api/**`
- `web/frontend/**`
- `src/**`
- `docs/api/**`
- `config/**`
- `scripts/**`
- `openspec/changes/**`
- `openspec/specs/**`

## Verification

- `env PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov web/backend/tests/test_adapter_split_data_quality_monitor_provider.py` -> `1 passed`
- `ruff check` on the eight authorized adapter files plus focused test -> `All checks passed`
- Import smoke for `BaseAdapter` and seven subclasses -> passed with minimal dummy required env; no service startup
- `openspec validate migrate-backend-singletons-to-lifecycle-di --strict` -> valid; PostHog network flush noise only
- `python governance/mainline/scripts/mainline_scope_gate.py ... --base-sha fabd674e8a748cdd2c51a80eebb5ad20b52bc737 --head-sha HEAD` -> pass
- `python scripts/compliance/markdown_governance_gate.py ...` -> errors 0, checked_files 6
- `git diff --check` -> passed
- GitNexus staged detect changes before commit -> low risk, 18 changed files, 84 changed symbols, 0 affected processes
- `gitnexus analyze` -> completed after commit

## Notes

Pre-edit GitNexus impact was MEDIUM for `BaseAdapter` and CRITICAL for `get_data_quality_monitor`; the implementation stays inside the approved adapter_split constructor seam and keeps runtime singleton fallback compatibility.
