### PR TITLE
docs(governance): decide data quality legacy adapter ownership

### DIFF
--- a/.planning/codebase/generated/data-quality-legacy-adapter-ownership-decision-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-legacy-adapter-ownership-decision-2026-05-28.json
@@ -1,0 +1,120 @@
+{
+  "schema_version": "2026-05-28.g2-decision.v1",
+  "node": "G2.202 data-quality legacy adapter compatibility ownership decision",
+  "generated_at": "2026-05-28T11:53:30+08:00",
+  "git": {
+    "branch": "g2-202-data-quality-legacy-adapter-ownership-decision",
+    "base_branch": "wip/root-dirty-20260403",
+    "base_head": "e672f1523c30037202310278daf71488681d9a1f",
+    "current_head_checked": "e672f1523c30037202310278daf71488681d9a1f",
+    "stale_if_head_mismatch": true
+  },
+  "parent": {
+    "node": "G2.201 data-quality canonical service adapter closeout / refresh",
+    "github_pr": 354,
+    "merge_commit": "e672f1523c30037202310278daf71488681d9a1f",
+    "relationship": "G2.201 selected this G2.202 decision-only legacy data adapter compatibility ownership gate"
+  },
+  "source_edit_authority": false,
+  "scope": {
+    "decision_targets": [
+      "web/backend/app/services/data_adapters/dashboard.py",
+      "web/backend/app/services/data_adapters/data_source.py"
+    ],
+    "forbidden_surfaces": [
+      "web/backend/app/services/market_data_adapter.py",
+      "web/backend/app/services/_data_quality_monitor_singleton.py",
+      "web/backend/app/services/data_quality_monitor.py",
+      "web/backend/app/services/adapters/**",
+      "web/backend/app/services/adapter_split/**",
+      "web/backend/app/api/**",
+      "web/frontend/**",
+      "src/**",
+      "tests/**",
+      "docs/api/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ]
+  },
+  "target_facts": [
+    {
+      "path": "web/backend/app/services/data_adapters/dashboard.py",
+      "line_count": 299,
+      "classes": [
+        "DashboardDataSourceAdapter"
+      ],
+      "get_data_quality_monitor_calls": 1,
+      "import_line": "from app.services.data_quality_monitor import get_data_quality_monitor",
+      "gitnexus_upstream_impact": {
+        "risk": "LOW",
+        "impacted_count": 0,
+        "direct": 0,
+        "processes_affected": 0
+      }
+    },
+    {
+      "path": "web/backend/app/services/data_adapters/data_source.py",
+      "line_count": 688,
+      "classes": [
+        "DataDataSourceAdapter"
+      ],
+      "get_data_quality_monitor_calls": 1,
+      "import_line": "from app.services.data_quality_monitor import get_data_quality_monitor",
+      "gitnexus_upstream_impact": {
+        "risk": "LOW",
+        "impacted_count": 0,
+        "direct": 0,
+        "processes_affected": 0
+      }
+    }
+  ],
+  "consumer_scan": {
+    "module_path_patterns": [
+      "app.services.data_adapters.dashboard",
+      "app.services.data_adapters.data_source",
+      "services.data_adapters.dashboard",
+      "services.data_adapters.data_source",
+      "data_adapters.dashboard",
+      "data_adapters.data_source"
+    ],
+    "external_python_legacy_module_imports": 0,
+    "legacy_module_imports": [],
+    "class_name_scan_note": "Class-name text hits are ambiguous because canonical app.services.adapters modules use the same class names. The active runtime class-name hits outside the two legacy files point to canonical adapters, the app.services.data_adapter facade, and data_source_factory imports through that facade.",
+    "facade_import_truth": {
+      "web/backend/app/services/data_adapter.py": "imports from app.services.adapters",
+      "web/backend/app/services/data_source_factory/data_source_factory.py": "imports DataDataSourceAdapter and DashboardDataSourceAdapter from app.services.data_adapter facade",
+      "web/backend/app/services/adapters/__init__.py": "re-exports canonical app.services.adapters classes"
+    }
+  },
+  "decision": {
+    "classification": "legacy_compatibility_surfaces_without_active_external_module_path_imports",
+    "ownership": "legacy compatibility ownership must be decided explicitly; static non-use is not deletion authority",
+    "source_lane_recommendation": "do_not_start_source_implementation_from_g2_202",
+    "selected_next_governance_target": "data-quality-legacy-adapter-compatibility-closure-authorization",
+    "recommended_next_work_item": "G2.203 data-quality legacy adapter compatibility closure authorization package",
+    "future_authorization_options": [
+      "authorize a narrow implementation to convert both files into explicit compatibility wrappers",
+      "authorize a narrow implementation to retire both files only if consumer/import smoke and rollback gates are satisfied",
+      "retain both files as historical compatibility surfaces if a current consumer contradiction appears"
+    ]
+  },
+  "future_g2_203_minimum_acceptance": [
+    "rerun module-path consumer scan at current HEAD",
+    "rerun GitNexus impact for both target files before any source edit authorization",
+    "define exact implementation shape before source edits: thin wrapper, retirement, or retained no-op",
+    "include import smoke for app.services.data_adapter and data_source_factory",
+    "include focused regression coverage if source implementation is later authorized",
+    "exclude market_data_adapter.py, singleton wrapper/backing API, canonical adapters, routes, OpenAPI, frontend, config, scripts, and OpenSpec files"
+  ],
+  "validation": {
+    "json_parse": "passed",
+    "yaml_parse": "passed",
+    "markdown_governance": "passed; checked_files=6; errors=0",
+    "openspec_validate": "passed; PostHog telemetry warning only",
+    "git_diff_check": "passed",
+    "mainline_scope_gate": "passed; changed_files=9; violations=0; report=/tmp/pr355-mainline-governance-report.json",
+    "gitnexus_staged_detect_changes": "low risk; changed_files=9; changed_symbols=0; affected_processes=0"
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T11:30:22+08:00`
-- Base HEAD checked: `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`
+- Prepared at: `2026-05-28T11:53:30+08:00`
+- Base HEAD checked: `e672f1523c30037202310278daf71488681d9a1f`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -38,12 +38,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#351` | `g2-198-data-quality-residual-adapter-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `a6b54ddfb24055552d634757f01dc03bd6ca6e62` | Decision selecting canonical service adapter provider authorization as G2.199 |
 | `#352` | `g2-199-data-quality-canonical-service-adapter-authorization` | `wip/root-dirty-20260403` | `MERGED` at `41bef3787160ec3bf7b9b31220df9d99a3437474` | Authorization package for G2.200 canonical service adapter provider implementation |
 | `#353` | `g2-200-data-quality-canonical-service-adapter-provider` | `wip/root-dirty-20260403` | `MERGED` at `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e` | Path-limited canonical service adapter provider implementation closed for G2.201 refresh |
+| `#354` | `g2-201-data-quality-canonical-service-adapter-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `e672f1523c30037202310278daf71488681d9a1f` | Governance closeout selecting G2.202 legacy adapter compatibility ownership decision |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-201-data-quality-canonical-service-adapter-closeout-refresh` | `origin/wip/root-dirty-20260403` at `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e` | Close the canonical service adapter provider lane and refresh residual data-quality monitor surfaces | No |
+| `g2-202-data-quality-legacy-adapter-ownership-decision` | `origin/wip/root-dirty-20260403` at `e672f1523c30037202310278daf71488681d9a1f` | Classify legacy data-quality adapter compatibility ownership and select the next authorization gate | No |
 
 ## OpenSpec Relationship
 
@@ -59,7 +60,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.201 is a governance-only closeout branch after PR `#353` merged G2.200. It
-closes the canonical service adapter implementation lane, refreshes the remaining
-data-quality monitor surfaces, and selects G2.202 as a decision-only legacy data
-adapter compatibility ownership gate.
+G2.202 is a governance-only decision branch after PR `#354` merged G2.201. It
+classifies the two legacy `web/backend/app/services/data_adapters/*` targets,
+records that exact module-path non-use is evidence but not deletion authority,
+and selects G2.203 as an authorization-only compatibility closure package.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T11:30:22+08:00`
-- Base HEAD checked: `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`
+- Prepared at: `2026-05-28T11:53:30+08:00`
+- Base HEAD checked: `e672f1523c30037202310278daf71488681d9a1f`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 is the active closeout / residual refresh selecting G2.202 |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 is the active decision package selecting G2.203 authorization-only legacy adapter compatibility closure |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T11:30:22+08:00`
-- Base HEAD checked: `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`
+- Prepared at: `2026-05-28T11:53:30+08:00`
+- Base HEAD checked: `e672f1523c30037202310278daf71488681d9a1f`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.201 data-quality canonical service adapter closeout / refresh | G/#79 service lifecycle DI | PR `#353` merged at `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`; G2.201 closes the canonical service adapter lane and selects the next decision target | If accepted, start G2.202 legacy data adapter compatibility ownership decision; do not open source authority directly |
+| P0 | Review G2.202 data-quality legacy adapter compatibility ownership decision | G/#79 service lifecycle DI | PR `#354` merged at `e672f1523c30037202310278daf71488681d9a1f`; G2.202 classifies two legacy `data_adapters` files as compatibility ownership surfaces | If accepted, start G2.203 authorization-only compatibility closure package; do not edit or delete legacy files directly from G2.202 |
+| P0 | Preserve G2.201 data-quality canonical service adapter closeout / refresh | G/#79 service lifecycle DI | PR `#354` merged; G2.201 closes the canonical service adapter lane and selects G2.202 | Do not reopen canonical service adapter source unless current HEAD evidence contradicts G2.200/G2.201 |
 | P0 | Preserve G2.200 data-quality canonical service adapter provider implementation | G/#79 service lifecycle DI | PR `#353` merged; canonical service adapters now have optional monitor injection with singleton fallback | Do not reopen canonical service adapter source unless current HEAD evidence contradicts G2.200 tests |
 | P0 | Preserve G2.199 data-quality canonical service adapter provider authorization | G/#79 service lifecycle DI | PR `#352` merged; G2.200 source authority was limited to two canonical service adapters and listed tests | Do not touch legacy data adapters, `market_data_adapter.py`, wrapper, or monitor internals without a new decision package |
 | P0 | Preserve G2.198 data-quality residual adapter ownership decision | G/#79 service lifecycle DI | PR `#351` merged; canonical service adapters selected as the G2.199/G2.200 target | Do not touch legacy data adapters, `market_data_adapter.py`, wrapper, or monitor internals without a new decision package |
@@ -43,8 +44,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.201 accurately record PR `#353` as merged at `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`?
-- Does G2.201 correctly close canonical service adapters while retaining singleton fallback calls as compatibility behavior?
-- Does G2.201 select G2.202 as a decision-only legacy data adapter compatibility ownership gate?
-- Are `market_data_adapter.py`, singleton wrapper, route/OpenAPI, frontend, config, script, and OpenSpec surfaces still deferred?
+- Does G2.202 correctly classify `web/backend/app/services/data_adapters/dashboard.py` and `web/backend/app/services/data_adapters/data_source.py` as legacy compatibility ownership surfaces?
+- Does G2.202 preserve the rule that module-path non-use is evidence, not deletion authority?
+- Does G2.202 correctly select G2.203 as an authorization-only compatibility closure package?
+- Are `market_data_adapter.py`, singleton wrapper, route/OpenAPI, frontend, config, script, canonical adapter, and OpenSpec surfaces still deferred?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T11:30:22+08:00`
-- Base HEAD checked: `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`
+- Prepared at: `2026-05-28T11:53:30+08:00`
+- Base HEAD checked: `e672f1523c30037202310278daf71488681d9a1f`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -63,8 +63,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-authorization-2026-05-28.md` | G2.199 human-readable authorization package | Accepted by PR `#352`; superseded for implementation evidence by G2.200 |
 | `.planning/codebase/generated/data-quality-canonical-service-adapter-provider-implementation-2026-05-28.json` | G2.200 canonical service adapter provider implementation evidence | Accepted by PR `#353`; superseded for residual refresh by G2.201 |
 | `docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-implementation-2026-05-28.md` | G2.200 human-readable implementation report | Accepted by PR `#353`; superseded for residual refresh by G2.201 |
-| `.planning/codebase/generated/data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.json` | G2.201 canonical service adapter closeout / residual refresh evidence | Current for HEAD `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`; review input until PR `#354` is accepted |
-| `docs/reports/quality/backend-data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.md` | G2.201 human-readable closeout / residual refresh report | Review input until PR `#354` is accepted |
+| `.planning/codebase/generated/data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.json` | G2.201 canonical service adapter closeout / residual refresh evidence | Accepted by PR `#354`; superseded for legacy adapter ownership by G2.202 |
+| `docs/reports/quality/backend-data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.md` | G2.201 human-readable closeout / residual refresh report | Accepted by PR `#354`; superseded for legacy adapter ownership by G2.202 |
+| `.planning/codebase/generated/data-quality-legacy-adapter-ownership-decision-2026-05-28.json` | G2.202 legacy data adapter compatibility ownership decision evidence | Current for HEAD `e672f1523c30037202310278daf71488681d9a1f`; review input until PR `#355` is accepted |
+| `docs/reports/quality/backend-data-quality-legacy-adapter-ownership-decision-2026-05-28.md` | G2.202 human-readable ownership decision report | Review input until PR `#355` is accepted |
 
 ## External State Inputs
 
@@ -89,7 +91,8 @@ state transition.
 | GitHub PR `#351` | `MERGED` | G2.198 residual adapter ownership decision merged by commit `a6b54ddfb24055552d634757f01dc03bd6ca6e62` |
 | GitHub PR `#352` | `MERGED` | G2.199 canonical service adapter authorization merged by commit `41bef3787160ec3bf7b9b31220df9d99a3437474` |
 | GitHub PR `#353` | `MERGED` | G2.200 canonical service adapter provider implementation merged by commit `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e` |
-| `origin/wip/root-dirty-20260403` | `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e` | Base used for this canonical service adapter closeout / refresh branch |
+| GitHub PR `#354` | `MERGED` | G2.201 canonical service adapter closeout / residual refresh merged by commit `e672f1523c30037202310278daf71488681d9a1f` |
+| `origin/wip/root-dirty-20260403` | `e672f1523c30037202310278daf71488681d9a1f` | Base used for this legacy adapter ownership decision branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T11:30:22+08:00",
+  "generated_at": "2026-05-28T11:53:30+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "cbd9b3a7ee730c72a63dbc7adb6490564c12c71e",
-  "split_branch": "g2-201-data-quality-canonical-service-adapter-closeout-refresh",
-  "scope": "data_quality_canonical_service_adapter_closeout_refresh",
+  "base_head": "e672f1523c30037202310278daf71488681d9a1f",
+  "split_branch": "g2-202-data-quality-legacy-adapter-ownership-decision",
+  "scope": "data_quality_legacy_adapter_ownership_decision",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -1524,12 +1524,14 @@
     {
       "id": "g2-201-data-quality-canonical-service-adapter-closeout-refresh",
       "type": "closeout_refresh",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.200 data-quality canonical service adapter provider implementation",
       "source_edit_authority": false,
       "parent_github_pr": 353,
       "parent_merge_commit": "cbd9b3a7ee730c72a63dbc7adb6490564c12c71e",
+      "github_pr": 354,
+      "merge_commit": "e672f1523c30037202310278daf71488681d9a1f",
       "evidence": [
         ".planning/codebase/generated/data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.json",
         "docs/reports/quality/backend-data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.md",
@@ -1584,7 +1586,77 @@
         "current_head_checked": "cbd9b3a7ee730c72a63dbc7adb6490564c12c71e",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.202 data-quality legacy adapter compatibility ownership decision without source authority."
+      "next_gate": "Superseded by G2.202 data-quality legacy adapter compatibility ownership decision."
+    },
+    {
+      "id": "g2-202-data-quality-legacy-adapter-ownership-decision",
+      "type": "decision_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.201 data-quality canonical service adapter closeout / refresh",
+      "source_edit_authority": false,
+      "parent_github_pr": 354,
+      "parent_merge_commit": "e672f1523c30037202310278daf71488681d9a1f",
+      "evidence": [
+        ".planning/codebase/generated/data-quality-legacy-adapter-ownership-decision-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-legacy-adapter-ownership-decision-2026-05-28.md",
+        "governance/mainline/task-cards/pr-355.yaml"
+      ],
+      "decision": {
+        "classification": "legacy_compatibility_surfaces_without_active_external_module_path_imports",
+        "ownership": "legacy compatibility ownership must be decided explicitly; static non-use is not deletion authority",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-202",
+        "selected_next_governance_target": "data-quality-legacy-adapter-compatibility-closure-authorization",
+        "recommended_next_work_item": "G2.203 data-quality legacy adapter compatibility closure authorization package",
+        "future_authorization_options": [
+          "thin compatibility wrapper",
+          "retirement with consumer/import smoke and rollback gates",
+          "retained legacy surface if current consumer contradiction appears"
+        ]
+      },
+      "target_facts": {
+        "legacy_dashboard": {
+          "path": "web/backend/app/services/data_adapters/dashboard.py",
+          "class": "DashboardDataSourceAdapter",
+          "lines": 299,
+          "get_data_quality_monitor_calls": 1,
+          "gitnexus_impact": "LOW; impacted_count=0"
+        },
+        "legacy_data_source": {
+          "path": "web/backend/app/services/data_adapters/data_source.py",
+          "class": "DataDataSourceAdapter",
+          "lines": 688,
+          "get_data_quality_monitor_calls": 1,
+          "gitnexus_impact": "LOW; impacted_count=0"
+        }
+      },
+      "consumer_scan": {
+        "external_python_legacy_module_imports": 0,
+        "class_name_scan_note": "ambiguous because canonical app.services.adapters modules share names",
+        "root_facade_truth": "web/backend/app/services/data_adapter.py imports from app.services.adapters",
+        "factory_truth": "data_source_factory imports through app.services.data_adapter facade"
+      },
+      "forbidden_surfaces_preserved": [
+        "web/backend/app/services/market_data_adapter.py",
+        "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "web/backend/app/services/data_quality_monitor.py",
+        "web/backend/app/services/adapters/**",
+        "web/backend/app/services/adapter_split/**",
+        "web/backend/app/api/**",
+        "web/frontend/**",
+        "src/**",
+        "tests/**",
+        "docs/api/**",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "freshness": {
+        "current_head_checked": "e672f1523c30037202310278daf71488681d9a1f",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.203 data-quality legacy adapter compatibility closure authorization without source authority."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T11:30:22+08:00`
-- Base HEAD checked: `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e`
+- Prepared at: `2026-05-28T11:53:30+08:00`
+- Base HEAD checked: `e672f1523c30037202310278daf71488681d9a1f`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -53,7 +53,8 @@ It proved a repeatable conveyor:
 | G2.198 data-quality residual adapter ownership decision | Merged by PR `#351` | Selects canonical service adapters as the next authorization target while deferring legacy data adapters, `market_data_adapter.py`, and wrapper retention |
 | G2.199 data-quality canonical service adapter provider authorization | Merged by PR `#352` | Authorizes future G2.200 implementation for canonical service adapters only; no source edits in G2.199 |
 | G2.200 data-quality canonical service adapter provider implementation | Merged by PR `#353` | Implements optional constructor monitor injection in the two canonical service adapters with focused TDD evidence |
-| G2.201 data-quality canonical service adapter closeout / refresh | For review | Closes the canonical service adapter lane and selects legacy data adapter compatibility ownership as the next decision gate |
+| G2.201 data-quality canonical service adapter closeout / refresh | Merged by PR `#354` | Closes the canonical service adapter lane and selects legacy data adapter compatibility ownership as the next decision gate |
+| G2.202 data-quality legacy adapter compatibility ownership decision | For review | Classifies two legacy `data_adapters` files as compatibility ownership surfaces and selects G2.203 authorization-only compatibility closure |
 
 ## Current Strategy Getter Residuals
 
@@ -476,11 +477,36 @@ GitNexus reference for deferred surfaces:
 | `web/backend/app/services/market_data_adapter.py` | LOW | `impacted_count=3`, `direct=1`, `processes_affected=0` |
 | `web/backend/app/services/_data_quality_monitor_singleton.py` | LOW | `impacted_count=19`, `direct=1`, `processes_affected=0` |
 
+## G2.202 Data-Quality Legacy Adapter Compatibility Ownership Decision
+
+At HEAD `e672f1523c30037202310278daf71488681d9a1f`, PR `#354` is merged and
+G2.201 is accepted.
+
+Decision result:
+
+| Target | Evidence | Decision |
+|---|---|---|
+| `web/backend/app/services/data_adapters/dashboard.py` | `DashboardDataSourceAdapter`, 299 lines, one `get_data_quality_monitor()` call, GitNexus `LOW/0` | Legacy compatibility ownership surface; no source edits in G2.202 |
+| `web/backend/app/services/data_adapters/data_source.py` | `DataDataSourceAdapter`, 688 lines, one `get_data_quality_monitor()` call, GitNexus `LOW/0` | Legacy compatibility ownership surface; no source edits in G2.202 |
+
+Consumer evidence:
+
+| Check | Result |
+|---|---|
+| Exact module-path imports of `app.services.data_adapters.dashboard` / `data_source` outside the legacy package | `0` |
+| Class-name text scan | Ambiguous because canonical `app.services.adapters.*` classes share the names |
+| Root facade | `web/backend/app/services/data_adapter.py` imports from canonical `app.services.adapters` |
+| Data source factory | Imports through `app.services.data_adapter` facade, not the legacy module path |
+
+G2.202 selects G2.203 as an authorization-only compatibility closure package.
+G2.203 must decide the exact implementation shape before any source lane:
+thin wrapper, retirement with rollback gates, or retained legacy surface.
+
 ## Next Gates
 
-- Review G2.201 data-quality canonical service adapter closeout / refresh.
-- If accepted, start G2.202 data-quality legacy adapter compatibility ownership decision.
-- Do not start a source lane for legacy adapters before G2.202 is accepted.
+- Review G2.202 data-quality legacy adapter compatibility ownership decision.
+- If accepted, start G2.203 data-quality legacy adapter compatibility closure authorization.
+- Do not start a source lane for legacy adapters before G2.203 authorization is accepted.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/reports/quality/backend-data-quality-legacy-adapter-ownership-decision-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-legacy-adapter-ownership-decision-2026-05-28.md
@@ -1,0 +1,93 @@
+# Backend Data-Quality Legacy Adapter Ownership Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Node: G2.202 data-quality legacy adapter compatibility ownership decision
+- Status: decision-only package
+- Prepared at: `2026-05-28T11:53:30+08:00`
+- Base HEAD checked: `e672f1523c30037202310278daf71488681d9a1f`
+- Parent closeout: G2.201, PR `#354`, merge commit `e672f1523c30037202310278daf71488681d9a1f`
+- Source edit authority: no
+
+Boundary note: this package classifies legacy adapter ownership. It does not
+authorize source edits, compatibility wrapper deletion, route changes, OpenAPI
+contract changes, frontend changes, config/script changes, OpenSpec changes, or
+GitHub issue label changes.
+
+## Decision
+
+G2.202 classifies these files as legacy compatibility ownership surfaces, not as
+an immediate implementation lane:
+
+| Target | Current fact | Decision |
+|---|---|---|
+| `web/backend/app/services/data_adapters/dashboard.py` | Contains `DashboardDataSourceAdapter`, one `get_data_quality_monitor()` call, GitNexus upstream impact `LOW/0` | Candidate for future compatibility closure authorization; no source edits here |
+| `web/backend/app/services/data_adapters/data_source.py` | Contains `DataDataSourceAdapter`, one `get_data_quality_monitor()` call, GitNexus upstream impact `LOW/0` | Candidate for future compatibility closure authorization; no source edits here |
+
+Module-path consumer scan found no external Python imports of
+`app.services.data_adapters.dashboard` or
+`app.services.data_adapters.data_source` outside the legacy package. This is
+useful evidence, but it is not deletion authority. Static non-use remains
+insufficient to remove compatibility surfaces without a separate authorization
+and rollback plan.
+
+## Consumer Evidence
+
+| Evidence | Result |
+|---|---|
+| Exact legacy module import scan | `external_python_legacy_module_imports=0` |
+| Class-name text scan | Ambiguous because canonical `app.services.adapters.*` classes use the same names |
+| Root facade truth | `web/backend/app/services/data_adapter.py` imports from canonical `app.services.adapters` |
+| Factory truth | `web/backend/app/services/data_source_factory/data_source_factory.py` imports through the root facade, not the legacy module path |
+| OpenAPI/docs/planning hits | Historical or generated references only; not runtime consumers |
+
+## Scope Classification
+
+| Surface | Classification | Source authority |
+|---|---|---|
+| Legacy `data_adapters/dashboard.py` and `data_adapters/data_source.py` | G2.202 decision target | No |
+| `market_data_adapter.py` root facade | Deferred owner-specific compatibility facade surface | No |
+| Singleton wrapper/backing API | Retained backing API; not a deletion lane | No |
+| Canonical service adapters | Closed by G2.200/G2.201 | No |
+| Route/OpenAPI/frontend/config/scripts/OpenSpec | Out of scope | No |
+
+## Next Gate
+
+Start G2.203 as an authorization-only package:
+
+| Future gate | Scope | Source authority |
+|---|---|---|
+| G2.203 data-quality legacy adapter compatibility closure authorization | Decide the exact approved implementation shape for the two legacy files: thin compatibility wrapper, retirement, or retained legacy surface | No |
+
+G2.203 must include, at minimum:
+
+- current-HEAD module-path consumer scan
+- GitNexus impact for both target files before authorizing any source edit lane
+- exact implementation shape and rollback plan
+- import smoke for `app.services.data_adapter` and `data_source_factory`
+- focused regression plan if a later source implementation is approved
+- explicit exclusion of `market_data_adapter.py`, singleton wrapper/backing API,
+  canonical adapters, routes, OpenAPI, frontend, config, scripts, and OpenSpec
+  files
+
+## Verification
+
+| Check | Result |
+|---|---|
+| JSON/YAML parse | Passed for generated decision JSON, `steward-index.json`, and `pr-355.yaml` |
+| Markdown governance | Passed, `checked_files=6`, `errors=0` |
+| OpenSpec validation | `openspec validate migrate-backend-singletons-to-lifecycle-di --strict` passed; PostHog network flush warning is telemetry noise |
+| Diff whitespace | `git diff --check` and `git diff --cached --check` passed |
+| GitNexus staged scope | Low risk, `changed_files=9`, `changed_symbols=0`, `affected_processes=0` |
+| Mainline scope gate | Passed, `changed_files=9`, `violations=0`, report `/tmp/pr355-mainline-governance-report.json` |
+
+## Non-Goals
+
+- Do not edit `web/backend/app/services/data_adapters/dashboard.py`.
+- Do not edit `web/backend/app/services/data_adapters/data_source.py`.
+- Do not delete or convert the legacy files in G2.202.
+- Do not touch `market_data_adapter.py`, singleton wrapper/backing API,
+  canonical adapters, routes, OpenAPI, frontend, config, scripts, or OpenSpec
+  files.

--- a/governance/mainline/task-cards/pr-355.yaml
+++ b/governance/mainline/task-cards/pr-355.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-355"
+  title: "Decide data-quality legacy adapter compatibility ownership"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-legacy-adapter-ownership-decision"
+  objective: "classify legacy data-quality adapter compatibility ownership and select the next authorization gate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only decision package; no route paths, HTTP methods, response models, OpenAPI examples, frontend behavior, PM2 workflows, or public API ownership changes"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-legacy-adapter-ownership-decision-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-legacy-adapter-ownership-decision-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-355.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/FUNCTION_TREE.md"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "governance/function-tree/catalog.yaml"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source implementation"
+  - "test source edits"
+  - "legacy data adapter deletion"
+  - "legacy data adapter wrapper conversion"
+  - "market_data_adapter.py edits"
+  - "singleton wrapper deletion"
+  - "route changes"
+  - "OpenAPI contract changes"
+  - "frontend changes"
+  - "OpenSpec proposal creation"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-legacy-adapter-ownership-decision-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-355.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-legacy-adapter-ownership-decision-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-355.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha e672f1523c30037202310278daf71488681d9a1f --head-sha HEAD --report /tmp/pr355-mainline-governance-report.json"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Treating G2.202 as deletion authority would bypass the required authorization and implementation gates."
+    - "Class-name text hits are ambiguous because canonical adapters share names with legacy adapters."
+  rollback_plan: "revert this PR to restore the post-#354 steward state and rerun the legacy adapter ownership decision."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "classify legacy data-quality adapter compatibility ownership and select the next authorization gate"
+    modified_scope: "governance reports, generated evidence, steward tree files, and one task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no backend source files are modified"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if the legacy adapter classification or next gate is incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T11:53:30+08:00"
+    approval_note: "Human maintainer approved continuing after PR #354 acceptance; this lane is decision-only legacy adapter compatibility ownership."
+    secondary_approved: true


### PR DESCRIPTION
## Summary

- Adds G2.202 decision-only package for data-quality legacy adapter compatibility ownership.
- Records evidence for web/backend/app/services/data_adapters/dashboard.py and web/backend/app/services/data_adapters/data_source.py: each has one data-quality monitor getter call, GitNexus LOW/0 impact, and no external Python module-path imports found.
- Updates steward tree state and selects G2.203 as an authorization-only compatibility closure package.

## Boundary

No backend source, tests, OpenSpec, route/OpenAPI, frontend, config, or script files are changed. G2.202 is not deletion authority.

## Verification

- JSON/YAML parse: passed
- Markdown governance: passed, checked_files=6, errors=0
- OpenSpec strict validate: valid; PostHog telemetry warning only
- git diff --check / cached check: passed
- GitNexus staged + compare: low risk, changed_files=9, changed_symbols=0, affected_processes=0
- Mainline scope gate: passed, changed_files=9, violations=0