### PR TITLE
docs(governance): authorize data quality service adapters

### DIFF
--- a/.planning/codebase/generated/data-quality-canonical-service-adapter-provider-authorization-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-canonical-service-adapter-provider-authorization-2026-05-28.json
@@ -1,0 +1,121 @@
+{
+  "schema_version": "2026-05-28.g2-199.authorization.v1",
+  "generated_at": "2026-05-28T10:14:06+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "a6b54ddfb24055552d634757f01dc03bd6ca6e62",
+  "worktree_branch": "g2-199-data-quality-canonical-service-adapter-authorization",
+  "status": "for_review",
+  "source_edit_authority": false,
+  "parent": {
+    "id": "g2-198-data-quality-residual-adapter-ownership-decision",
+    "github_pr": 351,
+    "state": "MERGED",
+    "merged_at": "2026-05-28T02:10:17Z",
+    "merge_commit": "a6b54ddfb24055552d634757f01dc03bd6ca6e62"
+  },
+  "authorization": {
+    "future_lane": "G2.200 data-quality canonical service adapter provider implementation",
+    "future_source_edit_authority_if_accepted": true,
+    "future_source_paths": [
+      "web/backend/app/services/adapters/dashboard_adapter.py",
+      "web/backend/app/services/adapters/data_adapter.py"
+    ],
+    "future_test_paths": [
+      "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py",
+      "tests/backend/test_data_adapter_regression.py",
+      "web/backend/tests/test_logging_noise_regressions.py"
+    ],
+    "future_implementation_shape": [
+      "Add optional keyword-only quality_monitor injection to both canonical service adapter constructors.",
+      "Preserve existing config positional constructor compatibility.",
+      "Use the injected monitor in async _trigger_quality_monitoring without calling the global getter.",
+      "Retain default runtime behavior by falling back to get_data_quality_monitor when no monitor is injected.",
+      "Keep app.services.data_adapter compatibility facade and data_source_factory construction behavior intact."
+    ]
+  },
+  "current_facts": {
+    "dashboard_adapter": {
+      "path": "web/backend/app/services/adapters/dashboard_adapter.py",
+      "class": "DashboardDataSourceAdapter",
+      "constructor": "def __init__(self, config: Dict[str, Any])",
+      "getter_import_line": 9,
+      "getter_call_line": 253,
+      "quality_monitor_parameter": false
+    },
+    "data_adapter": {
+      "path": "web/backend/app/services/adapters/data_adapter.py",
+      "class": "DataDataSourceAdapter",
+      "constructor": "def __init__(self, config: Dict[str, Any])",
+      "getter_import_line": 10,
+      "getter_call_line": 622,
+      "quality_monitor_parameter": false
+    },
+    "factory_relationship": {
+      "path": "web/backend/app/services/data_source_factory/data_source_factory.py",
+      "facade_import_line": 18,
+      "data_adapter_construction_line": 116,
+      "dashboard_adapter_construction_line": 119,
+      "decision_use": "future implementation must preserve construction through app.services.data_adapter facade"
+    },
+    "gitnexus_context": {
+      "dashboard_adapter_exact_file": "found canonical DashboardDataSourceAdapter at web/backend/app/services/adapters/dashboard_adapter.py; incoming graph refs empty",
+      "data_adapter_exact_file": "found canonical DataDataSourceAdapter at web/backend/app/services/adapters/data_adapter.py; incoming graph refs empty",
+      "note": "text scan and factory evidence are used because graph incoming refs do not capture the facade construction path"
+    }
+  },
+  "future_forbidden_surfaces": [
+    "web/backend/app/services/data_adapters/**",
+    "web/backend/app/services/market_data_adapter.py",
+    "web/backend/app/services/_data_quality_monitor_singleton.py",
+    "web/backend/app/services/data_quality_monitor.py",
+    "web/backend/app/api/**",
+    "web/frontend/**",
+    "src/**",
+    "docs/api/**",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**"
+  ],
+  "future_required_checks": [
+    "GitNexus impact/context before source edits on the exact target files or classes",
+    "TDD red/green for injected monitor avoiding global getter calls",
+    "focused pytest for web/backend/tests/test_data_quality_canonical_service_adapter_provider.py",
+    "focused regression coverage for tests/backend/test_data_adapter_regression.py and web/backend/tests/test_logging_noise_regressions.py when touched",
+    "ruff check on authorized source and test paths",
+    "import smoke for canonical adapter constructors through app.services.data_adapter and data_source_factory",
+    "openspec validate migrate-backend-singletons-to-lifecycle-di --strict",
+    "gitnexus_detect_changes(scope=staged)"
+  ],
+  "verification": {
+    "head": "a6b54ddfb24055552d634757f01dc03bd6ca6e62",
+    "worktree_status": "clean before edits",
+    "candidate_scan": "authorized candidates inspected for constructors, getter/import lines, factory relationship, and test surface existence",
+    "json_parse": "passed for this authorization artifact and steward-index.json",
+    "markdown_governance": {
+      "status": "passed",
+      "checked_files": 6,
+      "errors": 0
+    },
+    "openspec_validate": {
+      "change": "migrate-backend-singletons-to-lifecycle-di",
+      "strict": true,
+      "status": "passed"
+    },
+    "git_diff_check": "passed",
+    "gitnexus_staged_detect_changes": {
+      "status": "passed",
+      "risk_level": "low",
+      "changed_files": 9,
+      "changed_symbols": 0,
+      "affected_processes": 0
+    },
+    "mainline_scope_gate": {
+      "status": "passed",
+      "changed_files": 9,
+      "violations": 0,
+      "report": "/tmp/pr352-mainline-governance-report.json"
+    }
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T09:35:10+08:00`
-- Base HEAD checked: `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`
+- Prepared at: `2026-05-28T10:14:06+08:00`
+- Base HEAD checked: `a6b54ddfb24055552d634757f01dc03bd6ca6e62`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -35,12 +35,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#348` | `g2-195-data-quality-adapter-split-authorization` | `wip/root-dirty-20260403` | `MERGED` at `fabd674e8a748cdd2c51a80eebb5ad20b52bc737` | Authorization package for G2.196 adapter_split constructor provider implementation |
 | `#349` | `g2-196-data-quality-adapter-split-implementation` | `wip/root-dirty-20260403` | `MERGED` at `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb` | Path-limited `adapter_split` constructor provider implementation closed for G2.197 refresh |
 | `#350` | `g2-197-data-quality-monitor-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1` | Closeout / remaining candidate refresh selecting G2.198 residual adapter ownership decision |
+| `#351` | `g2-198-data-quality-residual-adapter-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `a6b54ddfb24055552d634757f01dc03bd6ca6e62` | Decision selecting canonical service adapter provider authorization as G2.199 |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-198-data-quality-residual-adapter-ownership-decision` | `origin/wip/root-dirty-20260403` at `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1` | Decide residual data-quality monitor adapter ownership and select the next authorization gate | No |
+| `g2-199-data-quality-canonical-service-adapter-authorization` | `origin/wip/root-dirty-20260403` at `a6b54ddfb24055552d634757f01dc03bd6ca6e62` | Authorize a future canonical service adapter provider implementation lane | No |
 
 ## OpenSpec Relationship
 
@@ -56,8 +57,8 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.198 is a governance-only decision branch after PR `#350` merged G2.197. It
-selects canonical service adapters as the next authorization target, defers
-legacy data adapters, `market_data_adapter.py`, and wrapper retention to separate
-decisions, and recommends G2.199 as authorization-only before any source
-implementation.
+G2.199 is a governance-only authorization branch after PR `#351` merged G2.198.
+It defines the future G2.200 path-limited implementation surface for canonical
+service adapters and keeps legacy data adapters, `market_data_adapter.py`,
+singleton wrapper, monitor internals, routes, frontend, and OpenSpec changes out
+of scope.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T09:35:10+08:00`
-- Base HEAD checked: `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`
+- Prepared at: `2026-05-28T10:14:06+08:00`
+- Base HEAD checked: `a6b54ddfb24055552d634757f01dc03bd6ca6e62`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 is the active residual adapter ownership decision |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 is the active canonical service adapter provider authorization |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T09:35:10+08:00`
-- Base HEAD checked: `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`
+- Prepared at: `2026-05-28T10:14:06+08:00`
+- Base HEAD checked: `a6b54ddfb24055552d634757f01dc03bd6ca6e62`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.198 data-quality residual adapter ownership decision | G/#79 service lifecycle DI | PR `#350` merged at `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`; G2.198 selects canonical service adapters as the next authorization target | If accepted, start G2.199 canonical service adapter provider authorization; do not start source implementation directly |
+| P0 | Review G2.199 data-quality canonical service adapter provider authorization | G/#79 service lifecycle DI | PR `#351` merged at `a6b54ddfb24055552d634757f01dc03bd6ca6e62`; G2.199 authorizes a future G2.200 implementation lane only if accepted | If accepted, start G2.200 canonical service adapter provider implementation; do not expand scope |
+| P0 | Preserve G2.198 data-quality residual adapter ownership decision | G/#79 service lifecycle DI | PR `#351` merged; canonical service adapters selected as next authorization target | Do not touch legacy data adapters, `market_data_adapter.py`, wrapper, or monitor internals under G2.199/G2.200 |
 | P0 | Preserve G2.197 data-quality monitor closeout / remaining candidate refresh | G/#79 service lifecycle DI | PR `#350` merged; `adapter_split` subclass constructor lane is closed and remaining candidates are classified | Do not bypass G2.198/G2.199 before touching service adapters, legacy adapters, `market_data_adapter.py`, or wrappers |
 | P0 | Preserve G2.196 data-quality `adapter_split` constructor provider implementation | G/#79 service lifecycle DI | PR `#349` merged; subclass-level `get_data_quality_monitor()` calls/imports are `0`; `BaseAdapter` fallback remains intentional | Do not expand into service adapters, legacy adapters, singleton wrappers, routes, or frontend |
 | P0 | Preserve G2.195 data-quality `adapter_split` constructor provider authorization | G/#79 service lifecycle DI | PR `#348` merged; G2.195 authorized only eight `adapter_split` source paths plus one focused test path | Treat the G2.196 implementation as closed after G2.197 review, not as authority for broader adapter migration |
@@ -40,8 +41,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.198 accurately record PR `#350` as merged at `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`?
-- Does G2.198 correctly select canonical service adapters as the next authorization target?
-- Are legacy data adapters, `market_data_adapter.py`, and wrapper retention still deferred to separate decisions?
-- Is G2.199 correctly positioned as authorization-only before any future source implementation?
+- Does G2.199 accurately record PR `#351` as merged at `a6b54ddfb24055552d634757f01dc03bd6ca6e62`?
+- Does G2.199 authorize only `dashboard_adapter.py`, `data_adapter.py`, and the listed tests for future G2.200?
+- Are legacy data adapters, `market_data_adapter.py`, wrapper, and monitor internals still forbidden for G2.200?
+- Is G2.200 correctly positioned as a later source implementation lane, not part of this authorization PR?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T09:35:10+08:00`
-- Base HEAD checked: `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`
+- Prepared at: `2026-05-28T10:14:06+08:00`
+- Base HEAD checked: `a6b54ddfb24055552d634757f01dc03bd6ca6e62`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -57,8 +57,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-adapter-split-constructor-provider-implementation-2026-05-28.md` | G2.196 human-readable implementation report | Accepted by PR `#349`; superseded for closeout / remaining candidate refresh by G2.197 |
 | `.planning/codebase/generated/data-quality-monitor-closeout-refresh-2026-05-28.json` | G2.197 data-quality monitor closeout / remaining candidate refresh evidence | Accepted by PR `#350`; superseded for residual adapter ownership decision by G2.198 |
 | `docs/reports/quality/backend-data-quality-monitor-closeout-refresh-2026-05-28.md` | G2.197 human-readable closeout / refresh report | Accepted by PR `#350`; superseded for residual adapter ownership decision by G2.198 |
-| `.planning/codebase/generated/data-quality-residual-adapter-ownership-decision-2026-05-28.json` | G2.198 residual data-quality adapter ownership decision evidence | Current for HEAD `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`; review input until PR `#351` is accepted |
-| `docs/reports/quality/backend-data-quality-residual-adapter-ownership-decision-2026-05-28.md` | G2.198 human-readable residual adapter ownership decision report | Review input until PR `#351` is accepted |
+| `.planning/codebase/generated/data-quality-residual-adapter-ownership-decision-2026-05-28.json` | G2.198 residual data-quality adapter ownership decision evidence | Accepted by PR `#351`; superseded for canonical service adapter authorization by G2.199 |
+| `docs/reports/quality/backend-data-quality-residual-adapter-ownership-decision-2026-05-28.md` | G2.198 human-readable residual adapter ownership decision report | Accepted by PR `#351`; superseded for canonical service adapter authorization by G2.199 |
+| `.planning/codebase/generated/data-quality-canonical-service-adapter-provider-authorization-2026-05-28.json` | G2.199 canonical service adapter provider authorization evidence | Current for HEAD `a6b54ddfb24055552d634757f01dc03bd6ca6e62`; review input until PR `#352` is accepted |
+| `docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-authorization-2026-05-28.md` | G2.199 human-readable authorization package | Review input until PR `#352` is accepted |
 
 ## External State Inputs
 
@@ -80,7 +82,8 @@ state transition.
 | GitHub PR `#348` | `MERGED` | G2.195 data-quality adapter_split constructor provider authorization merged by commit `fabd674e8a748cdd2c51a80eebb5ad20b52bc737` |
 | GitHub PR `#349` | `MERGED` | G2.196 data-quality adapter_split constructor provider implementation merged by commit `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb` |
 | GitHub PR `#350` | `MERGED` | G2.197 data-quality monitor closeout / refresh merged by commit `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1` |
-| `origin/wip/root-dirty-20260403` | `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1` | Base used for this residual adapter ownership decision branch |
+| GitHub PR `#351` | `MERGED` | G2.198 residual adapter ownership decision merged by commit `a6b54ddfb24055552d634757f01dc03bd6ca6e62` |
+| `origin/wip/root-dirty-20260403` | `a6b54ddfb24055552d634757f01dc03bd6ca6e62` | Base used for this canonical service adapter authorization branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T09:35:10+08:00",
+  "generated_at": "2026-05-28T10:14:06+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1",
-  "split_branch": "g2-198-data-quality-residual-adapter-ownership-decision",
-  "scope": "data_quality_residual_adapter_ownership_decision",
+  "base_head": "a6b54ddfb24055552d634757f01dc03bd6ca6e62",
+  "split_branch": "g2-199-data-quality-canonical-service-adapter-authorization",
+  "scope": "data_quality_canonical_service_adapter_provider_authorization",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -1321,7 +1321,7 @@
     {
       "id": "g2-198-data-quality-residual-adapter-ownership-decision",
       "type": "decision_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.197 data-quality monitor closeout / remaining candidate refresh",
       "source_edit_authority": false,
@@ -1375,10 +1375,83 @@
         ]
       },
       "freshness": {
-        "current_head_checked": "3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1",
+        "current_head_checked": "a6b54ddfb24055552d634757f01dc03bd6ca6e62",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.199 data-quality canonical service adapter provider authorization; do not start source implementation directly from G2.198."
+      "github_pr": {
+        "number": 351,
+        "url": "https://github.com/chengjon/mystocks/pull/351",
+        "state": "MERGED",
+        "merged_at": "2026-05-28T02:10:17Z",
+        "head_ref": "g2-198-data-quality-residual-adapter-ownership-decision",
+        "merge_commit": "a6b54ddfb24055552d634757f01dc03bd6ca6e62"
+      },
+      "next_gate": "Superseded by G2.199 data-quality canonical service adapter provider authorization."
+    },
+    {
+      "id": "g2-199-data-quality-canonical-service-adapter-provider-authorization",
+      "type": "authorization_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.198 data-quality residual adapter ownership decision",
+      "source_edit_authority": false,
+      "evidence": [
+        ".planning/codebase/generated/data-quality-canonical-service-adapter-provider-authorization-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-authorization-2026-05-28.md",
+        "governance/mainline/task-cards/pr-352.yaml"
+      ],
+      "future_source_edit_authority_if_accepted": true,
+      "authorized_future_lane": "G2.200 data-quality canonical service adapter provider implementation",
+      "authorized_future_source_paths": [
+        "web/backend/app/services/adapters/dashboard_adapter.py",
+        "web/backend/app/services/adapters/data_adapter.py"
+      ],
+      "authorized_future_test_paths": [
+        "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py",
+        "tests/backend/test_data_adapter_regression.py",
+        "web/backend/tests/test_logging_noise_regressions.py"
+      ],
+      "future_forbidden_surfaces": [
+        "web/backend/app/services/data_adapters/**",
+        "web/backend/app/services/market_data_adapter.py",
+        "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "web/backend/app/services/data_quality_monitor.py",
+        "web/backend/app/api/**",
+        "web/frontend/**",
+        "src/**",
+        "docs/api/**",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "current_facts": {
+        "dashboard_adapter": {
+          "constructor": "def __init__(self, config: Dict[str, Any])",
+          "getter_import_line": 9,
+          "getter_call_line": 253
+        },
+        "data_adapter": {
+          "constructor": "def __init__(self, config: Dict[str, Any])",
+          "getter_import_line": 10,
+          "getter_call_line": 622
+        },
+        "factory_relationship": "data_source_factory imports both adapters through app.services.data_adapter and constructs them with config.__dict__"
+      },
+      "future_required_checks": [
+        "GitNexus impact/context before exact source edits",
+        "TDD red/green for injected monitor avoiding global getter calls",
+        "focused pytest for data-quality canonical service adapter provider test",
+        "ruff on authorized source and test paths",
+        "import smoke through app.services.data_adapter and data_source_factory",
+        "openspec validate migrate-backend-singletons-to-lifecycle-di --strict",
+        "gitnexus_detect_changes(scope=staged)"
+      ],
+      "freshness": {
+        "current_head_checked": "a6b54ddfb24055552d634757f01dc03bd6ca6e62",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.200 data-quality canonical service adapter provider implementation with the authorized paths only."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T09:35:10+08:00`
-- Base HEAD checked: `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1`
+- Prepared at: `2026-05-28T10:14:06+08:00`
+- Base HEAD checked: `a6b54ddfb24055552d634757f01dc03bd6ca6e62`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -50,7 +50,8 @@ It proved a repeatable conveyor:
 | G2.195 data-quality `adapter_split` constructor provider authorization | Merged by PR `#348` | Authorizes the future G2.196 `adapter_split` constructor provider implementation lane while keeping source authority at none in that PR |
 | G2.196 data-quality `adapter_split` constructor provider implementation | Merged by PR `#349` | Implements optional constructor monitor injection in `adapter_split` only, with focused TDD evidence |
 | G2.197 data-quality monitor closeout / remaining candidate refresh | Merged by PR `#350` | Closes the `adapter_split` subclass constructor lane and refreshes remaining service adapter, legacy adapter, compatibility facade, and wrapper surfaces |
-| G2.198 data-quality residual adapter ownership decision | For review | Selects canonical service adapters as the next authorization target while deferring legacy data adapters, `market_data_adapter.py`, and wrapper retention |
+| G2.198 data-quality residual adapter ownership decision | Merged by PR `#351` | Selects canonical service adapters as the next authorization target while deferring legacy data adapters, `market_data_adapter.py`, and wrapper retention |
+| G2.199 data-quality canonical service adapter provider authorization | For review | Authorizes future G2.200 implementation for canonical service adapters only; no source edits in this PR |
 
 ## Current Strategy Getter Residuals
 
@@ -375,11 +376,45 @@ Selected future authorization candidate:
 G2.198 recommends G2.199 as an authorization-only package. It does not authorize
 source implementation directly.
 
+PR `#351` merged this lane at
+`a6b54ddfb24055552d634757f01dc03bd6ca6e62`.
+
+## G2.199 Data-Quality Canonical Service Adapter Provider Authorization
+
+At HEAD `a6b54ddfb24055552d634757f01dc03bd6ca6e62`, PR `#351` is merged and
+G2.198's ownership decision is accepted.
+
+G2.199 authorizes a future G2.200 implementation lane only after review
+acceptance. G2.199 itself has no source edit authority.
+
+Future authorized source paths:
+
+| Path | Future role |
+|---|---|
+| `web/backend/app/services/adapters/dashboard_adapter.py` | Add optional injectable data-quality monitor seam while preserving `config` positional constructor compatibility |
+| `web/backend/app/services/adapters/data_adapter.py` | Add optional injectable data-quality monitor seam while preserving `config` positional constructor compatibility |
+
+Future authorized test paths:
+
+| Path | Future role |
+|---|---|
+| `web/backend/tests/test_data_quality_canonical_service_adapter_provider.py` | New focused fake-monitor provider regression tests |
+| `tests/backend/test_data_adapter_regression.py` | Existing adapter regression coverage if needed |
+| `web/backend/tests/test_logging_noise_regressions.py` | Existing dashboard adapter logging/noise regression coverage if needed |
+
+Future forbidden surfaces remain:
+
+- legacy data adapters under `web/backend/app/services/data_adapters/`
+- `web/backend/app/services/market_data_adapter.py`
+- `web/backend/app/services/_data_quality_monitor_singleton.py`
+- `web/backend/app/services/data_quality_monitor.py`
+- route, frontend, OpenAPI contract, config, script, and OpenSpec change files
+
 ## Next Gates
 
-- Review G2.198 data-quality residual adapter ownership decision.
-- If accepted, start G2.199 data-quality canonical service adapter provider authorization.
-- Do not start another data-quality source implementation directly from G2.198.
+- Review G2.199 data-quality canonical service adapter provider authorization.
+- If accepted, start G2.200 data-quality canonical service adapter provider implementation.
+- Do not start G2.200 before G2.199 is accepted.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-authorization-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-authorization-2026-05-28.md
@@ -1,0 +1,139 @@
+# Backend Data-Quality Canonical Service Adapter Provider Authorization
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Node: G2.199 data-quality canonical service adapter provider authorization
+- Status: for review
+- Prepared at: `2026-05-28T10:14:06+08:00`
+- Base HEAD checked: `a6b54ddfb24055552d634757f01dc03bd6ca6e62`
+- Parent PR: `#351`
+- Parent merge commit: `a6b54ddfb24055552d634757f01dc03bd6ca6e62`
+- Source edit authority: no
+
+Boundary note: this report is an authorization package for a future lane. It
+does not authorize source changes in this PR, test changes in this PR, OpenSpec
+proposal creation, route/OpenAPI changes, issue label changes, PM2 commands, or
+PR merges.
+
+## Authorization Decision
+
+If G2.199 is accepted, it authorizes a later G2.200 implementation lane with a
+narrow canonical service adapter provider scope.
+
+| Future lane | Future source authority | Purpose |
+|---|---|---|
+| G2.200 data-quality canonical service adapter provider implementation | yes, only after G2.199 acceptance | Add injectable data-quality monitor construction for canonical service adapters while preserving default singleton compatibility |
+
+Authorized future source paths:
+
+| Path | Future role |
+|---|---|
+| `web/backend/app/services/adapters/dashboard_adapter.py` | Add injectable monitor/provider seam for `DashboardDataSourceAdapter` |
+| `web/backend/app/services/adapters/data_adapter.py` | Add injectable monitor/provider seam for `DataDataSourceAdapter` |
+
+Authorized future test paths:
+
+| Path | Future role |
+|---|---|
+| `web/backend/tests/test_data_quality_canonical_service_adapter_provider.py` | New focused fake-monitor constructor/provider regression tests |
+| `tests/backend/test_data_adapter_regression.py` | Existing adapter regression coverage if needed |
+| `web/backend/tests/test_logging_noise_regressions.py` | Existing dashboard adapter logging/noise regression coverage if needed |
+
+## Current Facts
+
+| File | Class | Constructor now | Getter/import evidence |
+|---|---|---|---|
+| `web/backend/app/services/adapters/dashboard_adapter.py` | `DashboardDataSourceAdapter` | `def __init__(self, config: Dict[str, Any])` | import line 9, getter call line 253 |
+| `web/backend/app/services/adapters/data_adapter.py` | `DataDataSourceAdapter` | `def __init__(self, config: Dict[str, Any])` | import line 10, getter call line 622 |
+
+Factory relationship:
+
+| File | Evidence | Future implementation constraint |
+|---|---|---|
+| `web/backend/app/services/data_source_factory/data_source_factory.py` | imports `DashboardDataSourceAdapter` and `DataDataSourceAdapter` through `app.services.data_adapter`; constructs them at lines 116 and 119 | Preserve construction through the compatibility facade and current config positional argument behavior |
+
+GitNexus context notes:
+
+| Target | Result | Decision use |
+|---|---|---|
+| `DashboardDataSourceAdapter` at `web/backend/app/services/adapters/dashboard_adapter.py` | exact-file context found; graph incoming refs empty | Text/factory evidence remains required for facade construction |
+| `DataDataSourceAdapter` at `web/backend/app/services/adapters/data_adapter.py` | exact-file context found; graph incoming refs empty | Text/factory evidence remains required for facade construction |
+
+## Future Implementation Shape
+
+The future G2.200 implementation should:
+
+- add an optional keyword-only `quality_monitor` argument to both canonical
+  service adapter constructors
+- preserve current `config` positional constructor compatibility
+- store the injected monitor and use it in async `_trigger_quality_monitoring`
+- avoid calling the global getter when a monitor is injected
+- preserve default runtime behavior by falling back to `get_data_quality_monitor`
+  when no monitor is injected
+- preserve `app.services.data_adapter` compatibility facade behavior
+- preserve `data_source_factory` construction behavior
+
+## Future Forbidden Surfaces
+
+G2.200 must not touch these surfaces unless a later authorization explicitly
+expands scope:
+
+- `web/backend/app/services/data_adapters/**`
+- `web/backend/app/services/market_data_adapter.py`
+- `web/backend/app/services/_data_quality_monitor_singleton.py`
+- `web/backend/app/services/data_quality_monitor.py`
+- `web/backend/app/api/**`
+- `web/frontend/**`
+- `src/**`
+- `docs/api/**`
+- `config/**`
+- `scripts/**`
+- `openspec/changes/**`
+- `openspec/specs/**`
+
+## Future Required Checks
+
+The future implementation lane should include:
+
+- GitNexus impact/context before source edits on the exact target files or
+  classes
+- TDD red/green for injected monitor avoiding global getter calls
+- focused pytest for
+  `web/backend/tests/test_data_quality_canonical_service_adapter_provider.py`
+- focused regression coverage for `tests/backend/test_data_adapter_regression.py`
+  and `web/backend/tests/test_logging_noise_regressions.py` if touched
+- ruff check on authorized source and test paths
+- import smoke for canonical adapter constructors through `app.services.data_adapter`
+  and `data_source_factory`
+- `openspec validate migrate-backend-singletons-to-lifecycle-di --strict`
+- `gitnexus_detect_changes(scope=staged)`
+
+## Preserved Boundaries
+
+G2.199 does not touch:
+
+- `web/backend/**`
+- `web/frontend/**`
+- `src/**`
+- `tests/**`
+- `config/**`
+- `scripts/**`
+- `openspec/changes/**`
+- `openspec/specs/**`
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Parent PR state | `#351` is `MERGED` at `a6b54ddfb24055552d634757f01dc03bd6ca6e62` |
+| Candidate scan | Target files inspected for constructors, getter/import lines, factory relationship, and test surface existence |
+| Source edit scope | No backend source edits in this package |
+| Next-gate classification | G2.200 future implementation only after G2.199 acceptance |
+| JSON parse | Passed for this authorization artifact and `steward-index.json` |
+| Markdown governance | Passed, `checked_files=6`, `errors=0` |
+| OpenSpec validation | `openspec validate migrate-backend-singletons-to-lifecycle-di --strict` passed |
+| Diff whitespace | `git diff --check` passed |
+| GitNexus staged scope | Low risk, `changed_files=9`, `changed_symbols=0`, `affected_processes=0` |
+| Mainline scope gate | Passed, `changed_files=9`, `violations=0`, report `/tmp/pr352-mainline-governance-report.json` |

--- a/governance/mainline/task-cards/pr-352.yaml
+++ b/governance/mainline/task-cards/pr-352.yaml
@@ -1,0 +1,111 @@
+version: "v0.2"
+
+task:
+  id: "pr-352"
+  title: "Authorize data-quality canonical service adapter provider implementation"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-canonical-service-adapter-provider-authorization"
+  objective: "authorize a future path-limited canonical service adapter provider implementation lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only future implementation authorization; no route paths, HTTP methods, response models, OpenAPI examples, frontend behavior, PM2 workflows, or public API ownership changes"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-canonical-service-adapter-provider-authorization-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-authorization-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-352.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source implementation in this PR"
+  - "test source edits in this PR"
+  - "legacy data_adapters migration"
+  - "market_data_adapter.py edits"
+  - "singleton wrapper deletion"
+  - "DataQualityMonitor internals"
+  - "route changes"
+  - "frontend changes"
+  - "OpenSpec proposal creation"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "node -e \"JSON.parse(require('fs').readFileSync('.planning/codebase/generated/data-quality-canonical-service-adapter-provider-authorization-2026-05-28.json','utf8')); JSON.parse(require('fs').readFileSync('.planning/codebase/steward-tree/steward-index.json','utf8'));\""
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-authorization-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-352.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha a6b54ddfb24055552d634757f01dc03bd6ca6e62 --head-sha HEAD --report /tmp/pr352-mainline-governance-report.json"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Treating this authorization package as current-PR source authority would bypass the required G2.200 implementation lane."
+    - "Future implementation must preserve app.services.data_adapter facade and data_source_factory construction behavior."
+  rollback_plan: "revert this PR to restore the post-#351 steward state and rerun the authorization package."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize future canonical service adapter provider implementation"
+    modified_scope: "governance reports, generated evidence, steward tree files, and one task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no backend source files are modified"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if authorization scope or future checks are incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T10:14:06+08:00"
+    approval_note: "Human maintainer approved continuing after PR #351 acceptance; this lane is authorization-only for a future canonical service adapter implementation."
+    secondary_approved: true


### PR DESCRIPTION
## Summary

- Add G2.199 authorization-only package for future G2.200 data-quality canonical service adapter provider implementation.
- Update steward tree, steward index, branch register, evidence index, completed ledger, and service lifecycle DI track.
- Add mainline task card for PR #352 with source-edit authority explicitly disabled.

## Governance Boundary

This PR authorizes no source code changes. Future G2.200 implementation may only start after this authorization package is accepted.

Authorized future source paths are limited to:
- web/backend/app/services/adapters/dashboard_adapter.py
- web/backend/app/services/adapters/data_adapter.py

Authorized future test paths are limited to:
- web/backend/tests/test_data_quality_canonical_service_adapter_provider.py
- tests/backend/test_data_adapter_regression.py
- web/backend/tests/test_logging_noise_regressions.py

## Verification

- JSON parse: passed for generated authorization artifact and steward-index.json
- Markdown governance: checked_files=6, errors=0
- OpenSpec: openspec validate migrate-backend-singletons-to-lifecycle-di --strict passed
- git diff --check: passed
- GitNexus staged detect changes: low risk, changed_files=9, changed_symbols=0, affected_processes=0
- Mainline scope gate: passed, changed_files=9, violations=0

## Next Gate

If this PR is accepted, start G2.200 implementation for the two canonical service adapters. Do not start G2.200 before this PR is accepted.