### PR TITLE
docs(governance): decide data quality monitor residual ownership

### DIFF
--- a/.planning/codebase/generated/data-quality-monitor-residual-ownership-decision-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-monitor-residual-ownership-decision-2026-05-28.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": "2026-05-28.decision-package.v1",
+  "generated_at": "2026-05-28T20:48:36+08:00",
+  "repo": "mystocks_spec",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "33b6ace2f68e23bcf07a12f53511d1f7b9fb8230",
+  "worktree_branch": "g2-210-data-quality-monitor-residual-ownership-decision",
+  "status": "for_review",
+  "source_edit_authority": false,
+  "parent": {
+    "lane": "G2.209 data-quality market_data_adapter.py provider seam closeout / residual refresh",
+    "github_pr": 362,
+    "merge_commit": "33b6ace2f68e23bcf07a12f53511d1f7b9fb8230",
+    "decision": "accepted closeout; remaining data-quality monitor surfaces require ownership decision before any new source lane"
+  },
+  "current_scan": {
+    "pattern": "get_data_quality_monitor|DataQualityMonitor",
+    "current_head_checked": "33b6ace2f68e23bcf07a12f53511d1f7b9fb8230",
+    "service_file_count": 7,
+    "service_hit_count": 21,
+    "test_file_count": 7,
+    "test_hit_count": 17,
+    "service_hits": [
+      {
+        "path": "web/backend/app/services/adapters_split/base_adapter.py",
+        "matches": 2,
+        "classification": "closed_adapter_split_fallback"
+      },
+      {
+        "path": "web/backend/app/services/adapters/dashboard_adapter.py",
+        "matches": 2,
+        "classification": "closed_canonical_service_adapter_fallback"
+      },
+      {
+        "path": "web/backend/app/services/adapters/data_adapter.py",
+        "matches": 2,
+        "classification": "closed_canonical_service_adapter_fallback"
+      },
+      {
+        "path": "web/backend/app/services/data_adapter.py.backup.20260130",
+        "matches": 3,
+        "classification": "historical_backup"
+      },
+      {
+        "path": "web/backend/app/services/data_quality_monitor.py",
+        "matches": 4,
+        "classification": "public_singleton_facade"
+      },
+      {
+        "path": "web/backend/app/services/market_data_adapter.py",
+        "matches": 2,
+        "classification": "closed_market_data_adapter_fallback"
+      },
+      {
+        "path": "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "matches": 6,
+        "classification": "singleton_backing_api"
+      }
+    ],
+    "test_hits": [
+      "web/backend/tests/test_large_file_split_regressions.py",
+      "web/backend/tests/test_adapter_split_data_quality_monitor_provider.py",
+      "web/backend/tests/test_data_quality_route_provider_regressions.py",
+      "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py",
+      "web/backend/tests/test_data_quality_legacy_data_adapter_compat.py",
+      "web/backend/tests/test_logging_noise_regressions.py",
+      "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py"
+    ]
+  },
+  "gitnexus_impact": {
+    "target": "Function:web/backend/app/services/_data_quality_monitor_singleton.py:get_data_quality_monitor",
+    "direction": "upstream",
+    "include_tests": true,
+    "max_depth": 2,
+    "risk": "CRITICAL",
+    "impacted_count": 24,
+    "direct": 20,
+    "processes_affected": 7,
+    "modules_affected": 4,
+    "affected_modules": [
+      "Services",
+      "Data_adapters",
+      "Api",
+      "Adapters"
+    ]
+  },
+  "decision": {
+    "classification": "high_risk_singleton_backing_api_ownership_surface",
+    "closed_surfaces_to_preserve": [
+      "web/backend/app/services/market_data_adapter.py",
+      "web/backend/app/services/adapters/dashboard_adapter.py",
+      "web/backend/app/services/adapters/data_adapter.py",
+      "web/backend/app/services/adapters_split/base_adapter.py"
+    ],
+    "ownership_surfaces_requiring_authorization": [
+      "web/backend/app/services/_data_quality_monitor_singleton.py",
+      "web/backend/app/services/data_quality_monitor.py"
+    ],
+    "separate_hygiene_surface": [
+      "web/backend/app/services/data_adapter.py.backup.20260130"
+    ],
+    "tests_are_contract_evidence_not_source_authority": true,
+    "implementation_from_this_package": false
+  },
+  "next_gate": {
+    "id": "G2.211",
+    "name": "data-quality monitor singleton/backing API authorization package",
+    "source_edit_authority": false,
+    "required_before_source_lane": [
+      "consumer matrix for data-quality route callers, service adapters, adapter_split constructors, and monitor_data_quality helper",
+      "explicit decision on public facade versus private singleton helper ownership",
+      "allowed source path list and focused test list for any future implementation",
+      "rollback plan for preserving route/API behavior and default fallback compatibility"
+    ]
+  },
+  "non_goals": [
+    "Do not edit web/backend source in G2.210.",
+    "Do not delete or rename get_data_quality_monitor.",
+    "Do not reopen closed market_data_adapter.py, canonical adapter, or adapter_split fallback lanes without contradictory current evidence.",
+    "Do not treat historical backup cleanup as service lifecycle DI implementation."
+  ],
+  "freshness": {
+    "current_head_checked": "33b6ace2f68e23bcf07a12f53511d1f7b9fb8230",
+    "stale_if_head_mismatch": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T19:32:39+08:00`
-- Base HEAD checked: `90d8f12cc01f9fb360abc531673e3ed9535706e7`
+- Prepared at: `2026-05-28T20:48:36+08:00`
+- Base HEAD checked: `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -46,12 +46,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#359` | `g2-206-data-quality-market-data-adapter-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0` | Decision package selecting G2.207 provider seam authorization |
 | `#360` | `g2-207-data-quality-market-data-adapter-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `b4b34375eef0186b81be9a24491328dab72c2e21` | Authorization package for G2.208 `market_data_adapter.py` provider seam implementation |
 | `#361` | `g2-208-data-quality-market-data-adapter-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `90d8f12cc01f9fb360abc531673e3ed9535706e7` | Path-limited `market_data_adapter.py` provider seam implementation closed for G2.209 refresh |
+| `#362` | `g2-209-data-quality-market-data-adapter-provider-closeout` | `wip/root-dirty-20260403` | `MERGED` at `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230` | Governance closeout selecting G2.210 data-quality monitor residual ownership decision |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-209-data-quality-market-data-adapter-provider-closeout` | `origin/wip/root-dirty-20260403` at `90d8f12cc01f9fb360abc531673e3ed9535706e7` | Close out the merged `market_data_adapter.py` provider seam and classify residuals | No |
+| `g2-210-data-quality-monitor-residual-ownership-decision` | `origin/wip/root-dirty-20260403` at `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230` | Decide remaining data-quality monitor singleton/backing API ownership and next authorization gate | No |
 
 ## OpenSpec Relationship
 
@@ -67,7 +68,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.209 is a no-source closeout / residual refresh branch after PR `#361` merged
-G2.208. It is limited to governance evidence, steward tree updates, and a task
-card. If accepted, the next gate is a G2.210 residual ownership decision, not a
-direct source implementation lane.
+G2.210 is a no-source residual ownership decision branch after PR `#362` merged
+G2.209. It is limited to governance evidence, steward tree updates, and a task
+card. If accepted, the next gate is a G2.211 singleton/backing API authorization
+package, not a direct source implementation lane.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T19:32:39+08:00`
-- Base HEAD checked: `90d8f12cc01f9fb360abc531673e3ed9535706e7`
+- Prepared at: `2026-05-28T20:48:36+08:00`
+- Base HEAD checked: `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 is the active closeout / residual refresh |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 is the active residual ownership decision |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T19:32:39+08:00`
-- Base HEAD checked: `90d8f12cc01f9fb360abc531673e3ed9535706e7`
+- Prepared at: `2026-05-28T20:48:36+08:00`
+- Base HEAD checked: `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.209 data-quality `market_data_adapter.py` provider seam closeout / residual refresh | G/#79 service lifecycle DI | PR `#361` merged at `90d8f12cc01f9fb360abc531673e3ed9535706e7`; G2.209 closes the target and classifies remaining data-quality monitor residuals without source edits | If accepted, start G2.210 residual ownership decision; do not open the next source lane directly |
+| P0 | Review G2.210 data-quality monitor residual ownership decision | G/#79 service lifecycle DI | PR `#362` merged at `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`; G2.210 classifies the singleton/backing API as a high-risk root ownership surface without source edits | If accepted, start G2.211 singleton/backing API authorization package; do not open source implementation directly |
+| P0 | Preserve G2.209 data-quality `market_data_adapter.py` provider seam closeout / residual refresh | G/#79 service lifecycle DI | PR `#362` merged; `market_data_adapter.py` is closed and remaining monitor residuals are routed to G2.210 ownership decision | Do not reopen closed G2.208/G2.209 source scope without contradictory current HEAD evidence |
 | P0 | Preserve G2.208 data-quality `market_data_adapter.py` provider seam implementation | G/#79 service lifecycle DI | PR `#361` merged; optional quality monitor injection is implemented for `MarketDataSourceAdapter` while preserving default singleton fallback | Do not reopen `market_data_adapter.py` source unless current HEAD evidence contradicts G2.208/G2.209 |
 | P0 | Preserve G2.207 data-quality `market_data_adapter.py` provider seam authorization package | G/#79 service lifecycle DI | PR `#360` merged; future implementation scope was limited to `market_data_adapter.py` plus focused tests | Do not expand into `data_source_factory`, singleton wrapper/backing API, routes, OpenAPI, frontend, config, scripts, or OpenSpec |
 | P0 | Preserve G2.206 data-quality `market_data_adapter.py` compatibility facade ownership decision | G/#79 service lifecycle DI | PR `#359` merged; `market_data_adapter.py` is an active factory-owned compatibility facade, not a deletion or thin-wrapper candidate | Do not implement from G2.206; use G2.207 authorization first |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T19:32:39+08:00`
-- Base HEAD checked: `90d8f12cc01f9fb360abc531673e3ed9535706e7`
+- Prepared at: `2026-05-28T20:48:36+08:00`
+- Base HEAD checked: `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -79,8 +79,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-market-data-adapter-provider-authorization-2026-05-28.md` | G2.207 human-readable provider seam authorization package | Accepted by PR `#360`; superseded for implementation evidence by G2.208 |
 | `.planning/codebase/generated/data-quality-market-data-adapter-provider-implementation-2026-05-28.json` | G2.208 `market_data_adapter.py` provider seam implementation evidence | Accepted by PR `#361`; superseded for closeout / residual refresh by G2.209 |
 | `docs/reports/quality/backend-data-quality-market-data-adapter-provider-implementation-2026-05-28.md` | G2.208 human-readable provider seam implementation report | Accepted by PR `#361`; superseded for closeout / residual refresh by G2.209 |
-| `.planning/codebase/generated/data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.json` | G2.209 `market_data_adapter.py` provider seam closeout / residual refresh evidence | Current for HEAD `90d8f12cc01f9fb360abc531673e3ed9535706e7`; review input until PR `#362` is accepted |
-| `docs/reports/quality/backend-data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.md` | G2.209 human-readable closeout / residual refresh report | Review input until PR `#362` is accepted |
+| `.planning/codebase/generated/data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.json` | G2.209 `market_data_adapter.py` provider seam closeout / residual refresh evidence | Accepted by PR `#362`; superseded for residual ownership by G2.210 |
+| `docs/reports/quality/backend-data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.md` | G2.209 human-readable closeout / residual refresh report | Accepted by PR `#362`; superseded for residual ownership by G2.210 |
+| `.planning/codebase/generated/data-quality-monitor-residual-ownership-decision-2026-05-28.json` | G2.210 data-quality monitor residual ownership decision evidence | Current for HEAD `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`; review input until PR `#363` is accepted |
+| `docs/reports/quality/backend-data-quality-monitor-residual-ownership-decision-2026-05-28.md` | G2.210 human-readable residual ownership decision report | Review input until PR `#363` is accepted |
 
 ## External State Inputs
 

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T19:32:39+08:00",
+  "generated_at": "2026-05-28T20:48:36+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "90d8f12cc01f9fb360abc531673e3ed9535706e7",
-  "split_branch": "g2-209-data-quality-market-data-adapter-provider-closeout",
-  "scope": "data_quality_market_data_adapter_provider_closeout_refresh",
+  "base_head": "33b6ace2f68e23bcf07a12f53511d1f7b9fb8230",
+  "split_branch": "g2-210-data-quality-monitor-residual-ownership-decision",
+  "scope": "data_quality_monitor_residual_ownership_decision",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -2010,12 +2010,14 @@
     {
       "id": "g2-209-data-quality-market-data-adapter-provider-closeout",
       "type": "closeout_refresh",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.208 data-quality market_data_adapter.py provider seam implementation",
       "source_edit_authority": false,
       "parent_github_pr": 361,
       "parent_merge_commit": "90d8f12cc01f9fb360abc531673e3ed9535706e7",
+      "github_pr": 362,
+      "merge_commit": "33b6ace2f68e23bcf07a12f53511d1f7b9fb8230",
       "evidence": [
         ".planning/codebase/generated/data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.json",
         "docs/reports/quality/backend-data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.md",
@@ -2050,7 +2052,58 @@
         "current_head_checked": "90d8f12cc01f9fb360abc531673e3ed9535706e7",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.210 data-quality monitor residual ownership decision without source authority."
+      "next_gate": "Superseded by G2.210 data-quality monitor residual ownership decision."
+    },
+    {
+      "id": "g2-210-data-quality-monitor-residual-ownership-decision",
+      "type": "decision_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.209 data-quality market_data_adapter.py provider seam closeout / residual refresh",
+      "source_edit_authority": false,
+      "parent_github_pr": 362,
+      "parent_merge_commit": "33b6ace2f68e23bcf07a12f53511d1f7b9fb8230",
+      "evidence": [
+        ".planning/codebase/generated/data-quality-monitor-residual-ownership-decision-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-monitor-residual-ownership-decision-2026-05-28.md",
+        "governance/mainline/task-cards/pr-363.yaml"
+      ],
+      "scan_facts": {
+        "pattern": "get_data_quality_monitor|DataQualityMonitor",
+        "service_file_count": 7,
+        "service_hit_count": 21,
+        "test_file_count": 7,
+        "test_hit_count": 17
+      },
+      "gitnexus_impact": {
+        "target": "web/backend/app/services/_data_quality_monitor_singleton.py:get_data_quality_monitor",
+        "risk": "CRITICAL",
+        "impacted_count": 24,
+        "direct": 20,
+        "processes_affected": 7,
+        "modules_affected": 4
+      },
+      "decision": {
+        "classification": "high_risk_singleton_backing_api_ownership_surface",
+        "preserve_closed_surfaces": [
+          "web/backend/app/services/market_data_adapter.py",
+          "web/backend/app/services/adapters/dashboard_adapter.py",
+          "web/backend/app/services/adapters/data_adapter.py",
+          "web/backend/app/services/adapters_split/base_adapter.py"
+        ],
+        "requires_authorization": [
+          "web/backend/app/services/_data_quality_monitor_singleton.py",
+          "web/backend/app/services/data_quality_monitor.py"
+        ],
+        "repository_hygiene_only": [
+          "web/backend/app/services/data_adapter.py.backup.20260130"
+        ]
+      },
+      "freshness": {
+        "current_head_checked": "33b6ace2f68e23bcf07a12f53511d1f7b9fb8230",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.211 data-quality monitor singleton/backing API authorization package without source authority."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -707,11 +707,42 @@ Residual classification:
 G2.209 has no source authority. It does not edit `web/backend/**`, route,
 OpenAPI, frontend, config, script, or OpenSpec surfaces.
 
+## G2.210 Data-Quality Monitor Residual Ownership Decision
+
+At HEAD `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`, PR `#362` is merged and
+G2.209 is accepted.
+
+Decision result:
+
+| Item | Result |
+|---|---|
+| Root getter | `web/backend/app/services/_data_quality_monitor_singleton.py:get_data_quality_monitor` |
+| GitNexus risk | CRITICAL |
+| Impacted symbols | 24 |
+| Direct dependents | 20 |
+| Affected processes | 7 |
+| Affected modules | 4 |
+| Source edit authority | None |
+
+Residual ownership classification:
+
+| Residual surface | Classification | Handling |
+|---|---|---|
+| `market_data_adapter.py` fallback | Closed market-data adapter fallback | Preserve G2.208/G2.209 closed status |
+| `adapters/dashboard_adapter.py`, `adapters/data_adapter.py` | Closed canonical service adapter fallback | Preserve G2.200/G2.201 closed status |
+| `adapters_split/base_adapter.py` | Closed adapter-split fallback | Preserve G2.196/G2.197 closed status |
+| `_data_quality_monitor_singleton.py`, `data_quality_monitor.py` | Singleton/backing API ownership surface | Requires G2.211 authorization package |
+| `data_adapter.py.backup.20260130` | Historical backup file | Separate repository hygiene authority required |
+
+G2.210 has no source authority. It records that the remaining singleton/backing
+API is a high-risk root ownership surface and must not be treated as a routine
+adapter/source cleanup.
+
 ## Next Gates
 
-- Review G2.209 `market_data_adapter.py` provider seam closeout / residual refresh.
-- If accepted, start G2.210 data-quality monitor residual ownership decision with no source edits.
-- Do not open the next source lane before G2.210 decides singleton/backing API and retained fallback ownership.
+- Review G2.210 data-quality monitor residual ownership decision.
+- If accepted, start G2.211 data-quality monitor singleton/backing API authorization package with no source edits.
+- Do not open the next source lane before G2.211 defines source authority, consumer matrix, focused tests, and rollback rules.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/reports/quality/backend-data-quality-monitor-residual-ownership-decision-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-monitor-residual-ownership-decision-2026-05-28.md
@@ -1,0 +1,136 @@
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Lane: G2.210 data-quality monitor residual ownership decision
+- Prepared at: `2026-05-28T20:48:36+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`
+- Parent lane: G2.209 data-quality `market_data_adapter.py` provider seam closeout / residual refresh
+- Parent PR: `#362`
+- Parent merge commit: `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`
+- Source edit authority: none
+
+Boundary note: this report records ownership classification and next-gate
+requirements only. It does not authorize backend source edits, getter deletion,
+route/OpenAPI changes, frontend changes, OpenSpec edits, issue label changes,
+PM2 commands, or PR merges.
+
+## Decision
+
+G2.210 classifies the remaining data-quality monitor residuals as a high-risk
+root ownership surface, not as another routine adapter or service implementation
+lane.
+
+The current root is `get_data_quality_monitor()` in
+`web/backend/app/services/_data_quality_monitor_singleton.py`. GitNexus reports
+CRITICAL upstream impact for that symbol: 24 impacted symbols, 20 direct
+dependents, 7 affected execution flows, and 4 affected modules.
+
+Because of that blast radius, the next action is G2.211, a dedicated
+singleton/backing API authorization package. G2.210 must not open a source
+implementation lane by itself.
+
+## Current Residual Scan
+
+Scan command intent: count `get_data_quality_monitor|DataQualityMonitor` in
+`web/backend/app/services` and `web/backend/tests` at HEAD
+`33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`.
+
+| Scope | Files | Hits |
+|---|---:|---:|
+| Service residuals | 7 | 21 |
+| Test references | 7 | 17 |
+
+Service classification:
+
+| Surface | Matches | Classification | G2.210 handling |
+|---|---:|---|---|
+| `web/backend/app/services/market_data_adapter.py` | 2 | Closed market-data adapter fallback | Preserve closed status from G2.208/G2.209 |
+| `web/backend/app/services/adapters/dashboard_adapter.py` | 2 | Closed canonical service adapter fallback | Preserve closed status from G2.200/G2.201 |
+| `web/backend/app/services/adapters/data_adapter.py` | 2 | Closed canonical service adapter fallback | Preserve closed status from G2.200/G2.201 |
+| `web/backend/app/services/adapters_split/base_adapter.py` | 2 | Closed adapter-split fallback | Preserve closed status from G2.196/G2.197 |
+| `web/backend/app/services/data_quality_monitor.py` | 4 | Public singleton facade | Requires G2.211 authorization decision |
+| `web/backend/app/services/_data_quality_monitor_singleton.py` | 6 | Singleton backing API | Requires G2.211 authorization decision |
+| `web/backend/app/services/data_adapter.py.backup.20260130` | 3 | Historical backup | Separate repository hygiene authority required |
+
+The test files are evidence of compatibility coverage, not source authority:
+
+- `web/backend/tests/test_adapter_split_data_quality_monitor_provider.py`
+- `web/backend/tests/test_data_quality_canonical_service_adapter_provider.py`
+- `web/backend/tests/test_data_quality_legacy_data_adapter_compat.py`
+- `web/backend/tests/test_data_quality_route_provider_regressions.py`
+- `web/backend/tests/test_large_file_split_regressions.py`
+- `web/backend/tests/test_logging_noise_regressions.py`
+- `web/backend/tests/test_market_data_adapter_quality_monitor_provider.py`
+
+## GitNexus Impact
+
+GitNexus command:
+
+```bash
+gitnexus impact get_data_quality_monitor --direction upstream --include-tests --max-depth 2
+```
+
+Recorded result:
+
+| Field | Value |
+|---|---:|
+| Target | `Function:web/backend/app/services/_data_quality_monitor_singleton.py:get_data_quality_monitor` |
+| Risk | CRITICAL |
+| Impacted count | 24 |
+| Direct dependents | 20 |
+| Affected processes | 7 |
+| Affected modules | 4 |
+
+Affected module groups: `Services`, `Data_adapters`, `Api`, and `Adapters`.
+
+The d=1 dependents include data-quality route handlers, canonical service
+adapters, adapter-split constructors, the market-data adapter trigger, and
+`monitor_data_quality()`. This confirms that direct deletion or migration of the
+singleton helper is a cross-module ownership decision.
+
+## Ownership Outcome
+
+| Ownership surface | Decision |
+|---|---|
+| Closed `market_data_adapter.py` fallback | Do not reopen without contradictory current HEAD evidence |
+| Closed canonical service adapter fallbacks | Do not reopen without contradictory current HEAD evidence |
+| Closed `adapter_split` fallback | Do not reopen without contradictory current HEAD evidence |
+| `data_quality_monitor.py` public facade | Route into G2.211 authorization package |
+| `_data_quality_monitor_singleton.py` backing API | Route into G2.211 authorization package |
+| Historical backup file | Keep outside service lifecycle DI; handle only through repository hygiene authority |
+
+## Next Gate
+
+Start G2.211 data-quality monitor singleton/backing API authorization package
+only after this decision package is accepted.
+
+G2.211 should remain governance-only until it explicitly defines:
+
+- consumer matrix for data-quality route callers, service adapters,
+  adapter-split constructors, and `monitor_data_quality()`
+- public facade versus private singleton helper ownership
+- allowed source paths and focused test paths for any later implementation
+- rollback plan preserving route/API behavior and default fallback compatibility
+- stop rule if GitNexus still reports HIGH or CRITICAL risk after scoping
+
+## Non-Goals
+
+- Do not edit `web/backend/**` in G2.210.
+- Do not delete or rename `get_data_quality_monitor()`.
+- Do not reopen closed G2.196/G2.197, G2.200/G2.201, or G2.208/G2.209 source
+  lanes from this report.
+- Do not treat `data_adapter.py.backup.20260130` cleanup as service lifecycle
+  DI implementation authority.
+
+## Verification Plan
+
+This package should be accepted only if:
+
+- JSON/YAML parse succeeds for the generated evidence and task card.
+- Markdown governance passes for this report and updated steward tree files.
+- OpenSpec validation passes for `migrate-backend-singletons-to-lifecycle-di`.
+- `git diff --check` and cached diff checks pass.
+- Mainline scope gate confirms only the listed governance paths changed.
+- GitNexus staged change detection reports no unexpected source impact.

--- a/governance/mainline/task-cards/pr-363.yaml
+++ b/governance/mainline/task-cards/pr-363.yaml
@@ -1,0 +1,110 @@
+version: "v0.2"
+
+task:
+  id: "pr-363-data-quality-monitor-residual-ownership-decision"
+  title: "Decide data-quality monitor residual ownership"
+  owner: "codex"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-monitor-residual-ownership-decision"
+  objective: "classify remaining data-quality monitor residuals and define the next authorization gate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Governance-only decision package; no runtime entrypoint changes."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-monitor-residual-ownership-decision-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-monitor-residual-ownership-decision-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-363.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "No backend source edits."
+  - "No getter deletion or rename."
+  - "No route, OpenAPI, frontend, config, script, or OpenSpec edits."
+  - "No PR merge or issue label changes."
+  - "No source implementation authority for G2.211."
+
+acceptance:
+  checks:
+    - id: "json-yaml-parse"
+      command: "python - <<'PY'\nimport json, yaml\nwith open('.planning/codebase/generated/data-quality-monitor-residual-ownership-decision-2026-05-28.json', encoding='utf-8') as f:\n    json.load(f)\nwith open('.planning/codebase/steward-tree/steward-index.json', encoding='utf-8') as f:\n    json.load(f)\nwith open('governance/mainline/task-cards/pr-363.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-monitor-residual-ownership-decision-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-363.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 33b6ace2f68e23bcf07a12f53511d1f7b9fb8230 --head-sha HEAD --report /tmp/pr363-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Decision package could be misread as source authorization; boundary notes and forbidden paths prevent that."
+    - "Residual counts are snapshot data; stale_if_head_mismatch requires refresh after HEAD changes."
+  rollback_plan: "Revert this governance-only commit; no runtime or source state changes are made."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Classify remaining data-quality monitor residuals after G2.209 and select a dedicated authorization gate."
+    modified_scope: "Only steward tree, generated evidence, quality report, and task-card governance files."
+    dependency_changes: "None."
+    legacy_logic_impact: "No runtime or compatibility behavior changes."
+    rollback_ready: "Yes; revert the governance commit."
+    risk_and_rollback_point: "Do not proceed to source implementation until G2.211 is separately authorized."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "current review thread human maintainer"
+    approved_at: "2026-05-28T20:48:36+08:00"
+    approval_note: "Approved to continue from G2.209 into G2.210 governance-only residual ownership decision."
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- Record G2.210 as a governance-only ownership decision after PR #362 merged.
- Classify remaining data-quality monitor residuals around `get_data_quality_monitor()`.
- Preserve closed fallback surfaces from G2.196/G2.197, G2.200/G2.201, and G2.208/G2.209.
- Route the singleton/backing API surface into G2.211 authorization instead of opening source implementation directly.

## Evidence

- Current HEAD checked: `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`.
- Residual scan: 7 service files / 21 service hits and 7 test files / 17 test hits for `get_data_quality_monitor|DataQualityMonitor`.
- GitNexus impact for `web/backend/app/services/_data_quality_monitor_singleton.py:get_data_quality_monitor`: CRITICAL, 24 impacted symbols, 20 direct dependents, 7 affected processes, 4 affected modules.

## Boundary

No source edits. No route/OpenAPI edits. No frontend, config, script, or OpenSpec edits. No getter deletion or rename. No PR merge authority.

## Verification

- JSON/YAML parse: passed
- Markdown governance: 6 checked files, 0 errors
- OpenSpec validate `migrate-backend-singletons-to-lifecycle-di --strict`: valid (PostHog telemetry flush noise only)
- `git diff --check` / cached diff check: passed
- Mainline scope gate for `pr-363.yaml`: pass=True
- Focused pytest: `web/backend/tests/test_market_data_adapter_quality_monitor_provider.py` 2 passed
- GitNexus compare from `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`: low risk, 0 changed symbols, 0 affected processes
EOF 2>&1
