### PR TITLE
docs(governance): authorize market data adapter provider seam

### DIFF
--- a/.planning/codebase/generated/data-quality-market-data-adapter-provider-authorization-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-market-data-adapter-provider-authorization-2026-05-28.json
@@ -1,0 +1,101 @@
+{
+  "schema_version": "2026-05-28.g2-authorization-package.v1",
+  "generated_at": "2026-05-28T17:41:53+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "git_head": "ded789ee5d49d6ddcce5d8a69af1901a8481d1f0",
+  "worktree_branch": "g2-207-data-quality-market-data-adapter-provider-authorization",
+  "parent_lane": "G2.206 data-quality market_data_adapter.py compatibility facade ownership decision",
+  "parent_pr": 359,
+  "parent_merge_commit": "ded789ee5d49d6ddcce5d8a69af1901a8481d1f0",
+  "scope": "governance authorization package only",
+  "source_edit_authority": false,
+  "authorized_future_lane": {
+    "id": "G2.208",
+    "name": "data-quality market_data_adapter.py provider seam implementation",
+    "source_edit_authority_after_acceptance": true,
+    "allowed_source_paths": [
+      "web/backend/app/services/market_data_adapter.py"
+    ],
+    "allowed_test_paths": [
+      "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py",
+      "web/backend/tests/test_market_data_service_getter_retirement.py"
+    ],
+    "consumer_check_paths": [
+      "web/backend/tests/_test_data_source_factory_management.py"
+    ],
+    "conditionally_allowed_source_paths": [],
+    "forbidden_source_paths": [
+      "web/backend/app/services/data_source_factory/**",
+      "web/backend/app/services/_data_quality_monitor_singleton.py",
+      "web/backend/app/services/data_quality_monitor.py",
+      "web/backend/app/services/adapters/**",
+      "web/backend/app/services/adapters_split/**",
+      "web/backend/app/services/data_adapters/**",
+      "web/backend/app/api/**",
+      "web/frontend/**",
+      "src/**",
+      "docs/api/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ]
+  },
+  "authorized_future_shape": {
+    "constructor_contract": "MarketDataSourceAdapter must preserve the existing positional config argument and may add keyword-only optional quality_monitor/provider parameters.",
+    "default_behavior": "Default construction must keep current singleton fallback behavior.",
+    "injected_behavior": "When an injected monitor/provider is supplied, _trigger_quality_monitoring must use it and must not call the module-level get_data_quality_monitor getter.",
+    "factory_compatibility": "data_source_factory must remain able to instantiate MarketDataSourceAdapter(config.__dict__) without source edits.",
+    "import_contract": "The app.services.market_data_adapter module path and MarketDataSourceAdapter class name must remain valid."
+  },
+  "required_future_tdd": {
+    "red": "A new focused test must fail before implementation because injected monitor/provider is not accepted or not used.",
+    "green": "Focused tests must pass after the provider seam is implemented.",
+    "regression": [
+      "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py",
+      "web/backend/tests/test_market_data_service_getter_retirement.py",
+      "web/backend/tests/_test_data_source_factory_management.py"
+    ]
+  },
+  "required_future_gitnexus": {
+    "pre_edit_impact_targets": [
+      "web/backend/app/services/market_data_adapter.py",
+      "MarketDataSourceAdapter"
+    ],
+    "stop_if_risk": [
+      "HIGH",
+      "CRITICAL"
+    ],
+    "pre_commit_detection": "run gitnexus detect_changes on staged scope before commit"
+  },
+  "current_evidence": {
+    "target_line_count": 481,
+    "constructor_line": 38,
+    "quality_monitor_getter_import_line": 10,
+    "quality_monitor_getter_call_line": 327,
+    "direct_app_importer": "web/backend/app/services/data_source_factory/data_source_factory.py",
+    "gitnexus_upstream_impact": {
+      "risk": "LOW",
+      "impacted_count": 3,
+      "direct": 1,
+      "processes_affected": 0
+    }
+  },
+  "non_goals": [
+    "source edits in G2.207",
+    "data_source_factory source edits in the future implementation unless separately authorized",
+    "market_data_adapter.py deletion",
+    "thin wrapper conversion",
+    "singleton wrapper deletion or privatization",
+    "DataQualityMonitor internals",
+    "route or OpenAPI changes",
+    "frontend changes",
+    "OpenSpec proposal creation",
+    "GitHub issue label changes"
+  ],
+  "freshness": {
+    "current_head_checked_at_review": "ded789ee5d49d6ddcce5d8a69af1901a8481d1f0",
+    "stale_if_head_mismatch": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -43,12 +43,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#356` | `g2-203-data-quality-legacy-adapter-compatibility-closure-authorization` | `wip/root-dirty-20260403` | `MERGED` at `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd` | Authorization package for G2.204 thin-wrapper compatibility implementation |
 | `#357` | `g2-204-data-quality-legacy-adapter-compatibility-wrapper` | `wip/root-dirty-20260403` | `MERGED` at `a621ba4ae66f581074a3b66539e296cbf0ced1b5` | Path-limited thin-wrapper implementation closed for G2.205 refresh |
 | `#358` | `g2-205-data-quality-legacy-adapter-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `44909f5d048700115da6a9eb9345957b8af3d077` | Governance closeout selecting G2.206 `market_data_adapter.py` compatibility facade ownership decision |
+| `#359` | `g2-206-data-quality-market-data-adapter-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0` | Decision package selecting G2.207 provider seam authorization |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-206-data-quality-market-data-adapter-ownership-decision` | `origin/wip/root-dirty-20260403` at `44909f5d048700115da6a9eb9345957b8af3d077` | Classify `market_data_adapter.py` compatibility facade ownership and select the next authorization gate | No |
+| `g2-207-data-quality-market-data-adapter-provider-authorization` | `origin/wip/root-dirty-20260403` at `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0` | Authorize the future path-limited `market_data_adapter.py` provider seam implementation | No |
 
 ## OpenSpec Relationship
 
@@ -64,7 +65,6 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.206 is a governance-only ownership decision branch after PR `#358` merged
-G2.205. It does not authorize deletion or source edits. If accepted, the next
-gate is a G2.207 authorization package for a narrow `market_data_adapter.py`
-provider seam.
+G2.207 is a governance-only authorization branch after PR `#359` merged G2.206.
+It does not edit source. If accepted, the next gate is a G2.208 implementation
+branch limited to the explicitly authorized source and test paths.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T17:17:56+08:00`
-- Base HEAD checked: `44909f5d048700115da6a9eb9345957b8af3d077`
+- Prepared at: `2026-05-28T17:41:53+08:00`
+- Base HEAD checked: `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 is the active `market_data_adapter.py` compatibility facade ownership decision |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 is the active provider seam authorization package |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T17:17:56+08:00`
-- Base HEAD checked: `44909f5d048700115da6a9eb9345957b8af3d077`
+- Prepared at: `2026-05-28T17:41:53+08:00`
+- Base HEAD checked: `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.206 data-quality `market_data_adapter.py` compatibility facade ownership decision | G/#79 service lifecycle DI | PR `#358` merged at `44909f5d048700115da6a9eb9345957b8af3d077`; G2.206 classifies `market_data_adapter.py` as an active factory-owned compatibility facade and opens no source authority | If accepted, start G2.207 provider seam authorization package; do not implement from G2.206 |
+| P0 | Review G2.207 data-quality `market_data_adapter.py` provider seam authorization package | G/#79 service lifecycle DI | PR `#359` merged at `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0`; G2.207 authorizes a future G2.208 implementation lane but opens no source authority in this PR | If accepted, start G2.208 implementation with authorized paths only |
+| P0 | Preserve G2.206 data-quality `market_data_adapter.py` compatibility facade ownership decision | G/#79 service lifecycle DI | PR `#359` merged; `market_data_adapter.py` is an active factory-owned compatibility facade, not a deletion or thin-wrapper candidate | Do not implement from G2.206; use G2.207 authorization first |
 | P0 | Preserve G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh | G/#79 service lifecycle DI | PR `#358` merged; legacy wrapper target is closed and `market_data_adapter.py` was selected as the next decision target | Do not open source work before G2.206 is accepted |
 | P0 | Preserve G2.204 data-quality legacy adapter compatibility wrapper implementation | G/#79 service lifecycle DI | PR `#357` merged; two legacy modules are thin wrappers and target legacy getter calls are `0` | Do not delete legacy modules or reopen the two wrapper targets without new evidence contradicting G2.204/G2.205 |
 | P0 | Preserve G2.203 data-quality legacy adapter compatibility closure authorization | G/#79 service lifecycle DI | PR `#356` merged; G2.203 authorizes only thin wrappers, not deletion | Do not delete legacy modules or expand beyond the two wrappers plus focused test |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -73,8 +73,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-implementation-2026-05-28.md` | G2.204 human-readable wrapper implementation report | Accepted by PR `#357`; superseded for closeout / residual refresh by G2.205 |
 | `.planning/codebase/generated/data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.json` | G2.205 legacy adapter wrapper closeout / residual refresh evidence | Accepted by PR `#358`; superseded for `market_data_adapter.py` ownership by G2.206 |
 | `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.md` | G2.205 human-readable closeout / residual refresh report | Accepted by PR `#358`; superseded for `market_data_adapter.py` ownership by G2.206 |
-| `.planning/codebase/generated/data-quality-market-data-adapter-ownership-decision-2026-05-28.json` | G2.206 `market_data_adapter.py` ownership decision evidence | Current for HEAD `44909f5d048700115da6a9eb9345957b8af3d077`; review input until PR `#359` is accepted |
-| `docs/reports/quality/backend-data-quality-market-data-adapter-ownership-decision-2026-05-28.md` | G2.206 human-readable ownership decision report | Review input until PR `#359` is accepted |
+| `.planning/codebase/generated/data-quality-market-data-adapter-ownership-decision-2026-05-28.json` | G2.206 `market_data_adapter.py` ownership decision evidence | Accepted by PR `#359`; superseded for provider seam authorization by G2.207 |
+| `docs/reports/quality/backend-data-quality-market-data-adapter-ownership-decision-2026-05-28.md` | G2.206 human-readable ownership decision report | Accepted by PR `#359`; superseded for provider seam authorization by G2.207 |
+| `.planning/codebase/generated/data-quality-market-data-adapter-provider-authorization-2026-05-28.json` | G2.207 `market_data_adapter.py` provider seam authorization evidence | Current for HEAD `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0`; review input until PR `#360` is accepted |
+| `docs/reports/quality/backend-data-quality-market-data-adapter-provider-authorization-2026-05-28.md` | G2.207 human-readable provider seam authorization package | Review input until PR `#360` is accepted |
 
 ## External State Inputs
 
@@ -104,7 +106,8 @@ state transition.
 | GitHub PR `#356` | `MERGED` | G2.203 legacy adapter compatibility closure authorization merged by commit `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd` |
 | GitHub PR `#357` | `MERGED` | G2.204 legacy adapter compatibility wrapper implementation merged by commit `a621ba4ae66f581074a3b66539e296cbf0ced1b5` |
 | GitHub PR `#358` | `MERGED` | G2.205 legacy adapter wrapper closeout / residual refresh merged by commit `44909f5d048700115da6a9eb9345957b8af3d077` |
-| `origin/wip/root-dirty-20260403` | `44909f5d048700115da6a9eb9345957b8af3d077` | Base used for this ownership decision branch |
+| GitHub PR `#359` | `MERGED` | G2.206 `market_data_adapter.py` ownership decision merged by commit `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0` |
+| `origin/wip/root-dirty-20260403` | `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0` | Base used for this authorization branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T17:17:56+08:00",
+  "generated_at": "2026-05-28T17:41:53+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "44909f5d048700115da6a9eb9345957b8af3d077",
-  "split_branch": "g2-206-data-quality-market-data-adapter-ownership-decision",
-  "scope": "data_quality_market_data_adapter_ownership_decision",
+  "base_head": "ded789ee5d49d6ddcce5d8a69af1901a8481d1f0",
+  "split_branch": "g2-207-data-quality-market-data-adapter-provider-authorization",
+  "scope": "data_quality_market_data_adapter_provider_authorization",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -1833,12 +1833,14 @@
     {
       "id": "g2-206-data-quality-market-data-adapter-ownership-decision",
       "type": "decision_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh",
       "source_edit_authority": false,
       "parent_github_pr": 358,
       "parent_merge_commit": "44909f5d048700115da6a9eb9345957b8af3d077",
+      "github_pr": 359,
+      "merge_commit": "ded789ee5d49d6ddcce5d8a69af1901a8481d1f0",
       "evidence": [
         ".planning/codebase/generated/data-quality-market-data-adapter-ownership-decision-2026-05-28.json",
         "docs/reports/quality/backend-data-quality-market-data-adapter-ownership-decision-2026-05-28.md",
@@ -1874,10 +1876,67 @@
         "openspec/specs/**"
       ],
       "freshness": {
-        "current_head_checked": "44909f5d048700115da6a9eb9345957b8af3d077",
+        "current_head_checked": "ded789ee5d49d6ddcce5d8a69af1901a8481d1f0",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.207 data-quality market_data_adapter.py provider seam authorization; no source implementation from G2.206."
+      "next_gate": "Superseded by G2.207 data-quality market_data_adapter.py provider seam authorization."
+    },
+    {
+      "id": "g2-207-data-quality-market-data-adapter-provider-authorization",
+      "type": "authorization_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.206 data-quality market_data_adapter.py compatibility facade ownership decision",
+      "source_edit_authority": false,
+      "parent_github_pr": 359,
+      "parent_merge_commit": "ded789ee5d49d6ddcce5d8a69af1901a8481d1f0",
+      "evidence": [
+        ".planning/codebase/generated/data-quality-market-data-adapter-provider-authorization-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-market-data-adapter-provider-authorization-2026-05-28.md",
+        "governance/mainline/task-cards/pr-360.yaml"
+      ],
+      "authorized_future_lane": {
+        "id": "G2.208",
+        "name": "data-quality market_data_adapter.py provider seam implementation",
+        "allowed_source_paths": [
+          "web/backend/app/services/market_data_adapter.py"
+        ],
+        "allowed_test_paths": [
+          "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py",
+          "web/backend/tests/test_market_data_service_getter_retirement.py"
+        ],
+        "consumer_check_paths": [
+          "web/backend/tests/_test_data_source_factory_management.py"
+        ]
+      },
+      "required_future_shape": {
+        "preserve_positional_config": true,
+        "keyword_only_optional_injection": true,
+        "preserve_singleton_fallback": true,
+        "injected_monitor_bypasses_module_getter": true,
+        "preserve_data_source_factory_constructor_call": true
+      },
+      "forbidden_future_expansion_without_new_decision": [
+        "web/backend/app/services/data_source_factory/**",
+        "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "web/backend/app/services/data_quality_monitor.py",
+        "web/backend/app/services/adapters/**",
+        "web/backend/app/services/adapters_split/**",
+        "web/backend/app/services/data_adapters/**",
+        "web/backend/app/api/**",
+        "web/frontend/**",
+        "src/**",
+        "docs/api/**",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "freshness": {
+        "current_head_checked": "ded789ee5d49d6ddcce5d8a69af1901a8481d1f0",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.208 data-quality market_data_adapter.py provider seam implementation with authorized paths only."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T17:17:56+08:00`
-- Base HEAD checked: `44909f5d048700115da6a9eb9345957b8af3d077`
+- Prepared at: `2026-05-28T17:41:53+08:00`
+- Base HEAD checked: `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -58,7 +58,8 @@ It proved a repeatable conveyor:
 | G2.203 data-quality legacy adapter compatibility closure authorization | Merged by PR `#356` | Authorizes only a future thin-wrapper compatibility implementation shape for the two legacy modules; deletion remains unauthorized |
 | G2.204 data-quality legacy adapter compatibility wrapper implementation | Merged by PR `#357` | Converts two legacy modules into thin wrappers, preserves old import paths, and reduces target legacy getter calls to `0` |
 | G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh | Merged by PR `#358` | Closes the legacy wrapper target and recommends G2.206 `market_data_adapter.py` compatibility facade ownership decision |
-| G2.206 data-quality `market_data_adapter.py` compatibility facade ownership decision | For review | Classifies `market_data_adapter.py` as active data-source-factory compatibility facade and recommends G2.207 provider seam authorization |
+| G2.206 data-quality `market_data_adapter.py` compatibility facade ownership decision | Merged by PR `#359` | Classifies `market_data_adapter.py` as active data-source-factory compatibility facade and recommends G2.207 provider seam authorization |
+| G2.207 data-quality `market_data_adapter.py` provider seam authorization | For review | Authorizes future G2.208 source implementation scope without source edits in G2.207 |
 
 ## Current Strategy Getter Residuals
 
@@ -613,11 +614,42 @@ G2.206 selects G2.207 as an authorization-only package for a future narrow
 provider seam. It does not authorize deletion, wrapper conversion, or source
 implementation.
 
+PR `#359` merged this lane at
+`ded789ee5d49d6ddcce5d8a69af1901a8481d1f0`.
+
+## G2.207 Data-Quality Market Data Adapter Provider Authorization
+
+At HEAD `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0`, PR `#359` is merged and
+G2.206 is accepted.
+
+Authorization result:
+
+| Future lane | Authorized source path | Authorized tests |
+|---|---|---|
+| G2.208 `market_data_adapter.py` provider seam implementation | `web/backend/app/services/market_data_adapter.py` | `web/backend/tests/test_market_data_adapter_quality_monitor_provider.py`, `web/backend/tests/test_market_data_service_getter_retirement.py` |
+
+Required future shape:
+
+- preserve the existing positional `config` constructor argument
+- add only keyword-only optional injection parameters
+- preserve singleton fallback behavior when no injection is supplied
+- ensure injected monitor/provider bypasses the module-level
+  `get_data_quality_monitor()` getter
+- keep `MarketDataSourceAdapter(config.__dict__)` compatible for
+  `data_source_factory`
+
+Forbidden in G2.208 unless a later package explicitly expands scope:
+
+- source edits under `web/backend/app/services/data_source_factory/**`
+- singleton wrapper deletion or privatization
+- `DataQualityMonitor` internals
+- route, OpenAPI, frontend, config, script, or OpenSpec changes
+
 ## Next Gates
 
-- Review G2.206 `market_data_adapter.py` compatibility facade ownership decision.
-- If accepted, start G2.207 `market_data_adapter.py` provider seam authorization package with no source edits in the authorization PR.
-- Do not open implementation before G2.207 explicitly authorizes paths, tests, rollback, and GitNexus checks.
+- Review G2.207 `market_data_adapter.py` provider seam authorization package.
+- If accepted, start G2.208 implementation with only the authorized source and test paths.
+- Do not expand G2.208 into `data_source_factory`, singleton wrapper/backing API, routes, OpenAPI, frontend, config, scripts, or OpenSpec changes.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/reports/quality/backend-data-quality-market-data-adapter-provider-authorization-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-market-data-adapter-provider-authorization-2026-05-28.md
@@ -1,0 +1,120 @@
+# Backend Data-Quality Market Data Adapter Provider Authorization
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: review candidate
+- Prepared at: `2026-05-28T17:41:53+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0`
+- Worktree branch: `g2-207-data-quality-market-data-adapter-provider-authorization`
+- Scope: governance authorization package only
+- Source edit authority: none
+
+## Parent State
+
+PR `#359` merged G2.206 at
+`ded789ee5d49d6ddcce5d8a69af1901a8481d1f0`.
+
+G2.206 classified `web/backend/app/services/market_data_adapter.py` as an
+active data-source-factory compatibility facade and selected this G2.207
+authorization package as the next gate.
+
+## Current Target Evidence
+
+| Item | Evidence |
+|---|---|
+| Target file | `web/backend/app/services/market_data_adapter.py` |
+| File size | 481 lines |
+| Existing constructor | `def __init__(self, config: Dict[str, Any])` at line 38 |
+| Existing getter import | `from app.services.data_quality_monitor import get_data_quality_monitor` at line 10 |
+| Existing getter call | `monitor = get_data_quality_monitor()` at line 327 |
+| Direct app importer | `web/backend/app/services/data_source_factory/data_source_factory.py` |
+| GitNexus upstream impact | LOW, impacted count `3`, direct `1`, processes affected `0` |
+
+The direct app importer currently instantiates the adapter as
+`MarketDataSourceAdapter(config.__dict__)`. Future implementation must preserve
+that call form unless a later authorization explicitly grants factory source
+edits.
+
+## Authorization Decision
+
+This PR authorizes a future G2.208 implementation lane, but does not implement
+it.
+
+| Future lane | Authorized source path | Authorized test paths |
+|---|---|---|
+| G2.208 data-quality `market_data_adapter.py` provider seam implementation | `web/backend/app/services/market_data_adapter.py` | `web/backend/tests/test_market_data_adapter_quality_monitor_provider.py`, `web/backend/tests/test_market_data_service_getter_retirement.py` |
+
+Future implementation may also run consumer compatibility tests against
+`web/backend/tests/_test_data_source_factory_management.py`, but this
+authorization does not grant source edits under `web/backend/app/services/data_source_factory/**`.
+
+## Authorized Future Shape
+
+G2.208 may add a narrow quality-monitor provider seam with these constraints:
+
+- Preserve the existing positional `config` argument.
+- Add only keyword-only optional injection parameters, such as
+  `quality_monitor` or a provider callable.
+- Preserve default singleton fallback behavior when no injection is supplied.
+- Make `_trigger_quality_monitoring` use the injected monitor/provider when
+  provided.
+- Keep `app.services.market_data_adapter` and `MarketDataSourceAdapter`
+  import-compatible.
+- Keep `data_source_factory` compatible with
+  `MarketDataSourceAdapter(config.__dict__)`.
+
+## Required Future Tests
+
+G2.208 must use TDD:
+
+| Phase | Required evidence |
+|---|---|
+| RED | A focused test fails before implementation because injected monitor/provider is not accepted or not used |
+| GREEN | Focused tests pass after the provider seam is implemented |
+| Regression | Existing market data service getter retirement and data-source-factory compatibility tests remain passing |
+
+Required future check set:
+
+- `web/backend/tests/test_market_data_adapter_quality_monitor_provider.py`
+- `web/backend/tests/test_market_data_service_getter_retirement.py`
+- `web/backend/tests/_test_data_source_factory_management.py`
+- targeted ruff for the authorized source and test files
+- OpenSpec strict validation for `migrate-backend-singletons-to-lifecycle-di`
+- staged GitNexus change detection before commit
+
+## Required Future GitNexus Gate
+
+Before editing source in G2.208, run GitNexus impact for:
+
+- `web/backend/app/services/market_data_adapter.py`
+- `MarketDataSourceAdapter`
+
+If either impact returns HIGH or CRITICAL risk, stop and return to review.
+
+## Explicit Non-Goals
+
+This authorization does not grant:
+
+- source edits in G2.207
+- source edits to `web/backend/app/services/data_source_factory/**`
+- deletion of `market_data_adapter.py`
+- thin-wrapper conversion of `market_data_adapter.py`
+- singleton wrapper deletion or privatization
+- `DataQualityMonitor` internals
+- route or OpenAPI changes
+- frontend changes
+- OpenSpec proposal creation
+- GitHub issue label changes
+
+## Evidence Artifacts
+
+| Artifact | Role |
+|---|---|
+| `.planning/codebase/generated/data-quality-market-data-adapter-ownership-decision-2026-05-28.json` | G2.206 ownership decision evidence |
+| `docs/reports/quality/backend-data-quality-market-data-adapter-ownership-decision-2026-05-28.md` | G2.206 human-readable ownership decision |
+| `.planning/codebase/generated/data-quality-market-data-adapter-provider-authorization-2026-05-28.json` | G2.207 machine-readable authorization package |
+| `docs/reports/quality/backend-data-quality-market-data-adapter-provider-authorization-2026-05-28.md` | G2.207 human-readable authorization package |
+| `governance/mainline/task-cards/pr-360.yaml` | G2.207 governance-only PR scope card |

--- a/governance/mainline/task-cards/pr-360.yaml
+++ b/governance/mainline/task-cards/pr-360.yaml
@@ -1,0 +1,120 @@
+version: "v0.2"
+
+task:
+  id: "pr-360"
+  title: "Authorize market data adapter provider seam implementation"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-market-data-adapter-provider-authorization"
+  objective: "authorize a future path-limited provider seam implementation for market_data_adapter.py without source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-market-data-adapter-provider-authorization-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-market-data-adapter-provider-authorization-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-360.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "source edits in this PR"
+  - "market_data_adapter.py edits in this PR"
+  - "data_source_factory source edits"
+  - "market_data_adapter.py deletion"
+  - "thin wrapper conversion"
+  - "singleton wrapper deletion"
+  - "DataQualityMonitor internals"
+  - "route changes"
+  - "OpenAPI contract changes"
+  - "frontend changes"
+  - "OpenSpec proposal creation"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-market-data-adapter-provider-authorization-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-360.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-market-data-adapter-provider-authorization-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-360.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha ded789ee5d49d6ddcce5d8a69af1901a8481d1f0 --head-sha HEAD --report /tmp/pr360-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Future implementation could accidentally edit data_source_factory instead of preserving compatibility by constructor design."
+    - "Future implementation could remove singleton fallback and break default construction."
+  rollback_plan: "revert this PR to return steward-tree state to the post-#359 ownership decision baseline, then rerun the authorization package."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "authorize a future market_data_adapter.py provider seam implementation"
+    modified_scope: "governance evidence, steward tree state, quality report, and one task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; source remains exactly as merged by PR #359"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if authorization evidence, scope gate, or governance checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T17:41:53+08:00"
+    approval_note: "Human maintainer approved continuing after PR #359 acceptance; this lane authorizes a future path-limited implementation only and opens no source edits in this PR."
+    secondary_approved: true


### PR DESCRIPTION
## Summary
- authorizes a future G2.208 path-limited provider seam implementation for web/backend/app/services/market_data_adapter.py
- preserves the existing positional config constructor contract and singleton fallback requirement
- forbids data_source_factory source edits, singleton wrapper changes, route/OpenAPI/frontend/config/script/OpenSpec changes

## Scope
- governance-only authorization package
- no backend source edits
- no runtime behavior changes

## Future G2.208 authorization summary
- allowed source: web/backend/app/services/market_data_adapter.py
- allowed tests: web/backend/tests/test_market_data_adapter_quality_monitor_provider.py and web/backend/tests/test_market_data_service_getter_retirement.py
- consumer check: web/backend/tests/_test_data_source_factory_management.py
- required: GitNexus impact before source edit and staged detect_changes before commit

## Validation
- JSON/YAML parse: passed
- Markdown governance gate: passed
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: passed
- mainline scope gate: passed
- git diff --check / cached diff check: passed
- GitNexus impact for market_data_adapter.py: LOW, direct=1, processes_affected=0
- GitNexus compare vs ded789ee5d49d6ddcce5d8a69af1901a8481d1f0: low risk, changed_symbols=0, affected_processes=0