### PR TITLE
docs(governance): close data quality service adapter lane

### DIFF
--- a/.planning/codebase/generated/data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.json
@@ -1,0 +1,154 @@
+{
+  "schema_version": "2026-05-28.g2-closeout-refresh.v1",
+  "generated_at": "2026-05-28T11:30:22+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "cbd9b3a7ee730c72a63dbc7adb6490564c12c71e",
+  "worktree_branch": "g2-201-data-quality-canonical-service-adapter-closeout-refresh",
+  "status": "closeout_refresh",
+  "source_edit_authority": false,
+  "parent": {
+    "node": "G2.200 data-quality canonical service adapter provider implementation",
+    "github_pr": 353,
+    "merge_commit": "cbd9b3a7ee730c72a63dbc7adb6490564c12c71e"
+  },
+  "closeout": {
+    "canonical_service_adapter_lane": "closed",
+    "implementation_result": "DashboardDataSourceAdapter and DataDataSourceAdapter accept keyword-only quality_monitor while preserving positional config construction and singleton fallback behavior",
+    "closed_paths": [
+      "web/backend/app/services/adapters/dashboard_adapter.py",
+      "web/backend/app/services/adapters/data_adapter.py",
+      "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py"
+    ]
+  },
+  "residual_scan": {
+    "git_head": "cbd9b3a7ee730c72a63dbc7adb6490564c12c71e",
+    "command": "rg -n \"get_data_quality_monitor\\\\(\" web/backend/app/services web/backend/app/api -g '*.py'",
+    "total_calls": 9,
+    "buckets": {
+      "route_provider_backing": {
+        "files": 1,
+        "calls": 1,
+        "entries": [
+          "web/backend/app/api/data_quality.py:52"
+        ],
+        "decision": "retained provider backing getter from prior route provider lane"
+      },
+      "adapter_split_base_fallback": {
+        "files": 1,
+        "calls": 1,
+        "entries": [
+          "web/backend/app/services/adapters_split/base_adapter.py:27"
+        ],
+        "decision": "closed adapter_split lane; retain default singleton fallback"
+      },
+      "canonical_service_adapter_fallback": {
+        "files": 2,
+        "calls": 2,
+        "entries": [
+          "web/backend/app/services/adapters/data_adapter.py:623",
+          "web/backend/app/services/adapters/dashboard_adapter.py:254"
+        ],
+        "decision": "closed by G2.200; retain fallback for default construction"
+      },
+      "legacy_data_adapter": {
+        "files": 2,
+        "calls": 2,
+        "entries": [
+          "web/backend/app/services/data_adapters/dashboard.py:249",
+          "web/backend/app/services/data_adapters/data_source.py:608"
+        ],
+        "decision": "select as G2.202 compatibility ownership decision target; no source authority from G2.201"
+      },
+      "market_data_adapter_facade": {
+        "files": 1,
+        "calls": 1,
+        "entries": [
+          "web/backend/app/services/market_data_adapter.py:327"
+        ],
+        "decision": "defer as root compatibility facade surface until an owner-specific decision package"
+      },
+      "singleton_wrapper_backing": {
+        "files": 1,
+        "calls": 2,
+        "entries": [
+          "web/backend/app/services/_data_quality_monitor_singleton.py:12",
+          "web/backend/app/services/_data_quality_monitor_singleton.py:24"
+        ],
+        "decision": "retain backing API; not a deletion lane"
+      }
+    }
+  },
+  "gitnexus_reference": {
+    "legacy_dashboard": {
+      "path": "web/backend/app/services/data_adapters/dashboard.py",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "processes_affected": 0
+    },
+    "legacy_data_source": {
+      "path": "web/backend/app/services/data_adapters/data_source.py",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "processes_affected": 0
+    },
+    "market_data_adapter_facade": {
+      "path": "web/backend/app/services/market_data_adapter.py",
+      "risk": "LOW",
+      "impacted_count": 3,
+      "direct": 1,
+      "processes_affected": 0
+    },
+    "singleton_wrapper_backing": {
+      "path": "web/backend/app/services/_data_quality_monitor_singleton.py",
+      "risk": "LOW",
+      "impacted_count": 19,
+      "direct": 1,
+      "processes_affected": 0
+    }
+  },
+  "verification": {
+    "post_merge_focused_pytest": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_canonical_service_adapter_provider.py tests/backend/test_data_adapter_regression.py web/backend/tests/test_logging_noise_regressions.py -q --tb=short --no-cov",
+      "status": "passed",
+      "result": "21 passed"
+    },
+    "post_merge_import_smoke": {
+      "status": "passed",
+      "note": "passed with minimal dummy required env through app.services.data_adapter and data_source_factory"
+    },
+    "openspec_validate": {
+      "command": "openspec validate migrate-backend-singletons-to-lifecycle-di --strict",
+      "status": "passed",
+      "note": "PostHog network flush warning observed after successful validation"
+    },
+    "json_yaml_parse": {
+      "status": "passed",
+      "files": [
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/generated/data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.json",
+        "governance/mainline/task-cards/pr-354.yaml"
+      ]
+    },
+    "markdown_governance": {
+      "status": "passed",
+      "checked_files": 6,
+      "errors": 0
+    },
+    "git_diff_check": "passed",
+    "gitnexus_staged_detect_changes": {
+      "status": "passed",
+      "risk_level": "low",
+      "changed_files": 9,
+      "changed_symbols": 0,
+      "affected_processes": 0
+    },
+    "mainline_scope_gate": {
+      "status": "passed",
+      "changed_files": 9,
+      "violations": 0,
+      "report": "/tmp/pr354-mainline-governance-report.json"
+    }
+  },
+  "next_gate": "G2.202 data-quality legacy adapter compatibility ownership decision; decision-only before any source implementation."
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T10:53:34+08:00`
-- Base HEAD checked: `41bef3787160ec3bf7b9b31220df9d99a3437474`
+- Prepared at: `2026-05-28T11:30:22+08:00`
+- Base HEAD checked: `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -37,12 +37,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#350` | `g2-197-data-quality-monitor-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1` | Closeout / remaining candidate refresh selecting G2.198 residual adapter ownership decision |
 | `#351` | `g2-198-data-quality-residual-adapter-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `a6b54ddfb24055552d634757f01dc03bd6ca6e62` | Decision selecting canonical service adapter provider authorization as G2.199 |
 | `#352` | `g2-199-data-quality-canonical-service-adapter-authorization` | `wip/root-dirty-20260403` | `MERGED` at `41bef3787160ec3bf7b9b31220df9d99a3437474` | Authorization package for G2.200 canonical service adapter provider implementation |
+| `#353` | `g2-200-data-quality-canonical-service-adapter-provider` | `wip/root-dirty-20260403` | `MERGED` at `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e` | Path-limited canonical service adapter provider implementation closed for G2.201 refresh |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-200-data-quality-canonical-service-adapter-provider` | `origin/wip/root-dirty-20260403` at `41bef3787160ec3bf7b9b31220df9d99a3437474` | Implement the authorized canonical service adapter provider seam | Yes, limited to `dashboard_adapter.py`, `data_adapter.py`, and focused tests |
+| `g2-201-data-quality-canonical-service-adapter-closeout-refresh` | `origin/wip/root-dirty-20260403` at `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e` | Close the canonical service adapter provider lane and refresh residual data-quality monitor surfaces | No |
 
 ## OpenSpec Relationship
 
@@ -58,8 +59,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.200 is a path-limited implementation branch after PR `#352` merged G2.199.
-It implements only the authorized constructor-level monitor seam for canonical
-service adapters and keeps legacy data adapters, `market_data_adapter.py`,
-singleton wrapper, monitor internals, routes, frontend, and OpenSpec changes out
-of scope.
+G2.201 is a governance-only closeout branch after PR `#353` merged G2.200. It
+closes the canonical service adapter implementation lane, refreshes the remaining
+data-quality monitor surfaces, and selects G2.202 as a decision-only legacy data
+adapter compatibility ownership gate.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T10:53:34+08:00`
-- Base HEAD checked: `41bef3787160ec3bf7b9b31220df9d99a3437474`
+- Prepared at: `2026-05-28T11:30:22+08:00`
+- Base HEAD checked: `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 is the active canonical service adapter provider implementation |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 is the active closeout / residual refresh selecting G2.202 |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T10:53:34+08:00`
-- Base HEAD checked: `41bef3787160ec3bf7b9b31220df9d99a3437474`
+- Prepared at: `2026-05-28T11:30:22+08:00`
+- Base HEAD checked: `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,8 +15,9 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.200 data-quality canonical service adapter provider implementation | G/#79 service lifecycle DI | PR `#352` merged at `41bef3787160ec3bf7b9b31220df9d99a3437474`; G2.200 implements only the authorized canonical service adapter monitor seam | If accepted, start G2.201 closeout / residual refresh before selecting another data-quality monitor surface |
-| P0 | Preserve G2.199 data-quality canonical service adapter provider authorization | G/#79 service lifecycle DI | PR `#352` merged; G2.200 source authority is limited to two canonical service adapters and listed tests | Do not touch legacy data adapters, `market_data_adapter.py`, wrapper, or monitor internals under G2.200 |
+| P0 | Review G2.201 data-quality canonical service adapter closeout / refresh | G/#79 service lifecycle DI | PR `#353` merged at `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`; G2.201 closes the canonical service adapter lane and selects the next decision target | If accepted, start G2.202 legacy data adapter compatibility ownership decision; do not open source authority directly |
+| P0 | Preserve G2.200 data-quality canonical service adapter provider implementation | G/#79 service lifecycle DI | PR `#353` merged; canonical service adapters now have optional monitor injection with singleton fallback | Do not reopen canonical service adapter source unless current HEAD evidence contradicts G2.200 tests |
+| P0 | Preserve G2.199 data-quality canonical service adapter provider authorization | G/#79 service lifecycle DI | PR `#352` merged; G2.200 source authority was limited to two canonical service adapters and listed tests | Do not touch legacy data adapters, `market_data_adapter.py`, wrapper, or monitor internals without a new decision package |
 | P0 | Preserve G2.198 data-quality residual adapter ownership decision | G/#79 service lifecycle DI | PR `#351` merged; canonical service adapters selected as the G2.199/G2.200 target | Do not touch legacy data adapters, `market_data_adapter.py`, wrapper, or monitor internals without a new decision package |
 | P0 | Preserve G2.197 data-quality monitor closeout / remaining candidate refresh | G/#79 service lifecycle DI | PR `#350` merged; `adapter_split` subclass constructor lane is closed and remaining candidates are classified | Do not bypass G2.198/G2.199 before touching service adapters, legacy adapters, `market_data_adapter.py`, or wrappers |
 | P0 | Preserve G2.196 data-quality `adapter_split` constructor provider implementation | G/#79 service lifecycle DI | PR `#349` merged; subclass-level `get_data_quality_monitor()` calls/imports are `0`; `BaseAdapter` fallback remains intentional | Do not expand into service adapters, legacy adapters, singleton wrappers, routes, or frontend |
@@ -42,8 +43,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.200 stay within the PR `#352` authorization boundary?
-- Does G2.200 preserve positional `config` constructor compatibility for both canonical service adapters?
-- Do the focused tests prove injected monitors bypass the global getter while default fallback remains available?
-- Are legacy data adapters, `market_data_adapter.py`, wrapper, route/OpenAPI, frontend, config, script, and OpenSpec surfaces still untouched?
+- Does G2.201 accurately record PR `#353` as merged at `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`?
+- Does G2.201 correctly close canonical service adapters while retaining singleton fallback calls as compatibility behavior?
+- Does G2.201 select G2.202 as a decision-only legacy data adapter compatibility ownership gate?
+- Are `market_data_adapter.py`, singleton wrapper, route/OpenAPI, frontend, config, script, and OpenSpec surfaces still deferred?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T10:53:34+08:00`
-- Base HEAD checked: `41bef3787160ec3bf7b9b31220df9d99a3437474`
+- Prepared at: `2026-05-28T11:30:22+08:00`
+- Base HEAD checked: `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -61,8 +61,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-residual-adapter-ownership-decision-2026-05-28.md` | G2.198 human-readable residual adapter ownership decision report | Accepted by PR `#351`; superseded for canonical service adapter authorization by G2.199 |
 | `.planning/codebase/generated/data-quality-canonical-service-adapter-provider-authorization-2026-05-28.json` | G2.199 canonical service adapter provider authorization evidence | Accepted by PR `#352`; superseded for implementation evidence by G2.200 |
 | `docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-authorization-2026-05-28.md` | G2.199 human-readable authorization package | Accepted by PR `#352`; superseded for implementation evidence by G2.200 |
-| `.planning/codebase/generated/data-quality-canonical-service-adapter-provider-implementation-2026-05-28.json` | G2.200 canonical service adapter provider implementation evidence | Current for HEAD `41bef3787160ec3bf7b9b31220df9d99a3437474`; review input until PR `#353` is accepted |
-| `docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-implementation-2026-05-28.md` | G2.200 human-readable implementation report | Review input until PR `#353` is accepted |
+| `.planning/codebase/generated/data-quality-canonical-service-adapter-provider-implementation-2026-05-28.json` | G2.200 canonical service adapter provider implementation evidence | Accepted by PR `#353`; superseded for residual refresh by G2.201 |
+| `docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-implementation-2026-05-28.md` | G2.200 human-readable implementation report | Accepted by PR `#353`; superseded for residual refresh by G2.201 |
+| `.planning/codebase/generated/data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.json` | G2.201 canonical service adapter closeout / residual refresh evidence | Current for HEAD `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`; review input until PR `#354` is accepted |
+| `docs/reports/quality/backend-data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.md` | G2.201 human-readable closeout / residual refresh report | Review input until PR `#354` is accepted |
 
 ## External State Inputs
 
@@ -86,7 +88,8 @@ state transition.
 | GitHub PR `#350` | `MERGED` | G2.197 data-quality monitor closeout / refresh merged by commit `3acf90c3ab17dbb3b47150a03f1cdee1c96dc8f1` |
 | GitHub PR `#351` | `MERGED` | G2.198 residual adapter ownership decision merged by commit `a6b54ddfb24055552d634757f01dc03bd6ca6e62` |
 | GitHub PR `#352` | `MERGED` | G2.199 canonical service adapter authorization merged by commit `41bef3787160ec3bf7b9b31220df9d99a3437474` |
-| `origin/wip/root-dirty-20260403` | `41bef3787160ec3bf7b9b31220df9d99a3437474` | Base used for this canonical service adapter implementation branch |
+| GitHub PR `#353` | `MERGED` | G2.200 canonical service adapter provider implementation merged by commit `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e` |
+| `origin/wip/root-dirty-20260403` | `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e` | Base used for this canonical service adapter closeout / refresh branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T10:53:34+08:00",
+  "generated_at": "2026-05-28T11:30:22+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "41bef3787160ec3bf7b9b31220df9d99a3437474",
-  "split_branch": "g2-200-data-quality-canonical-service-adapter-provider",
-  "scope": "data_quality_canonical_service_adapter_provider_implementation",
-  "source_edit_authority": true,
+  "base_head": "cbd9b3a7ee730c72a63dbc7adb6490564c12c71e",
+  "split_branch": "g2-201-data-quality-canonical-service-adapter-closeout-refresh",
+  "scope": "data_quality_canonical_service_adapter_closeout_refresh",
+  "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -1458,12 +1458,14 @@
     {
       "id": "g2-200-data-quality-canonical-service-adapter-provider-implementation",
       "type": "implementation",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.199 data-quality canonical service adapter provider authorization",
       "source_edit_authority": true,
       "parent_github_pr": 352,
       "parent_merge_commit": "41bef3787160ec3bf7b9b31220df9d99a3437474",
+      "github_pr": 353,
+      "merge_commit": "cbd9b3a7ee730c72a63dbc7adb6490564c12c71e",
       "evidence": [
         ".planning/codebase/generated/data-quality-canonical-service-adapter-provider-implementation-2026-05-28.json",
         "docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-implementation-2026-05-28.md",
@@ -1514,10 +1516,75 @@
         "openspec/specs/**"
       ],
       "freshness": {
-        "current_head_checked": "41bef3787160ec3bf7b9b31220df9d99a3437474",
+        "current_head_checked": "cbd9b3a7ee730c72a63dbc7adb6490564c12c71e",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.201 closeout / residual refresh before selecting another data-quality monitor surface."
+      "next_gate": "Superseded by G2.201 data-quality canonical service adapter closeout / refresh."
+    },
+    {
+      "id": "g2-201-data-quality-canonical-service-adapter-closeout-refresh",
+      "type": "closeout_refresh",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.200 data-quality canonical service adapter provider implementation",
+      "source_edit_authority": false,
+      "parent_github_pr": 353,
+      "parent_merge_commit": "cbd9b3a7ee730c72a63dbc7adb6490564c12c71e",
+      "evidence": [
+        ".planning/codebase/generated/data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.md",
+        "governance/mainline/task-cards/pr-354.yaml"
+      ],
+      "closeout_result": {
+        "canonical_service_adapter_lane": "closed",
+        "post_merge_focused_pytest": "21 passed",
+        "post_merge_import_smoke": "passed with minimal dummy required env",
+        "openspec_validate": "passed"
+      },
+      "residual_scan": {
+        "total_get_data_quality_monitor_calls": 9,
+        "route_provider_backing": {
+          "files": 1,
+          "calls": 1,
+          "decision": "retained provider backing getter"
+        },
+        "adapter_split_base_fallback": {
+          "files": 1,
+          "calls": 1,
+          "decision": "closed adapter_split lane; retain default singleton fallback"
+        },
+        "canonical_service_adapter_fallback": {
+          "files": 2,
+          "calls": 2,
+          "decision": "closed by G2.200; retain fallback for default construction"
+        },
+        "legacy_data_adapter": {
+          "files": 2,
+          "calls": 2,
+          "decision": "select as G2.202 compatibility ownership decision target"
+        },
+        "market_data_adapter_facade": {
+          "files": 1,
+          "calls": 1,
+          "decision": "defer as root compatibility facade surface"
+        },
+        "singleton_wrapper_backing": {
+          "files": 1,
+          "calls": 2,
+          "decision": "retain backing API; not a deletion lane"
+        }
+      },
+      "gitnexus_reference": {
+        "legacy_dashboard": "LOW; impacted_count=0",
+        "legacy_data_source": "LOW; impacted_count=0",
+        "market_data_adapter_facade": "LOW; impacted_count=3",
+        "singleton_wrapper_backing": "LOW; impacted_count=19"
+      },
+      "freshness": {
+        "current_head_checked": "cbd9b3a7ee730c72a63dbc7adb6490564c12c71e",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.202 data-quality legacy adapter compatibility ownership decision without source authority."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T10:53:34+08:00`
-- Base HEAD checked: `41bef3787160ec3bf7b9b31220df9d99a3437474`
+- Prepared at: `2026-05-28T11:30:22+08:00`
+- Base HEAD checked: `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -52,7 +52,8 @@ It proved a repeatable conveyor:
 | G2.197 data-quality monitor closeout / remaining candidate refresh | Merged by PR `#350` | Closes the `adapter_split` subclass constructor lane and refreshes remaining service adapter, legacy adapter, compatibility facade, and wrapper surfaces |
 | G2.198 data-quality residual adapter ownership decision | Merged by PR `#351` | Selects canonical service adapters as the next authorization target while deferring legacy data adapters, `market_data_adapter.py`, and wrapper retention |
 | G2.199 data-quality canonical service adapter provider authorization | Merged by PR `#352` | Authorizes future G2.200 implementation for canonical service adapters only; no source edits in G2.199 |
-| G2.200 data-quality canonical service adapter provider implementation | For review | Implements optional constructor monitor injection in the two canonical service adapters with focused TDD evidence |
+| G2.200 data-quality canonical service adapter provider implementation | Merged by PR `#353` | Implements optional constructor monitor injection in the two canonical service adapters with focused TDD evidence |
+| G2.201 data-quality canonical service adapter closeout / refresh | For review | Closes the canonical service adapter lane and selects legacy data adapter compatibility ownership as the next decision gate |
 
 ## Current Strategy Getter Residuals
 
@@ -439,11 +440,47 @@ Focused verification:
 | Import smoke | Passed with minimal dummy required env |
 | OpenSpec strict validate | Valid; PostHog network flush noise only |
 
+PR `#353` merged this lane at
+`cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`.
+
+## G2.201 Data-Quality Canonical Service Adapter Closeout / Refresh
+
+At HEAD `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`, PR `#353` is merged and
+G2.200 is accepted.
+
+Closeout result:
+
+| Surface | State | Decision |
+|---|---|---|
+| Canonical service adapters | Closed | `DashboardDataSourceAdapter` and `DataDataSourceAdapter` now support keyword-only `quality_monitor` injection while preserving singleton fallback |
+| Focused tests | Closed | Post-merge focused regression package records `21 passed` |
+| Function-tree / mainline mapping | Closed | `domain-01-node-03` maps the two canonical service adapter paths and focused test |
+
+Remaining `get_data_quality_monitor()` surface after G2.201 refresh:
+
+| Bucket | Files | Calls | Current decision |
+|---|---:|---:|---|
+| Route provider backing | 1 | 1 | Retained provider backing getter from prior route provider lane |
+| `adapter_split` base fallback | 1 | 1 | Closed adapter_split lane; retain default singleton fallback |
+| Canonical service adapter fallback | 2 | 2 | Closed by G2.200; retain fallback for default construction |
+| Legacy data adapters | 2 | 2 | Select as G2.202 compatibility ownership decision target; no source authority from G2.201 |
+| `market_data_adapter.py` facade | 1 | 1 | Defer as root compatibility facade surface until an owner-specific decision package |
+| Singleton wrapper / backing API | 1 | 2 | Retain backing API; not a deletion lane |
+
+GitNexus reference for deferred surfaces:
+
+| Target | Risk | Impact |
+|---|---|---|
+| `web/backend/app/services/data_adapters/dashboard.py` | LOW | `impacted_count=0`, `processes_affected=0` |
+| `web/backend/app/services/data_adapters/data_source.py` | LOW | `impacted_count=0`, `processes_affected=0` |
+| `web/backend/app/services/market_data_adapter.py` | LOW | `impacted_count=3`, `direct=1`, `processes_affected=0` |
+| `web/backend/app/services/_data_quality_monitor_singleton.py` | LOW | `impacted_count=19`, `direct=1`, `processes_affected=0` |
+
 ## Next Gates
 
-- Review G2.200 data-quality canonical service adapter provider implementation.
-- If accepted, start G2.201 closeout / residual refresh before selecting another data-quality monitor surface.
-- Do not start another source lane before G2.200 is accepted and closed out.
+- Review G2.201 data-quality canonical service adapter closeout / refresh.
+- If accepted, start G2.202 data-quality legacy adapter compatibility ownership decision.
+- Do not start a source lane for legacy adapters before G2.202 is accepted.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/reports/quality/backend-data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.md
@@ -1,0 +1,87 @@
+# Backend Data-Quality Canonical Service Adapter Closeout / Refresh
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Node: G2.201 data-quality canonical service adapter closeout / refresh
+- Status: closeout and residual refresh
+- Prepared at: `2026-05-28T11:30:22+08:00`
+- Base HEAD checked: `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`
+- Parent implementation: G2.200, PR `#353`, merge commit `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`
+- Source edit authority: no
+
+Boundary note: this closeout records accepted implementation evidence and selects
+the next decision gate. It does not authorize source edits, legacy adapter
+migration, wrapper deletion, route changes, OpenAPI contract changes, frontend
+changes, config/script changes, OpenSpec changes, or GitHub issue label changes.
+
+## Closeout Result
+
+G2.200 is closed as the canonical service adapter monitor-injection lane.
+
+| Surface | Result |
+|---|---|
+| `DashboardDataSourceAdapter` | Accepts keyword-only `quality_monitor`; preserves positional `config` construction; falls back to `get_data_quality_monitor()` when no monitor is injected |
+| `DataDataSourceAdapter` | Accepts keyword-only `quality_monitor`; preserves positional `config` construction; falls back to `get_data_quality_monitor()` when no monitor is injected |
+| Focused provider tests | Prove injected monitors bypass the module-level global getter for both canonical adapters |
+| Function-tree / mainline mapping | `domain-01-node-03` covers the two canonical service adapter paths and focused test path |
+
+## Post-Merge Verification
+
+| Check | Result |
+|---|---|
+| GitHub PR `#353` | `MERGED` at `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e` |
+| Focused regression package | `21 passed` |
+| Import smoke | Passed with minimal dummy required env through `app.services.data_adapter` and `data_source_factory` |
+| OpenSpec validation | `openspec validate migrate-backend-singletons-to-lifecycle-di --strict` passed; PostHog network flush warning is telemetry noise |
+| JSON/YAML parse | Passed for generated closeout JSON, `steward-index.json`, and `pr-354.yaml` |
+| Markdown governance | Passed, `checked_files=6`, `errors=0` |
+| Diff whitespace | `git diff --check` passed |
+| GitNexus staged scope | Low risk, `changed_files=9`, `changed_symbols=0`, `affected_processes=0` |
+| Mainline scope gate | Passed, `changed_files=9`, `violations=0`, report `/tmp/pr354-mainline-governance-report.json` |
+
+## Residual Scan
+
+Command:
+
+```bash
+rg -n "get_data_quality_monitor\\(" web/backend/app/services web/backend/app/api -g '*.py'
+```
+
+At HEAD `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`, the scan finds 9 calls.
+
+| Bucket | Files | Calls | Decision |
+|---|---:|---:|---|
+| Route provider backing | 1 | 1 | Retained provider backing getter from prior route provider lane |
+| `adapter_split` base fallback | 1 | 1 | Closed adapter_split lane; retain default singleton fallback |
+| Canonical service adapter fallback | 2 | 2 | Closed by G2.200; retain fallback for default construction |
+| Legacy data adapters | 2 | 2 | Select as G2.202 compatibility ownership decision target; no source authority from G2.201 |
+| `market_data_adapter.py` facade | 1 | 1 | Defer as root compatibility facade surface until an owner-specific decision package |
+| Singleton wrapper / backing API | 1 | 2 | Retain backing API; not a deletion lane |
+
+## GitNexus Reference
+
+| Target | Risk | Impact |
+|---|---|---|
+| `web/backend/app/services/data_adapters/dashboard.py` | LOW | `impacted_count=0`, `processes_affected=0` |
+| `web/backend/app/services/data_adapters/data_source.py` | LOW | `impacted_count=0`, `processes_affected=0` |
+| `web/backend/app/services/market_data_adapter.py` | LOW | `impacted_count=3`, `direct=1`, `processes_affected=0` |
+| `web/backend/app/services/_data_quality_monitor_singleton.py` | LOW | `impacted_count=19`, `direct=1`, `processes_affected=0` |
+
+The two legacy data adapter files show no graph consumers in this index, but
+static non-use is not deletion authority. They still need an explicit
+compatibility ownership decision before source implementation, retirement, or
+wrapper changes.
+
+## Next Gate
+
+Start G2.202 as a decision-only package:
+
+| Future gate | Scope | Source authority |
+|---|---|---|
+| G2.202 data-quality legacy adapter compatibility ownership decision | Classify `web/backend/app/services/data_adapters/dashboard.py` and `web/backend/app/services/data_adapters/data_source.py`; decide whether to authorize a future implementation lane, retain as compatibility, or defer | No |
+
+G2.202 must not batch `market_data_adapter.py`, singleton wrapper retirement,
+route/provider changes, canonical service adapter edits, OpenAPI contracts,
+frontend, config, scripts, or OpenSpec changes.

--- a/governance/mainline/task-cards/pr-354.yaml
+++ b/governance/mainline/task-cards/pr-354.yaml
@@ -1,0 +1,117 @@
+version: "v0.2"
+
+task:
+  id: "pr-354"
+  title: "Close data-quality canonical service adapter provider lane"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-canonical-service-adapter-closeout-refresh"
+  objective: "close the accepted canonical service adapter provider implementation and refresh remaining data-quality monitor surfaces"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only closeout and residual refresh; no route paths, HTTP methods, response models, OpenAPI examples, frontend behavior, PM2 workflows, or public API ownership changes"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-354.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/FUNCTION_TREE.md"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "governance/function-tree/catalog.yaml"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source implementation"
+  - "test source edits"
+  - "legacy data adapter migration"
+  - "market_data_adapter.py edits"
+  - "singleton wrapper deletion"
+  - "route changes"
+  - "OpenAPI contract changes"
+  - "frontend changes"
+  - "OpenSpec proposal creation"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-354.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-354.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha cbd9b3a7ee730c72a63dbc7adb6490564c12c71e --head-sha HEAD --report /tmp/pr354-mainline-governance-report.json"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Treating G2.201 as source authority would bypass the required G2.202 decision gate."
+    - "Legacy data adapter graph impact is low or empty, but static non-use is not deletion authority."
+  rollback_plan: "revert this PR to restore the post-#353 steward state and rerun the closeout / residual refresh."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close canonical service adapter provider implementation and refresh residual data-quality monitor surfaces"
+    modified_scope: "governance reports, generated evidence, steward tree files, and one task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no backend source files are modified"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if the residual classification or next gate is incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T11:26:09+08:00"
+    approval_note: "Human maintainer approved continuing after PR #353 acceptance; this lane is closeout and residual refresh only."
+    secondary_approved: true


### PR DESCRIPTION
## Summary

- Close G2.200 after PR #353 merged the canonical service adapter provider implementation.
- Refresh remaining `get_data_quality_monitor()` surfaces at current HEAD.
- Select G2.202 as a decision-only legacy data adapter compatibility ownership gate.
- Update steward tree, generated evidence, branch register, evidence index, completed ledger, and task card.

## Scope Boundary

This is governance-only. It does not modify backend source, tests, routes, OpenAPI contracts, frontend, config, scripts, function-tree catalog, or OpenSpec changes.

## Residual Refresh

Current residual scan finds 9 calls:

- Route provider backing: 1 file / 1 call, retained.
- adapter_split base fallback: 1 file / 1 call, closed lane fallback retained.
- Canonical service adapter fallback: 2 files / 2 calls, closed by G2.200 fallback retained.
- Legacy data adapters: 2 files / 2 calls, selected for G2.202 decision-only ownership package.
- market_data_adapter.py facade: 1 file / 1 call, deferred.
- Singleton wrapper/backing API: 1 file / 2 calls, retained.

## Verification

- Post-merge focused regression package: 21 passed.
- Post-merge import smoke: passed with minimal dummy required env.
- OpenSpec strict validate: passed; PostHog network flush warning observed after successful validation.
- JSON/YAML parse: passed.
- Markdown governance: checked_files=6, errors=0.
- git diff --check: passed.
- GitNexus staged/compare: low risk, changed_files=9, changed_symbols=0, affected_processes=0.
- Mainline scope gate: changed_files=9, violations=0.

## Next Gate

If accepted, start G2.202 data-quality legacy adapter compatibility ownership decision. Do not open source authority directly from this closeout.