### PR TITLE
refactor(services): inject data quality service adapters

### DIFF
--- a/.planning/codebase/generated/data-quality-canonical-service-adapter-provider-implementation-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-canonical-service-adapter-provider-implementation-2026-05-28.json
@@ -1,0 +1,143 @@
+{
+  "schema_version": "2026-05-28.g2-implementation.v1",
+  "generated_at": "2026-05-28T10:53:34+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "41bef3787160ec3bf7b9b31220df9d99a3437474",
+  "worktree_branch": "g2-200-data-quality-canonical-service-adapter-provider",
+  "status": "implementation_evidence",
+  "source_edit_authority": true,
+  "parent": {
+    "node": "G2.199 data-quality canonical service adapter provider authorization",
+    "github_pr": 352,
+    "merge_commit": "41bef3787160ec3bf7b9b31220df9d99a3437474"
+  },
+  "implementation": {
+    "node": "G2.200 data-quality canonical service adapter provider implementation",
+    "purpose": "add injectable data-quality monitor construction for canonical service adapters while preserving default singleton compatibility",
+    "changed_source_paths": [
+      "web/backend/app/services/adapters/dashboard_adapter.py",
+      "web/backend/app/services/adapters/data_adapter.py"
+    ],
+    "changed_test_paths": [
+      "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py"
+    ],
+    "changed_function_tree_paths": [
+      "governance/function-tree/catalog.yaml",
+      "docs/FUNCTION_TREE.md"
+    ],
+    "source_changes": {
+      "dashboard_adapter": {
+        "constructor_line": 25,
+        "constructor": "def __init__(self, config: Dict[str, Any], *, quality_monitor: Optional[Any] = None)",
+        "stored_field_line": 27,
+        "monitor_selection_line": 254,
+        "default_behavior": "falls back to get_data_quality_monitor() when quality_monitor is None"
+      },
+      "data_adapter": {
+        "constructor_line": 27,
+        "constructor": "def __init__(self, config: Dict[str, Any], *, quality_monitor: Optional[Any] = None)",
+        "stored_field_line": 29,
+        "monitor_selection_line": 623,
+        "default_behavior": "falls back to get_data_quality_monitor() when quality_monitor is None"
+      }
+    },
+    "preserved_behavior": [
+      "config remains the positional constructor argument",
+      "quality_monitor is keyword-only",
+      "app.services.data_adapter facade remains unchanged",
+      "data_source_factory construction through config.__dict__ remains compatible",
+      "route paths, OpenAPI contracts, frontend code, config, scripts, OpenSpec changes, monitor internals, wrapper, and legacy adapters remain untouched"
+    ]
+  },
+  "gitnexus_impact": {
+    "dashboard_adapter_file": {
+      "risk": "LOW",
+      "impacted_count": 5,
+      "direct": 2,
+      "processes_affected": 0,
+      "direct_files": [
+        "web/backend/tests/test_logging_noise_regressions.py",
+        "web/backend/app/services/adapters/__init__.py"
+      ]
+    },
+    "data_adapter_file": {
+      "risk": "LOW",
+      "impacted_count": 4,
+      "direct": 1,
+      "processes_affected": 0,
+      "direct_files": [
+        "web/backend/app/services/adapters/__init__.py"
+      ]
+    }
+  },
+  "verification": {
+    "tdd_red": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_canonical_service_adapter_provider.py -q --tb=short --no-cov",
+      "status": "failed_as_expected",
+      "failure": "constructors did not accept quality_monitor keyword argument"
+    },
+    "tdd_green": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_canonical_service_adapter_provider.py -q --tb=short --no-cov",
+      "status": "passed",
+      "result": "2 passed"
+    },
+    "focused_regression": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_canonical_service_adapter_provider.py tests/backend/test_data_adapter_regression.py web/backend/tests/test_logging_noise_regressions.py -q --tb=short --no-cov",
+      "status": "passed",
+      "result": "21 passed"
+    },
+    "ruff_changed_paths": {
+      "command": "ruff check web/backend/app/services/adapters/dashboard_adapter.py web/backend/app/services/adapters/data_adapter.py web/backend/tests/test_data_quality_canonical_service_adapter_provider.py",
+      "status": "passed"
+    },
+    "import_smoke": {
+      "initial_without_env": "blocked by required environment configuration: POSTGRESQL_HOST, POSTGRESQL_USER, POSTGRESQL_PASSWORD, JWT_SECRET_KEY, BACKEND_PORT, BACKEND_BACKUP_PORT",
+      "with_minimal_dummy_env": "passed"
+    },
+    "openspec_validate": {
+      "command": "openspec validate migrate-backend-singletons-to-lifecycle-di --strict",
+      "status": "passed",
+      "note": "PostHog network flush warning observed after successful validation"
+    },
+    "json_yaml_parse": {
+      "status": "passed",
+      "files": [
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/generated/data-quality-canonical-service-adapter-provider-implementation-2026-05-28.json",
+        "governance/mainline/task-cards/pr-353.yaml"
+      ]
+    },
+    "markdown_governance": {
+      "status": "passed",
+      "checked_files": 6,
+      "errors": 0
+    },
+    "git_diff_check": "passed",
+    "gitnexus_staged_detect_changes": {
+      "status": "passed",
+      "risk_level": "low",
+      "changed_files": 14,
+      "changed_symbols": 0,
+      "affected_processes": 0
+    },
+    "function_tree_mapping": {
+      "status": "updated",
+      "domain_id": "domain-01",
+      "node_id": "domain-01-node-03",
+      "mapped_paths": [
+        "web/backend/app/services/adapters/dashboard_adapter.py",
+        "web/backend/app/services/adapters/data_adapter.py",
+        "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py"
+      ],
+      "function_tree_mirror": "docs/FUNCTION_TREE.md"
+    },
+    "mainline_scope_gate": {
+      "status": "passed",
+      "changed_files": 14,
+      "violations": 0,
+      "report": "/tmp/pr353-mainline-governance-report.json"
+    }
+  },
+  "next_gate": "If G2.200 is accepted, run G2.201 closeout / residual refresh before selecting another data-quality monitor surface."
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T10:14:06+08:00`
-- Base HEAD checked: `a6b54ddfb24055552d634757f01dc03bd6ca6e62`
+- Prepared at: `2026-05-28T10:53:34+08:00`
+- Base HEAD checked: `41bef3787160ec3bf7b9b31220df9d99a3437474`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -36,12 +36,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#349` | `g2-196-data-quality-adapter-split-implementation` | `wip/root-dirty-20260403` | `MERGED` at `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb` | Path-limited `adapter_split` constructor provider implementation closed for G2.197 refresh |
 | `#350` | `g2-197-data-quality-monitor-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1` | Closeout / remaining candidate refresh selecting G2.198 residual adapter ownership decision |
 | `#351` | `g2-198-data-quality-residual-adapter-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `a6b54ddfb24055552d634757f01dc03bd6ca6e62` | Decision selecting canonical service adapter provider authorization as G2.199 |
+| `#352` | `g2-199-data-quality-canonical-service-adapter-authorization` | `wip/root-dirty-20260403` | `MERGED` at `41bef3787160ec3bf7b9b31220df9d99a3437474` | Authorization package for G2.200 canonical service adapter provider implementation |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-199-data-quality-canonical-service-adapter-authorization` | `origin/wip/root-dirty-20260403` at `a6b54ddfb24055552d634757f01dc03bd6ca6e62` | Authorize a future canonical service adapter provider implementation lane | No |
+| `g2-200-data-quality-canonical-service-adapter-provider` | `origin/wip/root-dirty-20260403` at `41bef3787160ec3bf7b9b31220df9d99a3437474` | Implement the authorized canonical service adapter provider seam | Yes, limited to `dashboard_adapter.py`, `data_adapter.py`, and focused tests |
 
 ## OpenSpec Relationship
 
@@ -57,8 +58,8 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.199 is a governance-only authorization branch after PR `#351` merged G2.198.
-It defines the future G2.200 path-limited implementation surface for canonical
+G2.200 is a path-limited implementation branch after PR `#352` merged G2.199.
+It implements only the authorized constructor-level monitor seam for canonical
 service adapters and keeps legacy data adapters, `market_data_adapter.py`,
 singleton wrapper, monitor internals, routes, frontend, and OpenSpec changes out
 of scope.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T10:14:06+08:00`
-- Base HEAD checked: `a6b54ddfb24055552d634757f01dc03bd6ca6e62`
+- Prepared at: `2026-05-28T10:53:34+08:00`
+- Base HEAD checked: `41bef3787160ec3bf7b9b31220df9d99a3437474`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 is the active canonical service adapter provider authorization |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 is the active canonical service adapter provider implementation |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T10:14:06+08:00`
-- Base HEAD checked: `a6b54ddfb24055552d634757f01dc03bd6ca6e62`
+- Prepared at: `2026-05-28T10:53:34+08:00`
+- Base HEAD checked: `41bef3787160ec3bf7b9b31220df9d99a3437474`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,8 +15,9 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.199 data-quality canonical service adapter provider authorization | G/#79 service lifecycle DI | PR `#351` merged at `a6b54ddfb24055552d634757f01dc03bd6ca6e62`; G2.199 authorizes a future G2.200 implementation lane only if accepted | If accepted, start G2.200 canonical service adapter provider implementation; do not expand scope |
-| P0 | Preserve G2.198 data-quality residual adapter ownership decision | G/#79 service lifecycle DI | PR `#351` merged; canonical service adapters selected as next authorization target | Do not touch legacy data adapters, `market_data_adapter.py`, wrapper, or monitor internals under G2.199/G2.200 |
+| P0 | Review G2.200 data-quality canonical service adapter provider implementation | G/#79 service lifecycle DI | PR `#352` merged at `41bef3787160ec3bf7b9b31220df9d99a3437474`; G2.200 implements only the authorized canonical service adapter monitor seam | If accepted, start G2.201 closeout / residual refresh before selecting another data-quality monitor surface |
+| P0 | Preserve G2.199 data-quality canonical service adapter provider authorization | G/#79 service lifecycle DI | PR `#352` merged; G2.200 source authority is limited to two canonical service adapters and listed tests | Do not touch legacy data adapters, `market_data_adapter.py`, wrapper, or monitor internals under G2.200 |
+| P0 | Preserve G2.198 data-quality residual adapter ownership decision | G/#79 service lifecycle DI | PR `#351` merged; canonical service adapters selected as the G2.199/G2.200 target | Do not touch legacy data adapters, `market_data_adapter.py`, wrapper, or monitor internals without a new decision package |
 | P0 | Preserve G2.197 data-quality monitor closeout / remaining candidate refresh | G/#79 service lifecycle DI | PR `#350` merged; `adapter_split` subclass constructor lane is closed and remaining candidates are classified | Do not bypass G2.198/G2.199 before touching service adapters, legacy adapters, `market_data_adapter.py`, or wrappers |
 | P0 | Preserve G2.196 data-quality `adapter_split` constructor provider implementation | G/#79 service lifecycle DI | PR `#349` merged; subclass-level `get_data_quality_monitor()` calls/imports are `0`; `BaseAdapter` fallback remains intentional | Do not expand into service adapters, legacy adapters, singleton wrappers, routes, or frontend |
 | P0 | Preserve G2.195 data-quality `adapter_split` constructor provider authorization | G/#79 service lifecycle DI | PR `#348` merged; G2.195 authorized only eight `adapter_split` source paths plus one focused test path | Treat the G2.196 implementation as closed after G2.197 review, not as authority for broader adapter migration |
@@ -41,8 +42,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.199 accurately record PR `#351` as merged at `a6b54ddfb24055552d634757f01dc03bd6ca6e62`?
-- Does G2.199 authorize only `dashboard_adapter.py`, `data_adapter.py`, and the listed tests for future G2.200?
-- Are legacy data adapters, `market_data_adapter.py`, wrapper, and monitor internals still forbidden for G2.200?
-- Is G2.200 correctly positioned as a later source implementation lane, not part of this authorization PR?
+- Does G2.200 stay within the PR `#352` authorization boundary?
+- Does G2.200 preserve positional `config` constructor compatibility for both canonical service adapters?
+- Do the focused tests prove injected monitors bypass the global getter while default fallback remains available?
+- Are legacy data adapters, `market_data_adapter.py`, wrapper, route/OpenAPI, frontend, config, script, and OpenSpec surfaces still untouched?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T10:14:06+08:00`
-- Base HEAD checked: `a6b54ddfb24055552d634757f01dc03bd6ca6e62`
+- Prepared at: `2026-05-28T10:53:34+08:00`
+- Base HEAD checked: `41bef3787160ec3bf7b9b31220df9d99a3437474`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -59,8 +59,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-monitor-closeout-refresh-2026-05-28.md` | G2.197 human-readable closeout / refresh report | Accepted by PR `#350`; superseded for residual adapter ownership decision by G2.198 |
 | `.planning/codebase/generated/data-quality-residual-adapter-ownership-decision-2026-05-28.json` | G2.198 residual data-quality adapter ownership decision evidence | Accepted by PR `#351`; superseded for canonical service adapter authorization by G2.199 |
 | `docs/reports/quality/backend-data-quality-residual-adapter-ownership-decision-2026-05-28.md` | G2.198 human-readable residual adapter ownership decision report | Accepted by PR `#351`; superseded for canonical service adapter authorization by G2.199 |
-| `.planning/codebase/generated/data-quality-canonical-service-adapter-provider-authorization-2026-05-28.json` | G2.199 canonical service adapter provider authorization evidence | Current for HEAD `a6b54ddfb24055552d634757f01dc03bd6ca6e62`; review input until PR `#352` is accepted |
-| `docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-authorization-2026-05-28.md` | G2.199 human-readable authorization package | Review input until PR `#352` is accepted |
+| `.planning/codebase/generated/data-quality-canonical-service-adapter-provider-authorization-2026-05-28.json` | G2.199 canonical service adapter provider authorization evidence | Accepted by PR `#352`; superseded for implementation evidence by G2.200 |
+| `docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-authorization-2026-05-28.md` | G2.199 human-readable authorization package | Accepted by PR `#352`; superseded for implementation evidence by G2.200 |
+| `.planning/codebase/generated/data-quality-canonical-service-adapter-provider-implementation-2026-05-28.json` | G2.200 canonical service adapter provider implementation evidence | Current for HEAD `41bef3787160ec3bf7b9b31220df9d99a3437474`; review input until PR `#353` is accepted |
+| `docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-implementation-2026-05-28.md` | G2.200 human-readable implementation report | Review input until PR `#353` is accepted |
 
 ## External State Inputs
 
@@ -83,7 +85,8 @@ state transition.
 | GitHub PR `#349` | `MERGED` | G2.196 data-quality adapter_split constructor provider implementation merged by commit `e4245ebe54c5ad6d2aebf4802d165d59700c9eeb` |
 | GitHub PR `#350` | `MERGED` | G2.197 data-quality monitor closeout / refresh merged by commit `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1` |
 | GitHub PR `#351` | `MERGED` | G2.198 residual adapter ownership decision merged by commit `a6b54ddfb24055552d634757f01dc03bd6ca6e62` |
-| `origin/wip/root-dirty-20260403` | `a6b54ddfb24055552d634757f01dc03bd6ca6e62` | Base used for this canonical service adapter authorization branch |
+| GitHub PR `#352` | `MERGED` | G2.199 canonical service adapter authorization merged by commit `41bef3787160ec3bf7b9b31220df9d99a3437474` |
+| `origin/wip/root-dirty-20260403` | `41bef3787160ec3bf7b9b31220df9d99a3437474` | Base used for this canonical service adapter implementation branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T10:14:06+08:00",
+  "generated_at": "2026-05-28T10:53:34+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "a6b54ddfb24055552d634757f01dc03bd6ca6e62",
-  "split_branch": "g2-199-data-quality-canonical-service-adapter-authorization",
-  "scope": "data_quality_canonical_service_adapter_provider_authorization",
-  "source_edit_authority": false,
+  "base_head": "41bef3787160ec3bf7b9b31220df9d99a3437474",
+  "split_branch": "g2-200-data-quality-canonical-service-adapter-provider",
+  "scope": "data_quality_canonical_service_adapter_provider_implementation",
+  "source_edit_authority": true,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -1391,10 +1391,12 @@
     {
       "id": "g2-199-data-quality-canonical-service-adapter-provider-authorization",
       "type": "authorization_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.198 data-quality residual adapter ownership decision",
       "source_edit_authority": false,
+      "github_pr": 352,
+      "merge_commit": "41bef3787160ec3bf7b9b31220df9d99a3437474",
       "evidence": [
         ".planning/codebase/generated/data-quality-canonical-service-adapter-provider-authorization-2026-05-28.json",
         "docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-authorization-2026-05-28.md",
@@ -1448,10 +1450,74 @@
         "gitnexus_detect_changes(scope=staged)"
       ],
       "freshness": {
-        "current_head_checked": "a6b54ddfb24055552d634757f01dc03bd6ca6e62",
+        "current_head_checked": "41bef3787160ec3bf7b9b31220df9d99a3437474",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.200 data-quality canonical service adapter provider implementation with the authorized paths only."
+      "next_gate": "Superseded by G2.200 data-quality canonical service adapter provider implementation."
+    },
+    {
+      "id": "g2-200-data-quality-canonical-service-adapter-provider-implementation",
+      "type": "implementation",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.199 data-quality canonical service adapter provider authorization",
+      "source_edit_authority": true,
+      "parent_github_pr": 352,
+      "parent_merge_commit": "41bef3787160ec3bf7b9b31220df9d99a3437474",
+      "evidence": [
+        ".planning/codebase/generated/data-quality-canonical-service-adapter-provider-implementation-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-implementation-2026-05-28.md",
+        "governance/mainline/task-cards/pr-353.yaml"
+      ],
+      "changed_source_paths": [
+        "web/backend/app/services/adapters/dashboard_adapter.py",
+        "web/backend/app/services/adapters/data_adapter.py"
+      ],
+      "changed_test_paths": [
+        "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py"
+      ],
+      "implementation_facts": {
+        "dashboard_adapter": {
+          "constructor": "def __init__(self, config: Dict[str, Any], *, quality_monitor: Optional[Any] = None)",
+          "stored_field_line": 27,
+          "monitor_selection_line": 254,
+          "default_fallback": "get_data_quality_monitor() when quality_monitor is None"
+        },
+        "data_adapter": {
+          "constructor": "def __init__(self, config: Dict[str, Any], *, quality_monitor: Optional[Any] = None)",
+          "stored_field_line": 29,
+          "monitor_selection_line": 623,
+          "default_fallback": "get_data_quality_monitor() when quality_monitor is None"
+        }
+      },
+      "verification": {
+        "gitnexus_impact": "LOW for both canonical adapter files",
+        "tdd_red": "2 failed on missing quality_monitor constructor keyword",
+        "tdd_green": "2 passed",
+        "focused_regression": "21 passed",
+        "ruff": "passed",
+        "import_smoke": "passed with minimal dummy required env",
+        "openspec_validate": "passed"
+      },
+      "forbidden_surfaces_preserved": [
+        "web/backend/app/services/data_adapters/**",
+        "web/backend/app/services/market_data_adapter.py",
+        "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "web/backend/app/services/data_quality_monitor.py",
+        "web/backend/app/api/**",
+        "web/frontend/**",
+        "src/**",
+        "docs/api/**",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "freshness": {
+        "current_head_checked": "41bef3787160ec3bf7b9b31220df9d99a3437474",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.201 closeout / residual refresh before selecting another data-quality monitor surface."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T10:14:06+08:00`
-- Base HEAD checked: `a6b54ddfb24055552d634757f01dc03bd6ca6e62`
+- Prepared at: `2026-05-28T10:53:34+08:00`
+- Base HEAD checked: `41bef3787160ec3bf7b9b31220df9d99a3437474`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -51,7 +51,8 @@ It proved a repeatable conveyor:
 | G2.196 data-quality `adapter_split` constructor provider implementation | Merged by PR `#349` | Implements optional constructor monitor injection in `adapter_split` only, with focused TDD evidence |
 | G2.197 data-quality monitor closeout / remaining candidate refresh | Merged by PR `#350` | Closes the `adapter_split` subclass constructor lane and refreshes remaining service adapter, legacy adapter, compatibility facade, and wrapper surfaces |
 | G2.198 data-quality residual adapter ownership decision | Merged by PR `#351` | Selects canonical service adapters as the next authorization target while deferring legacy data adapters, `market_data_adapter.py`, and wrapper retention |
-| G2.199 data-quality canonical service adapter provider authorization | For review | Authorizes future G2.200 implementation for canonical service adapters only; no source edits in this PR |
+| G2.199 data-quality canonical service adapter provider authorization | Merged by PR `#352` | Authorizes future G2.200 implementation for canonical service adapters only; no source edits in G2.199 |
+| G2.200 data-quality canonical service adapter provider implementation | For review | Implements optional constructor monitor injection in the two canonical service adapters with focused TDD evidence |
 
 ## Current Strategy Getter Residuals
 
@@ -410,11 +411,39 @@ Future forbidden surfaces remain:
 - `web/backend/app/services/data_quality_monitor.py`
 - route, frontend, OpenAPI contract, config, script, and OpenSpec change files
 
+PR `#352` merged this authorization lane at
+`41bef3787160ec3bf7b9b31220df9d99a3437474`.
+
+## G2.200 Data-Quality Canonical Service Adapter Provider Implementation
+
+At HEAD `41bef3787160ec3bf7b9b31220df9d99a3437474`, PR `#352` is merged and
+G2.199's authorization package is accepted.
+
+Implementation result:
+
+| Path | Result |
+|---|---|
+| `web/backend/app/services/adapters/dashboard_adapter.py` | Adds keyword-only `quality_monitor` and uses it in async quality monitoring before falling back to `get_data_quality_monitor()` |
+| `web/backend/app/services/adapters/data_adapter.py` | Adds keyword-only `quality_monitor` and uses it in async quality monitoring before falling back to `get_data_quality_monitor()` |
+| `web/backend/tests/test_data_quality_canonical_service_adapter_provider.py` | Proves injected monitors bypass the module-level global getter for both canonical adapters |
+
+Focused verification:
+
+| Check | Result |
+|---|---|
+| GitNexus impact | LOW for both canonical adapter files |
+| TDD red | Failed on missing `quality_monitor` constructor parameter |
+| TDD green | `2 passed` |
+| Focused regression package | `21 passed` |
+| Ruff authorized files | `All checks passed` |
+| Import smoke | Passed with minimal dummy required env |
+| OpenSpec strict validate | Valid; PostHog network flush noise only |
+
 ## Next Gates
 
-- Review G2.199 data-quality canonical service adapter provider authorization.
-- If accepted, start G2.200 data-quality canonical service adapter provider implementation.
-- Do not start G2.200 before G2.199 is accepted.
+- Review G2.200 data-quality canonical service adapter provider implementation.
+- If accepted, start G2.201 closeout / residual refresh before selecting another data-quality monitor surface.
+- Do not start another source lane before G2.200 is accepted and closed out.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/FUNCTION_TREE.md
+++ b/docs/FUNCTION_TREE.md
@@ -122,6 +122,7 @@
 | SinaFinance | ✅ | 5 | 股票评级 |
 | Tushare | ⚠️ | 6 | 需Token配置 |
 | Byapi | ⚠️ | 7 | 403问题待修 |
+| Backend canonical service adapters | ✅ | backend | `web/backend/app/services/adapters/dashboard_adapter.py` 与 `web/backend/app/services/adapters/data_adapter.py` 接入数据源工厂，并通过 G2.200 支持可注入 data-quality monitor seam |
 
 ### 1.4 K线数据服务 {#domain-01-node-04}
 

--- a/docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-implementation-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-implementation-2026-05-28.md
@@ -1,0 +1,106 @@
+# Backend Data-Quality Canonical Service Adapter Provider Implementation
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Node: G2.200 data-quality canonical service adapter provider implementation
+- Status: implementation evidence
+- Prepared at: `2026-05-28T10:53:34+08:00`
+- Base HEAD checked: `41bef3787160ec3bf7b9b31220df9d99a3437474`
+- Parent authorization: G2.199, PR `#352`, merge commit `41bef3787160ec3bf7b9b31220df9d99a3437474`
+- Branch: `g2-200-data-quality-canonical-service-adapter-provider`
+
+Boundary note: this implementation uses the source authority granted by G2.199
+only. It does not authorize legacy data adapter migration, `market_data_adapter.py`
+edits, monitor internals, wrapper deletion, routes, OpenAPI contracts, frontend,
+config, scripts, or OpenSpec change edits.
+
+## Implementation
+
+| Path | Change |
+|---|---|
+| `web/backend/app/services/adapters/dashboard_adapter.py` | Adds keyword-only `quality_monitor` constructor injection and stores it on `self._quality_monitor` |
+| `web/backend/app/services/adapters/data_adapter.py` | Adds keyword-only `quality_monitor` constructor injection and stores it on `self._quality_monitor` |
+| `web/backend/tests/test_data_quality_canonical_service_adapter_provider.py` | Adds focused async tests proving injected monitors bypass the global getter |
+| `governance/function-tree/catalog.yaml` | Registers the two canonical service adapter paths and focused test under `domain-01-node-03` so the mainline scope gate can map this implementation |
+| `docs/FUNCTION_TREE.md` | Mirrors the `domain-01-node-03` service adapter mapping required by mainline governance |
+
+Constructor compatibility is preserved:
+
+```python
+DashboardDataSourceAdapter(config)
+DataDataSourceAdapter(config)
+```
+
+New test-only / DI-capable construction is now available:
+
+```python
+DashboardDataSourceAdapter(config, quality_monitor=fake_monitor)
+DataDataSourceAdapter(config, quality_monitor=fake_monitor)
+```
+
+Runtime fallback is preserved: if `quality_monitor is None`, both adapters still
+call `get_data_quality_monitor()` at monitoring time.
+
+## GitNexus Impact
+
+| Target | Risk | Impact |
+|---|---|---|
+| `web/backend/app/services/adapters/dashboard_adapter.py` | LOW | `impacted_count=5`, `direct=2`, `processes_affected=0` |
+| `web/backend/app/services/adapters/data_adapter.py` | LOW | `impacted_count=4`, `direct=1`, `processes_affected=0` |
+
+Direct graph consumers remain limited to adapter package exports, the dashboard
+logging regression test, the compatibility facade, the data source factory, and
+the existing data adapter regression test.
+
+## TDD Evidence
+
+| Step | Result |
+|---|---|
+| Red | `2 failed` because both constructors rejected `quality_monitor` |
+| Green | `2 passed` after adding the keyword-only injection seam |
+
+The focused tests patch each module-level `get_data_quality_monitor` with a
+raising sentinel and assert the injected async monitor receives the exact
+`evaluate_data_quality(...)` call.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Focused pytest | `21 passed` for the new provider test plus `test_data_adapter_regression.py` and `test_logging_noise_regressions.py` |
+| Ruff | `ruff check` passed for the two source files and new test |
+| Import smoke without env | Blocked by existing required env validation for `POSTGRESQL_HOST`, `POSTGRESQL_USER`, `POSTGRESQL_PASSWORD`, `JWT_SECRET_KEY`, `BACKEND_PORT`, `BACKEND_BACKUP_PORT` |
+| Import smoke with minimal dummy env | Passed through `app.services.data_adapter` and `data_source_factory` imports |
+| OpenSpec validation | `openspec validate migrate-backend-singletons-to-lifecycle-di --strict` passed; PostHog network flush warning is telemetry noise |
+| JSON/YAML parse | Passed for generated implementation JSON, `steward-index.json`, and `pr-353.yaml` |
+| Markdown governance | Passed, `checked_files=6`, `errors=0` |
+| Diff whitespace | `git diff --check` passed |
+| GitNexus staged scope | Low risk, `changed_files=14`, `changed_symbols=0`, `affected_processes=0` |
+| Function-tree mapping | `domain-01-node-03` now covers the two canonical service adapter paths and focused test path; `docs/FUNCTION_TREE.md` mirror updated |
+| Mainline scope gate | Passed, `changed_files=14`, `violations=0`, report `/tmp/pr353-mainline-governance-report.json` |
+
+## Preserved Boundaries
+
+This lane did not touch:
+
+- `web/backend/app/services/data_adapters/**`
+- `web/backend/app/services/market_data_adapter.py`
+- `web/backend/app/services/_data_quality_monitor_singleton.py`
+- `web/backend/app/services/data_quality_monitor.py`
+- `web/backend/app/api/**`
+- `web/frontend/**`
+- `src/**`
+- `docs/api/**`
+- `config/**`
+- `scripts/**`
+- `openspec/changes/**`
+- `openspec/specs/**`
+
+## Next Gate
+
+If G2.200 is accepted, run G2.201 closeout / residual refresh before selecting
+another data-quality monitor surface. Do not batch legacy adapters, wrapper
+retirement, `market_data_adapter.py`, route/provider cleanup, or monitor internals
+into this implementation lane.

--- a/governance/function-tree/catalog.yaml
+++ b/governance/function-tree/catalog.yaml
@@ -54,8 +54,11 @@ domains:
         label: "1.3 多数据源集成"
         coverage_paths:
           - "src/adapters/**"
+          - "web/backend/app/services/adapters/dashboard_adapter.py"
+          - "web/backend/app/services/adapters/data_adapter.py"
           - "web/backend/app/services/adapters_split/**"
           - "web/backend/tests/test_adapter_split_data_quality_monitor_provider.py"
+          - "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py"
           - "config/data_sources*"
         entrypoints:
           governance:
@@ -65,8 +68,11 @@ domains:
             - "web/backend/app/api/market/**"
           core:
             - "src/adapters/**"
+            - "web/backend/app/services/adapters/dashboard_adapter.py"
+            - "web/backend/app/services/adapters/data_adapter.py"
           tests:
             - "tests/unit/adapters/**"
+            - "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py"
           operations:
             - "docs/operations/OPS_MANUAL.md"
       - id: "domain-01-node-04"

--- a/governance/mainline/task-cards/pr-353.yaml
+++ b/governance/mainline/task-cards/pr-353.yaml
@@ -1,0 +1,138 @@
+version: "v0.2"
+
+task:
+  id: "pr-353"
+  title: "Implement data-quality canonical service adapter provider seam"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-canonical-service-adapter-provider-implementation"
+  objective: "add injectable data-quality monitor construction for canonical service adapters while preserving singleton fallback compatibility"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "feature"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "domain-01"
+  node_id: "domain-01-node-03"
+  affected_entrypoints:
+    - "core"
+    - "tests"
+    - "governance"
+  update_status: "required"
+  secondary_domains: []
+  exemption_reason: "Constructor-level service seam only; no route paths, HTTP methods, response models, OpenAPI examples, frontend behavior, PM2 workflows, or public API ownership changes"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-canonical-service-adapter-provider-implementation-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-implementation-2026-05-28.md"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "governance/mainline/task-cards/pr-353.yaml"
+    - "web/backend/app/services/adapters/dashboard_adapter.py"
+    - "web/backend/app/services/adapters/data_adapter.py"
+    - "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py"
+  forbidden_paths:
+    - "web/backend/app/services/adapters_split/**"
+    - "web/backend/app/services/data_adapters/**"
+    - "web/backend/app/services/market_data_adapter.py"
+    - "web/backend/app/services/_data_quality_monitor_singleton.py"
+    - "web/backend/app/services/data_quality_monitor.py"
+    - "web/backend/app/api/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "legacy data_adapters migration"
+  - "adapter_split edits"
+  - "market_data_adapter.py edits"
+  - "singleton wrapper deletion"
+  - "DataQualityMonitor internals"
+  - "route changes"
+  - "OpenAPI contract changes"
+  - "frontend changes"
+  - "OpenSpec proposal creation"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_canonical_service_adapter_provider.py tests/backend/test_data_adapter_regression.py web/backend/tests/test_logging_noise_regressions.py -q --tb=short --no-cov"
+      required: true
+    - id: "ruff-authorized-files"
+      command: "ruff check web/backend/app/services/adapters/dashboard_adapter.py web/backend/app/services/adapters/data_adapter.py web/backend/tests/test_data_quality_canonical_service_adapter_provider.py"
+      required: true
+    - id: "import-smoke"
+      command: "env PYTHONPATH=web/backend POSTGRESQL_HOST=localhost POSTGRESQL_USER=test POSTGRESQL_PASSWORD=test JWT_SECRET_KEY=test-secret-key-with-enough-length-for-smoke BACKEND_PORT=8888 BACKEND_BACKUP_PORT=8889 python -c \"from app.services.data_adapter import DashboardDataSourceAdapter, DataDataSourceAdapter; from app.services.data_source_factory.data_source_factory import DataSourceFactory; DashboardDataSourceAdapter({'name':'smoke-dashboard'}); DataDataSourceAdapter({'name':'smoke-data'}); print('import smoke ok')\""
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-canonical-service-adapter-provider-implementation-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-353.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-implementation-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-353.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 41bef3787160ec3bf7b9b31220df9d99a3437474 --head-sha HEAD --report /tmp/pr353-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Constructor signature changes must remain backward compatible for app.services.data_adapter and data_source_factory construction."
+    - "Injecting a monitor must not bypass default singleton fallback behavior when no monitor is provided."
+  rollback_plan: "revert this PR to restore the post-#352 canonical service adapter behavior and rerun G2.200 authorization before retrying."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "implement canonical service adapter data-quality monitor provider seam"
+    modified_scope: "two canonical service adapter source files, one focused test, governance evidence, steward tree files, and one task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "default singleton fallback remains compatible; legacy adapters and wrapper are untouched"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if constructor compatibility, injected-monitor behavior, or mainline scope gate fails"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T10:46:53+08:00"
+    approval_note: "Human maintainer approved continuing after PR #352 acceptance; this lane implements only the G2.199-authorized canonical service adapter provider seam."
+    secondary_approved: true

--- a/web/backend/app/services/adapters/dashboard_adapter.py
+++ b/web/backend/app/services/adapters/dashboard_adapter.py
@@ -22,8 +22,9 @@ from .metrics import DataSourceMetrics
 class DashboardDataSourceAdapter(IDataSource):
     """仪表盘数据源适配器 - 集成现有 Dashboard API 到数据源工厂模式"""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], *, quality_monitor: Optional[Any] = None):
         self.config = config
+        self._quality_monitor = quality_monitor
         self.source_type = "dashboard"
         self.name = config.get("name", "Dashboard Source")
 
@@ -250,7 +251,7 @@ class DashboardDataSourceAdapter(IDataSource):
     ) -> None:
         """数据质量监控"""
         try:
-            monitor = get_data_quality_monitor()
+            monitor = self._quality_monitor if self._quality_monitor is not None else get_data_quality_monitor()
             await monitor.evaluate_data_quality(
                 data=data or {},
                 source=f"{self.source_type}:{endpoint}",
@@ -308,4 +309,3 @@ class DashboardDataSourceAdapter(IDataSource):
 # ============================================================================
 # Technical Analysis Data Source Adapter
 # ============================================================================
-

--- a/web/backend/app/services/adapters/data_adapter.py
+++ b/web/backend/app/services/adapters/data_adapter.py
@@ -24,8 +24,9 @@ from .metrics import DataSourceMetrics
 class DataDataSourceAdapter(DataAdapterMetricsMixin, IDataSource):
     """数据源适配器 - 集成现有 Data API 到数据源工厂模式"""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], *, quality_monitor: Optional[Any] = None):
         self.config = config
+        self._quality_monitor = quality_monitor
         self.source_type = "data"
         self.name = config.get("name", "Data Source")
 
@@ -619,7 +620,7 @@ class DataDataSourceAdapter(DataAdapterMetricsMixin, IDataSource):
     ) -> None:
         """触发数据质量监控"""
         try:
-            monitor = get_data_quality_monitor()
+            monitor = self._quality_monitor if self._quality_monitor is not None else get_data_quality_monitor()
             await monitor.evaluate_data_quality(
                 data=data or {},
                 source=f"{self.source_type}:{endpoint}",

--- a/web/backend/tests/test_data_quality_canonical_service_adapter_provider.py
+++ b/web/backend/tests/test_data_quality_canonical_service_adapter_provider.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.adapters.dashboard_adapter import DashboardDataSourceAdapter
+from app.services.adapters.data_adapter import DataDataSourceAdapter
+
+
+@pytest.mark.asyncio
+async def test_dashboard_adapter_uses_injected_quality_monitor_without_global_getter():
+    quality_monitor = AsyncMock()
+    quality_monitor.evaluate_data_quality = AsyncMock()
+
+    adapter = DashboardDataSourceAdapter({"name": "dashboard-test"}, quality_monitor=quality_monitor)
+
+    with patch(
+        "app.services.adapters.dashboard_adapter.get_data_quality_monitor",
+        side_effect=AssertionError("global getter should not be used when quality_monitor is injected"),
+    ):
+        await adapter._trigger_quality_monitoring(
+            "summary",
+            {"market_overview": {}},
+            12.5,
+            success=True,
+        )
+
+    quality_monitor.evaluate_data_quality.assert_awaited_once_with(
+        data={"market_overview": {}},
+        source="dashboard:summary",
+        response_time=12.5,
+        success=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_data_adapter_uses_injected_quality_monitor_without_global_getter():
+    quality_monitor = AsyncMock()
+    quality_monitor.evaluate_data_quality = AsyncMock()
+
+    adapter = DataDataSourceAdapter({"name": "data-test"}, quality_monitor=quality_monitor)
+
+    with patch(
+        "app.services.adapters.data_adapter.get_data_quality_monitor",
+        side_effect=AssertionError("global getter should not be used when quality_monitor is injected"),
+    ):
+        await adapter._trigger_quality_monitoring(
+            "stocks/daily",
+            {"rows": []},
+            9.25,
+            success=False,
+        )
+
+    quality_monitor.evaluate_data_quality.assert_awaited_once_with(
+        data={"rows": []},
+        source="data:stocks/daily",
+        response_time=9.25,
+        success=False,
+    )


### PR DESCRIPTION
## Summary

- Implement the G2.199-authorized data-quality monitor provider seam for canonical service adapters.
- Add keyword-only `quality_monitor` constructor injection to `DashboardDataSourceAdapter` and `DataDataSourceAdapter`.
- Preserve default singleton fallback behavior through `get_data_quality_monitor()` when no monitor is injected.
- Add focused async tests proving injected monitors bypass the module-level global getter.
- Update steward tree, machine-readable evidence, function-tree catalog/FUNCTION_TREE mirror, and mainline task card.

## Scope Boundary

This PR only touches the G2.199-authorized canonical service adapter implementation scope. It does not change legacy data adapters, adapter_split, market_data_adapter.py, monitor internals, wrapper retention, routes, OpenAPI contracts, frontend, config, scripts, or OpenSpec changes.

## Verification

- GitNexus impact before edit: LOW for both target adapter files.
- TDD red: 2 expected failures on missing `quality_monitor` constructor keyword.
- TDD green: 2 passed.
- Focused regression package: 21 passed.
- Ruff authorized files: passed.
- Import smoke through `app.services.data_adapter` and `data_source_factory`: passed with minimal dummy required env.
- JSON/YAML parse: passed.
- Markdown governance: checked_files=6, errors=0.
- OpenSpec strict validate: passed; PostHog network flush warning observed after successful validation.
- Mainline scope gate: changed_files=14, violations=0.
- GitNexus compare against PR #352 merge commit: low risk, changed_files=14, changed_symbols=0, affected_processes=0.

## Next Gate

If accepted, start G2.201 closeout / residual refresh before selecting another data-quality monitor surface.