### PR TITLE
docs(governance): close out market data adapter provider seam

### DIFF
--- a/.planning/codebase/generated/data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "2026-05-28.closeout-refresh.v1",
+  "generated_at": "2026-05-28T19:32:39+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "90d8f12cc01f9fb360abc531673e3ed9535706e7",
+  "worktree_branch": "g2-209-data-quality-market-data-adapter-provider-closeout",
+  "status": "closeout_refresh",
+  "source_edit_authority": false,
+  "parent": {
+    "node": "G2.208 data-quality market_data_adapter.py provider seam implementation",
+    "github_pr": 361,
+    "merge_commit": "90d8f12cc01f9fb360abc531673e3ed9535706e7",
+    "implementation_commit": "7c73e338e"
+  },
+  "closeout": {
+    "closed_target": "web/backend/app/services/market_data_adapter.py quality monitor provider seam",
+    "constructor_signature": "def __init__(self, config: Dict[str, Any], *, quality_monitor: Any = None):",
+    "stores_injected_monitor": true,
+    "monitor_selection": "monitor = self._quality_monitor if self._quality_monitor is not None else get_data_quality_monitor()",
+    "default_singleton_fallback_preserved": true,
+    "injected_monitor_bypasses_module_getter": true,
+    "data_source_factory_compatibility": {
+      "direct_import": "web/backend/app/services/data_source_factory/data_source_factory.py:32",
+      "constructor_call": "web/backend/app/services/data_source_factory/data_source_factory.py:113: MarketDataSourceAdapter(config.__dict__)",
+      "status": "preserved"
+    }
+  },
+  "residual_scan": {
+    "command_summary": "rg get_data_quality_monitor / quality_monitor across web/backend/app/services and web/backend/tests, plus MarketDataSourceAdapter reference scan",
+    "service_getter_hit_count": 15,
+    "test_getter_hit_count": 12,
+    "market_data_adapter_target_status": "closed_with_retained_singleton_fallback",
+    "live_service_files_with_get_data_quality_monitor": [
+      {
+        "path": "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "classification": "singleton_backing_api",
+        "handling": "retained; requires separate ownership decision before any source edits"
+      },
+      {
+        "path": "web/backend/app/services/data_quality_monitor.py",
+        "classification": "public_singleton_facade",
+        "handling": "retained; requires separate ownership decision before any source edits"
+      },
+      {
+        "path": "web/backend/app/services/adapters/dashboard_adapter.py",
+        "classification": "closed_canonical_service_adapter_fallback",
+        "handling": "covered by G2.200/G2.201; do not reopen unless current evidence contradicts those reports"
+      },
+      {
+        "path": "web/backend/app/services/adapters/data_adapter.py",
+        "classification": "closed_canonical_service_adapter_fallback",
+        "handling": "covered by G2.200/G2.201; do not reopen unless current evidence contradicts those reports"
+      },
+      {
+        "path": "web/backend/app/services/adapters_split/base_adapter.py",
+        "classification": "closed_adapter_split_base_fallback",
+        "handling": "covered by G2.196/G2.197; do not reopen unless current evidence contradicts those reports"
+      },
+      {
+        "path": "web/backend/app/services/market_data_adapter.py",
+        "classification": "closed_market_data_adapter_fallback",
+        "handling": "closed by G2.208/G2.209; retained fallback is intentional compatibility behavior"
+      }
+    ],
+    "historical_files_with_get_data_quality_monitor": [
+      {
+        "path": "web/backend/app/services/data_adapter.py.backup.20260130",
+        "classification": "historical_backup_file",
+        "handling": "not a G2.209 source target; cleanup requires separate repository hygiene authority"
+      }
+    ],
+    "test_files_with_get_data_quality_monitor": [
+      "web/backend/tests/test_adapter_split_data_quality_monitor_provider.py",
+      "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py",
+      "web/backend/tests/test_data_quality_legacy_data_adapter_compat.py",
+      "web/backend/tests/test_data_quality_route_provider_regressions.py",
+      "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py"
+    ]
+  },
+  "verification": {
+    "github_pr_361": {
+      "state": "MERGED",
+      "merge_commit": "90d8f12cc01f9fb360abc531673e3ed9535706e7",
+      "merged_at": "2026-05-28T11:28:46Z"
+    },
+    "post_merge_focused_pytest": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_adapter_quality_monitor_provider.py -q --no-cov --tb=short",
+      "expected_result": "2 passed"
+    },
+    "post_merge_regression_pytest": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_market_data_service_getter_retirement.py web/backend/tests/_test_data_source_factory_management.py -q --no-cov --tb=short",
+      "expected_result": "18 passed"
+    },
+    "openspec_validate": {
+      "command": "openspec validate migrate-backend-singletons-to-lifecycle-di --strict",
+      "expected_result": "valid; PostHog telemetry flush noise is non-blocking if validation succeeds"
+    }
+  },
+  "next_gate": {
+    "id": "G2.210",
+    "name": "data-quality monitor residual ownership decision",
+    "source_edit_authority": false,
+    "purpose": "Decide whether singleton/backing API, closed fallback surfaces, and historical backup cleanup need separate authorization lanes; do not open a source implementation directly from G2.209."
+  },
+  "non_goals": [
+    "No edits under web/backend/** in G2.209",
+    "No singleton wrapper deletion or privatization",
+    "No data_source_factory source changes",
+    "No route, OpenAPI, frontend, config, script, or OpenSpec change edits",
+    "No deletion of historical backup files"
+  ],
+  "freshness": {
+    "current_head_checked": "90d8f12cc01f9fb360abc531673e3ed9535706e7",
+    "stale_if_head_mismatch": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T13:15:46+08:00`
-- Base HEAD checked: `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd`
+- Prepared at: `2026-05-28T19:32:39+08:00`
+- Base HEAD checked: `90d8f12cc01f9fb360abc531673e3ed9535706e7`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -45,12 +45,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#358` | `g2-205-data-quality-legacy-adapter-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `44909f5d048700115da6a9eb9345957b8af3d077` | Governance closeout selecting G2.206 `market_data_adapter.py` compatibility facade ownership decision |
 | `#359` | `g2-206-data-quality-market-data-adapter-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0` | Decision package selecting G2.207 provider seam authorization |
 | `#360` | `g2-207-data-quality-market-data-adapter-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `b4b34375eef0186b81be9a24491328dab72c2e21` | Authorization package for G2.208 `market_data_adapter.py` provider seam implementation |
+| `#361` | `g2-208-data-quality-market-data-adapter-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `90d8f12cc01f9fb360abc531673e3ed9535706e7` | Path-limited `market_data_adapter.py` provider seam implementation closed for G2.209 refresh |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-208-data-quality-market-data-adapter-provider-implementation` | `origin/wip/root-dirty-20260403` at `b4b34375eef0186b81be9a24491328dab72c2e21` | Implement the path-limited `market_data_adapter.py` provider seam | Yes, limited |
+| `g2-209-data-quality-market-data-adapter-provider-closeout` | `origin/wip/root-dirty-20260403` at `90d8f12cc01f9fb360abc531673e3ed9535706e7` | Close out the merged `market_data_adapter.py` provider seam and classify residuals | No |
 
 ## OpenSpec Relationship
 
@@ -66,7 +67,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.208 is a path-limited source implementation branch after PR `#360` merged
-G2.207. It is limited to `market_data_adapter.py`, one focused provider seam
-test, function-tree mapping, and governance evidence. If accepted, the next gate
-is a G2.209 closeout / residual refresh.
+G2.209 is a no-source closeout / residual refresh branch after PR `#361` merged
+G2.208. It is limited to governance evidence, steward tree updates, and a task
+card. If accepted, the next gate is a G2.210 residual ownership decision, not a
+direct source implementation lane.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T17:58:00+08:00`
-- Base HEAD checked: `b4b34375eef0186b81be9a24491328dab72c2e21`
+- Prepared at: `2026-05-28T19:32:39+08:00`
+- Base HEAD checked: `90d8f12cc01f9fb360abc531673e3ed9535706e7`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 is the active `market_data_adapter.py` provider seam implementation |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 is the active closeout / residual refresh |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T17:58:00+08:00`
-- Base HEAD checked: `b4b34375eef0186b81be9a24491328dab72c2e21`
+- Prepared at: `2026-05-28T19:32:39+08:00`
+- Base HEAD checked: `90d8f12cc01f9fb360abc531673e3ed9535706e7`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.208 data-quality `market_data_adapter.py` provider seam implementation | G/#79 service lifecycle DI | PR `#360` merged at `b4b34375eef0186b81be9a24491328dab72c2e21`; G2.208 implements optional quality monitor injection for `MarketDataSourceAdapter` | If accepted, start G2.209 closeout / residual refresh; do not open the next source lane directly |
+| P0 | Review G2.209 data-quality `market_data_adapter.py` provider seam closeout / residual refresh | G/#79 service lifecycle DI | PR `#361` merged at `90d8f12cc01f9fb360abc531673e3ed9535706e7`; G2.209 closes the target and classifies remaining data-quality monitor residuals without source edits | If accepted, start G2.210 residual ownership decision; do not open the next source lane directly |
+| P0 | Preserve G2.208 data-quality `market_data_adapter.py` provider seam implementation | G/#79 service lifecycle DI | PR `#361` merged; optional quality monitor injection is implemented for `MarketDataSourceAdapter` while preserving default singleton fallback | Do not reopen `market_data_adapter.py` source unless current HEAD evidence contradicts G2.208/G2.209 |
 | P0 | Preserve G2.207 data-quality `market_data_adapter.py` provider seam authorization package | G/#79 service lifecycle DI | PR `#360` merged; future implementation scope was limited to `market_data_adapter.py` plus focused tests | Do not expand into `data_source_factory`, singleton wrapper/backing API, routes, OpenAPI, frontend, config, scripts, or OpenSpec |
 | P0 | Preserve G2.206 data-quality `market_data_adapter.py` compatibility facade ownership decision | G/#79 service lifecycle DI | PR `#359` merged; `market_data_adapter.py` is an active factory-owned compatibility facade, not a deletion or thin-wrapper candidate | Do not implement from G2.206; use G2.207 authorization first |
 | P0 | Preserve G2.205 data-quality legacy adapter compatibility wrapper closeout / residual refresh | G/#79 service lifecycle DI | PR `#358` merged; legacy wrapper target is closed and `market_data_adapter.py` was selected as the next decision target | Do not open source work before G2.206 is accepted |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T13:15:46+08:00`
-- Base HEAD checked: `142a2bf1c0c5f979cf9c32415d2f25832e7e62cd`
+- Prepared at: `2026-05-28T19:32:39+08:00`
+- Base HEAD checked: `90d8f12cc01f9fb360abc531673e3ed9535706e7`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -77,8 +77,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-market-data-adapter-ownership-decision-2026-05-28.md` | G2.206 human-readable ownership decision report | Accepted by PR `#359`; superseded for provider seam authorization by G2.207 |
 | `.planning/codebase/generated/data-quality-market-data-adapter-provider-authorization-2026-05-28.json` | G2.207 `market_data_adapter.py` provider seam authorization evidence | Accepted by PR `#360`; superseded for implementation evidence by G2.208 |
 | `docs/reports/quality/backend-data-quality-market-data-adapter-provider-authorization-2026-05-28.md` | G2.207 human-readable provider seam authorization package | Accepted by PR `#360`; superseded for implementation evidence by G2.208 |
-| `.planning/codebase/generated/data-quality-market-data-adapter-provider-implementation-2026-05-28.json` | G2.208 `market_data_adapter.py` provider seam implementation evidence | Current for HEAD `b4b34375eef0186b81be9a24491328dab72c2e21`; review input until PR `#361` is accepted |
-| `docs/reports/quality/backend-data-quality-market-data-adapter-provider-implementation-2026-05-28.md` | G2.208 human-readable provider seam implementation report | Review input until PR `#361` is accepted |
+| `.planning/codebase/generated/data-quality-market-data-adapter-provider-implementation-2026-05-28.json` | G2.208 `market_data_adapter.py` provider seam implementation evidence | Accepted by PR `#361`; superseded for closeout / residual refresh by G2.209 |
+| `docs/reports/quality/backend-data-quality-market-data-adapter-provider-implementation-2026-05-28.md` | G2.208 human-readable provider seam implementation report | Accepted by PR `#361`; superseded for closeout / residual refresh by G2.209 |
+| `.planning/codebase/generated/data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.json` | G2.209 `market_data_adapter.py` provider seam closeout / residual refresh evidence | Current for HEAD `90d8f12cc01f9fb360abc531673e3ed9535706e7`; review input until PR `#362` is accepted |
+| `docs/reports/quality/backend-data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.md` | G2.209 human-readable closeout / residual refresh report | Review input until PR `#362` is accepted |
 
 ## External State Inputs
 

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T17:58:00+08:00",
+  "generated_at": "2026-05-28T19:32:39+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "b4b34375eef0186b81be9a24491328dab72c2e21",
-  "split_branch": "g2-208-data-quality-market-data-adapter-provider-implementation",
-  "scope": "data_quality_market_data_adapter_provider_implementation",
-  "source_edit_authority": true,
+  "base_head": "90d8f12cc01f9fb360abc531673e3ed9535706e7",
+  "split_branch": "g2-209-data-quality-market-data-adapter-provider-closeout",
+  "scope": "data_quality_market_data_adapter_provider_closeout_refresh",
+  "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -1943,12 +1943,19 @@
     {
       "id": "g2-208-data-quality-market-data-adapter-provider-implementation",
       "type": "implementation",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.207 data-quality market_data_adapter.py provider seam authorization",
       "source_edit_authority": true,
       "parent_github_pr": 360,
       "parent_merge_commit": "b4b34375eef0186b81be9a24491328dab72c2e21",
+      "github_pr": {
+        "number": 361,
+        "url": "https://github.com/chengjon/mystocks/pull/361",
+        "state_at_closeout": "MERGED",
+        "head_ref": "g2-208-data-quality-market-data-adapter-provider-implementation",
+        "merge_commit": "90d8f12cc01f9fb360abc531673e3ed9535706e7"
+      },
       "evidence": [
         ".planning/codebase/generated/data-quality-market-data-adapter-provider-implementation-2026-05-28.json",
         "docs/reports/quality/backend-data-quality-market-data-adapter-provider-implementation-2026-05-28.md",
@@ -1995,10 +2002,55 @@
         "openspec/specs/**"
       ],
       "freshness": {
-        "current_head_checked": "b4b34375eef0186b81be9a24491328dab72c2e21",
+        "current_head_checked": "90d8f12cc01f9fb360abc531673e3ed9535706e7",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.209 data-quality market_data_adapter.py provider seam closeout / residual refresh without source authority."
+      "next_gate": "Superseded by G2.209 data-quality market_data_adapter.py provider seam closeout / residual refresh."
+    },
+    {
+      "id": "g2-209-data-quality-market-data-adapter-provider-closeout",
+      "type": "closeout_refresh",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.208 data-quality market_data_adapter.py provider seam implementation",
+      "source_edit_authority": false,
+      "parent_github_pr": 361,
+      "parent_merge_commit": "90d8f12cc01f9fb360abc531673e3ed9535706e7",
+      "evidence": [
+        ".planning/codebase/generated/data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.md",
+        "governance/mainline/task-cards/pr-362.yaml"
+      ],
+      "closed_target": "web/backend/app/services/market_data_adapter.py quality monitor provider seam",
+      "closeout_facts": {
+        "constructor_preserves_positional_config": true,
+        "keyword_only_quality_monitor": true,
+        "default_singleton_fallback_preserved": true,
+        "injected_monitor_bypasses_module_getter": true,
+        "data_source_factory_constructor_compatibility_preserved": true
+      },
+      "residual_classification": {
+        "closed_market_data_adapter_fallback": [
+          "web/backend/app/services/market_data_adapter.py"
+        ],
+        "closed_prior_fallbacks": [
+          "web/backend/app/services/adapters/dashboard_adapter.py",
+          "web/backend/app/services/adapters/data_adapter.py",
+          "web/backend/app/services/adapters_split/base_adapter.py"
+        ],
+        "retained_singleton_backing_api": [
+          "web/backend/app/services/_data_quality_monitor_singleton.py",
+          "web/backend/app/services/data_quality_monitor.py"
+        ],
+        "historical_backup_out_of_scope": [
+          "web/backend/app/services/data_adapter.py.backup.20260130"
+        ]
+      },
+      "freshness": {
+        "current_head_checked": "90d8f12cc01f9fb360abc531673e3ed9535706e7",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.210 data-quality monitor residual ownership decision without source authority."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -675,11 +675,43 @@ TDD evidence:
 G2.208 does not edit `data_source_factory`, singleton wrapper/backing API,
 route/OpenAPI, frontend, config, script, or OpenSpec surfaces.
 
+PR `#361` merged this lane at
+`90d8f12cc01f9fb360abc531673e3ed9535706e7`.
+
+## G2.209 Data-Quality Market Data Adapter Provider Closeout / Residual Refresh
+
+At HEAD `90d8f12cc01f9fb360abc531673e3ed9535706e7`, PR `#361` is merged and
+G2.208 is accepted.
+
+Closeout result:
+
+| Item | Result |
+|---|---|
+| Target path | `web/backend/app/services/market_data_adapter.py` |
+| Provider seam status | Closed |
+| Constructor compatibility | `MarketDataSourceAdapter(config)` preserved |
+| Injection compatibility | Keyword-only optional `quality_monitor` retained |
+| Default fallback | `get_data_quality_monitor()` fallback intentionally retained |
+| `data_source_factory` compatibility | `MarketDataSourceAdapter(config.__dict__)` remains compatible |
+
+Residual classification:
+
+| Residual surface | Classification | Handling |
+|---|---|---|
+| `market_data_adapter.py` fallback | Closed market-data adapter fallback | Do not reopen without contradictory current evidence |
+| `adapters/dashboard_adapter.py`, `adapters/data_adapter.py` | Closed canonical service adapter fallback | Covered by G2.200/G2.201 |
+| `adapters_split/base_adapter.py` | Closed adapter-split base fallback | Covered by G2.196/G2.197 |
+| `_data_quality_monitor_singleton.py`, `data_quality_monitor.py` | Singleton/backing API | Retained pending a separate ownership decision |
+| `data_adapter.py.backup.20260130` | Historical backup file | Separate repository hygiene authority required |
+
+G2.209 has no source authority. It does not edit `web/backend/**`, route,
+OpenAPI, frontend, config, script, or OpenSpec surfaces.
+
 ## Next Gates
 
-- Review G2.208 `market_data_adapter.py` provider seam implementation.
-- If accepted, start G2.209 closeout / residual refresh with no source edits.
-- Do not open the next source lane before G2.209 classifies remaining data-quality monitor surfaces.
+- Review G2.209 `market_data_adapter.py` provider seam closeout / residual refresh.
+- If accepted, start G2.210 data-quality monitor residual ownership decision with no source edits.
+- Do not open the next source lane before G2.210 decides singleton/backing API and retained fallback ownership.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/reports/quality/backend-data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.md
@@ -1,0 +1,91 @@
+# Backend Data-Quality Market Data Adapter Provider Closeout Refresh - 2026-05-28
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Lane: G2.209 data-quality `market_data_adapter.py` provider seam closeout / residual refresh
+- Prepared at: `2026-05-28T19:32:39+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `90d8f12cc01f9fb360abc531673e3ed9535706e7`
+- Parent PR: `#361`
+- Parent merge commit: `90d8f12cc01f9fb360abc531673e3ed9535706e7`
+- Source edit authority: none
+
+Boundary note: this report records closeout and residual classification only. It
+does not authorize source edits, singleton wrapper deletion, route/OpenAPI
+changes, frontend changes, OpenSpec edits, issue label changes, PM2 commands, or
+PR merges.
+
+## Closeout Result
+
+G2.208 is merged by PR `#361`. The target provider seam is closed for
+`web/backend/app/services/market_data_adapter.py`.
+
+| Checkpoint | Current result |
+|---|---|
+| Constructor compatibility | `def __init__(self, config: Dict[str, Any], *, quality_monitor: Any = None):` |
+| Positional `config` compatibility | Preserved |
+| Optional injection shape | Keyword-only `quality_monitor` |
+| Default behavior | Singleton fallback through `get_data_quality_monitor()` preserved |
+| Injected behavior | Injected monitor bypasses the module-level getter |
+| `data_source_factory` compatibility | `MarketDataSourceAdapter(config.__dict__)` remains the active factory call |
+
+G2.209 does not reopen `market_data_adapter.py`. The retained fallback is
+intentional compatibility behavior, not an unclosed implementation defect.
+
+## Residual Scan
+
+Residual scan at HEAD `90d8f12cc01f9fb360abc531673e3ed9535706e7`:
+
+| Metric | Count |
+|---|---:|
+| `get_data_quality_monitor` hits under `web/backend/app/services` | 15 |
+| `get_data_quality_monitor` hits under `web/backend/tests` | 12 |
+
+Residual classification:
+
+| Path | Classification | Handling |
+|---|---|---|
+| `web/backend/app/services/market_data_adapter.py` | Closed market-data adapter fallback | Closed by G2.208/G2.209; retained fallback is intentional |
+| `web/backend/app/services/adapters/dashboard_adapter.py` | Closed canonical service adapter fallback | Covered by G2.200/G2.201; do not reopen without contradictory current evidence |
+| `web/backend/app/services/adapters/data_adapter.py` | Closed canonical service adapter fallback | Covered by G2.200/G2.201; do not reopen without contradictory current evidence |
+| `web/backend/app/services/adapters_split/base_adapter.py` | Closed adapter-split base fallback | Covered by G2.196/G2.197; do not reopen without contradictory current evidence |
+| `web/backend/app/services/_data_quality_monitor_singleton.py` | Singleton backing API | Retained; requires separate ownership decision before source edits |
+| `web/backend/app/services/data_quality_monitor.py` | Public singleton facade | Retained; requires separate ownership decision before source edits |
+| `web/backend/app/services/data_adapter.py.backup.20260130` | Historical backup file | Not a G2.209 source target; cleanup needs separate repository hygiene authority |
+
+Test-only residuals are expected in:
+
+- `web/backend/tests/test_adapter_split_data_quality_monitor_provider.py`
+- `web/backend/tests/test_data_quality_canonical_service_adapter_provider.py`
+- `web/backend/tests/test_data_quality_legacy_data_adapter_compat.py`
+- `web/backend/tests/test_data_quality_route_provider_regressions.py`
+- `web/backend/tests/test_market_data_adapter_quality_monitor_provider.py`
+
+## Verification Plan
+
+The G2.209 PR must rerun the same post-merge evidence checks before it can be
+accepted:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_adapter_quality_monitor_provider.py -q --no-cov --tb=short
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_market_data_service_getter_retirement.py web/backend/tests/_test_data_source_factory_management.py -q --no-cov --tb=short
+python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null
+python -m json.tool .planning/codebase/generated/data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.json >/dev/null
+python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+openspec validate migrate-backend-singletons-to-lifecycle-di --strict
+python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-362.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 90d8f12cc01f9fb360abc531673e3ed9535706e7 --head-sha HEAD --report /tmp/pr362-mainline-governance-report.json
+```
+
+## Next Gate
+
+If G2.209 is accepted, start G2.210 as a decision package only:
+
+- decide whether singleton/backing API residuals need a dedicated ownership
+  package
+- keep closed fallback surfaces closed unless current evidence contradicts their
+  closeout reports
+- keep historical backup cleanup separate from service lifecycle DI source
+  implementation
+- do not open a new source implementation lane directly from G2.209

--- a/governance/mainline/task-cards/pr-362.yaml
+++ b/governance/mainline/task-cards/pr-362.yaml
@@ -1,0 +1,126 @@
+version: "v0.2"
+
+task:
+  id: "pr-362"
+  title: "Close out market data adapter quality monitor provider seam"
+  owner: "main"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-market-data-adapter-provider-closeout"
+  objective: "close out the merged market_data_adapter.py quality monitor provider seam and classify remaining residuals"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "G2.209 is a no-source closeout and residual classification package; it does not change route ownership, public API behavior, runtime entrypoints, or source coverage."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-362.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits"
+  - "data_source_factory source edits"
+  - "singleton wrapper deletion"
+  - "DataQualityMonitor internals"
+  - "canonical adapter edits"
+  - "legacy data adapter wrapper edits"
+  - "route changes"
+  - "OpenAPI contract changes"
+  - "frontend changes"
+  - "OpenSpec proposal creation"
+  - "GitHub issue label changes"
+  - "historical backup file deletion"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_adapter_quality_monitor_provider.py -q --no-cov --tb=short"
+      required: true
+    - id: "authorized-regression"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_market_data_service_getter_retirement.py web/backend/tests/_test_data_source_factory_management.py -q --no-cov --tb=short"
+      required: true
+    - id: "json-parse"
+      command: "python -m json.tool .planning/codebase/steward-tree/steward-index.json >/dev/null && python -m json.tool .planning/codebase/generated/data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.json >/dev/null"
+      required: true
+    - id: "yaml-parse"
+      command: "python - <<'PY'\nimport yaml\nwith open('governance/mainline/task-cards/pr-362.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-362.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 90d8f12cc01f9fb360abc531673e3ed9535706e7 --head-sha HEAD --report /tmp/pr362-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "A closeout report could incorrectly imply source authority for retained singleton/backing API residuals."
+    - "Residual fallback hits could be misread as unclosed defects instead of intentional compatibility behavior."
+  rollback_plan: "revert this PR to restore the post-#361 governance state, then rerun the residual scan before retrying G2.209."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "close out the merged market data adapter quality monitor provider seam and classify remaining residuals"
+    modified_scope: "governance evidence, steward tree files, and one task card only"
+    dependency_changes: "none"
+    legacy_logic_impact: "none; fallback retention is documented as intentional compatibility behavior"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert this PR if governance parsing, OpenSpec validation, scope gate, or post-merge regression checks fail"
+
+governance:
+  phase: "phase_a_pr_hard_gate"
+  mainline_drift_threshold_percent: 5
+  stop_rule_owner: "main"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "main"
+    approved_at: "2026-05-28T19:32:39+08:00"
+    approval_note: "Human maintainer approved continuing after PR #361 acceptance; this lane records closeout and residual classification only."
+    secondary_approved: true


### PR DESCRIPTION
## Summary

G2.209 closes out the merged G2.208 `market_data_adapter.py` quality monitor provider seam and refreshes residual classification. This is a no-source governance package after PR #361.

- records PR #361 as merged at `90d8f12cc01f9fb360abc531673e3ed9535706e7`
- confirms `MarketDataSourceAdapter(config)` compatibility and keyword-only `quality_monitor` injection are closed
- classifies retained `get_data_quality_monitor()` residuals as closed fallbacks, singleton/backing API, historical backup, or tests
- updates steward tree state, evidence index, branch register, completed ledger, and service lifecycle DI track
- adds machine-readable closeout evidence and PR #362 task card

## Scope

No source files are changed.

Changed governance / evidence paths:

- `.planning/codebase/generated/data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.json`
- `.planning/codebase/steward-tree/current-next-gates.md`
- `.planning/codebase/steward-tree/steward-index.json`
- `.planning/codebase/steward-tree/tracks/service-lifecycle-di.md`
- `.planning/codebase/steward-tree/branch-register.md`
- `.planning/codebase/steward-tree/evidence-index.md`
- `.planning/codebase/steward-tree/completed-ledger.md`
- `docs/reports/quality/backend-data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.md`
- `governance/mainline/task-cards/pr-362.yaml`

## Verification

Fresh checks were run from the G2.209 worktree.

- GitNexus staged detect changes: LOW, changed symbols 0, affected processes 0
- GitNexus compare detect changes after commit: LOW, changed symbols 0, affected processes 0
- `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_adapter_quality_monitor_provider.py -q --no-cov --tb=short`: 2 passed
- `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_market_data_service_getter_retirement.py web/backend/tests/_test_data_source_factory_management.py -q --no-cov --tb=short`: 18 passed
- JSON/YAML parse gate: passed
- Markdown governance gate: 6 checked files, 0 errors
- `openspec validate migrate-backend-singletons-to-lifecycle-di --strict`: valid; PostHog network flush emitted telemetry noise only
- `git diff --check` and `git diff --cached --check`: passed
- `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-362.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 90d8f12cc01f9fb360abc531673e3ed9535706e7 --head-sha HEAD --report /tmp/pr362-mainline-governance-report-postamend.json`: pass=True

## Boundaries

This PR does not edit `web/backend/**`, `web/frontend/**`, `src/**`, `docs/api/**`, `config/**`, `scripts/**`, `openspec/changes/**`, or `openspec/specs/**`.

Next gate after review/merge: G2.210 data-quality monitor residual ownership decision, still with no source authority unless separately approved.
