### PR TITLE
docs(governance): close out data quality legacy adapter wrappers

### DIFF
--- a/.planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "2026-05-28.g2-closeout-refresh.v1",
+  "generated_at": "2026-05-28T16:50:15+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "git_head": "a621ba4ae66f581074a3b66539e296cbf0ced1b5",
+  "worktree_branch": "g2-205-data-quality-legacy-adapter-closeout-refresh",
+  "parent_lane": "G2.204 data-quality legacy adapter compatibility wrapper implementation",
+  "parent_pr": 357,
+  "parent_merge_commit": "a621ba4ae66f581074a3b66539e296cbf0ced1b5",
+  "scope": "governance closeout and residual refresh only",
+  "source_edit_authority": false,
+  "closed_capability": {
+    "legacy_data_adapter_wrapper_modules": {
+      "state": "closed_for_thin_wrapper_compatibility",
+      "paths": [
+        "web/backend/app/services/data_adapters/dashboard.py",
+        "web/backend/app/services/data_adapters/data_source.py"
+      ],
+      "legacy_get_data_quality_monitor_calls": 0,
+      "deletion_authorized": false,
+      "old_import_paths_preserved": true
+    },
+    "focused_test": {
+      "path": "web/backend/tests/test_data_quality_legacy_data_adapter_compat.py",
+      "state": "present",
+      "role": "proves old module paths resolve to canonical adapter classes and legacy wrappers do not contain get_data_quality_monitor"
+    }
+  },
+  "post_merge_residual_scan": {
+    "scan_scope": "web/backend/app and web/backend/tests",
+    "all_text_hits": 42,
+    "active_app_hits_excluding_backup_files": 29,
+    "active_app_hits_by_file": {
+      "web/backend/app/api/data_quality.py": 17,
+      "web/backend/app/services/_data_quality_monitor_singleton.py": 2,
+      "web/backend/app/services/adapters_split/base_adapter.py": 2,
+      "web/backend/app/services/adapters/data_adapter.py": 2,
+      "web/backend/app/services/adapters/dashboard_adapter.py": 2,
+      "web/backend/app/services/data_quality_monitor.py": 2,
+      "web/backend/app/services/market_data_adapter.py": 2
+    },
+    "excluded_hits_by_file": {
+      "web/backend/app/services/data_adapter.py.backup.20260130": 3,
+      "web/backend/tests/test_adapter_split_data_quality_monitor_provider.py": 3,
+      "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py": 2,
+      "web/backend/tests/test_data_quality_legacy_data_adapter_compat.py": 2,
+      "web/backend/tests/test_data_quality_route_provider_regressions.py": 3
+    }
+  },
+  "residual_classification": {
+    "route_provider_backing": {
+      "files": [
+        "web/backend/app/api/data_quality.py"
+      ],
+      "decision": "retained route provider dependency surface; route-body direct-call migration already closed by G2.192/G2.193"
+    },
+    "adapter_split_base_fallback": {
+      "files": [
+        "web/backend/app/services/adapters_split/base_adapter.py"
+      ],
+      "decision": "retained default singleton fallback after G2.196 constructor injection"
+    },
+    "canonical_service_adapter_fallbacks": {
+      "files": [
+        "web/backend/app/services/adapters/dashboard_adapter.py",
+        "web/backend/app/services/adapters/data_adapter.py"
+      ],
+      "decision": "retained default singleton fallback after G2.200 optional monitor injection"
+    },
+    "legacy_data_adapter_wrappers": {
+      "files": [
+        "web/backend/app/services/data_adapters/dashboard.py",
+        "web/backend/app/services/data_adapters/data_source.py"
+      ],
+      "decision": "closed by G2.204; no remaining getter calls in the legacy wrapper targets"
+    },
+    "market_data_adapter_facade": {
+      "files": [
+        "web/backend/app/services/market_data_adapter.py"
+      ],
+      "decision": "remaining compatibility facade; requires owner-specific decision package before any source implementation"
+    },
+    "singleton_wrapper_and_backing_api": {
+      "files": [
+        "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "web/backend/app/services/data_quality_monitor.py"
+      ],
+      "decision": "retained backing API; not a deletion or privatization lane"
+    },
+    "backup_artifact": {
+      "files": [
+        "web/backend/app/services/data_adapter.py.backup.20260130"
+      ],
+      "decision": "excluded from active source residual count; handle only through repository cleanup governance"
+    },
+    "tests": {
+      "decision": "expected regression evidence; not source residuals"
+    }
+  },
+  "recommended_next_gate": {
+    "id": "G2.206",
+    "name": "data-quality market_data_adapter compatibility facade ownership decision",
+    "type": "governance decision package",
+    "source_edit_authority": false,
+    "reason": "legacy data_adapter wrappers are now closed; market_data_adapter.py remains the next owner-specific compatibility facade before singleton wrapper retirement can be considered"
+  },
+  "non_goals": [
+    "backend source edits",
+    "legacy wrapper deletion",
+    "market_data_adapter.py edits",
+    "singleton wrapper deletion or privatization",
+    "DataQualityMonitor internals",
+    "route or OpenAPI changes",
+    "frontend changes",
+    "OpenSpec proposal creation",
+    "GitHub issue label changes"
+  ],
+  "freshness": {
+    "current_head_checked_at_review": "a621ba4ae66f581074a3b66539e296cbf0ced1b5",
+    "stale_if_head_mismatch": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -41,12 +41,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#354` | `g2-201-data-quality-canonical-service-adapter-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `e672f1523c30037202310278daf71488681d9a1f` | Governance closeout selecting G2.202 legacy adapter compatibility ownership decision |
 | `#355` | `g2-202-data-quality-legacy-adapter-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f` | Decision package selecting G2.203 legacy adapter compatibility closure authorization |
 | `#356` | `g2-203-data-quality-legacy-adapter-compatibility-closure-authorization` | `wip/root-dirty-20260403` | `MERGED` at `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd` | Authorization package for G2.204 thin-wrapper compatibility implementation |
+| `#357` | `g2-204-data-quality-legacy-adapter-compatibility-wrapper` | `wip/root-dirty-20260403` | `MERGED` at `a621ba4ae66f581074a3b66539e296cbf0ced1b5` | Path-limited thin-wrapper implementation closed for G2.205 refresh |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-204-data-quality-legacy-adapter-compatibility-wrapper` | `origin/wip/root-dirty-20260403` at `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd` | Implement thin compatibility wrappers for the two legacy data-quality adapter modules | Yes, limited |
+| `g2-205-data-quality-legacy-adapter-closeout-refresh` | `origin/wip/root-dirty-20260403` at `a621ba4ae66f581074a3b66539e296cbf0ced1b5` | Close out the legacy wrapper target and refresh remaining data-quality monitor residual ownership | No |
 
 ## OpenSpec Relationship
 
@@ -62,8 +63,8 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.204 is a source implementation branch after PR `#356` merged G2.203. It is
-limited to converting the two legacy `web/backend/app/services/data_adapters/*`
-targets into thin compatibility wrappers and adding one focused test. It does
-not authorize deletion or expansion into other adapter, wrapper, route, OpenAPI,
-frontend, config, script, or OpenSpec surfaces.
+G2.205 is a governance-only closeout branch after PR `#357` merged G2.204. It
+does not authorize deletion or expansion into other adapter, wrapper, route,
+OpenAPI, frontend, config, script, or OpenSpec surfaces. If accepted, the next
+gate is a G2.206 decision package for `market_data_adapter.py` compatibility
+facade ownership.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T13:15:46+08:00`
-- Base HEAD checked: `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd`
+- Prepared at: `2026-05-28T16:50:15+08:00`
+- Base HEAD checked: `a621ba4ae66f581074a3b66539e296cbf0ced1b5`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 is the active thin-wrapper legacy adapter compatibility implementation |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 is the active closeout / residual refresh for the legacy wrapper target |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T13:15:46+08:00`
-- Base HEAD checked: `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd`
+- Prepared at: `2026-05-28T16:50:15+08:00`
+- Base HEAD checked: `a621ba4ae66f581074a3b66539e296cbf0ced1b5`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.204 data-quality legacy adapter compatibility wrapper implementation | G/#79 service lifecycle DI | PR `#356` merged at `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd`; G2.204 converts two legacy modules into thin wrappers and keeps old import paths | If accepted, start G2.205 closeout / residual refresh; do not open the next source lane directly |
+| P0 | Review G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh | G/#79 service lifecycle DI | PR `#357` merged at `a621ba4ae66f581074a3b66539e296cbf0ced1b5`; G2.205 closes the legacy wrapper target and refreshes remaining monitor surfaces without source edits | If accepted, start G2.206 `market_data_adapter.py` compatibility facade ownership decision; no source authority |
+| P0 | Preserve G2.204 data-quality legacy adapter compatibility wrapper implementation | G/#79 service lifecycle DI | PR `#357` merged; two legacy modules are thin wrappers and target legacy getter calls are `0` | Do not delete legacy modules or reopen the two wrapper targets without new evidence contradicting G2.204/G2.205 |
 | P0 | Preserve G2.203 data-quality legacy adapter compatibility closure authorization | G/#79 service lifecycle DI | PR `#356` merged; G2.203 authorizes only thin wrappers, not deletion | Do not delete legacy modules or expand beyond the two wrappers plus focused test |
 | P0 | Preserve G2.202 data-quality legacy adapter compatibility ownership decision | G/#79 service lifecycle DI | PR `#355` merged; G2.202 classifies two legacy `data_adapters` files as compatibility ownership surfaces | Do not edit or delete legacy files directly from G2.202 |
 | P0 | Preserve G2.201 data-quality canonical service adapter closeout / refresh | G/#79 service lifecycle DI | PR `#354` merged; G2.201 closes the canonical service adapter lane and selects G2.202 | Do not reopen canonical service adapter source unless current HEAD evidence contradicts G2.200/G2.201 |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -69,8 +69,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-legacy-adapter-ownership-decision-2026-05-28.md` | G2.202 human-readable ownership decision report | Accepted by PR `#355`; superseded for closure authorization by G2.203 |
 | `.planning/codebase/generated/data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.json` | G2.203 legacy adapter compatibility closure authorization evidence | Accepted by PR `#356`; superseded for wrapper implementation by G2.204 |
 | `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.md` | G2.203 human-readable compatibility closure authorization report | Accepted by PR `#356`; superseded for wrapper implementation by G2.204 |
-| `.planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-implementation-2026-05-28.json` | G2.204 legacy adapter compatibility wrapper implementation evidence | Current for HEAD `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd`; review input until PR `#357` is accepted |
-| `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-implementation-2026-05-28.md` | G2.204 human-readable wrapper implementation report | Review input until PR `#357` is accepted |
+| `.planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-implementation-2026-05-28.json` | G2.204 legacy adapter compatibility wrapper implementation evidence | Accepted by PR `#357`; superseded for closeout / residual refresh by G2.205 |
+| `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-implementation-2026-05-28.md` | G2.204 human-readable wrapper implementation report | Accepted by PR `#357`; superseded for closeout / residual refresh by G2.205 |
+| `.planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.json` | G2.205 legacy adapter wrapper closeout / residual refresh evidence | Current for HEAD `a621ba4ae66f581074a3b66539e296cbf0ced1b5`; review input until PR `#358` is accepted |
+| `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.md` | G2.205 human-readable closeout / residual refresh report | Review input until PR `#358` is accepted |
 
 ## External State Inputs
 
@@ -98,7 +100,8 @@ state transition.
 | GitHub PR `#354` | `MERGED` | G2.201 canonical service adapter closeout / residual refresh merged by commit `e672f1523c30037202310278daf71488681d9a1f` |
 | GitHub PR `#355` | `MERGED` | G2.202 legacy adapter ownership decision merged by commit `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f` |
 | GitHub PR `#356` | `MERGED` | G2.203 legacy adapter compatibility closure authorization merged by commit `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd` |
-| `origin/wip/root-dirty-20260403` | `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd` | Base used for this compatibility wrapper implementation branch |
+| GitHub PR `#357` | `MERGED` | G2.204 legacy adapter compatibility wrapper implementation merged by commit `a621ba4ae66f581074a3b66539e296cbf0ced1b5` |
+| `origin/wip/root-dirty-20260403` | `a621ba4ae66f581074a3b66539e296cbf0ced1b5` | Base used for this closeout / residual refresh branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T13:15:46+08:00",
+  "generated_at": "2026-05-28T16:50:15+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "142a2bf1c0c5f979cf9c32415d2f25832e7e62cd",
-  "split_branch": "g2-204-data-quality-legacy-adapter-compatibility-wrapper",
-  "scope": "data_quality_legacy_adapter_compatibility_wrapper_implementation",
-  "source_edit_authority": true,
+  "base_head": "a621ba4ae66f581074a3b66539e296cbf0ced1b5",
+  "split_branch": "g2-205-data-quality-legacy-adapter-closeout-refresh",
+  "scope": "data_quality_legacy_adapter_compatibility_wrapper_closeout_refresh",
+  "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -1718,12 +1718,14 @@
     {
       "id": "g2-204-data-quality-legacy-adapter-compatibility-wrapper-implementation",
       "type": "implementation",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.203 data-quality legacy adapter compatibility closure authorization",
       "source_edit_authority": true,
       "parent_github_pr": 356,
       "parent_merge_commit": "142a2bf1c0c5f979cf9c32415d2f25832e7e62cd",
+      "github_pr": 357,
+      "merge_commit": "a621ba4ae66f581074a3b66539e296cbf0ced1b5",
       "evidence": [
         ".planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-implementation-2026-05-28.json",
         "docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-implementation-2026-05-28.md",
@@ -1771,10 +1773,60 @@
         "openspec/specs/**"
       ],
       "freshness": {
-        "current_head_checked": "142a2bf1c0c5f979cf9c32415d2f25832e7e62cd",
+        "current_head_checked": "a621ba4ae66f581074a3b66539e296cbf0ced1b5",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh without new source authority."
+      "next_gate": "Superseded by G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh."
+    },
+    {
+      "id": "g2-205-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh",
+      "type": "closeout_refresh",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.204 data-quality legacy adapter compatibility wrapper implementation",
+      "source_edit_authority": false,
+      "parent_github_pr": 357,
+      "parent_merge_commit": "a621ba4ae66f581074a3b66539e296cbf0ced1b5",
+      "evidence": [
+        ".planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.md",
+        "governance/mainline/task-cards/pr-358.yaml"
+      ],
+      "closeout_facts": {
+        "legacy_wrapper_target_state": "closed",
+        "legacy_wrapper_get_data_quality_monitor_calls": 0,
+        "legacy_wrapper_deletion_authorized": false,
+        "old_import_paths_preserved": true
+      },
+      "residual_refresh": {
+        "all_text_hits_under_app_and_tests": 42,
+        "active_app_hits_excluding_backup_files": 29,
+        "active_app_hits_by_file": {
+          "web/backend/app/api/data_quality.py": 17,
+          "web/backend/app/services/_data_quality_monitor_singleton.py": 2,
+          "web/backend/app/services/adapters_split/base_adapter.py": 2,
+          "web/backend/app/services/adapters/data_adapter.py": 2,
+          "web/backend/app/services/adapters/dashboard_adapter.py": 2,
+          "web/backend/app/services/data_quality_monitor.py": 2,
+          "web/backend/app/services/market_data_adapter.py": 2
+        }
+      },
+      "recommended_next_gate": "G2.206 data-quality market_data_adapter.py compatibility facade ownership decision without source authority",
+      "forbidden_surfaces_preserved": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "docs/api/**",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "freshness": {
+        "current_head_checked": "a621ba4ae66f581074a3b66539e296cbf0ced1b5",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.206 data-quality market_data_adapter.py compatibility facade ownership decision; no source edits."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T13:15:46+08:00`
-- Base HEAD checked: `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd`
+- Prepared at: `2026-05-28T16:50:15+08:00`
+- Base HEAD checked: `a621ba4ae66f581074a3b66539e296cbf0ced1b5`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -56,7 +56,8 @@ It proved a repeatable conveyor:
 | G2.201 data-quality canonical service adapter closeout / refresh | Merged by PR `#354` | Closes the canonical service adapter lane and selects legacy data adapter compatibility ownership as the next decision gate |
 | G2.202 data-quality legacy adapter compatibility ownership decision | Merged by PR `#355` | Classifies two legacy `data_adapters` files as compatibility ownership surfaces and selects G2.203 authorization-only compatibility closure |
 | G2.203 data-quality legacy adapter compatibility closure authorization | Merged by PR `#356` | Authorizes only a future thin-wrapper compatibility implementation shape for the two legacy modules; deletion remains unauthorized |
-| G2.204 data-quality legacy adapter compatibility wrapper implementation | For review | Converts two legacy modules into thin wrappers, preserves old import paths, and reduces target legacy getter calls to `0` |
+| G2.204 data-quality legacy adapter compatibility wrapper implementation | Merged by PR `#357` | Converts two legacy modules into thin wrappers, preserves old import paths, and reduces target legacy getter calls to `0` |
+| G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh | For review | Closes the legacy wrapper target and recommends G2.206 `market_data_adapter.py` compatibility facade ownership decision |
 
 ## Current Strategy Getter Residuals
 
@@ -553,11 +554,44 @@ TDD evidence:
 | Targeted ruff/import smoke | Passed |
 | Legacy getter scan | `0` calls in the two wrapper modules |
 
+PR `#357` merged this lane at
+`a621ba4ae66f581074a3b66539e296cbf0ced1b5`.
+
+## G2.205 Data-Quality Legacy Adapter Compatibility Wrapper Closeout / Refresh
+
+At HEAD `a621ba4ae66f581074a3b66539e296cbf0ced1b5`, PR `#357` is merged and
+G2.204 is accepted.
+
+Closeout result:
+
+| Surface | State | Decision |
+|---|---|---|
+| Legacy data adapter wrappers | Closed | The two legacy modules preserve old import paths and contain `0` `get_data_quality_monitor` calls |
+| Wrapper deletion | Not authorized | Legacy modules remain compatibility surfaces |
+| Focused compatibility test | Present | `web/backend/tests/test_data_quality_legacy_data_adapter_compat.py` remains the regression check |
+
+Remaining active app `get_data_quality_monitor` surface after G2.205 refresh:
+
+| Bucket | Files | Active hits | Current decision |
+|---|---:|---:|---|
+| Route provider backing | 1 | 17 | Retain as FastAPI dependency/provider surface; route-body direct-call migration is already closed |
+| `adapter_split` base fallback | 1 | 2 | Retain default singleton fallback after G2.196 constructor injection |
+| Canonical service adapter fallbacks | 2 | 4 | Retain default singleton fallback after G2.200 optional monitor injection |
+| Legacy data adapter wrappers | 2 | 0 | Closed by G2.204/G2.205 |
+| `market_data_adapter.py` facade | 1 | 2 | Select as G2.206 compatibility facade ownership decision target |
+| Singleton wrapper / backing API | 2 | 4 | Retain public backing API; not a deletion lane |
+
+Excluded text hits:
+
+- `web/backend/app/services/data_adapter.py.backup.20260130` is a backup artifact
+  and is not counted as active source.
+- Focused tests are expected regression evidence, not source residuals.
+
 ## Next Gates
 
-- Review G2.204 data-quality legacy adapter compatibility wrapper implementation.
-- If accepted, start G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh.
-- Do not open the next source lane before G2.205 refresh classifies remaining data-quality monitor surfaces.
+- Review G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh.
+- If accepted, start G2.206 `market_data_adapter.py` compatibility facade ownership decision with no source authority.
+- Do not open the next source lane before G2.206 classifies the compatibility facade and its relation to singleton wrapper retirement.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.md
@@ -1,0 +1,93 @@
+# Backend Data-Quality Legacy Adapter Compatibility Wrapper Closeout Refresh
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: review candidate
+- Prepared at: `2026-05-28T16:50:15+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `a621ba4ae66f581074a3b66539e296cbf0ced1b5`
+- Worktree branch: `g2-205-data-quality-legacy-adapter-closeout-refresh`
+- Scope: governance closeout and residual refresh only
+- Source edit authority: none
+
+## Parent State
+
+PR `#357` merged G2.204 at
+`a621ba4ae66f581074a3b66539e296cbf0ced1b5`.
+
+G2.204 converted the two legacy data-quality adapter modules into thin
+compatibility wrappers while preserving old import paths:
+
+| Target | Post-merge state |
+|---|---|
+| `web/backend/app/services/data_adapters/dashboard.py` | Thin wrapper re-exporting canonical `DashboardDataSourceAdapter` |
+| `web/backend/app/services/data_adapters/data_source.py` | Thin wrapper re-exporting canonical `DataDataSourceAdapter` |
+| `web/backend/tests/test_data_quality_legacy_data_adapter_compat.py` | Focused compatibility test for old import paths and getter removal |
+
+Deletion remains unauthorized. The wrappers are compatibility surfaces, not dead
+files.
+
+## Closed Capability
+
+| Item | State | Evidence |
+|---|---|---|
+| Legacy wrapper target getter calls | Closed | `0` `get_data_quality_monitor` calls remain in the two legacy wrapper modules |
+| Old module import paths | Preserved | Old module paths import canonical adapter classes |
+| Legacy module deletion | Not authorized | G2.203 allowed only thin wrappers, not removal |
+| Focused compatibility regression | Present | `web/backend/tests/test_data_quality_legacy_data_adapter_compat.py` |
+
+## Post-Merge Residual Refresh
+
+Post-merge text scan for `get_data_quality_monitor` under `web/backend/app` and
+`web/backend/tests` produced `42` total hits. Active app hits excluding backup
+files are `29`.
+
+| Bucket | Files | Active hits | Current decision |
+|---|---:|---:|---|
+| Route provider backing | 1 | 17 | Retain as FastAPI dependency/provider surface; route-body direct-call migration is already closed by G2.192/G2.193 |
+| `adapter_split` base fallback | 1 | 2 | Retain default singleton fallback after G2.196 constructor injection |
+| Canonical service adapter fallbacks | 2 | 4 | Retain default fallback after G2.200 optional monitor injection |
+| Legacy data adapter wrappers | 2 | 0 | Closed by G2.204; no remaining getter calls in target wrappers |
+| `market_data_adapter.py` facade | 1 | 2 | Remaining compatibility facade; needs owner-specific decision before source work |
+| Singleton wrapper / backing API | 2 | 4 | Retain public backing API; not a deletion lane |
+| Backup artifact | 1 | 3 | Excluded from active source residual count; route through cleanup governance only |
+| Tests | 4 | 10 | Expected regression evidence, not implementation backlog |
+
+## Recommended Next Gate
+
+Start G2.206 as a governance decision package:
+
+| Next gate | Type | Source authority | Reason |
+|---|---|---|---|
+| G2.206 data-quality `market_data_adapter.py` compatibility facade ownership decision | Decision package | None | The legacy wrapper target is closed. `market_data_adapter.py` is now the next owner-specific compatibility facade that must be classified before singleton wrapper retirement can be considered |
+
+G2.206 should not edit source. It should decide whether the
+`market_data_adapter.py` facade is retained, wrapped, migrated, or scheduled for
+a later authorized implementation lane.
+
+## Explicit Non-Goals
+
+This closeout does not authorize:
+
+- backend source edits
+- legacy wrapper deletion
+- `market_data_adapter.py` edits
+- singleton wrapper deletion or privatization
+- `DataQualityMonitor` internals
+- route or OpenAPI changes
+- frontend changes
+- OpenSpec proposal creation
+- GitHub issue label changes
+
+## Evidence Artifacts
+
+| Artifact | Role |
+|---|---|
+| `.planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-implementation-2026-05-28.json` | G2.204 implementation evidence |
+| `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-implementation-2026-05-28.md` | G2.204 implementation report |
+| `governance/mainline/task-cards/pr-357.yaml` | G2.204 source implementation scope card |
+| `.planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.json` | G2.205 machine-readable closeout / residual refresh |
+| `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.md` | G2.205 human-readable closeout / residual refresh |
+| `governance/mainline/task-cards/pr-358.yaml` | G2.205 governance-only PR scope card |

--- a/governance/mainline/task-cards/pr-358.yaml
+++ b/governance/mainline/task-cards/pr-358.yaml
@@ -1,0 +1,118 @@
+version: "v0.2"
+
+task:
+  id: "pr-358"
+  title: "Close out data-quality legacy adapter compatibility wrappers"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-legacy-adapter-wrapper-closeout-refresh"
+  objective: "record PR #357 closeout and refresh remaining data-quality monitor residual ownership without source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout / residual refresh only; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-358.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits"
+  - "legacy wrapper deletion"
+  - "market_data_adapter.py edits"
+  - "singleton wrapper deletion"
+  - "DataQualityMonitor internals"
+  - "route changes"
+  - "OpenAPI contract changes"
+  - "frontend changes"
+  - "OpenSpec proposal creation"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-358.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-358.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha a621ba4ae66f581074a3b66539e296cbf0ced1b5 --head-sha HEAD --report /tmp/pr358-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Residual counts can be misread as direct implementation backlog without bucket classification."
+    - "Legacy wrappers must not be deleted from a closeout PR."
+  rollback_plan: "revert this PR to return steward-tree state to the post-#357 implementation baseline, then rerun the residual refresh."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out G2.204 and refresh remaining data-quality monitor residual ownership"
+    modified_scope: "governance evidence, steward tree state, quality report, and one task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source remains exactly as merged by PR #357"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if residual classification, scope gate, or governance checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T16:50:15+08:00"
+    approval_note: "Human maintainer approved continuing after PR #357 acceptance; this lane records closeout and residual refresh only."
+    secondary_approved: true


### PR DESCRIPTION
## Summary
- closes G2.204 after PR #357 merged at a621ba4ae66f581074a3b66539e296cbf0ced1b5
- records the legacy data adapter wrappers as closed with 0 target get_data_quality_monitor calls and deletion still unauthorized
- refreshes remaining data-quality monitor residual buckets and recommends G2.206 market_data_adapter.py compatibility facade ownership decision

## Scope
- governance-only closeout / residual refresh
- no backend source edits
- no route, OpenAPI, frontend, config, script, or OpenSpec changes

## Validation
- JSON/YAML parse: passed
- Markdown governance gate: passed
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: passed
- mainline scope gate: passed
- git diff --check / cached diff check: passed
- GitNexus compare vs a621ba4ae66f: low risk, changed_symbols=0, affected_processes=0