### PR TITLE
docs(governance): authorize data quality legacy adapter closure

### DIFF
--- a/.planning/codebase/generated/data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "2026-05-28.g2-authorization.v1",
+  "node": "G2.203 data-quality legacy adapter compatibility closure authorization",
+  "generated_at": "2026-05-28T12:37:20+08:00",
+  "git": {
+    "branch": "g2-203-data-quality-legacy-adapter-compatibility-closure-authorization",
+    "base_branch": "wip/root-dirty-20260403",
+    "base_head": "bf5d5ffba6bfc837c009a3d937cf0a9e6549883f",
+    "current_head_checked": "bf5d5ffba6bfc837c009a3d937cf0a9e6549883f",
+    "stale_if_head_mismatch": true
+  },
+  "parent": {
+    "node": "G2.202 data-quality legacy adapter compatibility ownership decision",
+    "github_pr": 355,
+    "merge_commit": "bf5d5ffba6bfc837c009a3d937cf0a9e6549883f",
+    "relationship": "G2.202 selected this authorization-only compatibility closure package"
+  },
+  "source_edit_authority": false,
+  "future_source_lane": {
+    "recommended_node": "G2.204 data-quality legacy adapter compatibility wrapper implementation",
+    "authorized_shape": "convert the two legacy data_adapters modules into thin compatibility wrappers that re-export canonical app.services.adapters classes",
+    "deletion_authorized": false,
+    "source_authority_after_human_acceptance": true,
+    "allowed_source_paths_after_acceptance": [
+      "web/backend/app/services/data_adapters/dashboard.py",
+      "web/backend/app/services/data_adapters/data_source.py"
+    ],
+    "allowed_test_paths_after_acceptance": [
+      "web/backend/tests/test_data_quality_legacy_data_adapter_compat.py"
+    ]
+  },
+  "current_evidence": {
+    "exact_legacy_module_imports_outside_package": 0,
+    "total_get_data_quality_monitor_calls": 9,
+    "legacy_target_getter_calls": [
+      {
+        "path": "web/backend/app/services/data_adapters/dashboard.py",
+        "line": 249,
+        "line_text": "monitor = get_data_quality_monitor()"
+      },
+      {
+        "path": "web/backend/app/services/data_adapters/data_source.py",
+        "line": 608,
+        "line_text": "monitor = get_data_quality_monitor()"
+      }
+    ],
+    "gitnexus": {
+      "web/backend/app/services/data_adapters/dashboard.py": {
+        "risk": "LOW",
+        "impacted_count": 0,
+        "direct": 0,
+        "processes_affected": 0
+      },
+      "web/backend/app/services/data_adapters/data_source.py": {
+        "risk": "LOW",
+        "impacted_count": 0,
+        "direct": 0,
+        "processes_affected": 0
+      }
+    }
+  },
+  "authorization_decision": {
+    "classification": "authorize_thin_wrapper_implementation_after_human_acceptance",
+    "why_not_delete": "Exact module-path consumer count is zero, but static non-use is not deletion authority and hidden consumers may rely on old import paths.",
+    "why_thin_wrapper": "Thin wrappers preserve old module paths while removing duplicate legacy implementation bodies and their direct global monitor calls.",
+    "source_lane_recommendation": "start G2.204 only after this authorization package is accepted"
+  },
+  "future_g2_204_acceptance": [
+    "GitNexus impact for both legacy files before editing",
+    "red test proving legacy module imports resolve to canonical classes or equivalent wrapper contract",
+    "convert only the two legacy modules to thin wrappers; do not delete files",
+    "focused test coverage for legacy module import compatibility and canonical class identity or behavior",
+    "import smoke for app.services.data_adapter and data_source_factory",
+    "targeted ruff for changed source and test files",
+    "rg verification that get_data_quality_monitor() no longer appears in the two legacy modules",
+    "GitNexus staged detect_changes before commit",
+    "mainline scope gate with G2.204 task card"
+  ],
+  "forbidden_future_g2_204_scope": [
+    "web/backend/app/services/market_data_adapter.py",
+    "web/backend/app/services/_data_quality_monitor_singleton.py",
+    "web/backend/app/services/data_quality_monitor.py",
+    "web/backend/app/services/adapters/**",
+    "web/backend/app/services/adapters_split/**",
+    "web/backend/app/api/**",
+    "web/frontend/**",
+    "src/**",
+    "docs/api/**",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**"
+  ],
+  "validation": {
+    "json_parse": "passed",
+    "yaml_parse": "passed",
+    "markdown_governance": "passed; checked_files=6; errors=0",
+    "openspec_validate": "passed; PostHog telemetry warning only",
+    "git_diff_check": "passed",
+    "mainline_scope_gate": "passed; changed_files=9; violations=0; report=/tmp/pr356-mainline-governance-report.json",
+    "gitnexus_staged_detect_changes": "low risk; changed_files=9; changed_symbols=0; affected_processes=0"
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T11:53:30+08:00`
-- Base HEAD checked: `e672f1523c30037202310278daf71488681d9a1f`
+- Prepared at: `2026-05-28T12:37:20+08:00`
+- Base HEAD checked: `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -39,12 +39,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#352` | `g2-199-data-quality-canonical-service-adapter-authorization` | `wip/root-dirty-20260403` | `MERGED` at `41bef3787160ec3bf7b9b31220df9d99a3437474` | Authorization package for G2.200 canonical service adapter provider implementation |
 | `#353` | `g2-200-data-quality-canonical-service-adapter-provider` | `wip/root-dirty-20260403` | `MERGED` at `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e` | Path-limited canonical service adapter provider implementation closed for G2.201 refresh |
 | `#354` | `g2-201-data-quality-canonical-service-adapter-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `e672f1523c30037202310278daf71488681d9a1f` | Governance closeout selecting G2.202 legacy adapter compatibility ownership decision |
+| `#355` | `g2-202-data-quality-legacy-adapter-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f` | Decision package selecting G2.203 legacy adapter compatibility closure authorization |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-202-data-quality-legacy-adapter-ownership-decision` | `origin/wip/root-dirty-20260403` at `e672f1523c30037202310278daf71488681d9a1f` | Classify legacy data-quality adapter compatibility ownership and select the next authorization gate | No |
+| `g2-203-data-quality-legacy-adapter-compatibility-closure-authorization` | `origin/wip/root-dirty-20260403` at `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f` | Authorize future thin-wrapper compatibility closure for the two legacy data-quality adapter modules | No |
 
 ## OpenSpec Relationship
 
@@ -60,7 +61,8 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.202 is a governance-only decision branch after PR `#354` merged G2.201. It
-classifies the two legacy `web/backend/app/services/data_adapters/*` targets,
-records that exact module-path non-use is evidence but not deletion authority,
-and selects G2.203 as an authorization-only compatibility closure package.
+G2.203 is a governance-only authorization branch after PR `#355` merged G2.202.
+It authorizes only a future thin-wrapper implementation shape for the two
+legacy `web/backend/app/services/data_adapters/*` targets. It does not authorize
+deletion, direct source edits in this PR, or expansion into other adapter,
+wrapper, route, OpenAPI, frontend, config, script, or OpenSpec surfaces.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T11:53:30+08:00`
-- Base HEAD checked: `e672f1523c30037202310278daf71488681d9a1f`
+- Prepared at: `2026-05-28T12:37:20+08:00`
+- Base HEAD checked: `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 is the active decision package selecting G2.203 authorization-only legacy adapter compatibility closure |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 is the active authorization package for thin-wrapper legacy adapter compatibility closure |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T11:53:30+08:00`
-- Base HEAD checked: `e672f1523c30037202310278daf71488681d9a1f`
+- Prepared at: `2026-05-28T12:37:20+08:00`
+- Base HEAD checked: `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.202 data-quality legacy adapter compatibility ownership decision | G/#79 service lifecycle DI | PR `#354` merged at `e672f1523c30037202310278daf71488681d9a1f`; G2.202 classifies two legacy `data_adapters` files as compatibility ownership surfaces | If accepted, start G2.203 authorization-only compatibility closure package; do not edit or delete legacy files directly from G2.202 |
+| P0 | Review G2.203 data-quality legacy adapter compatibility closure authorization | G/#79 service lifecycle DI | PR `#355` merged at `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f`; G2.203 authorizes only a future thin-wrapper compatibility implementation shape | If accepted, start G2.204 source lane for two legacy modules plus one focused test; do not delete files |
+| P0 | Preserve G2.202 data-quality legacy adapter compatibility ownership decision | G/#79 service lifecycle DI | PR `#355` merged; G2.202 classifies two legacy `data_adapters` files as compatibility ownership surfaces | Do not edit or delete legacy files directly from G2.202 |
 | P0 | Preserve G2.201 data-quality canonical service adapter closeout / refresh | G/#79 service lifecycle DI | PR `#354` merged; G2.201 closes the canonical service adapter lane and selects G2.202 | Do not reopen canonical service adapter source unless current HEAD evidence contradicts G2.200/G2.201 |
 | P0 | Preserve G2.200 data-quality canonical service adapter provider implementation | G/#79 service lifecycle DI | PR `#353` merged; canonical service adapters now have optional monitor injection with singleton fallback | Do not reopen canonical service adapter source unless current HEAD evidence contradicts G2.200 tests |
 | P0 | Preserve G2.199 data-quality canonical service adapter provider authorization | G/#79 service lifecycle DI | PR `#352` merged; G2.200 source authority was limited to two canonical service adapters and listed tests | Do not touch legacy data adapters, `market_data_adapter.py`, wrapper, or monitor internals without a new decision package |
@@ -44,8 +45,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.202 correctly classify `web/backend/app/services/data_adapters/dashboard.py` and `web/backend/app/services/data_adapters/data_source.py` as legacy compatibility ownership surfaces?
-- Does G2.202 preserve the rule that module-path non-use is evidence, not deletion authority?
-- Does G2.202 correctly select G2.203 as an authorization-only compatibility closure package?
+- Does G2.203 correctly authorize only thin compatibility wrappers for the two legacy `data_adapters` modules?
+- Does G2.203 preserve the rule that deletion is not authorized?
+- Does G2.203 correctly select G2.204 as a separate source implementation lane after human acceptance?
 - Are `market_data_adapter.py`, singleton wrapper, route/OpenAPI, frontend, config, script, canonical adapter, and OpenSpec surfaces still deferred?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T11:53:30+08:00`
-- Base HEAD checked: `e672f1523c30037202310278daf71488681d9a1f`
+- Prepared at: `2026-05-28T12:37:20+08:00`
+- Base HEAD checked: `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -65,8 +65,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-canonical-service-adapter-provider-implementation-2026-05-28.md` | G2.200 human-readable implementation report | Accepted by PR `#353`; superseded for residual refresh by G2.201 |
 | `.planning/codebase/generated/data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.json` | G2.201 canonical service adapter closeout / residual refresh evidence | Accepted by PR `#354`; superseded for legacy adapter ownership by G2.202 |
 | `docs/reports/quality/backend-data-quality-canonical-service-adapter-closeout-refresh-2026-05-28.md` | G2.201 human-readable closeout / residual refresh report | Accepted by PR `#354`; superseded for legacy adapter ownership by G2.202 |
-| `.planning/codebase/generated/data-quality-legacy-adapter-ownership-decision-2026-05-28.json` | G2.202 legacy data adapter compatibility ownership decision evidence | Current for HEAD `e672f1523c30037202310278daf71488681d9a1f`; review input until PR `#355` is accepted |
-| `docs/reports/quality/backend-data-quality-legacy-adapter-ownership-decision-2026-05-28.md` | G2.202 human-readable ownership decision report | Review input until PR `#355` is accepted |
+| `.planning/codebase/generated/data-quality-legacy-adapter-ownership-decision-2026-05-28.json` | G2.202 legacy data adapter compatibility ownership decision evidence | Accepted by PR `#355`; superseded for closure authorization by G2.203 |
+| `docs/reports/quality/backend-data-quality-legacy-adapter-ownership-decision-2026-05-28.md` | G2.202 human-readable ownership decision report | Accepted by PR `#355`; superseded for closure authorization by G2.203 |
+| `.planning/codebase/generated/data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.json` | G2.203 legacy adapter compatibility closure authorization evidence | Current for HEAD `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f`; review input until PR `#356` is accepted |
+| `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.md` | G2.203 human-readable compatibility closure authorization report | Review input until PR `#356` is accepted |
 
 ## External State Inputs
 
@@ -92,7 +94,8 @@ state transition.
 | GitHub PR `#352` | `MERGED` | G2.199 canonical service adapter authorization merged by commit `41bef3787160ec3bf7b9b31220df9d99a3437474` |
 | GitHub PR `#353` | `MERGED` | G2.200 canonical service adapter provider implementation merged by commit `cbd9b3a7ee730c72a63dbc7adb6490564c12c71e` |
 | GitHub PR `#354` | `MERGED` | G2.201 canonical service adapter closeout / residual refresh merged by commit `e672f1523c30037202310278daf71488681d9a1f` |
-| `origin/wip/root-dirty-20260403` | `e672f1523c30037202310278daf71488681d9a1f` | Base used for this legacy adapter ownership decision branch |
+| GitHub PR `#355` | `MERGED` | G2.202 legacy adapter ownership decision merged by commit `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f` |
+| `origin/wip/root-dirty-20260403` | `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f` | Base used for this compatibility closure authorization branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T11:53:30+08:00",
+  "generated_at": "2026-05-28T12:37:20+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "e672f1523c30037202310278daf71488681d9a1f",
-  "split_branch": "g2-202-data-quality-legacy-adapter-ownership-decision",
-  "scope": "data_quality_legacy_adapter_ownership_decision",
+  "base_head": "bf5d5ffba6bfc837c009a3d937cf0a9e6549883f",
+  "split_branch": "g2-203-data-quality-legacy-adapter-compatibility-closure-authorization",
+  "scope": "data_quality_legacy_adapter_compatibility_closure_authorization",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -1591,12 +1591,14 @@
     {
       "id": "g2-202-data-quality-legacy-adapter-ownership-decision",
       "type": "decision_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.201 data-quality canonical service adapter closeout / refresh",
       "source_edit_authority": false,
       "parent_github_pr": 354,
       "parent_merge_commit": "e672f1523c30037202310278daf71488681d9a1f",
+      "github_pr": 355,
+      "merge_commit": "bf5d5ffba6bfc837c009a3d937cf0a9e6549883f",
       "evidence": [
         ".planning/codebase/generated/data-quality-legacy-adapter-ownership-decision-2026-05-28.json",
         "docs/reports/quality/backend-data-quality-legacy-adapter-ownership-decision-2026-05-28.md",
@@ -1656,7 +1658,60 @@
         "current_head_checked": "e672f1523c30037202310278daf71488681d9a1f",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.203 data-quality legacy adapter compatibility closure authorization without source authority."
+      "next_gate": "Superseded by G2.203 data-quality legacy adapter compatibility closure authorization."
+    },
+    {
+      "id": "g2-203-data-quality-legacy-adapter-compatibility-closure-authorization",
+      "type": "authorization_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.202 data-quality legacy adapter compatibility ownership decision",
+      "source_edit_authority": false,
+      "parent_github_pr": 355,
+      "parent_merge_commit": "bf5d5ffba6bfc837c009a3d937cf0a9e6549883f",
+      "evidence": [
+        ".planning/codebase/generated/data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.md",
+        "governance/mainline/task-cards/pr-356.yaml"
+      ],
+      "authorization": {
+        "classification": "authorize-thin-wrapper-implementation-after-human-acceptance",
+        "recommended_next_work_item": "G2.204 data-quality legacy adapter compatibility wrapper implementation",
+        "authorized_shape": "convert both legacy data_adapters modules into thin compatibility wrappers re-exporting canonical app.services.adapters classes",
+        "deletion_authorized": false,
+        "future_source_lane_paths": [
+          "web/backend/app/services/data_adapters/dashboard.py",
+          "web/backend/app/services/data_adapters/data_source.py",
+          "web/backend/tests/test_data_quality_legacy_data_adapter_compat.py"
+        ]
+      },
+      "current_evidence": {
+        "external_python_legacy_module_imports": 0,
+        "target_getter_calls": 2,
+        "legacy_dashboard": "LOW; impacted_count=0; getter line 249",
+        "legacy_data_source": "LOW; impacted_count=0; getter line 608",
+        "why_not_delete": "static non-use is not deletion authority; thin wrappers preserve hidden import compatibility"
+      },
+      "forbidden_surfaces_preserved": [
+        "web/backend/app/services/market_data_adapter.py",
+        "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "web/backend/app/services/data_quality_monitor.py",
+        "web/backend/app/services/adapters/**",
+        "web/backend/app/services/adapters_split/**",
+        "web/backend/app/api/**",
+        "web/frontend/**",
+        "src/**",
+        "docs/api/**",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "freshness": {
+        "current_head_checked": "bf5d5ffba6bfc837c009a3d937cf0a9e6549883f",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.204 data-quality legacy adapter compatibility wrapper implementation with source authority limited to two legacy modules and one focused test."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T11:53:30+08:00`
-- Base HEAD checked: `e672f1523c30037202310278daf71488681d9a1f`
+- Prepared at: `2026-05-28T12:37:20+08:00`
+- Base HEAD checked: `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -54,7 +54,8 @@ It proved a repeatable conveyor:
 | G2.199 data-quality canonical service adapter provider authorization | Merged by PR `#352` | Authorizes future G2.200 implementation for canonical service adapters only; no source edits in G2.199 |
 | G2.200 data-quality canonical service adapter provider implementation | Merged by PR `#353` | Implements optional constructor monitor injection in the two canonical service adapters with focused TDD evidence |
 | G2.201 data-quality canonical service adapter closeout / refresh | Merged by PR `#354` | Closes the canonical service adapter lane and selects legacy data adapter compatibility ownership as the next decision gate |
-| G2.202 data-quality legacy adapter compatibility ownership decision | For review | Classifies two legacy `data_adapters` files as compatibility ownership surfaces and selects G2.203 authorization-only compatibility closure |
+| G2.202 data-quality legacy adapter compatibility ownership decision | Merged by PR `#355` | Classifies two legacy `data_adapters` files as compatibility ownership surfaces and selects G2.203 authorization-only compatibility closure |
+| G2.203 data-quality legacy adapter compatibility closure authorization | For review | Authorizes only a future thin-wrapper compatibility implementation shape for the two legacy modules; deletion remains unauthorized |
 
 ## Current Strategy Getter Residuals
 
@@ -502,11 +503,37 @@ G2.202 selects G2.203 as an authorization-only compatibility closure package.
 G2.203 must decide the exact implementation shape before any source lane:
 thin wrapper, retirement with rollback gates, or retained legacy surface.
 
+## G2.203 Data-Quality Legacy Adapter Compatibility Closure Authorization
+
+At HEAD `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f`, PR `#355` is merged and
+G2.202 is accepted.
+
+Authorization result:
+
+| Future lane | Authorized files | Authorized shape |
+|---|---|---|
+| G2.204 data-quality legacy adapter compatibility wrapper implementation | `web/backend/app/services/data_adapters/dashboard.py`, `web/backend/app/services/data_adapters/data_source.py`, `web/backend/tests/test_data_quality_legacy_data_adapter_compat.py` | Thin compatibility wrappers re-exporting canonical `app.services.adapters` classes |
+
+Current evidence:
+
+| Check | Result |
+|---|---|
+| Exact external imports of legacy module paths | `0` |
+| Target getter calls | Two calls total, one in each legacy module |
+| GitNexus impact | LOW/0 for both target files |
+| Deletion authority | Not granted |
+
+G2.203 does not authorize source edits in this PR. If accepted, G2.204 may edit
+only the two legacy modules and one focused compatibility test. It must not
+delete files, touch `market_data_adapter.py`, alter singleton wrapper/backing
+APIs, edit canonical adapters, or expand into routes, OpenAPI, frontend, config,
+scripts, or OpenSpec files.
+
 ## Next Gates
 
-- Review G2.202 data-quality legacy adapter compatibility ownership decision.
-- If accepted, start G2.203 data-quality legacy adapter compatibility closure authorization.
-- Do not start a source lane for legacy adapters before G2.203 authorization is accepted.
+- Review G2.203 data-quality legacy adapter compatibility closure authorization.
+- If accepted, start G2.204 data-quality legacy adapter compatibility wrapper implementation.
+- Do not delete legacy modules; G2.204 is limited to thin wrappers plus focused tests.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.md
@@ -1,0 +1,97 @@
+# Backend Data-Quality Legacy Adapter Compatibility Closure Authorization
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Node: G2.203 data-quality legacy adapter compatibility closure authorization
+- Status: authorization-only package
+- Prepared at: `2026-05-28T12:37:20+08:00`
+- Base HEAD checked: `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f`
+- Parent decision: G2.202, PR `#355`, merge commit `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f`
+- Source edit authority in this PR: no
+
+Boundary note: this authorization package defines what a future implementation
+lane may do after human acceptance. It does not edit source files, delete legacy
+modules, change routes, change OpenAPI contracts, change frontend behavior,
+change config/scripts, create OpenSpec proposals, or change GitHub issue labels.
+
+## Authorization Decision
+
+If accepted, G2.203 authorizes a future G2.204 source lane with this exact
+implementation shape:
+
+Convert the two legacy `data_adapters` modules into thin compatibility wrappers
+that re-export the canonical `app.services.adapters` classes.
+
+Deletion is not authorized.
+
+| Future lane | Authorized source paths | Authorized test path | Authorized shape |
+|---|---|---|---|
+| G2.204 data-quality legacy adapter compatibility wrapper implementation | `web/backend/app/services/data_adapters/dashboard.py`, `web/backend/app/services/data_adapters/data_source.py` | `web/backend/tests/test_data_quality_legacy_data_adapter_compat.py` | Thin wrappers preserving old module import paths |
+
+## Evidence
+
+At HEAD `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f`:
+
+| Check | Result |
+|---|---|
+| Exact external imports of `app.services.data_adapters.dashboard` / `data_source` | `0` |
+| `web/backend/app/services/data_adapters/dashboard.py` | 299 lines, class `DashboardDataSourceAdapter`, one `get_data_quality_monitor()` call at line 249 |
+| `web/backend/app/services/data_adapters/data_source.py` | 688 lines, class `DataDataSourceAdapter`, one `get_data_quality_monitor()` call at line 608 |
+| GitNexus impact for `dashboard.py` | LOW, `impacted_count=0`, `processes_affected=0` |
+| GitNexus impact for `data_source.py` | LOW, `impacted_count=0`, `processes_affected=0` |
+
+Why not delete:
+
+- exact module-path consumer count is useful evidence, not deletion authority
+- hidden consumers may still rely on the old module import paths
+- thin wrappers remove duplicated legacy implementation and getter calls while
+  preserving compatibility
+
+## Future G2.204 Required Checks
+
+G2.204 must be a separate source implementation lane after G2.203 is accepted.
+It must include:
+
+- GitNexus impact for both legacy files before editing
+- a red test proving legacy module import compatibility
+- conversion of only the two legacy modules into thin wrappers
+- no file deletion
+- focused tests for legacy module imports and canonical class identity or
+  equivalent wrapper behavior
+- import smoke for `app.services.data_adapter` and `data_source_factory`
+- targeted ruff for changed source and test files
+- `rg` verification that `get_data_quality_monitor()` no longer appears in the
+  two legacy modules
+- GitNexus staged `detect_changes`
+- mainline scope gate with a G2.204 task card
+
+## Forbidden Future Scope
+
+G2.204 must not batch any of these:
+
+- `web/backend/app/services/market_data_adapter.py`
+- `web/backend/app/services/_data_quality_monitor_singleton.py`
+- `web/backend/app/services/data_quality_monitor.py`
+- `web/backend/app/services/adapters/**`
+- `web/backend/app/services/adapters_split/**`
+- `web/backend/app/api/**`
+- `web/frontend/**`
+- `src/**`
+- `docs/api/**`
+- `config/**`
+- `scripts/**`
+- `openspec/changes/**`
+- `openspec/specs/**`
+
+## Verification
+
+| Check | Result |
+|---|---|
+| JSON/YAML parse | Passed for generated authorization JSON, `steward-index.json`, and `pr-356.yaml` |
+| Markdown governance | Passed, `checked_files=6`, `errors=0` |
+| OpenSpec validation | `openspec validate migrate-backend-singletons-to-lifecycle-di --strict` passed; PostHog network flush warning is telemetry noise |
+| Diff whitespace | `git diff --check` and `git diff --cached --check` passed |
+| GitNexus staged scope | Low risk, `changed_files=9`, `changed_symbols=0`, `affected_processes=0` |
+| Mainline scope gate | Passed, `changed_files=9`, `violations=0`, report `/tmp/pr356-mainline-governance-report.json` |

--- a/governance/mainline/task-cards/pr-356.yaml
+++ b/governance/mainline/task-cards/pr-356.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-356"
+  title: "Authorize data-quality legacy adapter compatibility closure"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-legacy-adapter-compatibility-closure-authorization"
+  objective: "authorize the future legacy adapter compatibility wrapper implementation shape without source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only authorization package; no route paths, HTTP methods, response models, OpenAPI examples, frontend behavior, PM2 workflows, or public API ownership changes"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-356.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/FUNCTION_TREE.md"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "governance/function-tree/catalog.yaml"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source implementation"
+  - "test source edits"
+  - "legacy data adapter deletion"
+  - "legacy data adapter wrapper conversion in this PR"
+  - "market_data_adapter.py edits"
+  - "singleton wrapper deletion"
+  - "route changes"
+  - "OpenAPI contract changes"
+  - "frontend changes"
+  - "OpenSpec proposal creation"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-356.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-356.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha bf5d5ffba6bfc837c009a3d937cf0a9e6549883f --head-sha HEAD --report /tmp/pr356-mainline-governance-report.json"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Treating G2.203 as source authority would bypass the required G2.204 implementation lane."
+    - "Deleting legacy modules would remove compatibility paths; G2.203 authorizes thin wrappers only, not deletion."
+  rollback_plan: "revert this PR to restore the post-#355 steward state and rerun the compatibility closure authorization."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize future thin-wrapper compatibility closure for two legacy data-quality adapter modules"
+    modified_scope: "governance reports, generated evidence, steward tree files, and one task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; no backend source files are modified"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if the authorization shape or next gate is incorrect"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T12:37:20+08:00"
+    approval_note: "Human maintainer approved continuing after PR #355 acceptance; this lane is authorization-only and does not edit source."
+    secondary_approved: true


### PR DESCRIPTION
## Summary

- Adds G2.203 authorization-only package for data-quality legacy adapter compatibility closure.
- Authorizes only a future thin-wrapper implementation shape for web/backend/app/services/data_adapters/dashboard.py and data_source.py.
- Keeps deletion unauthorized and preserves market_data_adapter.py, singleton wrapper/backing API, canonical adapters, routes, OpenAPI, frontend, config, scripts, and OpenSpec as out of scope.

## Boundary

No backend source, tests, OpenSpec, route/OpenAPI, frontend, config, or script files are changed in this PR. Source authority begins only if this package is accepted and a separate G2.204 implementation lane is opened.

## Verification

- JSON/YAML parse: passed
- Markdown governance: passed, checked_files=6, errors=0
- OpenSpec strict validate: valid; PostHog telemetry warning only
- git diff --check / cached check: passed
- GitNexus staged + compare: low risk, changed_files=9, changed_symbols=0, affected_processes=0
- Mainline scope gate: passed, changed_files=9, violations=0