### PR TITLE
docs(governance): decide data quality adapter ownership

### DIFF
--- a/.planning/codebase/generated/data-quality-residual-adapter-ownership-decision-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-residual-adapter-ownership-decision-2026-05-28.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": "2026-05-28.g2-198.decision.v1",
+  "generated_at": "2026-05-28T09:35:10+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1",
+  "worktree_branch": "g2-198-data-quality-residual-adapter-ownership-decision",
+  "status": "for_review",
+  "source_edit_authority": false,
+  "parent": {
+    "id": "g2-197-data-quality-monitor-closeout-refresh",
+    "github_pr": 350,
+    "state": "MERGED",
+    "merged_at": "2026-05-28T01:29:45Z",
+    "merge_commit": "3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1"
+  },
+  "candidate_facts": {
+    "canonical_service_adapters": {
+      "files": [
+        "web/backend/app/services/adapters/dashboard_adapter.py",
+        "web/backend/app/services/adapters/data_adapter.py"
+      ],
+      "getter_calls": 2,
+      "getter_imports": 2,
+      "constructor_quality_monitor_parameters": 0,
+      "active_factory_relationship": "data_source_factory imports DashboardDataSourceAdapter and DataDataSourceAdapter through app.services.data_adapter facade",
+      "decision": "selected_next_authorization_target"
+    },
+    "legacy_data_adapters": {
+      "files": [
+        "web/backend/app/services/data_adapters/dashboard.py",
+        "web/backend/app/services/data_adapters/data_source.py"
+      ],
+      "getter_calls": 2,
+      "getter_imports": 2,
+      "direct_module_text_consumers": 0,
+      "decision": "defer to compatibility ownership decision; do not delete from static search alone"
+    },
+    "market_data_adapter_compatibility": {
+      "files": [
+        "web/backend/app/services/market_data_adapter.py"
+      ],
+      "getter_calls": 1,
+      "getter_imports": 1,
+      "factory_constructed": true,
+      "decision": "defer as root compatibility facade surface"
+    },
+    "service_wrapper_and_canonical_monitor": {
+      "files": [
+        "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "web/backend/app/services/data_quality_monitor.py"
+      ],
+      "getter_calls_or_exports": 2,
+      "decision": "retain backing API and canonical implementation; not a deletion lane"
+    }
+  },
+  "decision": {
+    "classification": "canonical_service_adapters_first",
+    "selected_next_governance_target": "data-quality-canonical-service-adapter-provider-authorization",
+    "recommended_next_work_item": "G2.199 data-quality canonical service adapter provider authorization package",
+    "source_lane_recommendation": "do-not-start-source-implementation-from-g2-198",
+    "future_authorization_candidate": {
+      "source_paths": [
+        "web/backend/app/services/adapters/dashboard_adapter.py",
+        "web/backend/app/services/adapters/data_adapter.py"
+      ],
+      "likely_test_surfaces": [
+        "tests/backend/test_data_adapter_regression.py",
+        "web/backend/tests/test_logging_noise_regressions.py"
+      ],
+      "must_preserve": [
+        "app.services.data_adapter compatibility facade",
+        "data_source_factory construction behavior",
+        "async _trigger_quality_monitoring behavior",
+        "default runtime singleton fallback compatibility"
+      ]
+    },
+    "deferred_surfaces": [
+      "legacy data_adapters compatibility",
+      "market_data_adapter.py compatibility facade",
+      "singleton wrapper retention / eventual retirement",
+      "DataQualityMonitor implementation internals"
+    ]
+  },
+  "verification": {
+    "head": "3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1",
+    "worktree_status": "clean before edits",
+    "candidate_scan": "residual candidates inspected for getter/import lines, constructors, factory relationships, and text consumers",
+    "json_parse": "passed",
+    "markdown_governance": "errors=0, checked_files=6",
+    "openspec_validate": "migrate-backend-singletons-to-lifecycle-di valid",
+    "mainline_scope_gate": "passed",
+    "gitnexus_detect_changes_staged": {
+      "risk": "low",
+      "changed_files": 9,
+      "changed_symbols": 0,
+      "affected_processes": 0
+    }
+  },
+  "forbidden_scope_preserved": [
+    "web/backend/**",
+    "web/frontend/**",
+    "src/**",
+    "tests/**",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**"
+  ]
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T09:14:57+08:00`
-- Base HEAD checked: `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`
+- Prepared at: `2026-05-28T09:35:10+08:00`
+- Base HEAD checked: `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -34,12 +34,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#347` | `g2-194-data-quality-adapter-seam-design` | `wip/root-dirty-20260403` | `MERGED` at `e30e16605df6aaa333989a7ac247bab3dcd0dd01` | Governance design decision selecting G2.195 adapter_split constructor provider authorization |
 | `#348` | `g2-195-data-quality-adapter-split-authorization` | `wip/root-dirty-20260403` | `MERGED` at `fabd674e8a748cdd2c51a80eebb5ad20b52bc737` | Authorization package for G2.196 adapter_split constructor provider implementation |
 | `#349` | `g2-196-data-quality-adapter-split-implementation` | `wip/root-dirty-20260403` | `MERGED` at `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb` | Path-limited `adapter_split` constructor provider implementation closed for G2.197 refresh |
+| `#350` | `g2-197-data-quality-monitor-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1` | Closeout / remaining candidate refresh selecting G2.198 residual adapter ownership decision |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-197-data-quality-monitor-closeout-refresh` | `origin/wip/root-dirty-20260403` at `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb` | Close out PR `#349`, refresh remaining data-quality monitor candidates, and select the next decision gate | No |
+| `g2-198-data-quality-residual-adapter-ownership-decision` | `origin/wip/root-dirty-20260403` at `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1` | Decide residual data-quality monitor adapter ownership and select the next authorization gate | No |
 
 ## OpenSpec Relationship
 
@@ -55,8 +56,8 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.197 is a governance-only closeout branch after PR `#349` merged G2.196. It
-records the `adapter_split` constructor provider implementation as closed,
-refreshes the remaining service adapter / legacy data adapter / compatibility
-facade / wrapper surfaces, and recommends G2.198 as a decision-only next gate.
-It must not authorize another data-quality monitor source lane directly.
+G2.198 is a governance-only decision branch after PR `#350` merged G2.197. It
+selects canonical service adapters as the next authorization target, defers
+legacy data adapters, `market_data_adapter.py`, and wrapper retention to separate
+decisions, and recommends G2.199 as authorization-only before any source
+implementation.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T09:14:57+08:00`
-- Base HEAD checked: `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`
+- Prepared at: `2026-05-28T09:35:10+08:00`
+- Base HEAD checked: `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 is the active closeout / remaining data-quality monitor candidate refresh |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 is the active residual adapter ownership decision |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T09:14:57+08:00`
-- Base HEAD checked: `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`
+- Prepared at: `2026-05-28T09:35:10+08:00`
+- Base HEAD checked: `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.197 data-quality monitor closeout / remaining candidate refresh | G/#79 service lifecycle DI | PR `#349` merged at `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`; G2.197 closes the `adapter_split` subclass constructor lane and refreshes remaining candidates | If accepted, start G2.198 residual adapter ownership decision; do not start source implementation directly |
+| P0 | Review G2.198 data-quality residual adapter ownership decision | G/#79 service lifecycle DI | PR `#350` merged at `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`; G2.198 selects canonical service adapters as the next authorization target | If accepted, start G2.199 canonical service adapter provider authorization; do not start source implementation directly |
+| P0 | Preserve G2.197 data-quality monitor closeout / remaining candidate refresh | G/#79 service lifecycle DI | PR `#350` merged; `adapter_split` subclass constructor lane is closed and remaining candidates are classified | Do not bypass G2.198/G2.199 before touching service adapters, legacy adapters, `market_data_adapter.py`, or wrappers |
 | P0 | Preserve G2.196 data-quality `adapter_split` constructor provider implementation | G/#79 service lifecycle DI | PR `#349` merged; subclass-level `get_data_quality_monitor()` calls/imports are `0`; `BaseAdapter` fallback remains intentional | Do not expand into service adapters, legacy adapters, singleton wrappers, routes, or frontend |
 | P0 | Preserve G2.195 data-quality `adapter_split` constructor provider authorization | G/#79 service lifecycle DI | PR `#348` merged; G2.195 authorized only eight `adapter_split` source paths plus one focused test path | Treat the G2.196 implementation as closed after G2.197 review, not as authority for broader adapter migration |
 | P0 | Preserve G2.194 data-quality adapter constructor seam design | G/#79 service lifecycle DI | PR `#347` merged; G2.194 selected `adapter_split` constructor seam as the next authorization target | Do not implement adapter changes outside the accepted G2.195/G2.196 scope |
@@ -39,8 +40,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.197 accurately record PR `#349` as merged at `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`?
-- Does G2.197 correctly close the `adapter_split` subclass constructor lane while retaining the `BaseAdapter` fallback?
-- Are service adapters, legacy data adapters, `market_data_adapter.py`, and wrapper retention still separated into the next decision gate?
-- Is G2.198 correctly positioned as a decision-only residual adapter ownership package rather than another direct source lane?
+- Does G2.198 accurately record PR `#350` as merged at `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`?
+- Does G2.198 correctly select canonical service adapters as the next authorization target?
+- Are legacy data adapters, `market_data_adapter.py`, and wrapper retention still deferred to separate decisions?
+- Is G2.199 correctly positioned as authorization-only before any future source implementation?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T09:14:57+08:00`
-- Base HEAD checked: `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`
+- Prepared at: `2026-05-28T09:35:10+08:00`
+- Base HEAD checked: `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -55,8 +55,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-authorization-2026-05-28.md` | G2.195 human-readable authorization package | Accepted by PR `#348`; superseded for implementation evidence by G2.196 |
 | `.planning/codebase/generated/data-quality-adapter-split-constructor-provider-implementation-2026-05-28.json` | G2.196 data-quality `adapter_split` constructor provider implementation evidence | Accepted by PR `#349`; superseded for closeout / remaining candidate refresh by G2.197 |
 | `docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-implementation-2026-05-28.md` | G2.196 human-readable implementation report | Accepted by PR `#349`; superseded for closeout / remaining candidate refresh by G2.197 |
-| `.planning/codebase/generated/data-quality-monitor-closeout-refresh-2026-05-28.json` | G2.197 data-quality monitor closeout / remaining candidate refresh evidence | Current for HEAD `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`; review input until PR `#350` is accepted |
-| `docs/reports/quality/backend-data-quality-monitor-closeout-refresh-2026-05-28.md` | G2.197 human-readable closeout / refresh report | Review input until PR `#350` is accepted |
+| `.planning/codebase/generated/data-quality-monitor-closeout-refresh-2026-05-28.json` | G2.197 data-quality monitor closeout / remaining candidate refresh evidence | Accepted by PR `#350`; superseded for residual adapter ownership decision by G2.198 |
+| `docs/reports/quality/backend-data-quality-monitor-closeout-refresh-2026-05-28.md` | G2.197 human-readable closeout / refresh report | Accepted by PR `#350`; superseded for residual adapter ownership decision by G2.198 |
+| `.planning/codebase/generated/data-quality-residual-adapter-ownership-decision-2026-05-28.json` | G2.198 residual data-quality adapter ownership decision evidence | Current for HEAD `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`; review input until PR `#351` is accepted |
+| `docs/reports/quality/backend-data-quality-residual-adapter-ownership-decision-2026-05-28.md` | G2.198 human-readable residual adapter ownership decision report | Review input until PR `#351` is accepted |
 
 ## External State Inputs
 
@@ -77,7 +79,8 @@ state transition.
 | GitHub PR `#347` | `MERGED` | G2.194 data-quality adapter constructor seam design merged by commit `e30e16605df6aaa333989a7ac247bab3dcd0dd01` |
 | GitHub PR `#348` | `MERGED` | G2.195 data-quality adapter_split constructor provider authorization merged by commit `fabd674e8a748cdd2c51a80eebb5ad20b52bc737` |
 | GitHub PR `#349` | `MERGED` | G2.196 data-quality adapter_split constructor provider implementation merged by commit `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb` |
-| `origin/wip/root-dirty-20260403` | `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb` | Base used for this closeout / remaining candidate refresh branch |
+| GitHub PR `#350` | `MERGED` | G2.197 data-quality monitor closeout / refresh merged by commit `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1` |
+| `origin/wip/root-dirty-20260403` | `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1` | Base used for this residual adapter ownership decision branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T09:14:57+08:00",
+  "generated_at": "2026-05-28T09:35:10+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "e4245ebe54c5ad6d2aebf4802d165d59700c9eeb",
-  "split_branch": "g2-197-data-quality-monitor-closeout-refresh",
-  "scope": "data_quality_monitor_closeout_refresh",
+  "base_head": "3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1",
+  "split_branch": "g2-198-data-quality-residual-adapter-ownership-decision",
+  "scope": "data_quality_residual_adapter_ownership_decision",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -1241,7 +1241,7 @@
     {
       "id": "g2-197-data-quality-monitor-closeout-refresh",
       "type": "closeout_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.196 data-quality adapter_split constructor provider implementation",
       "source_edit_authority": false,
@@ -1305,10 +1305,80 @@
         }
       },
       "freshness": {
-        "current_head_checked": "e4245ebe54c5ad6d2aebf4802d165d59700c9eeb",
+        "current_head_checked": "3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.198 data-quality residual adapter ownership decision; do not start source implementation directly from G2.197."
+      "github_pr": {
+        "number": 350,
+        "url": "https://github.com/chengjon/mystocks/pull/350",
+        "state": "MERGED",
+        "merged_at": "2026-05-28T01:29:45Z",
+        "head_ref": "g2-197-data-quality-monitor-closeout-refresh",
+        "merge_commit": "3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1"
+      },
+      "next_gate": "Superseded by G2.198 data-quality residual adapter ownership decision."
+    },
+    {
+      "id": "g2-198-data-quality-residual-adapter-ownership-decision",
+      "type": "decision_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.197 data-quality monitor closeout / remaining candidate refresh",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/data-quality-residual-adapter-ownership-decision-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-residual-adapter-ownership-decision-2026-05-28.md",
+        "governance/mainline/task-cards/pr-351.yaml"
+      ],
+      "candidate_facts": {
+        "canonical_service_adapters": {
+          "files": 2,
+          "getter_calls": 2,
+          "paths": [
+            "web/backend/app/services/adapters/dashboard_adapter.py",
+            "web/backend/app/services/adapters/data_adapter.py"
+          ],
+          "decision": "selected_next_authorization_target"
+        },
+        "legacy_data_adapters": {
+          "files": 2,
+          "getter_calls": 2,
+          "paths": [
+            "web/backend/app/services/data_adapters/dashboard.py",
+            "web/backend/app/services/data_adapters/data_source.py"
+          ],
+          "decision": "defer to compatibility ownership decision; do not delete from static search alone"
+        },
+        "market_data_adapter_compatibility": {
+          "files": 1,
+          "getter_calls": 1,
+          "paths": [
+            "web/backend/app/services/market_data_adapter.py"
+          ],
+          "decision": "defer as root compatibility facade surface"
+        },
+        "service_wrapper_and_canonical_monitor": {
+          "files": 2,
+          "decision": "retain backing API and canonical implementation"
+        }
+      },
+      "decision": {
+        "classification": "canonical_service_adapters_first",
+        "selected_next_governance_target": "data-quality-canonical-service-adapter-provider-authorization",
+        "recommended_next_work_item": "G2.199 data-quality canonical service adapter provider authorization package",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-198",
+        "deferred_surfaces": [
+          "legacy data_adapters compatibility",
+          "market_data_adapter.py compatibility facade",
+          "singleton wrapper retention / eventual retirement",
+          "DataQualityMonitor implementation internals"
+        ]
+      },
+      "freshness": {
+        "current_head_checked": "3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.199 data-quality canonical service adapter provider authorization; do not start source implementation directly from G2.198."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T09:14:57+08:00`
-- Base HEAD checked: `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb`
+- Prepared at: `2026-05-28T09:35:10+08:00`
+- Base HEAD checked: `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -49,7 +49,8 @@ It proved a repeatable conveyor:
 | G2.194 data-quality adapter constructor seam design | Merged by PR `#347` | Selects `adapter_split` constructor provider authorization as the next gate, defines test-double contract, and keeps source authority at none |
 | G2.195 data-quality `adapter_split` constructor provider authorization | Merged by PR `#348` | Authorizes the future G2.196 `adapter_split` constructor provider implementation lane while keeping source authority at none in that PR |
 | G2.196 data-quality `adapter_split` constructor provider implementation | Merged by PR `#349` | Implements optional constructor monitor injection in `adapter_split` only, with focused TDD evidence |
-| G2.197 data-quality monitor closeout / remaining candidate refresh | For review | Closes the `adapter_split` subclass constructor lane and refreshes remaining service adapter, legacy adapter, compatibility facade, and wrapper surfaces |
+| G2.197 data-quality monitor closeout / remaining candidate refresh | Merged by PR `#350` | Closes the `adapter_split` subclass constructor lane and refreshes remaining service adapter, legacy adapter, compatibility facade, and wrapper surfaces |
+| G2.198 data-quality residual adapter ownership decision | For review | Selects canonical service adapters as the next authorization target while deferring legacy data adapters, `market_data_adapter.py`, and wrapper retention |
 
 ## Current Strategy Getter Residuals
 
@@ -347,11 +348,38 @@ Remaining data-quality monitor surfaces:
 G2.197 recommends G2.198 as a decision-only residual adapter ownership package.
 It does not authorize another source implementation lane.
 
+PR `#350` merged this lane at
+`3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`.
+
+## G2.198 Data-Quality Residual Adapter Ownership Decision
+
+At HEAD `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`, PR `#350` is merged and
+the G2.197 closeout / refresh is accepted.
+
+G2.198 selects canonical service adapters as the next ownership target:
+
+| Surface | Files | Getter calls | Current decision |
+|---|---:|---:|---|
+| canonical service adapters | 2 | 2 | Select as G2.199 authorization target |
+| legacy data adapters | 2 | 2 | Defer to compatibility ownership decision |
+| `market_data_adapter.py` | 1 | 1 | Defer as root compatibility facade surface |
+| singleton wrapper / canonical monitor | 2 | 2 or re-export | Retain backing API and canonical implementation |
+
+Selected future authorization candidate:
+
+| Path | Role |
+|---|---|
+| `web/backend/app/services/adapters/dashboard_adapter.py` | Canonical dashboard data-source adapter, currently calls `get_data_quality_monitor()` in async monitoring helper |
+| `web/backend/app/services/adapters/data_adapter.py` | Canonical data data-source adapter, currently calls `get_data_quality_monitor()` in async monitoring helper |
+
+G2.198 recommends G2.199 as an authorization-only package. It does not authorize
+source implementation directly.
+
 ## Next Gates
 
-- Review G2.197 data-quality monitor closeout / remaining candidate refresh.
-- If accepted, start G2.198 data-quality residual adapter ownership decision.
-- Do not start another data-quality source implementation directly from G2.197.
+- Review G2.198 data-quality residual adapter ownership decision.
+- If accepted, start G2.199 data-quality canonical service adapter provider authorization.
+- Do not start another data-quality source implementation directly from G2.198.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/reports/quality/backend-data-quality-residual-adapter-ownership-decision-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-residual-adapter-ownership-decision-2026-05-28.md
@@ -1,0 +1,124 @@
+# Backend Data-Quality Residual Adapter Ownership Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Node: G2.198 data-quality residual adapter ownership decision
+- Status: for review
+- Prepared at: `2026-05-28T09:35:10+08:00`
+- Base HEAD checked: `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`
+- Parent PR: `#350`
+- Parent merge commit: `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`
+- Source edit authority: no
+
+Boundary note: this report records an ownership decision only. It does not
+authorize backend source changes, test changes, OpenSpec proposal creation,
+route/OpenAPI changes, issue label changes, PM2 commands, or PR merges.
+
+## Decision
+
+G2.198 selects canonical service adapters as the next data-quality monitor
+ownership target.
+
+The next recommended gate is:
+
+| Next gate | Type | Source authority | Purpose |
+|---|---|---|---|
+| G2.199 data-quality canonical service adapter provider authorization | authorization package | no in G2.199 itself | Define a future path-limited implementation lane for canonical service adapters |
+
+G2.198 does not authorize implementation. If G2.199 is accepted, a later
+implementation lane may be opened with explicit source paths and test scope.
+
+## Candidate Facts
+
+| Surface | Files | Getter calls | Getter imports | Current decision |
+|---|---:|---:|---:|---|
+| canonical service adapters | 2 | 2 | 2 | Select as next authorization target |
+| legacy data adapters | 2 | 2 | 2 | Defer to compatibility ownership decision |
+| `market_data_adapter.py` | 1 | 1 | 1 | Defer as root compatibility facade |
+| singleton wrapper / canonical monitor | 2 | 2 or re-export | 1 | Retain backing API and canonical implementation |
+
+Candidate file details:
+
+| File | Class | Getter/import lines | Decision |
+|---|---|---|---|
+| `web/backend/app/services/adapters/dashboard_adapter.py` | `DashboardDataSourceAdapter` | import line 9, call line 253 | selected for future authorization |
+| `web/backend/app/services/adapters/data_adapter.py` | `DataDataSourceAdapter` | import line 10, call line 622 | selected for future authorization |
+| `web/backend/app/services/data_adapters/dashboard.py` | `DashboardDataSourceAdapter` | import line 10, call line 249 | defer; legacy compatibility surface |
+| `web/backend/app/services/data_adapters/data_source.py` | `DataDataSourceAdapter` | import line 10, call line 608 | defer; legacy compatibility surface |
+| `web/backend/app/services/market_data_adapter.py` | `MarketDataSourceAdapter` | import line 10, call line 327 | defer; root compatibility facade |
+| `web/backend/app/services/_data_quality_monitor_singleton.py` | n/a | definition line 12, helper line 24 | retain backing singleton helper |
+| `web/backend/app/services/data_quality_monitor.py` | `DataQualityMonitor` and rules | re-export line 714 | retain canonical implementation and public export |
+
+Factory relationship:
+
+| File | Evidence | Decision use |
+|---|---|---|
+| `web/backend/app/services/data_source_factory/data_source_factory.py` | imports `DashboardDataSourceAdapter` and `DataDataSourceAdapter` through `app.services.data_adapter`; constructs them at lines 116 and 119 | canonical service adapters are active through the compatibility facade and should be handled before legacy directory cleanup |
+| `web/backend/app/services/data_source_factory/data_source_factory.py` | imports and constructs `MarketDataSourceAdapter` | `market_data_adapter.py` remains an active compatibility facade and needs separate ownership planning |
+
+## Rationale
+
+Canonical service adapters are the narrowest active residual surface after the
+`adapter_split` closeout. They have exactly two getter calls, no constructor
+`quality_monitor` parameter, and active factory reachability through the
+`app.services.data_adapter` compatibility facade.
+
+Legacy `data_adapters` modules have no direct module text consumers in the
+current scan, but static non-use is not deletion authority. They may still carry
+compatibility or historical import obligations and must remain deferred to a
+separate compatibility decision.
+
+`market_data_adapter.py` is larger, factory-constructed, and already belongs to a
+compatibility facade / market-data ownership surface. It should not be bundled
+with the canonical service adapter authorization.
+
+The singleton wrapper and canonical monitor implementation are retained backing
+APIs. This decision does not delete, rename, privatize, or move them.
+
+## Future G2.199 Authorization Candidate
+
+Likely future source paths:
+
+- `web/backend/app/services/adapters/dashboard_adapter.py`
+- `web/backend/app/services/adapters/data_adapter.py`
+
+Likely future test surfaces:
+
+- `tests/backend/test_data_adapter_regression.py`
+- `web/backend/tests/test_logging_noise_regressions.py`
+
+Future authorization must preserve:
+
+- `app.services.data_adapter` compatibility facade behavior
+- `data_source_factory` construction behavior
+- async `_trigger_quality_monitoring(...)` behavior
+- default runtime singleton fallback compatibility
+
+## Preserved Boundaries
+
+G2.198 does not touch:
+
+- `web/backend/**`
+- `web/frontend/**`
+- `src/**`
+- `tests/**`
+- `config/**`
+- `scripts/**`
+- `openspec/changes/**`
+- `openspec/specs/**`
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Parent PR state | `#350` is `MERGED` at `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1` |
+| Candidate scan | Residual files inspected for getter/import lines, constructors, factory relationships, and text consumers |
+| Source edit scope | No backend source edits in this package |
+| Next-gate classification | G2.199 authorization package; no direct source implementation from G2.198 |
+| JSON parse | Passed for generated artifact and `steward-index.json` |
+| Markdown governance | `errors=0`, `checked_files=6` |
+| OpenSpec strict validate | `migrate-backend-singletons-to-lifecycle-di` valid |
+| GitNexus staged detect changes | Low risk; 9 changed governance files, 0 changed symbols, 0 affected processes |
+| Mainline scope gate | Passed |

--- a/governance/mainline/task-cards/pr-351.yaml
+++ b/governance/mainline/task-cards/pr-351.yaml
@@ -1,0 +1,112 @@
+version: "v0.2"
+
+task:
+  id: "pr-351"
+  title: "Decide data-quality residual adapter ownership"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-residual-adapter-ownership-decision"
+  objective: "classify remaining data-quality monitor adapter surfaces and select the next authorization gate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only residual adapter ownership decision; no route paths, HTTP methods, response models, OpenAPI examples, frontend behavior, PM2 workflows, or public API ownership changes"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-residual-adapter-ownership-decision-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-residual-adapter-ownership-decision-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-351.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source implementation"
+  - "test source edits"
+  - "adapter migration"
+  - "legacy data adapter deletion"
+  - "market_data_adapter.py edits"
+  - "singleton wrapper deletion"
+  - "DataQualityMonitor internals"
+  - "route changes"
+  - "frontend changes"
+  - "OpenSpec proposal creation"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "node -e \"JSON.parse(require('fs').readFileSync('.planning/codebase/generated/data-quality-residual-adapter-ownership-decision-2026-05-28.json','utf8')); JSON.parse(require('fs').readFileSync('.planning/codebase/steward-tree/steward-index.json','utf8'));\""
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-residual-adapter-ownership-decision-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-351.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1 --head-sha HEAD --report /tmp/pr351-mainline-governance-report.json"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Treating this decision as source authority would bypass the required authorization package."
+    - "Legacy data_adapters have zero direct module text consumers in this scan, but static non-use is not deletion authority."
+  rollback_plan: "revert this PR to restore the post-#350 steward state and rerun the residual ownership decision."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "decide residual data-quality monitor adapter ownership"
+    modified_scope: "governance reports, generated evidence, steward tree files, and one task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no backend source files are modified"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if candidate classification or next-gate selection is incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T09:35:10+08:00"
+    approval_note: "Human maintainer approved continuing after PR #350 acceptance; this lane is decision-only residual ownership classification."
+    secondary_approved: true


### PR DESCRIPTION
## Summary

G2.198 decides ownership for the remaining data-quality monitor adapter surfaces after PR #350 merged.

- Selects canonical service adapters as the next authorization target.
- Defers legacy `data_adapters`, `market_data_adapter.py`, and singleton wrapper/canonical monitor retention to separate decisions.
- Records that G2.199 should be authorization-only before any future source implementation.
- Updates steward tree state, evidence index, branch register, completed ledger, and service lifecycle DI track.

## Decision

Next gate: G2.199 data-quality canonical service adapter provider authorization.

Likely future source paths for that later authorization:

- `web/backend/app/services/adapters/dashboard_adapter.py`
- `web/backend/app/services/adapters/data_adapter.py`

This PR itself is decision-only and does not authorize source edits.

## Boundary

This PR does not modify backend source, tests, frontend, config, scripts, OpenSpec changes/specs, route behavior, OpenAPI contracts, PM2 workflows, or issue labels.

## Verification

- JSON parse for generated artifact and steward-index -> passed
- Markdown governance gate -> errors 0, checked_files 6
- `openspec validate migrate-backend-singletons-to-lifecycle-di --strict` -> valid
- GitNexus staged detect changes -> low risk, 9 changed governance files, 0 changed symbols, 0 affected processes
- Mainline scope gate -> pass
- `git diff --check` / cached diff check -> passed

## Next Gate

If accepted, start G2.199 data-quality canonical service adapter provider authorization. Do not start source implementation directly from G2.198.
