### PR TITLE
refactor(services): inject market data adapter quality monitor

### DIFF
--- a/.planning/codebase/generated/data-quality-market-data-adapter-provider-implementation-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-market-data-adapter-provider-implementation-2026-05-28.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": "2026-05-28.g2-implementation-package.v1",
+  "generated_at": "2026-05-28T17:58:00+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "git_head": "b4b34375eef0186b81be9a24491328dab72c2e21",
+  "worktree_branch": "g2-208-data-quality-market-data-adapter-provider-implementation",
+  "parent_lane": "G2.207 data-quality market_data_adapter.py provider seam authorization",
+  "parent_pr": 360,
+  "parent_merge_commit": "b4b34375eef0186b81be9a24491328dab72c2e21",
+  "scope": "path-limited provider seam implementation",
+  "source_edit_authority": true,
+  "changed_source_paths": [
+    "web/backend/app/services/market_data_adapter.py"
+  ],
+  "changed_test_paths": [
+    "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py"
+  ],
+  "changed_governance_paths": [
+    "docs/FUNCTION_TREE.md",
+    "governance/function-tree/catalog.yaml"
+  ],
+  "implementation_result": {
+    "constructor_contract": "MarketDataSourceAdapter keeps positional config and adds keyword-only optional quality_monitor",
+    "default_behavior": "No injected monitor keeps the module-level get_data_quality_monitor fallback",
+    "injected_behavior": "Injected quality_monitor is used by _trigger_quality_monitoring and bypasses the module-level getter",
+    "factory_compatibility": "MarketDataSourceAdapter(config.__dict__) remains valid because the new parameter is keyword-only optional",
+    "target_file_line_count_after": 482,
+    "target_get_data_quality_monitor_text_hits_after": 2
+  },
+  "tdd_evidence": {
+    "red": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_adapter_quality_monitor_provider.py -q --no-cov --tb=short",
+      "result": "1 failed",
+      "expected_failure": "TypeError: MarketDataSourceAdapter.__init__() got an unexpected keyword argument 'quality_monitor'"
+    },
+    "green": {
+      "focused_new_test": "2 passed",
+      "authorized_regression": "18 passed",
+      "ruff_authorized_files": "All checks passed"
+    }
+  },
+  "gitnexus_evidence": {
+    "pre_edit_file_impact": {
+      "target": "web/backend/app/services/market_data_adapter.py",
+      "risk": "LOW",
+      "impacted_count": 3,
+      "direct": 1,
+      "processes_affected": 0
+    },
+    "pre_edit_class_impact": {
+      "target": "MarketDataSourceAdapter",
+      "risk": "LOW",
+      "impacted_count": 0,
+      "direct": 0,
+      "processes_affected": 0
+    }
+  },
+  "required_post_commit_checks": [
+    "focused pytest for new test",
+    "authorized regression pytest set",
+    "targeted ruff",
+    "JSON/YAML parse",
+    "Markdown governance gate",
+    "OpenSpec strict validation",
+    "mainline scope gate",
+    "GitNexus staged/compare detect_changes"
+  ],
+  "non_goals_preserved": [
+    "web/backend/app/services/data_source_factory/** source edits",
+    "web/backend/app/services/_data_quality_monitor_singleton.py edits",
+    "web/backend/app/services/data_quality_monitor.py edits",
+    "adapters/adapters_split/data_adapters edits",
+    "route or OpenAPI changes",
+    "frontend changes",
+    "OpenSpec proposal creation",
+    "GitHub issue label changes"
+  ],
+  "recommended_next_gate": {
+    "id": "G2.209",
+    "name": "data-quality market_data_adapter.py provider seam closeout / residual refresh",
+    "type": "governance closeout package",
+    "source_edit_authority": false
+  },
+  "freshness": {
+    "current_head_checked_at_review": "b4b34375eef0186b81be9a24491328dab72c2e21",
+    "stale_if_head_mismatch": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -44,12 +44,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#357` | `g2-204-data-quality-legacy-adapter-compatibility-wrapper` | `wip/root-dirty-20260403` | `MERGED` at `a621ba4ae66f581074a3b66539e296cbf0ced1b5` | Path-limited thin-wrapper implementation closed for G2.205 refresh |
 | `#358` | `g2-205-data-quality-legacy-adapter-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `44909f5d048700115da6a9eb9345957b8af3d077` | Governance closeout selecting G2.206 `market_data_adapter.py` compatibility facade ownership decision |
 | `#359` | `g2-206-data-quality-market-data-adapter-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0` | Decision package selecting G2.207 provider seam authorization |
+| `#360` | `g2-207-data-quality-market-data-adapter-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `b4b34375eef0186b81be9a24491328dab72c2e21` | Authorization package for G2.208 `market_data_adapter.py` provider seam implementation |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-207-data-quality-market-data-adapter-provider-authorization` | `origin/wip/root-dirty-20260403` at `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0` | Authorize the future path-limited `market_data_adapter.py` provider seam implementation | No |
+| `g2-208-data-quality-market-data-adapter-provider-implementation` | `origin/wip/root-dirty-20260403` at `b4b34375eef0186b81be9a24491328dab72c2e21` | Implement the path-limited `market_data_adapter.py` provider seam | Yes, limited |
 
 ## OpenSpec Relationship
 
@@ -65,6 +66,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.207 is a governance-only authorization branch after PR `#359` merged G2.206.
-It does not edit source. If accepted, the next gate is a G2.208 implementation
-branch limited to the explicitly authorized source and test paths.
+G2.208 is a path-limited source implementation branch after PR `#360` merged
+G2.207. It is limited to `market_data_adapter.py`, one focused provider seam
+test, function-tree mapping, and governance evidence. If accepted, the next gate
+is a G2.209 closeout / residual refresh.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T17:41:53+08:00`
-- Base HEAD checked: `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0`
+- Prepared at: `2026-05-28T17:58:00+08:00`
+- Base HEAD checked: `b4b34375eef0186b81be9a24491328dab72c2e21`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 is the active provider seam authorization package |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 is the active `market_data_adapter.py` provider seam implementation |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T17:41:53+08:00`
-- Base HEAD checked: `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0`
+- Prepared at: `2026-05-28T17:58:00+08:00`
+- Base HEAD checked: `b4b34375eef0186b81be9a24491328dab72c2e21`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.207 data-quality `market_data_adapter.py` provider seam authorization package | G/#79 service lifecycle DI | PR `#359` merged at `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0`; G2.207 authorizes a future G2.208 implementation lane but opens no source authority in this PR | If accepted, start G2.208 implementation with authorized paths only |
+| P0 | Review G2.208 data-quality `market_data_adapter.py` provider seam implementation | G/#79 service lifecycle DI | PR `#360` merged at `b4b34375eef0186b81be9a24491328dab72c2e21`; G2.208 implements optional quality monitor injection for `MarketDataSourceAdapter` | If accepted, start G2.209 closeout / residual refresh; do not open the next source lane directly |
+| P0 | Preserve G2.207 data-quality `market_data_adapter.py` provider seam authorization package | G/#79 service lifecycle DI | PR `#360` merged; future implementation scope was limited to `market_data_adapter.py` plus focused tests | Do not expand into `data_source_factory`, singleton wrapper/backing API, routes, OpenAPI, frontend, config, scripts, or OpenSpec |
 | P0 | Preserve G2.206 data-quality `market_data_adapter.py` compatibility facade ownership decision | G/#79 service lifecycle DI | PR `#359` merged; `market_data_adapter.py` is an active factory-owned compatibility facade, not a deletion or thin-wrapper candidate | Do not implement from G2.206; use G2.207 authorization first |
 | P0 | Preserve G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh | G/#79 service lifecycle DI | PR `#358` merged; legacy wrapper target is closed and `market_data_adapter.py` was selected as the next decision target | Do not open source work before G2.206 is accepted |
 | P0 | Preserve G2.204 data-quality legacy adapter compatibility wrapper implementation | G/#79 service lifecycle DI | PR `#357` merged; two legacy modules are thin wrappers and target legacy getter calls are `0` | Do not delete legacy modules or reopen the two wrapper targets without new evidence contradicting G2.204/G2.205 |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -75,8 +75,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-legacy-adapter-compatibility-wrapper-closeout-refresh-2026-05-28.md` | G2.205 human-readable closeout / residual refresh report | Accepted by PR `#358`; superseded for `market_data_adapter.py` ownership by G2.206 |
 | `.planning/codebase/generated/data-quality-market-data-adapter-ownership-decision-2026-05-28.json` | G2.206 `market_data_adapter.py` ownership decision evidence | Accepted by PR `#359`; superseded for provider seam authorization by G2.207 |
 | `docs/reports/quality/backend-data-quality-market-data-adapter-ownership-decision-2026-05-28.md` | G2.206 human-readable ownership decision report | Accepted by PR `#359`; superseded for provider seam authorization by G2.207 |
-| `.planning/codebase/generated/data-quality-market-data-adapter-provider-authorization-2026-05-28.json` | G2.207 `market_data_adapter.py` provider seam authorization evidence | Current for HEAD `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0`; review input until PR `#360` is accepted |
-| `docs/reports/quality/backend-data-quality-market-data-adapter-provider-authorization-2026-05-28.md` | G2.207 human-readable provider seam authorization package | Review input until PR `#360` is accepted |
+| `.planning/codebase/generated/data-quality-market-data-adapter-provider-authorization-2026-05-28.json` | G2.207 `market_data_adapter.py` provider seam authorization evidence | Accepted by PR `#360`; superseded for implementation evidence by G2.208 |
+| `docs/reports/quality/backend-data-quality-market-data-adapter-provider-authorization-2026-05-28.md` | G2.207 human-readable provider seam authorization package | Accepted by PR `#360`; superseded for implementation evidence by G2.208 |
+| `.planning/codebase/generated/data-quality-market-data-adapter-provider-implementation-2026-05-28.json` | G2.208 `market_data_adapter.py` provider seam implementation evidence | Current for HEAD `b4b34375eef0186b81be9a24491328dab72c2e21`; review input until PR `#361` is accepted |
+| `docs/reports/quality/backend-data-quality-market-data-adapter-provider-implementation-2026-05-28.md` | G2.208 human-readable provider seam implementation report | Review input until PR `#361` is accepted |
 
 ## External State Inputs
 
@@ -107,7 +109,8 @@ state transition.
 | GitHub PR `#357` | `MERGED` | G2.204 legacy adapter compatibility wrapper implementation merged by commit `a621ba4ae66f581074a3b66539e296cbf0ced1b5` |
 | GitHub PR `#358` | `MERGED` | G2.205 legacy adapter wrapper closeout / residual refresh merged by commit `44909f5d048700115da6a9eb9345957b8af3d077` |
 | GitHub PR `#359` | `MERGED` | G2.206 `market_data_adapter.py` ownership decision merged by commit `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0` |
-| `origin/wip/root-dirty-20260403` | `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0` | Base used for this authorization branch |
+| GitHub PR `#360` | `MERGED` | G2.207 `market_data_adapter.py` provider seam authorization merged by commit `b4b34375eef0186b81be9a24491328dab72c2e21` |
+| `origin/wip/root-dirty-20260403` | `b4b34375eef0186b81be9a24491328dab72c2e21` | Base used for this implementation branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T17:41:53+08:00",
+  "generated_at": "2026-05-28T17:58:00+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "ded789ee5d49d6ddcce5d8a69af1901a8481d1f0",
-  "split_branch": "g2-207-data-quality-market-data-adapter-provider-authorization",
-  "scope": "data_quality_market_data_adapter_provider_authorization",
-  "source_edit_authority": false,
+  "base_head": "b4b34375eef0186b81be9a24491328dab72c2e21",
+  "split_branch": "g2-208-data-quality-market-data-adapter-provider-implementation",
+  "scope": "data_quality_market_data_adapter_provider_implementation",
+  "source_edit_authority": true,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -1884,12 +1884,14 @@
     {
       "id": "g2-207-data-quality-market-data-adapter-provider-authorization",
       "type": "authorization_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.206 data-quality market_data_adapter.py compatibility facade ownership decision",
       "source_edit_authority": false,
       "parent_github_pr": 359,
       "parent_merge_commit": "ded789ee5d49d6ddcce5d8a69af1901a8481d1f0",
+      "github_pr": 360,
+      "merge_commit": "b4b34375eef0186b81be9a24491328dab72c2e21",
       "evidence": [
         ".planning/codebase/generated/data-quality-market-data-adapter-provider-authorization-2026-05-28.json",
         "docs/reports/quality/backend-data-quality-market-data-adapter-provider-authorization-2026-05-28.md",
@@ -1933,10 +1935,70 @@
         "openspec/specs/**"
       ],
       "freshness": {
-        "current_head_checked": "ded789ee5d49d6ddcce5d8a69af1901a8481d1f0",
+        "current_head_checked": "b4b34375eef0186b81be9a24491328dab72c2e21",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.208 data-quality market_data_adapter.py provider seam implementation with authorized paths only."
+      "next_gate": "Superseded by G2.208 data-quality market_data_adapter.py provider seam implementation."
+    },
+    {
+      "id": "g2-208-data-quality-market-data-adapter-provider-implementation",
+      "type": "implementation",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.207 data-quality market_data_adapter.py provider seam authorization",
+      "source_edit_authority": true,
+      "parent_github_pr": 360,
+      "parent_merge_commit": "b4b34375eef0186b81be9a24491328dab72c2e21",
+      "evidence": [
+        ".planning/codebase/generated/data-quality-market-data-adapter-provider-implementation-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-market-data-adapter-provider-implementation-2026-05-28.md",
+        "governance/mainline/task-cards/pr-361.yaml"
+      ],
+      "changed_source_paths": [
+        "web/backend/app/services/market_data_adapter.py"
+      ],
+      "changed_test_paths": [
+        "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py"
+      ],
+      "changed_governance_paths": [
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml"
+      ],
+      "implementation_facts": {
+        "constructor_preserves_positional_config": true,
+        "keyword_only_quality_monitor": true,
+        "default_singleton_fallback_preserved": true,
+        "injected_monitor_bypasses_module_getter": true,
+        "data_source_factory_constructor_compatibility_preserved": true
+      },
+      "verification": {
+        "gitnexus_pre_edit_impact": "LOW for target file and class",
+        "tdd_red": "1 failed on unexpected quality_monitor keyword argument",
+        "focused_pytest_green": "2 passed",
+        "authorized_regression_pytest": "18 passed",
+        "ruff": "passed"
+      },
+      "forbidden_surfaces_preserved": [
+        "web/backend/app/services/data_source_factory/**",
+        "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "web/backend/app/services/data_quality_monitor.py",
+        "web/backend/app/services/adapters/**",
+        "web/backend/app/services/adapters_split/**",
+        "web/backend/app/services/data_adapters/**",
+        "web/backend/app/api/**",
+        "web/frontend/**",
+        "src/**",
+        "docs/api/**",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "freshness": {
+        "current_head_checked": "b4b34375eef0186b81be9a24491328dab72c2e21",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.209 data-quality market_data_adapter.py provider seam closeout / residual refresh without source authority."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-28T17:41:53+08:00`
-- Base HEAD checked: `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0`
+- Prepared at: `2026-05-28T17:58:00+08:00`
+- Base HEAD checked: `b4b34375eef0186b81be9a24491328dab72c2e21`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -59,7 +59,8 @@ It proved a repeatable conveyor:
 | G2.204 data-quality legacy adapter compatibility wrapper implementation | Merged by PR `#357` | Converts two legacy modules into thin wrappers, preserves old import paths, and reduces target legacy getter calls to `0` |
 | G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh | Merged by PR `#358` | Closes the legacy wrapper target and recommends G2.206 `market_data_adapter.py` compatibility facade ownership decision |
 | G2.206 data-quality `market_data_adapter.py` compatibility facade ownership decision | Merged by PR `#359` | Classifies `market_data_adapter.py` as active data-source-factory compatibility facade and recommends G2.207 provider seam authorization |
-| G2.207 data-quality `market_data_adapter.py` provider seam authorization | For review | Authorizes future G2.208 source implementation scope without source edits in G2.207 |
+| G2.207 data-quality `market_data_adapter.py` provider seam authorization | Merged by PR `#360` | Authorizes future G2.208 source implementation scope without source edits in G2.207 |
+| G2.208 data-quality `market_data_adapter.py` provider seam implementation | For review | Implements optional quality monitor injection while preserving default singleton fallback and data-source-factory constructor compatibility |
 
 ## Current Strategy Getter Residuals
 
@@ -645,11 +646,40 @@ Forbidden in G2.208 unless a later package explicitly expands scope:
 - `DataQualityMonitor` internals
 - route, OpenAPI, frontend, config, script, or OpenSpec changes
 
+PR `#360` merged this lane at
+`b4b34375eef0186b81be9a24491328dab72c2e21`.
+
+## G2.208 Data-Quality Market Data Adapter Provider Implementation
+
+At HEAD `b4b34375eef0186b81be9a24491328dab72c2e21`, PR `#360` is merged and
+G2.207 is accepted.
+
+Implementation result:
+
+| Item | Before | After |
+|---|---|---|
+| `MarketDataSourceAdapter` constructor | `config` only | `config`, plus keyword-only optional `quality_monitor` |
+| Default quality monitor behavior | module-level getter fallback | preserved |
+| Injected quality monitor behavior | not supported | injected monitor bypasses module-level getter |
+| `data_source_factory` constructor compatibility | `MarketDataSourceAdapter(config.__dict__)` | preserved |
+
+TDD evidence:
+
+| Phase | Result |
+|---|---|
+| RED | `1 failed` on unexpected `quality_monitor` keyword argument |
+| GREEN | focused provider seam test `2 passed` |
+| Regression | authorized market adapter / factory regression package `18 passed` |
+| Ruff | authorized files passed |
+
+G2.208 does not edit `data_source_factory`, singleton wrapper/backing API,
+route/OpenAPI, frontend, config, script, or OpenSpec surfaces.
+
 ## Next Gates
 
-- Review G2.207 `market_data_adapter.py` provider seam authorization package.
-- If accepted, start G2.208 implementation with only the authorized source and test paths.
-- Do not expand G2.208 into `data_source_factory`, singleton wrapper/backing API, routes, OpenAPI, frontend, config, scripts, or OpenSpec changes.
+- Review G2.208 `market_data_adapter.py` provider seam implementation.
+- If accepted, start G2.209 closeout / residual refresh with no source edits.
+- Do not open the next source lane before G2.209 classifies remaining data-quality monitor surfaces.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/FUNCTION_TREE.md
+++ b/docs/FUNCTION_TREE.md
@@ -124,6 +124,7 @@
 | Byapi | ⚠️ | 7 | 403问题待修 |
 | Backend canonical service adapters | ✅ | backend | `web/backend/app/services/adapters/dashboard_adapter.py` 与 `web/backend/app/services/adapters/data_adapter.py` 接入数据源工厂，并通过 G2.200 支持可注入 data-quality monitor seam |
 | Backend legacy data adapter wrappers | ✅ | backend | `web/backend/app/services/data_adapters/dashboard.py` 与 `web/backend/app/services/data_adapters/data_source.py` 通过 G2.204 保留旧模块路径并重导出 canonical adapters |
+| Backend market data adapter facade | ✅ | backend | `web/backend/app/services/market_data_adapter.py` 通过 G2.208 保留 `MarketDataSourceAdapter(config)` 兼容构造，并支持可注入 data-quality monitor seam |
 
 ### 1.4 K线数据服务 {#domain-01-node-04}
 

--- a/docs/reports/quality/backend-data-quality-market-data-adapter-provider-implementation-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-market-data-adapter-provider-implementation-2026-05-28.md
@@ -1,0 +1,88 @@
+# Backend Data-Quality Market Data Adapter Provider Implementation
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: review candidate
+- Prepared at: `2026-05-28T17:58:00+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `b4b34375eef0186b81be9a24491328dab72c2e21`
+- Worktree branch: `g2-208-data-quality-market-data-adapter-provider-implementation`
+- Scope: path-limited source implementation
+- Source edit authority: yes, limited by G2.207
+
+## Parent State
+
+PR `#360` merged G2.207 at
+`b4b34375eef0186b81be9a24491328dab72c2e21`.
+
+G2.207 authorized only a narrow provider seam implementation for
+`web/backend/app/services/market_data_adapter.py`, plus focused tests.
+
+## Implementation Result
+
+| Item | Result |
+|---|---|
+| Constructor contract | `MarketDataSourceAdapter` keeps positional `config` and adds keyword-only optional `quality_monitor` |
+| Default behavior | Without injection, `_trigger_quality_monitoring` still falls back to `get_data_quality_monitor()` |
+| Injected behavior | With injection, `_trigger_quality_monitoring` uses the supplied monitor and bypasses the module-level getter |
+| Factory compatibility | `MarketDataSourceAdapter(config.__dict__)` remains valid because the new parameter is keyword-only optional |
+| Function-tree mapping | `domain-01-node-03` now records the market data adapter facade and focused test |
+
+Changed source path:
+
+- `web/backend/app/services/market_data_adapter.py`
+
+Changed test path:
+
+- `web/backend/tests/test_market_data_adapter_quality_monitor_provider.py`
+
+## TDD Evidence
+
+| Phase | Result |
+|---|---|
+| RED | New focused test failed with `TypeError: MarketDataSourceAdapter.__init__() got an unexpected keyword argument 'quality_monitor'` |
+| GREEN | New focused test passed with `2 passed` |
+| Regression | Authorized regression package passed with `18 passed` |
+| Ruff | Authorized source/test files passed |
+
+## GitNexus Evidence
+
+Pre-edit impact checks were run before source edits:
+
+| Target | Risk | Impact |
+|---|---|---|
+| `web/backend/app/services/market_data_adapter.py` | LOW | `impacted_count=3`, `direct=1`, `processes_affected=0` |
+| `MarketDataSourceAdapter` | LOW | `impacted_count=0`, `direct=0`, `processes_affected=0` |
+
+## Preserved Boundaries
+
+This implementation did not edit:
+
+- `web/backend/app/services/data_source_factory/**`
+- `web/backend/app/services/_data_quality_monitor_singleton.py`
+- `web/backend/app/services/data_quality_monitor.py`
+- `web/backend/app/services/adapters/**`
+- `web/backend/app/services/adapters_split/**`
+- `web/backend/app/services/data_adapters/**`
+- `web/backend/app/api/**`
+- frontend, `src`, config, scripts, docs/api, or OpenSpec files
+
+## Recommended Next Gate
+
+Start G2.209 as a governance-only closeout / residual refresh package.
+
+G2.209 should confirm the market data adapter provider seam is closed and
+classify the remaining data-quality monitor residuals before any singleton
+wrapper or backing API retirement is considered.
+
+## Evidence Artifacts
+
+| Artifact | Role |
+|---|---|
+| `.planning/codebase/generated/data-quality-market-data-adapter-provider-authorization-2026-05-28.json` | G2.207 authorization package |
+| `docs/reports/quality/backend-data-quality-market-data-adapter-provider-authorization-2026-05-28.md` | G2.207 human-readable authorization package |
+| `.planning/codebase/generated/data-quality-market-data-adapter-provider-implementation-2026-05-28.json` | G2.208 machine-readable implementation evidence |
+| `docs/reports/quality/backend-data-quality-market-data-adapter-provider-implementation-2026-05-28.md` | G2.208 human-readable implementation report |
+| `governance/mainline/task-cards/pr-361.yaml` | G2.208 source implementation scope card |

--- a/governance/function-tree/catalog.yaml
+++ b/governance/function-tree/catalog.yaml
@@ -58,10 +58,12 @@ domains:
           - "web/backend/app/services/adapters/data_adapter.py"
           - "web/backend/app/services/data_adapters/dashboard.py"
           - "web/backend/app/services/data_adapters/data_source.py"
+          - "web/backend/app/services/market_data_adapter.py"
           - "web/backend/app/services/adapters_split/**"
           - "web/backend/tests/test_adapter_split_data_quality_monitor_provider.py"
           - "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py"
           - "web/backend/tests/test_data_quality_legacy_data_adapter_compat.py"
+          - "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py"
           - "config/data_sources*"
         entrypoints:
           governance:
@@ -75,10 +77,12 @@ domains:
             - "web/backend/app/services/adapters/data_adapter.py"
             - "web/backend/app/services/data_adapters/dashboard.py"
             - "web/backend/app/services/data_adapters/data_source.py"
+            - "web/backend/app/services/market_data_adapter.py"
           tests:
             - "tests/unit/adapters/**"
             - "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py"
             - "web/backend/tests/test_data_quality_legacy_data_adapter_compat.py"
+            - "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py"
           operations:
             - "docs/operations/OPS_MANUAL.md"
       - id: "domain-01-node-04"

--- a/governance/mainline/task-cards/pr-361.yaml
+++ b/governance/mainline/task-cards/pr-361.yaml
@@ -1,0 +1,138 @@
+version: "v0.2"
+
+task:
+  id: "pr-361"
+  title: "Implement market data adapter quality monitor provider seam"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-market-data-adapter-provider-implementation"
+  objective: "implement the G2.207-authorized quality monitor provider seam in market_data_adapter.py"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "feature"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "domain-01"
+  node_id: "domain-01-node-03"
+  affected_entrypoints:
+    - "core"
+    - "tests"
+    - "governance"
+  update_status: "required"
+  secondary_domains: []
+  exemption_reason: "Path-limited backend data-source integration seam; no route, HTTP method, response model, OpenAPI example, frontend behavior, PM2 workflow, or public API ownership change."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-market-data-adapter-provider-implementation-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-market-data-adapter-provider-implementation-2026-05-28.md"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "governance/mainline/task-cards/pr-361.yaml"
+    - "web/backend/app/services/market_data_adapter.py"
+    - "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py"
+  forbidden_paths:
+    - "web/backend/app/services/data_source_factory/**"
+    - "web/backend/app/services/_data_quality_monitor_singleton.py"
+    - "web/backend/app/services/data_quality_monitor.py"
+    - "web/backend/app/services/adapters/**"
+    - "web/backend/app/services/adapters_split/**"
+    - "web/backend/app/services/data_adapters/**"
+    - "web/backend/app/api/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "data_source_factory source edits"
+  - "singleton wrapper deletion"
+  - "DataQualityMonitor internals"
+  - "canonical adapter edits"
+  - "legacy data adapter wrapper edits"
+  - "route changes"
+  - "OpenAPI contract changes"
+  - "frontend changes"
+  - "OpenSpec proposal creation"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_adapter_quality_monitor_provider.py -q --no-cov --tb=short"
+      required: true
+    - id: "authorized-regression"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_market_data_service_getter_retirement.py web/backend/tests/_test_data_source_factory_management.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff-authorized-files"
+      command: "ruff check web/backend/app/services/market_data_adapter.py web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_market_data_service_getter_retirement.py"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-market-data-adapter-provider-implementation-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-361.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-market-data-adapter-provider-implementation-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-361.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha b4b34375eef0186b81be9a24491328dab72c2e21 --head-sha HEAD --report /tmp/pr361-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Changing constructor shape could break data_source_factory if the new parameter were not keyword-only optional."
+    - "Removing singleton fallback would break default construction."
+  rollback_plan: "revert this PR to restore the post-#360 market_data_adapter.py behavior and rerun G2.207 authorization before retrying."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "implement optional quality monitor injection for market data adapter quality monitoring"
+    modified_scope: "one backend service file, one focused test file, function-tree mapping, governance evidence, steward tree files, and one task card"
+    dependency_changes: "none"
+    legacy_logic_impact: "default construction keeps existing singleton fallback; injected monitor bypasses module getter"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if focused tests, data-source-factory compatibility, or scope gates fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T17:58:00+08:00"
+    approval_note: "Human maintainer approved continuing after PR #360 acceptance; this lane implements only the G2.207-authorized provider seam."
+    secondary_approved: true

--- a/web/backend/app/services/market_data_adapter.py
+++ b/web/backend/app/services/market_data_adapter.py
@@ -35,11 +35,12 @@ class DataSourceMetrics:
 class MarketDataSourceAdapter(IDataSource):
     """市场数据源适配器 - 集成现有 MarketDataService 到数据源工厂模式"""
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], *, quality_monitor: Any = None):
         self.config = config
         self.source_type = "market"
         self.name = config.get("name", "Market Data Source")
         self.mode = config.get("mode", "mock")
+        self._quality_monitor = quality_monitor
 
         # Lazy initialization of services (only when needed)
         self._market_service = None
@@ -324,7 +325,7 @@ class MarketDataSourceAdapter(IDataSource):
     ) -> None:
         """触发数据质量监控"""
         try:
-            monitor = get_data_quality_monitor()
+            monitor = self._quality_monitor if self._quality_monitor is not None else get_data_quality_monitor()
             await monitor.evaluate_data_quality(
                 data=data or {},
                 source=f"{self.source_type}:{endpoint}",

--- a/web/backend/tests/test_market_data_adapter_quality_monitor_provider.py
+++ b/web/backend/tests/test_market_data_adapter_quality_monitor_provider.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.market_data_adapter import MarketDataSourceAdapter
+
+
+class FakeQualityMonitor:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def evaluate_data_quality(
+        self,
+        *,
+        data: dict[str, object],
+        source: str,
+        response_time: float,
+        success: bool,
+    ) -> None:
+        self.calls.append(
+            {
+                "data": data,
+                "source": source,
+                "response_time": response_time,
+                "success": success,
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_market_data_adapter_uses_injected_quality_monitor(monkeypatch):
+    def fail_getter():
+        raise AssertionError("module-level getter should not be called")
+
+    monkeypatch.setattr("app.services.market_data_adapter.get_data_quality_monitor", fail_getter)
+    monitor = FakeQualityMonitor()
+
+    adapter = MarketDataSourceAdapter({"mode": "mock"}, quality_monitor=monitor)
+
+    await adapter._trigger_quality_monitoring(
+        endpoint="fund-flow",
+        data={"symbol": "000001"},
+        response_time=12.5,
+        success=True,
+    )
+
+    assert monitor.calls == [
+        {
+            "data": {"symbol": "000001"},
+            "source": "market:fund-flow",
+            "response_time": 12.5,
+            "success": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_market_data_adapter_preserves_default_quality_monitor_fallback(monkeypatch):
+    monitor = FakeQualityMonitor()
+    monkeypatch.setattr("app.services.market_data_adapter.get_data_quality_monitor", lambda: monitor)
+
+    adapter = MarketDataSourceAdapter({"mode": "mock"})
+
+    await adapter._trigger_quality_monitoring(
+        endpoint="quotes",
+        data=None,
+        response_time=4.0,
+        success=False,
+    )
+
+    assert monitor.calls == [
+        {
+            "data": {},
+            "source": "market:quotes",
+            "response_time": 4.0,
+            "success": False,
+        }
+    ]


### PR DESCRIPTION
## Summary

G2.208 implements the approved `market_data_adapter.py` data-quality monitor provider seam from G2.207 / PR #360.

- preserves `MarketDataSourceAdapter(config)` positional compatibility
- adds keyword-only optional `quality_monitor` injection
- keeps default fallback through `get_data_quality_monitor()` when no provider is injected
- proves injected monitor path bypasses the module-level getter
- updates steward tree, Function Tree, generated evidence, and the PR task card

## Scope

Changed source path:

- `web/backend/app/services/market_data_adapter.py`

Changed test path:

- `web/backend/tests/test_market_data_adapter_quality_monitor_provider.py`

Governance / evidence paths:

- `.planning/codebase/generated/data-quality-market-data-adapter-provider-implementation-2026-05-28.json`
- `.planning/codebase/steward-tree/current-next-gates.md`
- `.planning/codebase/steward-tree/steward-index.json`
- `.planning/codebase/steward-tree/tracks/service-lifecycle-di.md`
- `.planning/codebase/steward-tree/branch-register.md`
- `.planning/codebase/steward-tree/evidence-index.md`
- `.planning/codebase/steward-tree/completed-ledger.md`
- `docs/reports/quality/backend-data-quality-market-data-adapter-provider-implementation-2026-05-28.md`
- `docs/FUNCTION_TREE.md`
- `governance/function-tree/catalog.yaml`
- `governance/mainline/task-cards/pr-361.yaml`

## Verification

Fresh pre-commit and post-commit gates were run from the G2.208 worktree.

- GitNexus pre-edit impact: LOW, direct importer count 1, affected process count 0
- GitNexus staged detect changes: LOW, affected process count 0
- GitNexus compare detect changes after commit: LOW, affected process count 0
- `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_adapter_quality_monitor_provider.py -q --no-cov --tb=short`: 2 passed
- `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_market_data_service_getter_retirement.py web/backend/tests/_test_data_source_factory_management.py -q --no-cov --tb=short`: 18 passed
- `ruff check web/backend/app/services/market_data_adapter.py web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_market_data_service_getter_retirement.py`: passed
- JSON/YAML parse gate: passed
- Markdown governance gate: 7 checked files, 0 errors
- `openspec validate migrate-backend-singletons-to-lifecycle-di --strict`: valid; PostHog network flush emitted telemetry noise only
- `git diff --cached --check`: passed before commit
- `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-361.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha b4b34375eef0186b81be9a24491328dab72c2e21 --head-sha HEAD --report /tmp/pr361-mainline-governance-report-postcommit.json`: pass=True
- `gitnexus analyze`: completed after source commit

## Boundaries

This PR does not modify `web/backend/app/services/data_source_factory/**`, singleton wrapper/backing API, routes, OpenAPI, frontend, config, scripts, or OpenSpec change/spec files.

Next gate after review/merge: G2.209 closeout / residual refresh, with no source authority unless separately approved.
