### PR TITLE
docs(governance): close data quality monitor adapter split lane

### DIFF
--- a/.planning/codebase/generated/data-quality-monitor-closeout-refresh-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-monitor-closeout-refresh-2026-05-28.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": "2026-05-28.g2-197.closeout-refresh.v1",
+  "generated_at": "2026-05-28T09:14:57+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "e4245ebe54c5ad6d2aebf4802d165d59700c9eeb",
+  "worktree_branch": "g2-197-data-quality-monitor-closeout-refresh",
+  "status": "for_review",
+  "source_edit_authority": false,
+  "parent": {
+    "id": "g2-196-data-quality-adapter-split-constructor-provider-implementation",
+    "github_pr": 349,
+    "state": "MERGED",
+    "merged_at": "2026-05-28T01:11:29Z",
+    "merge_commit": "e4245ebe54c5ad6d2aebf4802d165d59700c9eeb"
+  },
+  "closed_surface": {
+    "adapter_split": {
+      "files": 8,
+      "subclass_get_data_quality_monitor_calls": 0,
+      "subclass_get_data_quality_monitor_imports": 0,
+      "base_adapter_singleton_fallback_calls": 1,
+      "base_adapter_singleton_fallback_imports": 1,
+      "constructors_accepting_quality_monitor": 8,
+      "decision": "closed_for_subclass_constructor_provider_migration; BaseAdapter fallback retained for compatibility"
+    }
+  },
+  "residual_inventory": {
+    "files_scanned": 152,
+    "files_with_monitor_refs": 15,
+    "buckets": {
+      "adapters_split": {
+        "files": 8,
+        "getter_calls": 1,
+        "getter_imports": 1,
+        "decision": "closed; only BaseAdapter fallback remains"
+      },
+      "service_adapters": {
+        "files": 2,
+        "getter_calls": 2,
+        "getter_imports": 2,
+        "paths": [
+          "web/backend/app/services/adapters/dashboard_adapter.py",
+          "web/backend/app/services/adapters/data_adapter.py"
+        ],
+        "decision": "defer to residual adapter ownership decision"
+      },
+      "data_adapters": {
+        "files": 2,
+        "getter_calls": 2,
+        "getter_imports": 2,
+        "paths": [
+          "web/backend/app/services/data_adapters/dashboard.py",
+          "web/backend/app/services/data_adapters/data_source.py"
+        ],
+        "decision": "defer to legacy data adapter compatibility decision"
+      },
+      "market_data_adapter_compatibility": {
+        "files": 1,
+        "getter_calls": 1,
+        "getter_imports": 1,
+        "paths": [
+          "web/backend/app/services/market_data_adapter.py"
+        ],
+        "decision": "defer as root compatibility facade surface"
+      },
+      "service_wrapper_and_canonical_monitor": {
+        "files": 2,
+        "getter_calls": 2,
+        "getter_imports": 1,
+        "paths": [
+          "web/backend/app/services/_data_quality_monitor_singleton.py",
+          "web/backend/app/services/data_quality_monitor.py"
+        ],
+        "decision": "retain backing API and canonical implementation; not a deletion lane"
+      }
+    }
+  },
+  "recommended_next_gate": {
+    "id": "g2-198-data-quality-residual-adapter-ownership-decision",
+    "type": "decision_package",
+    "source_edit_authority": false,
+    "purpose": "decide whether the next data-quality monitor lane should target service adapters, legacy data adapters, market_data_adapter compatibility, or wrapper retention; do not open source implementation directly from G2.197"
+  },
+  "verification": {
+    "inventory_script": "scanned web/backend/app/services/**/*.py and counted get_data_quality_monitor/DataQualityMonitor/quality_monitor references",
+    "git_head": "e4245ebe54c5ad6d2aebf4802d165d59700c9eeb",
+    "worktree_status": "clean before edits",
+    "json_parse": "passed",
+    "markdown_governance": "errors=0, checked_files=6",
+    "openspec_validate": "migrate-backend-singletons-to-lifecycle-di valid",
+    "mainline_scope_gate": "passed after task-card required governance metadata was added",
+    "gitnexus_detect_changes_staged": {
+      "risk": "low",
+      "changed_files": 9,
+      "changed_symbols": 0,
+      "affected_processes": 0
+    }
+  },
+  "forbidden_scope_preserved": [
+    "web/backend/**",
+    "web/frontend/**",
+    "src/**",
+    "tests/**",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**"
+  ]
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T07:45:53+08:00`
-- Base HEAD checked: `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`
+- Prepared at: `2026-05-28T09:14:57+08:00`
+- Base HEAD checked: `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -33,12 +33,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#346` | `g2-193-data-quality-route-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `ea659d52903a5e9884d396069526ea08f15109a6` | Governance closeout / remaining surface refresh selecting G2.194 adapter constructor seam design |
 | `#347` | `g2-194-data-quality-adapter-seam-design` | `wip/root-dirty-20260403` | `MERGED` at `e30e16605df6aaa333989a7ac247bab3dcd0dd01` | Governance design decision selecting G2.195 adapter_split constructor provider authorization |
 | `#348` | `g2-195-data-quality-adapter-split-authorization` | `wip/root-dirty-20260403` | `MERGED` at `fabd674e8a748cdd2c51a80eebb5ad20b52bc737` | Authorization package for G2.196 adapter_split constructor provider implementation |
+| `#349` | `g2-196-data-quality-adapter-split-implementation` | `wip/root-dirty-20260403` | `MERGED` at `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb` | Path-limited `adapter_split` constructor provider implementation closed for G2.197 refresh |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-196-data-quality-adapter-split-implementation` | `origin/wip/root-dirty-20260403` at `fabd674e8a748cdd2c51a80eebb5ad20b52bc737` | Implement the authorized `adapter_split` constructor provider seam with focused TDD evidence | Yes; limited to eight `adapter_split` source files plus one focused test |
+| `g2-197-data-quality-monitor-closeout-refresh` | `origin/wip/root-dirty-20260403` at `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb` | Close out PR `#349`, refresh remaining data-quality monitor candidates, and select the next decision gate | No |
 
 ## OpenSpec Relationship
 
@@ -54,8 +55,8 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.196 is a path-limited source implementation branch after PR `#348` merged
-G2.195. It may edit only the eight authorized `adapter_split` source files plus
-one focused test, alongside governance evidence and steward updates. If
-accepted, it should be followed by G2.197 closeout / remaining candidate refresh
-before any further data-quality monitor migration lane is selected.
+G2.197 is a governance-only closeout branch after PR `#349` merged G2.196. It
+records the `adapter_split` constructor provider implementation as closed,
+refreshes the remaining service adapter / legacy data adapter / compatibility
+facade / wrapper surfaces, and recommends G2.198 as a decision-only next gate.
+It must not authorize another data-quality monitor source lane directly.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T07:45:53+08:00`
-- Base HEAD checked: `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`
+- Prepared at: `2026-05-28T09:14:57+08:00`
+- Base HEAD checked: `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 is the active path-limited data-quality `adapter_split` constructor provider implementation |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 is the active closeout / remaining data-quality monitor candidate refresh |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T07:45:53+08:00`
-- Base HEAD checked: `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`
+- Prepared at: `2026-05-28T09:14:57+08:00`
+- Base HEAD checked: `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,8 +15,9 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.196 data-quality `adapter_split` constructor provider implementation | G/#79 service lifecycle DI | PR `#348` merged at `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`; G2.196 implements the authorized `adapter_split` constructor injection seam with focused TDD evidence | If accepted, start G2.197 data-quality monitor closeout / remaining candidate refresh |
-| P0 | Preserve G2.195 data-quality `adapter_split` constructor provider authorization | G/#79 service lifecycle DI | PR `#348` merged; G2.195 authorized only eight `adapter_split` source paths plus one focused test path | Do not expand G2.196 into service adapters, legacy adapters, singleton wrappers, routes, or frontend |
+| P0 | Review G2.197 data-quality monitor closeout / remaining candidate refresh | G/#79 service lifecycle DI | PR `#349` merged at `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`; G2.197 closes the `adapter_split` subclass constructor lane and refreshes remaining candidates | If accepted, start G2.198 residual adapter ownership decision; do not start source implementation directly |
+| P0 | Preserve G2.196 data-quality `adapter_split` constructor provider implementation | G/#79 service lifecycle DI | PR `#349` merged; subclass-level `get_data_quality_monitor()` calls/imports are `0`; `BaseAdapter` fallback remains intentional | Do not expand into service adapters, legacy adapters, singleton wrappers, routes, or frontend |
+| P0 | Preserve G2.195 data-quality `adapter_split` constructor provider authorization | G/#79 service lifecycle DI | PR `#348` merged; G2.195 authorized only eight `adapter_split` source paths plus one focused test path | Treat the G2.196 implementation as closed after G2.197 review, not as authority for broader adapter migration |
 | P0 | Preserve G2.194 data-quality adapter constructor seam design | G/#79 service lifecycle DI | PR `#347` merged; G2.194 selected `adapter_split` constructor seam as the next authorization target | Do not implement adapter changes outside the accepted G2.195/G2.196 scope |
 | P0 | Preserve G2.193 data-quality route provider closeout / remaining candidate refresh | G/#79 service lifecycle DI | PR `#346` merged; route-body migration is closed, remaining adapter surfaces are refreshed, and G2.194 design has been accepted | Do not reopen route-body provider migration while authorizing `adapter_split` constructor work |
 | P0 | Preserve G2.192 data-quality route provider implementation | G/#79 service lifecycle DI | PR `#345` merged; route body `get_data_quality_monitor()` and `monitor_data_quality()` calls are both `0` | Do not start adapter constructor implementation from G2.192, G2.193, G2.194, or G2.195 |
@@ -38,8 +39,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.196 modify only the eight authorized `adapter_split` source files and one focused test?
-- Does default singleton fallback remain in `BaseAdapter` for existing callers?
-- Are subclass-level `get_data_quality_monitor()` calls and imports retired without touching forbidden surfaces?
-- Is G2.197 correctly positioned as closeout / remaining candidate refresh rather than another direct source lane?
+- Does G2.197 accurately record PR `#349` as merged at `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`?
+- Does G2.197 correctly close the `adapter_split` subclass constructor lane while retaining the `BaseAdapter` fallback?
+- Are service adapters, legacy data adapters, `market_data_adapter.py`, and wrapper retention still separated into the next decision gate?
+- Is G2.198 correctly positioned as a decision-only residual adapter ownership package rather than another direct source lane?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T07:45:53+08:00`
-- Base HEAD checked: `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`
+- Prepared at: `2026-05-28T09:14:57+08:00`
+- Base HEAD checked: `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -53,8 +53,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-adapter-seam-design-decision-2026-05-28.md` | G2.194 human-readable adapter seam design decision report | Accepted by PR `#347`; superseded for implementation authorization by G2.195 |
 | `.planning/codebase/generated/data-quality-adapter-split-constructor-provider-authorization-2026-05-28.json` | G2.195 data-quality `adapter_split` constructor provider authorization evidence | Accepted by PR `#348`; superseded for implementation evidence by G2.196 |
 | `docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-authorization-2026-05-28.md` | G2.195 human-readable authorization package | Accepted by PR `#348`; superseded for implementation evidence by G2.196 |
-| `.planning/codebase/generated/data-quality-adapter-split-constructor-provider-implementation-2026-05-28.json` | G2.196 data-quality `adapter_split` constructor provider implementation evidence | Current for HEAD `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`; review input until PR `#349` is accepted |
-| `docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-implementation-2026-05-28.md` | G2.196 human-readable implementation report | Review input until PR `#349` is accepted |
+| `.planning/codebase/generated/data-quality-adapter-split-constructor-provider-implementation-2026-05-28.json` | G2.196 data-quality `adapter_split` constructor provider implementation evidence | Accepted by PR `#349`; superseded for closeout / remaining candidate refresh by G2.197 |
+| `docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-implementation-2026-05-28.md` | G2.196 human-readable implementation report | Accepted by PR `#349`; superseded for closeout / remaining candidate refresh by G2.197 |
+| `.planning/codebase/generated/data-quality-monitor-closeout-refresh-2026-05-28.json` | G2.197 data-quality monitor closeout / remaining candidate refresh evidence | Current for HEAD `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`; review input until PR `#350` is accepted |
+| `docs/reports/quality/backend-data-quality-monitor-closeout-refresh-2026-05-28.md` | G2.197 human-readable closeout / refresh report | Review input until PR `#350` is accepted |
 
 ## External State Inputs
 
@@ -74,7 +76,8 @@ state transition.
 | GitHub PR `#346` | `MERGED` | G2.193 data-quality route provider closeout / refresh merged by commit `ea659d52903a5e9884d396069526ea08f15109a6` |
 | GitHub PR `#347` | `MERGED` | G2.194 data-quality adapter constructor seam design merged by commit `e30e16605df6aaa333989a7ac247bab3dcd0dd01` |
 | GitHub PR `#348` | `MERGED` | G2.195 data-quality adapter_split constructor provider authorization merged by commit `fabd674e8a748cdd2c51a80eebb5ad20b52bc737` |
-| `origin/wip/root-dirty-20260403` | `fabd674e8a748cdd2c51a80eebb5ad20b52bc737` | Base used for this adapter_split constructor provider implementation branch |
+| GitHub PR `#349` | `MERGED` | G2.196 data-quality adapter_split constructor provider implementation merged by commit `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb` |
+| `origin/wip/root-dirty-20260403` | `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb` | Base used for this closeout / remaining candidate refresh branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T07:45:53+08:00",
+  "generated_at": "2026-05-28T09:14:57+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "fabd674e8a748cdd2c51a80eebb5ad20b52bc737",
-  "split_branch": "g2-196-data-quality-adapter-split-implementation",
-  "scope": "data_quality_adapter_split_constructor_provider_implementation",
-  "source_edit_authority": true,
+  "base_head": "e4245ebe54c5ad6d2aebf4802d165d59700c9eeb",
+  "split_branch": "g2-197-data-quality-monitor-closeout-refresh",
+  "scope": "data_quality_monitor_closeout_refresh",
+  "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -1180,7 +1180,7 @@
     {
       "id": "g2-196-data-quality-adapter-split-constructor-provider-implementation",
       "type": "implementation_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.195 data-quality adapter_split constructor provider authorization",
       "source_edit_authority": true,
@@ -1225,10 +1225,90 @@
       "gitnexus_detect_changes_staged": "low risk; 18 changed files, 84 changed symbols, 0 affected processes"
     },
       "freshness": {
-        "current_head_checked": "fabd674e8a748cdd2c51a80eebb5ad20b52bc737",
+        "current_head_checked": "e4245ebe54c5ad6d2aebf4802d165d59700c9eeb",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.197 closeout / remaining candidate refresh before selecting another data-quality monitor migration lane."
+      "github_pr": {
+        "number": 349,
+        "url": "https://github.com/chengjon/mystocks/pull/349",
+        "state": "MERGED",
+        "merged_at": "2026-05-28T01:11:29Z",
+        "head_ref": "g2-196-data-quality-adapter-split-implementation",
+        "merge_commit": "e4245ebe54c5ad6d2aebf4802d165d59700c9eeb"
+      },
+      "next_gate": "Superseded by G2.197 data-quality monitor closeout / remaining candidate refresh."
+    },
+    {
+      "id": "g2-197-data-quality-monitor-closeout-refresh",
+      "type": "closeout_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.196 data-quality adapter_split constructor provider implementation",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/data-quality-monitor-closeout-refresh-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-monitor-closeout-refresh-2026-05-28.md",
+        "governance/mainline/task-cards/pr-350.yaml"
+      ],
+      "closeout_result": {
+        "github_pr": {
+          "number": 349,
+          "url": "https://github.com/chengjon/mystocks/pull/349",
+          "state": "MERGED",
+          "merge_commit": "e4245ebe54c5ad6d2aebf4802d165d59700c9eeb"
+        },
+        "adapter_split_subclass_get_data_quality_monitor_calls": 0,
+        "adapter_split_subclass_get_data_quality_monitor_imports": 0,
+        "base_adapter_singleton_fallback_calls": 1,
+        "constructors_accepting_quality_monitor": 8
+      },
+      "candidate_refresh": {
+        "adapter_split": {
+          "files": 8,
+          "getter_calls": 1,
+          "decision": "closed; only BaseAdapter compatibility fallback remains"
+        },
+        "service_adapters": {
+          "files": 2,
+          "getter_calls": 2,
+          "paths": [
+            "web/backend/app/services/adapters/dashboard_adapter.py",
+            "web/backend/app/services/adapters/data_adapter.py"
+          ],
+          "decision": "defer to residual adapter ownership decision"
+        },
+        "legacy_data_adapters": {
+          "files": 2,
+          "getter_calls": 2,
+          "paths": [
+            "web/backend/app/services/data_adapters/dashboard.py",
+            "web/backend/app/services/data_adapters/data_source.py"
+          ],
+          "decision": "defer to owner-specific compatibility decision"
+        },
+        "market_data_adapter_compatibility": {
+          "files": 1,
+          "getter_calls": 1,
+          "paths": [
+            "web/backend/app/services/market_data_adapter.py"
+          ],
+          "decision": "defer as root compatibility facade surface"
+        },
+        "service_wrapper_and_canonical_monitor": {
+          "files": 2,
+          "getter_calls": 2,
+          "paths": [
+            "web/backend/app/services/_data_quality_monitor_singleton.py",
+            "web/backend/app/services/data_quality_monitor.py"
+          ],
+          "decision": "retain backing API and canonical implementation; not a deletion lane"
+        }
+      },
+      "freshness": {
+        "current_head_checked": "e4245ebe54c5ad6d2aebf4802d165d59700c9eeb",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.198 data-quality residual adapter ownership decision; do not start source implementation directly from G2.197."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T07:45:53+08:00`
-- Base HEAD checked: `fabd674e8a748cdd2c51a80eebb5ad20b52bc737`
+- Prepared at: `2026-05-28T09:14:57+08:00`
+- Base HEAD checked: `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -48,7 +48,8 @@ It proved a repeatable conveyor:
 | G2.193 data-quality route provider closeout / remaining candidate refresh | Merged by PR `#346` | Marks route-body provider migration closed and selects adapter constructor seam design / test-double decision as the next governance gate |
 | G2.194 data-quality adapter constructor seam design | Merged by PR `#347` | Selects `adapter_split` constructor provider authorization as the next gate, defines test-double contract, and keeps source authority at none |
 | G2.195 data-quality `adapter_split` constructor provider authorization | Merged by PR `#348` | Authorizes the future G2.196 `adapter_split` constructor provider implementation lane while keeping source authority at none in that PR |
-| G2.196 data-quality `adapter_split` constructor provider implementation | For review | Implements optional constructor monitor injection in `adapter_split` only, with focused TDD evidence |
+| G2.196 data-quality `adapter_split` constructor provider implementation | Merged by PR `#349` | Implements optional constructor monitor injection in `adapter_split` only, with focused TDD evidence |
+| G2.197 data-quality monitor closeout / remaining candidate refresh | For review | Closes the `adapter_split` subclass constructor lane and refreshes remaining service adapter, legacy adapter, compatibility facade, and wrapper surfaces |
 
 ## Current Strategy Getter Residuals
 
@@ -316,12 +317,41 @@ Focused verification:
 | Import smoke | Passed with minimal dummy required env |
 | OpenSpec strict validate | Valid; PostHog network flush noise only |
 
+PR `#349` merged this lane at
+`e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`.
+
+## G2.197 Data-Quality Monitor Closeout / Refresh
+
+At HEAD `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`, PR `#349` is merged and
+the G2.196 `adapter_split` implementation is closed.
+
+Closeout result:
+
+| Item | Current value |
+|---|---:|
+| `adapter_split` subclass `get_data_quality_monitor()` calls | 0 |
+| `adapter_split` subclass `get_data_quality_monitor` imports | 0 |
+| `BaseAdapter` compatibility fallback calls | 1 |
+| Constructors accepting `quality_monitor` | 8 |
+
+Remaining data-quality monitor surfaces:
+
+| Surface | Files | Getter calls | Current decision |
+|---|---:|---:|---|
+| `adapter_split` | 8 | 1 | Closed; only `BaseAdapter` compatibility fallback remains |
+| service adapters | 2 | 2 | Defer to residual adapter ownership decision |
+| legacy data adapters | 2 | 2 | Defer to owner-specific compatibility decision |
+| `market_data_adapter.py` | 1 | 1 | Defer as root compatibility facade surface |
+| singleton wrapper / canonical monitor | 2 | 2 | Retain backing API and canonical implementation; not a deletion lane |
+
+G2.197 recommends G2.198 as a decision-only residual adapter ownership package.
+It does not authorize another source implementation lane.
+
 ## Next Gates
 
-- Review G2.196 data-quality `adapter_split` constructor provider implementation.
-- If accepted, start G2.197 data-quality monitor closeout / remaining candidate
-  refresh.
-- Do not start another data-quality source implementation directly from G2.196.
+- Review G2.197 data-quality monitor closeout / remaining candidate refresh.
+- If accepted, start G2.198 data-quality residual adapter ownership decision.
+- Do not start another data-quality source implementation directly from G2.197.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/reports/quality/backend-data-quality-monitor-closeout-refresh-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-monitor-closeout-refresh-2026-05-28.md
@@ -1,0 +1,98 @@
+# Backend Data-Quality Monitor Closeout Refresh
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Node: G2.197 data-quality monitor closeout / remaining candidate refresh
+- Status: for review
+- Prepared at: `2026-05-28T09:14:57+08:00`
+- Base HEAD checked: `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`
+- Parent PR: `#349`
+- Parent merge commit: `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`
+- Source edit authority: no
+
+Boundary note: this report records closeout and next-gate classification only. It
+does not authorize backend source changes, test changes, OpenSpec proposal
+creation, route/OpenAPI changes, issue label changes, PM2 commands, or PR merges.
+
+## Parent Closeout
+
+PR `#349` merged G2.196 and closed the authorized `adapter_split` constructor
+provider implementation lane.
+
+| Item | Current result |
+|---|---:|
+| `adapter_split` subclass `get_data_quality_monitor()` calls | 0 |
+| `adapter_split` subclass `get_data_quality_monitor` imports | 0 |
+| `BaseAdapter` fallback `get_data_quality_monitor()` calls | 1 |
+| Constructors accepting `quality_monitor` | 8 |
+| Focused regression test | 1 passed in G2.196 |
+
+The remaining `BaseAdapter` fallback is intentional compatibility behavior. It is
+not counted as a subclass migration residual and must not be deleted by this
+closeout package.
+
+## Current Residual Inventory
+
+At HEAD `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`, the refresh scanned
+`web/backend/app/services/**/*.py`.
+
+| Bucket | Files | Getter calls | Getter imports | Current decision |
+|---|---:|---:|---:|---|
+| `adapter_split` | 8 | 1 | 1 | Closed; only `BaseAdapter` compatibility fallback remains |
+| service adapters | 2 | 2 | 2 | Defer to residual adapter ownership decision |
+| legacy data adapters | 2 | 2 | 2 | Defer to legacy compatibility decision |
+| `market_data_adapter.py` compatibility facade | 1 | 1 | 1 | Defer as root compatibility facade surface |
+| singleton wrapper / canonical monitor | 2 | 2 | 1 | Retain backing API and canonical implementation; not a deletion lane |
+
+Residual candidate paths:
+
+| Bucket | Paths |
+|---|---|
+| service adapters | `web/backend/app/services/adapters/dashboard_adapter.py`, `web/backend/app/services/adapters/data_adapter.py` |
+| legacy data adapters | `web/backend/app/services/data_adapters/dashboard.py`, `web/backend/app/services/data_adapters/data_source.py` |
+| compatibility facade | `web/backend/app/services/market_data_adapter.py` |
+| retained wrapper / implementation | `web/backend/app/services/_data_quality_monitor_singleton.py`, `web/backend/app/services/data_quality_monitor.py` |
+
+## Decision
+
+G2.197 closes the `adapter_split` subclass constructor provider lane and refreshes
+the remaining data-quality monitor surfaces. It does not choose another source
+implementation lane.
+
+The next recommended gate is:
+
+| Next gate | Type | Source authority | Purpose |
+|---|---|---|---|
+| G2.198 data-quality residual adapter ownership decision | decision package | no | Decide whether the next lane should target service adapters, legacy data adapters, `market_data_adapter.py`, or wrapper retention |
+
+G2.198 should remain decision-only unless a later authorization packet explicitly
+selects a path-limited implementation lane.
+
+## Preserved Boundaries
+
+G2.197 does not touch:
+
+- `web/backend/**`
+- `web/frontend/**`
+- `src/**`
+- `tests/**`
+- `config/**`
+- `scripts/**`
+- `openspec/changes/**`
+- `openspec/specs/**`
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Parent PR state | `#349` is `MERGED` at `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb` |
+| Residual scan | `152` service Python files scanned; `15` files contain monitor refs |
+| Source edit scope | No backend source edits in this package |
+| Next-gate classification | G2.198 decision-only residual adapter ownership package |
+| JSON parse | Passed for generated artifact and `steward-index.json` |
+| Markdown governance | `errors=0`, `checked_files=6` |
+| OpenSpec strict validate | `migrate-backend-singletons-to-lifecycle-di` valid |
+| GitNexus staged detect changes | Low risk; 9 changed governance files, 0 changed symbols, 0 affected processes |
+| Mainline scope gate | Passed after task-card required governance metadata was added |

--- a/governance/mainline/task-cards/pr-350.yaml
+++ b/governance/mainline/task-cards/pr-350.yaml
@@ -1,0 +1,107 @@
+version: "v0.2"
+
+task:
+  id: "pr-350"
+  title: "Close out data-quality monitor adapter_split lane and refresh residual candidates"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-monitor-closeout-refresh"
+  objective: "record PR #349 closeout and refresh remaining data-quality monitor ownership candidates"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only closeout and residual candidate refresh; no route paths, HTTP methods, response models, OpenAPI examples, frontend behavior, PM2 workflows, or public API ownership changes"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-monitor-closeout-refresh-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-monitor-closeout-refresh-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-350.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source implementation"
+  - "test source edits"
+  - "adapter migration"
+  - "singleton wrapper deletion"
+  - "DataQualityMonitor internals"
+  - "route changes"
+  - "frontend changes"
+  - "OpenSpec proposal creation"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "node -e \"JSON.parse(require('fs').readFileSync('.planning/codebase/generated/data-quality-monitor-closeout-refresh-2026-05-28.json','utf8')); JSON.parse(require('fs').readFileSync('.planning/codebase/steward-tree/steward-index.json','utf8'));\""
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-monitor-closeout-refresh-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-350.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha e4245ebe54c5ad6d2aebf4802d165d59700c9eeb --head-sha HEAD --report /tmp/pr350-mainline-governance-report.json"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "G2.197 is governance-only; accidentally treating it as source implementation authority would reopen a broader data-quality monitor migration without authorization."
+    - "Residual candidate counts are snapshot facts at HEAD e4245ebe54c5ad6d2aebf4802d165d59700c9eeb and must be refreshed before any future source lane."
+  rollback_plan: "revert this PR to restore the steward tree to the post-#349 state and rerun the residual inventory refresh."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close G2.196 and refresh remaining data-quality monitor candidates"
+    modified_scope: "governance reports, generated evidence, steward tree files, and one task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no backend source files are modified"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if residual classification or steward state is incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T09:14:57+08:00"
+    approval_note: "Human maintainer approved continuing after PR #349 acceptance; this lane is closeout and residual refresh only."
+    secondary_approved: true


### PR DESCRIPTION
## Summary

Closes the G2.196 data-quality adapter_split constructor provider lane after PR #349 merged, and refreshes the remaining data-quality monitor ownership candidates.

- Marks PR #349 / G2.196 as merged in the steward tree.
- Records adapter_split subclass getter calls/imports as closed: 0 subclass calls, 0 subclass imports, BaseAdapter fallback retained.
- Refreshes residual candidates across service adapters, legacy data adapters, market_data_adapter compatibility, and singleton wrapper/canonical monitor retention.
- Selects G2.198 as the next decision-only residual adapter ownership package.

## Boundary

This PR is governance-only. It does not modify backend source, tests, frontend, config, scripts, OpenSpec changes/specs, route behavior, OpenAPI contracts, PM2 workflows, or issue labels.

## Verification

- JSON parse for generated artifact and steward-index -> passed
- Markdown governance gate -> errors 0, checked_files 6
- `openspec validate migrate-backend-singletons-to-lifecycle-di --strict` -> valid
- GitNexus staged detect changes -> low risk, 9 changed governance files, 0 changed symbols, 0 affected processes
- Mainline scope gate -> pass
- `git diff --check` / cached diff check -> passed

## Next Gate

If accepted, start G2.198 data-quality residual adapter ownership decision. Do not start another data-quality monitor source implementation directly from G2.197.
