### PR TITLE
docs(governance): authorize data quality monitor singleton seam

### DIFF
--- a/.planning/codebase/generated/data-quality-monitor-singleton-authorization-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-monitor-singleton-authorization-2026-05-28.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": "2026-05-28.authorization-package.v1",
+  "generated_at": "2026-05-28T22:18:21+08:00",
+  "repo": "mystocks_spec",
+  "base_branch": "wip/root-dirty-20260403",
+  "git_head": "619be9cac1f9516b3df42a41ca362ca9d42d5c9a",
+  "worktree_branch": "g2-211-data-quality-monitor-singleton-authorization",
+  "parent_lane": "G2.210 data-quality monitor residual ownership decision",
+  "parent_pr": 363,
+  "parent_merge_commit": "619be9cac1f9516b3df42a41ca362ca9d42d5c9a",
+  "scope": "data_quality_monitor_singleton_backing_api_authorization",
+  "source_edit_authority": false,
+  "authorized_future_lane": {
+    "id": "G2.212",
+    "name": "data-quality monitor singleton/backing API compatibility implementation",
+    "source_edit_authority_after_acceptance": true,
+    "allowed_source_paths": [
+      "web/backend/app/services/_data_quality_monitor_singleton.py",
+      "web/backend/app/services/data_quality_monitor.py"
+    ],
+    "allowed_test_paths": [
+      "web/backend/tests/test_data_quality_monitor_singleton_provider.py"
+    ],
+    "required_regression_test_paths": [
+      "web/backend/tests/test_data_quality_route_provider_regressions.py",
+      "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py",
+      "web/backend/tests/test_adapter_split_data_quality_monitor_provider.py",
+      "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py",
+      "web/backend/tests/test_logging_noise_regressions.py",
+      "web/backend/tests/test_large_file_split_regressions.py"
+    ],
+    "forbidden_source_paths": [
+      "web/backend/app/api/**",
+      "web/backend/app/services/adapters/**",
+      "web/backend/app/services/adapters_split/**",
+      "web/backend/app/services/data_adapters/**",
+      "web/backend/app/services/market_data_adapter.py",
+      "web/backend/app/services/data_adapter.py.backup.20260130",
+      "web/frontend/**",
+      "src/**",
+      "docs/api/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ]
+  },
+  "authorized_future_shape": [
+    "Preserve public imports from app.services.data_quality_monitor, including get_data_quality_monitor and monitor_data_quality.",
+    "Preserve default singleton fallback behavior when no override or provider is supplied.",
+    "Allow only compatibility-oriented helper additions in _data_quality_monitor_singleton.py, such as explicit provider/reset hooks for tests or lifecycle wiring.",
+    "Allow data_quality_monitor.py edits only for re-export/import surface maintenance; do not change DataQualityMonitor internals.",
+    "Do not migrate route handlers, adapters, adapter_split constructors, or market_data_adapter.py in G2.212."
+  ],
+  "current_consumer_matrix": {
+    "route_provider": {
+      "path": "web/backend/app/api/data_quality.py",
+      "state": "already uses get_data_quality_monitor_provider and Depends",
+      "future_source_edits_authorized": false
+    },
+    "closed_adapter_fallbacks": [
+      "web/backend/app/services/adapters/dashboard_adapter.py",
+      "web/backend/app/services/adapters/data_adapter.py",
+      "web/backend/app/services/adapters_split/base_adapter.py",
+      "web/backend/app/services/market_data_adapter.py"
+    ],
+    "singleton_backing_api": [
+      "web/backend/app/services/_data_quality_monitor_singleton.py",
+      "web/backend/app/services/data_quality_monitor.py"
+    ],
+    "historical_backup": [
+      "web/backend/app/services/data_adapter.py.backup.20260130"
+    ]
+  },
+  "required_future_tdd": {
+    "red": "A focused singleton provider/reset test fails before implementation because no explicit test-safe override/reset hook exists.",
+    "green": "The focused singleton provider/reset test passes after compatibility helpers are added without changing default runtime behavior.",
+    "regression": "Existing route provider, canonical adapter, adapter_split, market_data_adapter, logging-noise, and large-file split regression tests remain passing."
+  },
+  "required_future_gitnexus": [
+    "Run impact for get_data_quality_monitor before editing.",
+    "Run context for get_data_quality_monitor and monitor_data_quality before editing.",
+    "Known impact is CRITICAL from G2.210; stop only if the future diff expands beyond the authorized two source files or introduces additional HIGH/CRITICAL surfaces outside the known consumer matrix.",
+    "Run staged detect_changes before commit."
+  ],
+  "non_goals": [
+    "source edits in G2.211",
+    "route/provider migration in G2.212",
+    "adapter or adapter_split migration in G2.212",
+    "market_data_adapter.py edits in G2.212",
+    "DataQualityMonitor class internals",
+    "historical backup cleanup",
+    "getter deletion or rename",
+    "OpenAPI, frontend, config, script, or OpenSpec edits"
+  ],
+  "freshness": {
+    "current_head_checked": "619be9cac1f9516b3df42a41ca362ca9d42d5c9a",
+    "stale_if_head_mismatch": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T20:48:36+08:00`
-- Base HEAD checked: `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`
+- Prepared at: `2026-05-28T22:18:21+08:00`
+- Base HEAD checked: `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -47,12 +47,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#360` | `g2-207-data-quality-market-data-adapter-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `b4b34375eef0186b81be9a24491328dab72c2e21` | Authorization package for G2.208 `market_data_adapter.py` provider seam implementation |
 | `#361` | `g2-208-data-quality-market-data-adapter-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `90d8f12cc01f9fb360abc531673e3ed9535706e7` | Path-limited `market_data_adapter.py` provider seam implementation closed for G2.209 refresh |
 | `#362` | `g2-209-data-quality-market-data-adapter-provider-closeout` | `wip/root-dirty-20260403` | `MERGED` at `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230` | Governance closeout selecting G2.210 data-quality monitor residual ownership decision |
+| `#363` | `g2-210-data-quality-monitor-residual-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `619be9cac1f9516b3df42a41ca362ca9d42d5c9a` | Decision package selecting G2.211 singleton/backing API authorization |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-210-data-quality-monitor-residual-ownership-decision` | `origin/wip/root-dirty-20260403` at `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230` | Decide remaining data-quality monitor singleton/backing API ownership and next authorization gate | No |
+| `g2-211-data-quality-monitor-singleton-authorization` | `origin/wip/root-dirty-20260403` at `619be9cac1f9516b3df42a41ca362ca9d42d5c9a` | Authorize future data-quality monitor singleton/backing API compatibility implementation | No |
 
 ## OpenSpec Relationship
 
@@ -68,7 +69,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.210 is a no-source residual ownership decision branch after PR `#362` merged
-G2.209. It is limited to governance evidence, steward tree updates, and a task
-card. If accepted, the next gate is a G2.211 singleton/backing API authorization
-package, not a direct source implementation lane.
+G2.211 is a no-source authorization branch after PR `#363` merged G2.210. It is
+limited to governance evidence, steward tree updates, and a task card. If
+accepted, the next gate is a separate G2.212 source implementation lane limited
+to the authorized singleton/backing API paths.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T20:48:36+08:00`
-- Base HEAD checked: `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`
+- Prepared at: `2026-05-28T22:18:21+08:00`
+- Base HEAD checked: `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 is the active residual ownership decision |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 merged by PR `#363`; G2.211 is the active singleton/backing API authorization |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T20:48:36+08:00`
-- Base HEAD checked: `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`
+- Prepared at: `2026-05-28T22:18:21+08:00`
+- Base HEAD checked: `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.210 data-quality monitor residual ownership decision | G/#79 service lifecycle DI | PR `#362` merged at `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`; G2.210 classifies the singleton/backing API as a high-risk root ownership surface without source edits | If accepted, start G2.211 singleton/backing API authorization package; do not open source implementation directly |
+| P0 | Review G2.211 data-quality monitor singleton/backing API authorization | G/#79 service lifecycle DI | PR `#363` merged at `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`; G2.211 authorizes a future path-limited G2.212 compatibility implementation without source edits in this PR | If accepted, start G2.212 implementation in a separate source lane; do not edit routes, adapters, OpenAPI, frontend, config, scripts, or OpenSpec |
+| P0 | Preserve G2.210 data-quality monitor residual ownership decision | G/#79 service lifecycle DI | PR `#363` merged; singleton/backing API is a high-risk root ownership surface, not a routine cleanup | Use G2.211 authorization before any source lane |
 | P0 | Preserve G2.209 data-quality `market_data_adapter.py` provider seam closeout / residual refresh | G/#79 service lifecycle DI | PR `#362` merged; `market_data_adapter.py` is closed and remaining monitor residuals are routed to G2.210 ownership decision | Do not reopen closed G2.208/G2.209 source scope without contradictory current HEAD evidence |
 | P0 | Preserve G2.208 data-quality `market_data_adapter.py` provider seam implementation | G/#79 service lifecycle DI | PR `#361` merged; optional quality monitor injection is implemented for `MarketDataSourceAdapter` while preserving default singleton fallback | Do not reopen `market_data_adapter.py` source unless current HEAD evidence contradicts G2.208/G2.209 |
 | P0 | Preserve G2.207 data-quality `market_data_adapter.py` provider seam authorization package | G/#79 service lifecycle DI | PR `#360` merged; future implementation scope was limited to `market_data_adapter.py` plus focused tests | Do not expand into `data_source_factory`, singleton wrapper/backing API, routes, OpenAPI, frontend, config, scripts, or OpenSpec |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T20:48:36+08:00`
-- Base HEAD checked: `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`
+- Prepared at: `2026-05-28T22:18:21+08:00`
+- Base HEAD checked: `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -81,8 +81,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-market-data-adapter-provider-implementation-2026-05-28.md` | G2.208 human-readable provider seam implementation report | Accepted by PR `#361`; superseded for closeout / residual refresh by G2.209 |
 | `.planning/codebase/generated/data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.json` | G2.209 `market_data_adapter.py` provider seam closeout / residual refresh evidence | Accepted by PR `#362`; superseded for residual ownership by G2.210 |
 | `docs/reports/quality/backend-data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.md` | G2.209 human-readable closeout / residual refresh report | Accepted by PR `#362`; superseded for residual ownership by G2.210 |
-| `.planning/codebase/generated/data-quality-monitor-residual-ownership-decision-2026-05-28.json` | G2.210 data-quality monitor residual ownership decision evidence | Current for HEAD `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230`; review input until PR `#363` is accepted |
-| `docs/reports/quality/backend-data-quality-monitor-residual-ownership-decision-2026-05-28.md` | G2.210 human-readable residual ownership decision report | Review input until PR `#363` is accepted |
+| `.planning/codebase/generated/data-quality-monitor-residual-ownership-decision-2026-05-28.json` | G2.210 data-quality monitor residual ownership decision evidence | Accepted by PR `#363`; superseded for singleton/backing API authorization by G2.211 |
+| `docs/reports/quality/backend-data-quality-monitor-residual-ownership-decision-2026-05-28.md` | G2.210 human-readable residual ownership decision report | Accepted by PR `#363`; superseded for singleton/backing API authorization by G2.211 |
+| `.planning/codebase/generated/data-quality-monitor-singleton-authorization-2026-05-28.json` | G2.211 data-quality monitor singleton/backing API authorization evidence | Current for HEAD `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`; review input until PR `#364` is accepted |
+| `docs/reports/quality/backend-data-quality-monitor-singleton-authorization-2026-05-28.md` | G2.211 human-readable singleton/backing API authorization report | Review input until PR `#364` is accepted |
 
 ## External State Inputs
 

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T20:48:36+08:00",
+  "generated_at": "2026-05-28T22:18:21+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "33b6ace2f68e23bcf07a12f53511d1f7b9fb8230",
-  "split_branch": "g2-210-data-quality-monitor-residual-ownership-decision",
-  "scope": "data_quality_monitor_residual_ownership_decision",
+  "base_head": "619be9cac1f9516b3df42a41ca362ca9d42d5c9a",
+  "split_branch": "g2-211-data-quality-monitor-singleton-authorization",
+  "scope": "data_quality_monitor_singleton_authorization",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -2057,12 +2057,14 @@
     {
       "id": "g2-210-data-quality-monitor-residual-ownership-decision",
       "type": "decision_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.209 data-quality market_data_adapter.py provider seam closeout / residual refresh",
       "source_edit_authority": false,
       "parent_github_pr": 362,
       "parent_merge_commit": "33b6ace2f68e23bcf07a12f53511d1f7b9fb8230",
+      "github_pr": 363,
+      "merge_commit": "619be9cac1f9516b3df42a41ca362ca9d42d5c9a",
       "evidence": [
         ".planning/codebase/generated/data-quality-monitor-residual-ownership-decision-2026-05-28.json",
         "docs/reports/quality/backend-data-quality-monitor-residual-ownership-decision-2026-05-28.md",
@@ -2103,7 +2105,51 @@
         "current_head_checked": "33b6ace2f68e23bcf07a12f53511d1f7b9fb8230",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.211 data-quality monitor singleton/backing API authorization package without source authority."
+      "next_gate": "Superseded by G2.211 data-quality monitor singleton/backing API authorization package."
+    },
+    {
+      "id": "g2-211-data-quality-monitor-singleton-authorization",
+      "type": "authorization_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.210 data-quality monitor residual ownership decision",
+      "source_edit_authority": false,
+      "parent_github_pr": 363,
+      "parent_merge_commit": "619be9cac1f9516b3df42a41ca362ca9d42d5c9a",
+      "evidence": [
+        ".planning/codebase/generated/data-quality-monitor-singleton-authorization-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-monitor-singleton-authorization-2026-05-28.md",
+        "governance/mainline/task-cards/pr-364.yaml"
+      ],
+      "authorized_future_lane": {
+        "id": "G2.212",
+        "name": "data-quality monitor singleton/backing API compatibility implementation",
+        "allowed_source_paths": [
+          "web/backend/app/services/_data_quality_monitor_singleton.py",
+          "web/backend/app/services/data_quality_monitor.py"
+        ],
+        "allowed_test_paths": [
+          "web/backend/tests/test_data_quality_monitor_singleton_provider.py"
+        ],
+        "required_regression_test_paths": [
+          "web/backend/tests/test_data_quality_route_provider_regressions.py",
+          "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py",
+          "web/backend/tests/test_adapter_split_data_quality_monitor_provider.py",
+          "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py",
+          "web/backend/tests/test_logging_noise_regressions.py",
+          "web/backend/tests/test_large_file_split_regressions.py"
+        ]
+      },
+      "authorization_constraints": [
+        "preserve get_data_quality_monitor and monitor_data_quality public imports",
+        "preserve default singleton fallback behavior",
+        "do not edit routes, adapters, adapter_split constructors, market_data_adapter.py, OpenAPI, frontend, config, scripts, or OpenSpec"
+      ],
+      "freshness": {
+        "current_head_checked": "619be9cac1f9516b3df42a41ca362ca9d42d5c9a",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.212 data-quality monitor singleton/backing API compatibility implementation in a separate source lane."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -738,11 +738,39 @@ G2.210 has no source authority. It records that the remaining singleton/backing
 API is a high-risk root ownership surface and must not be treated as a routine
 adapter/source cleanup.
 
+## G2.211 Data-Quality Monitor Singleton Authorization
+
+At HEAD `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`, PR `#363` is merged and
+G2.210 is accepted.
+
+Authorization result:
+
+| Item | Result |
+|---|---|
+| Future lane | G2.212 data-quality monitor singleton/backing API compatibility implementation |
+| Current PR source authority | None |
+| Future source authority after acceptance | Yes, path-limited |
+| Authorized future source paths | `web/backend/app/services/_data_quality_monitor_singleton.py`, `web/backend/app/services/data_quality_monitor.py` |
+| Authorized future focused test | `web/backend/tests/test_data_quality_monitor_singleton_provider.py` |
+| Route/adapters future source authority | None |
+
+Future G2.212 constraints:
+
+- preserve `get_data_quality_monitor()` and `monitor_data_quality()` public
+  imports from `app.services.data_quality_monitor`
+- preserve default singleton fallback behavior
+- allow only compatibility/provider helper additions in
+  `_data_quality_monitor_singleton.py`
+- allow `data_quality_monitor.py` edits only for facade import / `__all__`
+  maintenance
+- do not migrate routes, adapters, adapter-split constructors, or
+  `market_data_adapter.py`
+
 ## Next Gates
 
-- Review G2.210 data-quality monitor residual ownership decision.
-- If accepted, start G2.211 data-quality monitor singleton/backing API authorization package with no source edits.
-- Do not open the next source lane before G2.211 defines source authority, consumer matrix, focused tests, and rollback rules.
+- Review G2.211 data-quality monitor singleton/backing API authorization package.
+- If accepted, start G2.212 data-quality monitor singleton/backing API compatibility implementation in a separate source lane.
+- Do not edit routes, adapters, adapter-split constructors, `market_data_adapter.py`, OpenAPI, frontend, config, scripts, or OpenSpec in G2.212.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/reports/quality/backend-data-quality-monitor-singleton-authorization-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-monitor-singleton-authorization-2026-05-28.md
@@ -1,0 +1,135 @@
+# Backend Data-Quality Monitor Singleton Authorization
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Lane: G2.211 data-quality monitor singleton/backing API authorization
+- Prepared at: `2026-05-28T22:18:21+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`
+- Parent lane: G2.210 data-quality monitor residual ownership decision
+- Parent PR: `#363`
+- Parent merge commit: `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`
+- Source edit authority in this PR: none
+
+Boundary note: this report authorizes a future implementation lane only. It does
+not edit backend source, delete getters, change route/OpenAPI behavior, change
+frontend/config/script files, create OpenSpec proposals, change issue labels,
+run PM2 workflows, or merge PRs.
+
+## Parent State
+
+G2.210 classified `get_data_quality_monitor()` as a CRITICAL impact root
+ownership surface:
+
+| Field | Value |
+|---|---:|
+| Impacted symbols | 24 |
+| Direct dependents | 20 |
+| Affected processes | 7 |
+| Affected modules | 4 |
+
+That finding means the next source lane must be narrow and compatibility-first.
+It must not migrate routes, adapters, or `market_data_adapter.py` as part of the
+singleton/backing API work.
+
+## Current Consumer Matrix
+
+| Surface | Current state | G2.212 authority |
+|---|---|---|
+| `web/backend/app/api/data_quality.py` | Already uses `get_data_quality_monitor_provider` and `Depends` | No source edits |
+| `web/backend/app/services/adapters/dashboard_adapter.py` | Closed canonical adapter fallback | No source edits |
+| `web/backend/app/services/adapters/data_adapter.py` | Closed canonical adapter fallback | No source edits |
+| `web/backend/app/services/adapters_split/base_adapter.py` | Closed adapter-split fallback | No source edits |
+| `web/backend/app/services/market_data_adapter.py` | Closed market-data adapter fallback | No source edits |
+| `web/backend/app/services/_data_quality_monitor_singleton.py` | Singleton backing API | Authorized future source path |
+| `web/backend/app/services/data_quality_monitor.py` | Public facade and re-export surface | Authorized future source path only for import/re-export maintenance |
+| `web/backend/app/services/data_adapter.py.backup.20260130` | Historical backup | No source edits; repository hygiene only |
+
+## Authorization Decision
+
+This PR authorizes a future G2.212 implementation lane, but does not implement
+it.
+
+| Future lane | Authorized source paths | Authorized test path |
+|---|---|---|
+| G2.212 data-quality monitor singleton/backing API compatibility implementation | `web/backend/app/services/_data_quality_monitor_singleton.py`, `web/backend/app/services/data_quality_monitor.py` | `web/backend/tests/test_data_quality_monitor_singleton_provider.py` |
+
+Future implementation must preserve these public imports:
+
+- `from app.services.data_quality_monitor import get_data_quality_monitor`
+- `from app.services.data_quality_monitor import monitor_data_quality`
+
+## Authorized Future Shape
+
+G2.212 may add a narrow compatibility/provider seam with these constraints:
+
+- Preserve the existing `get_data_quality_monitor()` name, import path, return
+  behavior, and default singleton fallback.
+- Preserve `monitor_data_quality()` and keep it routed through the same monitor
+  resolution policy.
+- Allow only compatibility-oriented helper additions in
+  `_data_quality_monitor_singleton.py`, such as explicit provider/reset hooks
+  for tests or lifecycle wiring.
+- Allow `data_quality_monitor.py` edits only to maintain facade imports and
+  `__all__` re-exports.
+- Do not change `DataQualityMonitor` class internals.
+- Do not migrate routes, adapters, adapter-split constructors, or
+  `market_data_adapter.py`.
+
+## Required Future Tests
+
+G2.212 must use TDD:
+
+| Phase | Required evidence |
+|---|---|
+| RED | A focused singleton provider/reset test fails before implementation because no explicit test-safe override/reset hook exists |
+| GREEN | The focused singleton provider/reset test passes after compatibility helpers are added |
+| Regression | Existing route/provider and adapter compatibility tests remain passing |
+
+Required future check set:
+
+- `web/backend/tests/test_data_quality_monitor_singleton_provider.py`
+- `web/backend/tests/test_data_quality_route_provider_regressions.py`
+- `web/backend/tests/test_data_quality_canonical_service_adapter_provider.py`
+- `web/backend/tests/test_adapter_split_data_quality_monitor_provider.py`
+- `web/backend/tests/test_market_data_adapter_quality_monitor_provider.py`
+- `web/backend/tests/test_logging_noise_regressions.py`
+- `web/backend/tests/test_large_file_split_regressions.py`
+- targeted ruff for the authorized source and test files
+- OpenSpec strict validation for `migrate-backend-singletons-to-lifecycle-di`
+- staged GitNexus change detection before commit
+
+## Required Future GitNexus Gate
+
+Before editing source in G2.212, run GitNexus impact/context for:
+
+- `get_data_quality_monitor`
+- `monitor_data_quality`
+- `web/backend/app/services/_data_quality_monitor_singleton.py`
+
+Known G2.210 impact is CRITICAL. G2.212 may proceed only if the future diff stays
+inside the two authorized source files and the focused test path. Stop and
+return to review if the implementation needs route, adapter, OpenAPI, frontend,
+config, script, or OpenSpec edits.
+
+## Explicit Non-Goals
+
+This authorization does not grant:
+
+- source edits in G2.211
+- route/provider migration in G2.212
+- adapter or adapter-split migration in G2.212
+- `market_data_adapter.py` edits in G2.212
+- `DataQualityMonitor` class internals
+- historical backup cleanup
+- `get_data_quality_monitor()` deletion or rename
+- OpenAPI, frontend, config, script, or OpenSpec edits
+- GitHub issue label changes
+
+## Evidence Artifacts
+
+- `.planning/codebase/generated/data-quality-monitor-singleton-authorization-2026-05-28.json`
+- `docs/reports/quality/backend-data-quality-monitor-singleton-authorization-2026-05-28.md`
+- `governance/mainline/task-cards/pr-364.yaml`

--- a/governance/mainline/task-cards/pr-364.yaml
+++ b/governance/mainline/task-cards/pr-364.yaml
@@ -1,0 +1,114 @@
+version: "v0.2"
+
+task:
+  id: "pr-364"
+  title: "Authorize data-quality monitor singleton/backing API implementation"
+  owner: "codex"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-monitor-singleton-authorization"
+  objective: "authorize a future path-limited singleton/backing API compatibility implementation without source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Authorization-only package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-monitor-singleton-authorization-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-monitor-singleton-authorization-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-364.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "source edits in this PR"
+  - "route/provider migration in this PR"
+  - "adapter or adapter_split migration in this PR"
+  - "market_data_adapter.py edits in this PR"
+  - "DataQualityMonitor class internals"
+  - "historical backup cleanup"
+  - "getter deletion or rename"
+  - "OpenAPI, frontend, config, script, or OpenSpec edits"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "json-yaml-parse"
+      command: "python - <<'PY'\nimport json, yaml\nwith open('.planning/codebase/generated/data-quality-monitor-singleton-authorization-2026-05-28.json', encoding='utf-8') as f:\n    json.load(f)\nwith open('.planning/codebase/steward-tree/steward-index.json', encoding='utf-8') as f:\n    json.load(f)\nwith open('governance/mainline/task-cards/pr-364.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-monitor-singleton-authorization-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-364.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 619be9cac1f9516b3df42a41ca362ca9d42d5c9a --head-sha HEAD --report /tmp/pr364-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Authorization package could be misread as source implementation; forbidden paths and boundary notes prevent that."
+    - "Future implementation touches a CRITICAL impact root; G2.212 must remain compatibility-first and path-limited."
+  rollback_plan: "Revert this governance-only commit; no runtime or source state changes are made."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Authorize a future narrow singleton/backing API compatibility implementation."
+    modified_scope: "Only steward tree, generated evidence, quality report, and task-card governance files."
+    dependency_changes: "None."
+    legacy_logic_impact: "No runtime or compatibility behavior changes in this PR."
+    rollback_ready: "Yes; revert the governance commit."
+    risk_and_rollback_point: "Do not proceed to source implementation until this authorization is accepted and G2.212 is opened separately."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "current review thread human maintainer"
+    approved_at: "2026-05-28T22:18:21+08:00"
+    approval_note: "Approved to continue from G2.210 into G2.211 governance-only authorization package after PR #363 merge."
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- Record G2.211 as a governance-only authorization package after PR #363 merged.
- Authorize a future G2.212 path-limited singleton/backing API compatibility implementation.
- Keep this PR free of source edits and keep route/adapters/OpenAPI/frontend/config/scripts/OpenSpec out of scope.

## Authorized Future Lane

G2.212 may edit only:

- `web/backend/app/services/_data_quality_monitor_singleton.py`
- `web/backend/app/services/data_quality_monitor.py`
- `web/backend/tests/test_data_quality_monitor_singleton_provider.py`

Required regressions include data-quality route provider, canonical adapter, adapter_split, market_data_adapter, logging-noise, and large-file split tests.

## Boundary

No source edits in this PR. No getter deletion or rename. No route/provider migration. No adapter or adapter_split migration. No `market_data_adapter.py` edits. No OpenAPI, frontend, config, script, or OpenSpec edits.

## Verification

- JSON/YAML parse: passed
- Markdown governance: 6 checked files, 0 errors
- OpenSpec validate `migrate-backend-singletons-to-lifecycle-di --strict`: valid (PostHog telemetry flush noise only)
- `git diff --check` / cached diff check: passed
- Mainline scope gate for `pr-364.yaml`: pass=True
- GitNexus staged/compare: low risk, 0 changed symbols, 0 affected processes
EOF 2>&1
