### PR TITLE
docs(governance): decide market data adapter ownership

### DIFF
--- a/.planning/codebase/generated/data-quality-market-data-adapter-ownership-decision-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-market-data-adapter-ownership-decision-2026-05-28.json
@@ -1,0 +1,87 @@
+{
+  "schema_version": "2026-05-28.g2-decision-package.v1",
+  "generated_at": "2026-05-28T17:17:56+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "git_head": "44909f5d048700115da6a9eb9345957b8af3d077",
+  "worktree_branch": "g2-206-data-quality-market-data-adapter-ownership-decision",
+  "parent_lane": "G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh",
+  "parent_pr": 358,
+  "parent_merge_commit": "44909f5d048700115da6a9eb9345957b8af3d077",
+  "scope": "governance decision package only",
+  "source_edit_authority": false,
+  "target": {
+    "path": "web/backend/app/services/market_data_adapter.py",
+    "classification": "active factory-owned compatibility facade",
+    "line_count": 481,
+    "classes": [
+      "DataSourceMetrics",
+      "MarketDataSourceAdapter"
+    ],
+    "getter_import_line": 10,
+    "getter_call_line": 327,
+    "get_data_quality_monitor_hits": 2
+  },
+  "consumer_evidence": {
+    "app_direct_refs": [
+      "web/backend/app/services/data_source_factory/data_source_factory.py:32",
+      "web/backend/app/services/data_source_factory/data_source_factory.py:113"
+    ],
+    "test_refs": [
+      "web/backend/tests/_test_data_source_factory_support.py",
+      "web/backend/tests/_test_data_source_factory_management.py",
+      "web/backend/tests/test_market_data_service_getter_retirement.py"
+    ],
+    "gitnexus_upstream_impact": {
+      "risk": "LOW",
+      "impacted_count": 3,
+      "direct": 1,
+      "processes_affected": 0,
+      "direct_importer": "web/backend/app/services/data_source_factory/data_source_factory.py"
+    }
+  },
+  "decision": {
+    "ownership": "data-source-factory compatibility facade",
+    "delete_now": false,
+    "thin_wrapper_now": false,
+    "source_implementation_now": false,
+    "recommended_next_gate": "G2.207 data-quality market_data_adapter.py provider seam authorization",
+    "recommended_next_gate_type": "authorization package",
+    "recommended_future_shape": "preserve MarketDataSourceAdapter and module path; authorize a narrow optional quality monitor/provider seam that defaults to current singleton behavior; require focused tests proving factory compatibility and injected-monitor bypass"
+  },
+  "future_authorization_candidate": {
+    "allowed_source_candidate_paths": [
+      "web/backend/app/services/market_data_adapter.py"
+    ],
+    "allowed_test_candidate_paths": [
+      "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py",
+      "web/backend/tests/test_market_data_service_getter_retirement.py"
+    ],
+    "conditional_test_or_consumer_checks": [
+      "web/backend/app/services/data_source_factory/data_source_factory.py must remain compatible as the direct app importer",
+      "data_source_factory should be tested but not edited unless an authorization package explicitly grants it"
+    ],
+    "forbidden_future_expansion_without_new_decision": [
+      "web/backend/app/services/_data_quality_monitor_singleton.py",
+      "web/backend/app/services/data_quality_monitor.py",
+      "web/backend/app/services/data_source_factory/** source edits",
+      "web/backend/app/api/**",
+      "web/frontend/**",
+      "src/**",
+      "docs/api/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ]
+  },
+  "residual_position_after_decision": {
+    "legacy_data_adapter_wrappers": "closed by G2.204/G2.205",
+    "market_data_adapter_facade": "selected for G2.207 authorization",
+    "singleton_wrapper_and_backing_api": "retain until market_data_adapter facade and remaining retained fallback surfaces have accepted closeout evidence"
+  },
+  "freshness": {
+    "current_head_checked_at_review": "44909f5d048700115da6a9eb9345957b8af3d077",
+    "stale_if_head_mismatch": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -42,12 +42,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#355` | `g2-202-data-quality-legacy-adapter-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f` | Decision package selecting G2.203 legacy adapter compatibility closure authorization |
 | `#356` | `g2-203-data-quality-legacy-adapter-compatibility-closure-authorization` | `wip/root-dirty-20260403` | `MERGED` at `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd` | Authorization package for G2.204 thin-wrapper compatibility implementation |
 | `#357` | `g2-204-data-quality-legacy-adapter-compatibility-wrapper` | `wip/root-dirty-20260403` | `MERGED` at `a621ba4ae66f581074a3b66539e296cbf0ced1b5` | Path-limited thin-wrapper implementation closed for G2.205 refresh |
+| `#358` | `g2-205-data-quality-legacy-adapter-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `44909f5d048700115da6a9eb9345957b8af3d077` | Governance closeout selecting G2.206 `market_data_adapter.py` compatibility facade ownership decision |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-205-data-quality-legacy-adapter-closeout-refresh` | `origin/wip/root-dirty-20260403` at `a621ba4ae66f581074a3b66539e296cbf0ced1b5` | Close out the legacy wrapper target and refresh remaining data-quality monitor residual ownership | No |
+| `g2-206-data-quality-market-data-adapter-ownership-decision` | `origin/wip/root-dirty-20260403` at `44909f5d048700115da6a9eb9345957b8af3d077` | Classify `market_data_adapter.py` compatibility facade ownership and select the next authorization gate | No |
 
 ## OpenSpec Relationship
 
@@ -63,8 +64,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.205 is a governance-only closeout branch after PR `#357` merged G2.204. It
-does not authorize deletion or expansion into other adapter, wrapper, route,
-OpenAPI, frontend, config, script, or OpenSpec surfaces. If accepted, the next
-gate is a G2.206 decision package for `market_data_adapter.py` compatibility
-facade ownership.
+G2.206 is a governance-only ownership decision branch after PR `#358` merged
+G2.205. It does not authorize deletion or source edits. If accepted, the next
+gate is a G2.207 authorization package for a narrow `market_data_adapter.py`
+provider seam.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T16:50:15+08:00`
-- Base HEAD checked: `a621ba4ae66f581074a3b66539e296cbf0ced1b5`
+- Prepared at: `2026-05-28T17:17:56+08:00`
+- Base HEAD checked: `44909f5d048700115da6a9eb9345957b8af3d077`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 is the active closeout / residual refresh for the legacy wrapper target |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 is the active `market_data_adapter.py` compatibility facade ownership decision |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T16:50:15+08:00`
-- Base HEAD checked: `a621ba4ae66f581074a3b66539e296cbf0ced1b5`
+- Prepared at: `2026-05-28T17:17:56+08:00`
+- Base HEAD checked: `44909f5d048700115da6a9eb9345957b8af3d077`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh | G/#79 service lifecycle DI | PR `#357` merged at `a621ba4ae66f581074a3b66539e296cbf0ced1b5`; G2.205 closes the legacy wrapper target and refreshes remaining monitor surfaces without source edits | If accepted, start G2.206 `market_data_adapter.py` compatibility facade ownership decision; no source authority |
+| P0 | Review G2.206 data-quality `market_data_adapter.py` compatibility facade ownership decision | G/#79 service lifecycle DI | PR `#358` merged at `44909f5d048700115da6a9eb9345957b8af3d077`; G2.206 classifies `market_data_adapter.py` as an active factory-owned compatibility facade and opens no source authority | If accepted, start G2.207 provider seam authorization package; do not implement from G2.206 |
+| P0 | Preserve G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh | G/#79 service lifecycle DI | PR `#358` merged; legacy wrapper target is closed and `market_data_adapter.py` was selected as the next decision target | Do not open source work before G2.206 is accepted |
 | P0 | Preserve G2.204 data-quality legacy adapter compatibility wrapper implementation | G/#79 service lifecycle DI | PR `#357` merged; two legacy modules are thin wrappers and target legacy getter calls are `0` | Do not delete legacy modules or reopen the two wrapper targets without new evidence contradicting G2.204/G2.205 |
 | P0 | Preserve G2.203 data-quality legacy adapter compatibility closure authorization | G/#79 service lifecycle DI | PR `#356` merged; G2.203 authorizes only thin wrappers, not deletion | Do not delete legacy modules or expand beyond the two wrappers plus focused test |
 | P0 | Preserve G2.202 data-quality legacy adapter compatibility ownership decision | G/#79 service lifecycle DI | PR `#355` merged; G2.202 classifies two legacy `data_adapters` files as compatibility ownership surfaces | Do not edit or delete legacy files directly from G2.202 |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -71,8 +71,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-closure-authorization-2026-05-28.md` | G2.203 human-readable compatibility closure authorization report | Accepted by PR `#356`; superseded for wrapper implementation by G2.204 |
 | `.planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-implementation-2026-05-28.json` | G2.204 legacy adapter compatibility wrapper implementation evidence | Accepted by PR `#357`; superseded for closeout / residual refresh by G2.205 |
 | `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-implementation-2026-05-28.md` | G2.204 human-readable wrapper implementation report | Accepted by PR `#357`; superseded for closeout / residual refresh by G2.205 |
-| `.planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.json` | G2.205 legacy adapter wrapper closeout / residual refresh evidence | Current for HEAD `a621ba4ae66f581074a3b66539e296cbf0ced1b5`; review input until PR `#358` is accepted |
-| `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.md` | G2.205 human-readable closeout / residual refresh report | Review input until PR `#358` is accepted |
+| `.planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.json` | G2.205 legacy adapter wrapper closeout / residual refresh evidence | Accepted by PR `#358`; superseded for `market_data_adapter.py` ownership by G2.206 |
+| `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.md` | G2.205 human-readable closeout / residual refresh report | Accepted by PR `#358`; superseded for `market_data_adapter.py` ownership by G2.206 |
+| `.planning/codebase/generated/data-quality-market-data-adapter-ownership-decision-2026-05-28.json` | G2.206 `market_data_adapter.py` ownership decision evidence | Current for HEAD `44909f5d048700115da6a9eb9345957b8af3d077`; review input until PR `#359` is accepted |
+| `docs/reports/quality/backend-data-quality-market-data-adapter-ownership-decision-2026-05-28.md` | G2.206 human-readable ownership decision report | Review input until PR `#359` is accepted |
 
 ## External State Inputs
 
@@ -101,7 +103,8 @@ state transition.
 | GitHub PR `#355` | `MERGED` | G2.202 legacy adapter ownership decision merged by commit `bf5d5ffba6bfc837c009a3d937cf0a9e6549883f` |
 | GitHub PR `#356` | `MERGED` | G2.203 legacy adapter compatibility closure authorization merged by commit `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd` |
 | GitHub PR `#357` | `MERGED` | G2.204 legacy adapter compatibility wrapper implementation merged by commit `a621ba4ae66f581074a3b66539e296cbf0ced1b5` |
-| `origin/wip/root-dirty-20260403` | `a621ba4ae66f581074a3b66539e296cbf0ced1b5` | Base used for this closeout / residual refresh branch |
+| GitHub PR `#358` | `MERGED` | G2.205 legacy adapter wrapper closeout / residual refresh merged by commit `44909f5d048700115da6a9eb9345957b8af3d077` |
+| `origin/wip/root-dirty-20260403` | `44909f5d048700115da6a9eb9345957b8af3d077` | Base used for this ownership decision branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T16:50:15+08:00",
+  "generated_at": "2026-05-28T17:17:56+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "a621ba4ae66f581074a3b66539e296cbf0ced1b5",
-  "split_branch": "g2-205-data-quality-legacy-adapter-closeout-refresh",
-  "scope": "data_quality_legacy_adapter_compatibility_wrapper_closeout_refresh",
+  "base_head": "44909f5d048700115da6a9eb9345957b8af3d077",
+  "split_branch": "g2-206-data-quality-market-data-adapter-ownership-decision",
+  "scope": "data_quality_market_data_adapter_ownership_decision",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -1781,12 +1781,14 @@
     {
       "id": "g2-205-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh",
       "type": "closeout_refresh",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.204 data-quality legacy adapter compatibility wrapper implementation",
       "source_edit_authority": false,
       "parent_github_pr": 357,
       "parent_merge_commit": "a621ba4ae66f581074a3b66539e296cbf0ced1b5",
+      "github_pr": 358,
+      "merge_commit": "44909f5d048700115da6a9eb9345957b8af3d077",
       "evidence": [
         ".planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.json",
         "docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.md",
@@ -1823,10 +1825,59 @@
         "openspec/specs/**"
       ],
       "freshness": {
-        "current_head_checked": "a621ba4ae66f581074a3b66539e296cbf0ced1b5",
+        "current_head_checked": "44909f5d048700115da6a9eb9345957b8af3d077",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.206 data-quality market_data_adapter.py compatibility facade ownership decision; no source edits."
+      "next_gate": "Superseded by G2.206 data-quality market_data_adapter.py compatibility facade ownership decision."
+    },
+    {
+      "id": "g2-206-data-quality-market-data-adapter-ownership-decision",
+      "type": "decision_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh",
+      "source_edit_authority": false,
+      "parent_github_pr": 358,
+      "parent_merge_commit": "44909f5d048700115da6a9eb9345957b8af3d077",
+      "evidence": [
+        ".planning/codebase/generated/data-quality-market-data-adapter-ownership-decision-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-market-data-adapter-ownership-decision-2026-05-28.md",
+        "governance/mainline/task-cards/pr-359.yaml"
+      ],
+      "target": {
+        "path": "web/backend/app/services/market_data_adapter.py",
+        "classification": "active factory-owned compatibility facade",
+        "line_count": 481,
+        "getter_hits": 2,
+        "direct_app_importer": "web/backend/app/services/data_source_factory/data_source_factory.py"
+      },
+      "gitnexus_evidence": {
+        "risk": "LOW",
+        "impacted_count": 3,
+        "direct": 1,
+        "processes_affected": 0
+      },
+      "decision": {
+        "delete_now": false,
+        "thin_wrapper_now": false,
+        "source_implementation_now": false,
+        "recommended_next_gate": "G2.207 data-quality market_data_adapter.py provider seam authorization"
+      },
+      "forbidden_surfaces_preserved": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "docs/api/**",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "freshness": {
+        "current_head_checked": "44909f5d048700115da6a9eb9345957b8af3d077",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.207 data-quality market_data_adapter.py provider seam authorization; no source implementation from G2.206."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T16:50:15+08:00`
-- Base HEAD checked: `a621ba4ae66f581074a3b66539e296cbf0ced1b5`
+- Prepared at: `2026-05-28T17:17:56+08:00`
+- Base HEAD checked: `44909f5d048700115da6a9eb9345957b8af3d077`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -57,7 +57,8 @@ It proved a repeatable conveyor:
 | G2.202 data-quality legacy adapter compatibility ownership decision | Merged by PR `#355` | Classifies two legacy `data_adapters` files as compatibility ownership surfaces and selects G2.203 authorization-only compatibility closure |
 | G2.203 data-quality legacy adapter compatibility closure authorization | Merged by PR `#356` | Authorizes only a future thin-wrapper compatibility implementation shape for the two legacy modules; deletion remains unauthorized |
 | G2.204 data-quality legacy adapter compatibility wrapper implementation | Merged by PR `#357` | Converts two legacy modules into thin wrappers, preserves old import paths, and reduces target legacy getter calls to `0` |
-| G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh | For review | Closes the legacy wrapper target and recommends G2.206 `market_data_adapter.py` compatibility facade ownership decision |
+| G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh | Merged by PR `#358` | Closes the legacy wrapper target and recommends G2.206 `market_data_adapter.py` compatibility facade ownership decision |
+| G2.206 data-quality `market_data_adapter.py` compatibility facade ownership decision | For review | Classifies `market_data_adapter.py` as active data-source-factory compatibility facade and recommends G2.207 provider seam authorization |
 
 ## Current Strategy Getter Residuals
 
@@ -587,11 +588,36 @@ Excluded text hits:
   and is not counted as active source.
 - Focused tests are expected regression evidence, not source residuals.
 
+PR `#358` merged this lane at
+`44909f5d048700115da6a9eb9345957b8af3d077`.
+
+## G2.206 Data-Quality Market Data Adapter Ownership Decision
+
+At HEAD `44909f5d048700115da6a9eb9345957b8af3d077`, PR `#358` is merged and
+G2.205 is accepted.
+
+Decision result:
+
+| Target | Evidence | Decision |
+|---|---|---|
+| `web/backend/app/services/market_data_adapter.py` | 481 lines; defines `DataSourceMetrics` and `MarketDataSourceAdapter`; imports `get_data_quality_monitor` at line 10 and calls it at line 327 | Active data-source-factory compatibility facade; no source edits in G2.206 |
+| `web/backend/app/services/data_source_factory/data_source_factory.py` | Direct app importer and constructor caller | Must remain compatible; test in future lane, but do not edit unless explicitly authorized |
+
+GitNexus reference:
+
+| Target | Risk | Impact |
+|---|---|---|
+| `web/backend/app/services/market_data_adapter.py` | LOW | `impacted_count=3`, `direct=1`, `processes_affected=0` |
+
+G2.206 selects G2.207 as an authorization-only package for a future narrow
+provider seam. It does not authorize deletion, wrapper conversion, or source
+implementation.
+
 ## Next Gates
 
-- Review G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh.
-- If accepted, start G2.206 `market_data_adapter.py` compatibility facade ownership decision with no source authority.
-- Do not open the next source lane before G2.206 classifies the compatibility facade and its relation to singleton wrapper retirement.
+- Review G2.206 `market_data_adapter.py` compatibility facade ownership decision.
+- If accepted, start G2.207 `market_data_adapter.py` provider seam authorization package with no source edits in the authorization PR.
+- Do not open implementation before G2.207 explicitly authorizes paths, tests, rollback, and GitNexus checks.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/reports/quality/backend-data-quality-market-data-adapter-ownership-decision-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-market-data-adapter-ownership-decision-2026-05-28.md
@@ -1,0 +1,116 @@
+# Backend Data-Quality Market Data Adapter Ownership Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: review candidate
+- Prepared at: `2026-05-28T17:17:56+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `44909f5d048700115da6a9eb9345957b8af3d077`
+- Worktree branch: `g2-206-data-quality-market-data-adapter-ownership-decision`
+- Scope: governance decision package only
+- Source edit authority: none
+
+## Parent State
+
+PR `#358` merged G2.205 at
+`44909f5d048700115da6a9eb9345957b8af3d077`.
+
+G2.205 closed the two legacy data adapter wrapper targets and selected
+`market_data_adapter.py` as the next owner-specific compatibility facade to
+classify before singleton wrapper retirement can be considered.
+
+## Target Facts
+
+| Item | Current evidence |
+|---|---|
+| Target file | `web/backend/app/services/market_data_adapter.py` |
+| File size | 481 lines |
+| Local classes | `DataSourceMetrics`, `MarketDataSourceAdapter` |
+| `get_data_quality_monitor` import | line 10 |
+| `get_data_quality_monitor` call | line 327 inside `_trigger_quality_monitoring` |
+| Direct app consumer | `web/backend/app/services/data_source_factory/data_source_factory.py` |
+| GitNexus upstream impact | LOW, impacted count `3`, direct `1`, processes affected `0` |
+
+Direct app references are limited to:
+
+| File | Role |
+|---|---|
+| `web/backend/app/services/data_source_factory/data_source_factory.py:32` | Imports `MarketDataSourceAdapter` |
+| `web/backend/app/services/data_source_factory/data_source_factory.py:113` | Instantiates `MarketDataSourceAdapter(config.__dict__)` |
+
+Relevant test references already exist in:
+
+- `web/backend/tests/_test_data_source_factory_support.py`
+- `web/backend/tests/_test_data_source_factory_management.py`
+- `web/backend/tests/test_market_data_service_getter_retirement.py`
+
+## Decision
+
+`market_data_adapter.py` is an active data-source-factory compatibility facade,
+not a deletion candidate and not a simple thin-wrapper candidate.
+
+| Question | Decision |
+|---|---|
+| Delete now? | No |
+| Convert to thin wrapper now? | No |
+| Open source implementation from this PR? | No |
+| Next gate | G2.207 data-quality `market_data_adapter.py` provider seam authorization |
+| Future implementation shape candidate | Preserve `MarketDataSourceAdapter` and the module path; authorize a narrow optional quality monitor/provider seam that defaults to current singleton behavior |
+
+## Recommended G2.207 Authorization Shape
+
+G2.207 should be an authorization package, not an implementation PR.
+
+Recommended future source candidate:
+
+| Path | Candidate role |
+|---|---|
+| `web/backend/app/services/market_data_adapter.py` | Add optional injected quality monitor/provider seam while preserving default construction |
+
+Recommended future tests:
+
+| Path | Candidate role |
+|---|---|
+| `web/backend/tests/test_market_data_adapter_quality_monitor_provider.py` | Prove injected monitor bypasses the module-level getter for market data adapter quality monitoring |
+| `web/backend/tests/test_market_data_service_getter_retirement.py` | Preserve existing compatibility expectations |
+
+The direct app consumer
+`web/backend/app/services/data_source_factory/data_source_factory.py` must remain
+compatible. It should be tested in the future lane, but source edits to
+`data_source_factory` should remain forbidden unless the G2.207 authorization
+explicitly grants them.
+
+## Explicit Non-Goals
+
+This decision does not authorize:
+
+- backend source edits
+- deletion of `market_data_adapter.py`
+- conversion of `market_data_adapter.py` to a thin wrapper
+- source edits to `data_source_factory`
+- singleton wrapper deletion or privatization
+- `DataQualityMonitor` internals
+- route or OpenAPI changes
+- frontend changes
+- OpenSpec proposal creation
+- GitHub issue label changes
+
+## Residual Position
+
+| Surface | Current handling after G2.206 |
+|---|---|
+| Legacy data adapter wrappers | Closed by G2.204/G2.205 |
+| `market_data_adapter.py` facade | Selected for G2.207 authorization |
+| Singleton wrapper / backing API | Retain until market adapter facade and remaining fallback surfaces have accepted closeout evidence |
+
+## Evidence Artifacts
+
+| Artifact | Role |
+|---|---|
+| `.planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.json` | G2.205 closeout / residual refresh evidence |
+| `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.md` | G2.205 human-readable closeout / residual refresh |
+| `.planning/codebase/generated/data-quality-market-data-adapter-ownership-decision-2026-05-28.json` | G2.206 machine-readable decision evidence |
+| `docs/reports/quality/backend-data-quality-market-data-adapter-ownership-decision-2026-05-28.md` | G2.206 human-readable decision report |
+| `governance/mainline/task-cards/pr-359.yaml` | G2.206 governance-only PR scope card |

--- a/governance/mainline/task-cards/pr-359.yaml
+++ b/governance/mainline/task-cards/pr-359.yaml
@@ -1,0 +1,119 @@
+version: "v0.2"
+
+task:
+  id: "pr-359"
+  title: "Decide market data adapter compatibility facade ownership"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-market-data-adapter-ownership-decision"
+  objective: "classify market_data_adapter.py ownership and select the next authorization gate without source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision-only ownership package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-market-data-adapter-ownership-decision-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-market-data-adapter-ownership-decision-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-359.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits"
+  - "market_data_adapter.py edits"
+  - "market_data_adapter.py deletion"
+  - "source edits to data_source_factory"
+  - "singleton wrapper deletion"
+  - "DataQualityMonitor internals"
+  - "route changes"
+  - "OpenAPI contract changes"
+  - "frontend changes"
+  - "OpenSpec proposal creation"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-market-data-adapter-ownership-decision-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-359.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-market-data-adapter-ownership-decision-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-359.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 44909f5d048700115da6a9eb9345957b8af3d077 --head-sha HEAD --report /tmp/pr359-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "The compatibility facade can be misread as dead code because it has a narrow direct app importer."
+    - "Authorizing deletion or source edits from this decision package would bypass G2.207."
+  rollback_plan: "revert this PR to return steward-tree state to the post-#358 closeout baseline, then rerun the ownership decision."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "classify market_data_adapter.py ownership and select the next authorization gate"
+    modified_scope: "governance evidence, steward tree state, quality report, and one task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source remains exactly as merged by PR #358"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if decision evidence, scope gate, or governance checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T17:17:56+08:00"
+    approval_note: "Human maintainer approved continuing after PR #358 acceptance; this lane records ownership decision only and opens no source authority."
+    secondary_approved: true


### PR DESCRIPTION
## Summary
- classifies web/backend/app/services/market_data_adapter.py as an active data-source-factory compatibility facade
- records current evidence: 481 lines, MarketDataSourceAdapter/DataSourceMetrics, get_data_quality_monitor import/call, one direct app importer via data_source_factory
- selects G2.207 as a provider seam authorization package; this PR opens no source authority

## Scope
- governance-only decision package
- no backend source edits
- no route, OpenAPI, frontend, config, script, or OpenSpec changes

## Validation
- JSON/YAML parse: passed
- Markdown governance gate: passed
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: passed
- mainline scope gate: passed
- git diff --check / cached diff check: passed
- GitNexus impact for market_data_adapter.py: LOW, direct=1, processes_affected=0
- GitNexus compare vs 44909f5d048700115da6a9eb9345957b8af3d077: low risk, changed_symbols=0, affected_processes=0