### PR TITLE
G2.212 add data-quality monitor provider seam

### DIFF
--- a/.planning/codebase/generated/data-quality-monitor-singleton-implementation-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-monitor-singleton-implementation-2026-05-28.json
@@ -1,0 +1,119 @@
+{
+  "schema_version": "2026-05-28.g2-implementation-evidence.v1",
+  "id": "g2-212-data-quality-monitor-singleton-implementation",
+  "generated_at": "2026-05-28T22:40:00+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "535a6d9c1565b4ced7942cb4082104f2fb0506fd",
+  "branch": "g2-212-data-quality-monitor-singleton-implementation",
+  "parent_gate": {
+    "id": "g2-211-data-quality-monitor-singleton-authorization",
+    "github_pr": 364,
+    "merge_commit": "535a6d9c1565b4ced7942cb4082104f2fb0506fd",
+    "accepted_scope": "path-limited source implementation for the data-quality monitor singleton/backing API compatibility seam"
+  },
+  "openspec": {
+    "change_id": "migrate-backend-singletons-to-lifecycle-di",
+    "approval_status": "approved",
+    "validate_command": "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+  },
+  "source_edit_authority": true,
+  "authorized_paths": {
+    "source": [
+      "web/backend/app/services/_data_quality_monitor_singleton.py",
+      "web/backend/app/services/data_quality_monitor.py"
+    ],
+    "tests": [
+      "web/backend/tests/test_data_quality_monitor_singleton_provider.py"
+    ],
+    "governance": [
+      ".planning/codebase/generated/data-quality-monitor-singleton-implementation-2026-05-28.json",
+      ".planning/codebase/steward-tree/current-next-gates.md",
+      ".planning/codebase/steward-tree/steward-index.json",
+      ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+      ".planning/codebase/steward-tree/branch-register.md",
+      ".planning/codebase/steward-tree/evidence-index.md",
+      ".planning/codebase/steward-tree/completed-ledger.md",
+      "docs/FUNCTION_TREE.md",
+      "governance/function-tree/catalog.yaml",
+      "docs/reports/quality/backend-data-quality-monitor-singleton-implementation-2026-05-28.md",
+      "governance/mainline/task-cards/pr-365.yaml"
+    ]
+  },
+  "forbidden_scope": [
+    "web/backend/app/api/**",
+    "web/backend/app/services/adapters/**",
+    "web/backend/app/services/adapters_split/**",
+    "web/backend/app/services/data_adapters/**",
+    "web/backend/app/services/market_data_adapter.py",
+    "web/backend/app/services/data_adapter.py.backup.20260130",
+    "web/frontend/**",
+    "src/**",
+    "docs/api/**",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**"
+  ],
+  "implementation": {
+    "summary": "Preserve default global DataQualityMonitor fallback while adding explicit provider/reset hooks for lifecycle wiring and focused tests.",
+    "public_imports_preserved": [
+      "app.services.data_quality_monitor.get_data_quality_monitor",
+      "app.services.data_quality_monitor.monitor_data_quality"
+    ],
+    "public_imports_added": [
+      "app.services.data_quality_monitor.set_data_quality_monitor_provider",
+      "app.services.data_quality_monitor.reset_data_quality_monitor_provider"
+    ],
+    "default_singleton_fallback_preserved": true,
+    "route_adapter_scope_changed": false,
+    "openapi_scope_changed": false
+  },
+  "gitnexus_pre_edit": {
+    "get_data_quality_monitor": {
+      "risk": "CRITICAL",
+      "impacted_count": 24,
+      "direct": 20,
+      "processes_affected": 7,
+      "modules_affected": 4,
+      "disposition": "Known high-risk root seam from G2.210; G2.211 authorized only a compatibility-first provider hook inside the singleton/backing API paths."
+    },
+    "monitor_data_quality": {
+      "risk": "LOW",
+      "impacted_count": 1,
+      "direct": 1,
+      "disposition": "Covered by focused provider-hook regression test."
+    }
+  },
+  "tdd": {
+    "red_command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py -q --no-cov --tb=short",
+    "red_result": "ImportError before implementation: reset_data_quality_monitor_provider was not exported from app.services.data_quality_monitor.",
+    "green_command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py -q --no-cov --tb=short",
+    "green_result": "3 passed"
+  },
+  "verification": {
+    "focused_pytest": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py -q --no-cov --tb=short",
+      "result": "3 passed"
+    },
+    "authorized_non_large_regression": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py web/backend/tests/test_data_quality_route_provider_regressions.py web/backend/tests/test_data_quality_canonical_service_adapter_provider.py web/backend/tests/test_adapter_split_data_quality_monitor_provider.py web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short",
+      "result": "20 passed"
+    },
+    "large_file_split_regression_record": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_large_file_split_regressions.py -q --no-cov --tb=short || true",
+      "result": "35 passed, 4 failed",
+      "failure_disposition": "Existing unrelated baseline failures in missing historical split files/exports; not fixed in G2.212."
+    },
+    "ruff": {
+      "command": "ruff check web/backend/app/services/_data_quality_monitor_singleton.py web/backend/app/services/data_quality_monitor.py web/backend/tests/test_data_quality_monitor_singleton_provider.py",
+      "result": "All checks passed"
+    }
+  },
+  "next_gate": {
+    "id": "g2-213",
+    "name": "data-quality monitor singleton/backing API closeout and residual refresh",
+    "source_edit_authority": false,
+    "purpose": "Review G2.212 implementation evidence, classify remaining residuals, and decide whether any further source lane is warranted."
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T22:18:21+08:00`
-- Base HEAD checked: `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`
+- Prepared at: `2026-05-28T22:40:00+08:00`
+- Base HEAD checked: `535a6d9c1565b4ced7942cb4082104f2fb0506fd`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -48,12 +48,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#361` | `g2-208-data-quality-market-data-adapter-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `90d8f12cc01f9fb360abc531673e3ed9535706e7` | Path-limited `market_data_adapter.py` provider seam implementation closed for G2.209 refresh |
 | `#362` | `g2-209-data-quality-market-data-adapter-provider-closeout` | `wip/root-dirty-20260403` | `MERGED` at `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230` | Governance closeout selecting G2.210 data-quality monitor residual ownership decision |
 | `#363` | `g2-210-data-quality-monitor-residual-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `619be9cac1f9516b3df42a41ca362ca9d42d5c9a` | Decision package selecting G2.211 singleton/backing API authorization |
+| `#364` | `g2-211-data-quality-monitor-singleton-authorization` | `wip/root-dirty-20260403` | `MERGED` at `535a6d9c1565b4ced7942cb4082104f2fb0506fd` | Authorization package selecting G2.212 data-quality monitor singleton/backing API implementation |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-211-data-quality-monitor-singleton-authorization` | `origin/wip/root-dirty-20260403` at `619be9cac1f9516b3df42a41ca362ca9d42d5c9a` | Authorize future data-quality monitor singleton/backing API compatibility implementation | No |
+| `g2-212-data-quality-monitor-singleton-implementation` | `origin/wip/root-dirty-20260403` at `535a6d9c1565b4ced7942cb4082104f2fb0506fd` | Implement data-quality monitor singleton/backing API provider/reset hook while preserving default singleton fallback | Yes, limited to the authorized singleton/backing API paths and focused test |
 
 ## OpenSpec Relationship
 
@@ -69,7 +70,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.211 is a no-source authorization branch after PR `#363` merged G2.210. It is
-limited to governance evidence, steward tree updates, and a task card. If
-accepted, the next gate is a separate G2.212 source implementation lane limited
-to the authorized singleton/backing API paths.
+G2.212 is the source implementation branch after PR `#364` merged G2.211. It is
+limited to the authorized singleton/backing API paths plus one focused test and
+governance evidence. If accepted, the next gate is G2.213 closeout / residual
+refresh with no source edits.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T22:18:21+08:00`
-- Base HEAD checked: `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`
+- Prepared at: `2026-05-28T22:40:00+08:00`
+- Base HEAD checked: `535a6d9c1565b4ced7942cb4082104f2fb0506fd`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 merged by PR `#363`; G2.211 is the active singleton/backing API authorization |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 merged by PR `#363`; G2.211 merged by PR `#364`; G2.212 is the active singleton/backing API implementation review |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T22:18:21+08:00`
-- Base HEAD checked: `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`
+- Prepared at: `2026-05-28T22:40:00+08:00`
+- Base HEAD checked: `535a6d9c1565b4ced7942cb4082104f2fb0506fd`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.211 data-quality monitor singleton/backing API authorization | G/#79 service lifecycle DI | PR `#363` merged at `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`; G2.211 authorizes a future path-limited G2.212 compatibility implementation without source edits in this PR | If accepted, start G2.212 implementation in a separate source lane; do not edit routes, adapters, OpenAPI, frontend, config, scripts, or OpenSpec |
+| P0 | Review G2.212 data-quality monitor singleton/backing API compatibility implementation | G/#79 service lifecycle DI | PR `#364` merged at `535a6d9c1565b4ced7942cb4082104f2fb0506fd`; G2.212 adds a provider/reset hook while preserving default singleton fallback | If accepted, start G2.213 closeout / residual refresh with no source edits |
+| P0 | Preserve G2.211 data-quality monitor singleton/backing API authorization | G/#79 service lifecycle DI | PR `#364` merged; G2.211 authorized a future path-limited G2.212 compatibility implementation | Do not expand G2.212 beyond the two authorized source files and one focused test |
 | P0 | Preserve G2.210 data-quality monitor residual ownership decision | G/#79 service lifecycle DI | PR `#363` merged; singleton/backing API is a high-risk root ownership surface, not a routine cleanup | Use G2.211 authorization before any source lane |
 | P0 | Preserve G2.209 data-quality `market_data_adapter.py` provider seam closeout / residual refresh | G/#79 service lifecycle DI | PR `#362` merged; `market_data_adapter.py` is closed and remaining monitor residuals are routed to G2.210 ownership decision | Do not reopen closed G2.208/G2.209 source scope without contradictory current HEAD evidence |
 | P0 | Preserve G2.208 data-quality `market_data_adapter.py` provider seam implementation | G/#79 service lifecycle DI | PR `#361` merged; optional quality monitor injection is implemented for `MarketDataSourceAdapter` while preserving default singleton fallback | Do not reopen `market_data_adapter.py` source unless current HEAD evidence contradicts G2.208/G2.209 |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -83,8 +83,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-market-data-adapter-provider-closeout-refresh-2026-05-28.md` | G2.209 human-readable closeout / residual refresh report | Accepted by PR `#362`; superseded for residual ownership by G2.210 |
 | `.planning/codebase/generated/data-quality-monitor-residual-ownership-decision-2026-05-28.json` | G2.210 data-quality monitor residual ownership decision evidence | Accepted by PR `#363`; superseded for singleton/backing API authorization by G2.211 |
 | `docs/reports/quality/backend-data-quality-monitor-residual-ownership-decision-2026-05-28.md` | G2.210 human-readable residual ownership decision report | Accepted by PR `#363`; superseded for singleton/backing API authorization by G2.211 |
-| `.planning/codebase/generated/data-quality-monitor-singleton-authorization-2026-05-28.json` | G2.211 data-quality monitor singleton/backing API authorization evidence | Current for HEAD `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`; review input until PR `#364` is accepted |
-| `docs/reports/quality/backend-data-quality-monitor-singleton-authorization-2026-05-28.md` | G2.211 human-readable singleton/backing API authorization report | Review input until PR `#364` is accepted |
+| `.planning/codebase/generated/data-quality-monitor-singleton-authorization-2026-05-28.json` | G2.211 data-quality monitor singleton/backing API authorization evidence | Accepted by PR `#364`; superseded for implementation evidence by G2.212 |
+| `docs/reports/quality/backend-data-quality-monitor-singleton-authorization-2026-05-28.md` | G2.211 human-readable singleton/backing API authorization report | Accepted by PR `#364`; superseded for implementation evidence by G2.212 |
+| `.planning/codebase/generated/data-quality-monitor-singleton-implementation-2026-05-28.json` | G2.212 data-quality monitor singleton/backing API implementation evidence | Current for HEAD `535a6d9c1565b4ced7942cb4082104f2fb0506fd`; review input until PR `#365` is accepted |
+| `docs/reports/quality/backend-data-quality-monitor-singleton-implementation-2026-05-28.md` | G2.212 human-readable singleton/backing API implementation report | Review input until PR `#365` is accepted |
 
 ## External State Inputs
 

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T22:18:21+08:00",
+  "generated_at": "2026-05-28T22:40:00+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "619be9cac1f9516b3df42a41ca362ca9d42d5c9a",
-  "split_branch": "g2-211-data-quality-monitor-singleton-authorization",
-  "scope": "data_quality_monitor_singleton_authorization",
-  "source_edit_authority": false,
+  "base_head": "535a6d9c1565b4ced7942cb4082104f2fb0506fd",
+  "split_branch": "g2-212-data-quality-monitor-singleton-implementation",
+  "scope": "data_quality_monitor_singleton_implementation",
+  "source_edit_authority": true,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -2110,12 +2110,14 @@
     {
       "id": "g2-211-data-quality-monitor-singleton-authorization",
       "type": "authorization_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.210 data-quality monitor residual ownership decision",
       "source_edit_authority": false,
       "parent_github_pr": 363,
       "parent_merge_commit": "619be9cac1f9516b3df42a41ca362ca9d42d5c9a",
+      "github_pr": 364,
+      "merge_commit": "535a6d9c1565b4ced7942cb4082104f2fb0506fd",
       "evidence": [
         ".planning/codebase/generated/data-quality-monitor-singleton-authorization-2026-05-28.json",
         "docs/reports/quality/backend-data-quality-monitor-singleton-authorization-2026-05-28.md",
@@ -2149,7 +2151,61 @@
         "current_head_checked": "619be9cac1f9516b3df42a41ca362ca9d42d5c9a",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.212 data-quality monitor singleton/backing API compatibility implementation in a separate source lane."
+      "next_gate": "Superseded by G2.212 data-quality monitor singleton/backing API compatibility implementation."
+    },
+    {
+      "id": "g2-212-data-quality-monitor-singleton-implementation",
+      "type": "implementation",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.211 data-quality monitor singleton/backing API authorization",
+      "source_edit_authority": true,
+      "parent_github_pr": 364,
+      "parent_merge_commit": "535a6d9c1565b4ced7942cb4082104f2fb0506fd",
+      "evidence": [
+        ".planning/codebase/generated/data-quality-monitor-singleton-implementation-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-monitor-singleton-implementation-2026-05-28.md",
+        "governance/mainline/task-cards/pr-365.yaml"
+      ],
+      "changed_source_paths": [
+        "web/backend/app/services/_data_quality_monitor_singleton.py",
+        "web/backend/app/services/data_quality_monitor.py"
+      ],
+      "changed_test_paths": [
+        "web/backend/tests/test_data_quality_monitor_singleton_provider.py"
+      ],
+      "function_tree": {
+        "domain_id": "domain-01",
+        "node_id": "domain-01-node-03",
+        "updated_paths": [
+          "docs/FUNCTION_TREE.md",
+          "governance/function-tree/catalog.yaml"
+        ]
+      },
+      "implementation_result": {
+        "public_imports_preserved": [
+          "get_data_quality_monitor",
+          "monitor_data_quality"
+        ],
+        "public_hooks_added": [
+          "set_data_quality_monitor_provider",
+          "reset_data_quality_monitor_provider"
+        ],
+        "default_singleton_fallback_preserved": true,
+        "route_adapter_openapi_scope_changed": false
+      },
+      "verification": {
+        "focused_pytest": "3 passed",
+        "authorized_non_large_regression": "20 passed",
+        "large_file_split_regression_record": "35 passed, 4 failed existing unrelated baseline issues",
+        "ruff": "passed",
+        "openspec_validate": "passed"
+      },
+      "freshness": {
+        "current_head_checked": "535a6d9c1565b4ced7942cb4082104f2fb0506fd",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.213 data-quality monitor singleton/backing API closeout / residual refresh with no source edits."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -766,11 +766,44 @@ Future G2.212 constraints:
 - do not migrate routes, adapters, adapter-split constructors, or
   `market_data_adapter.py`
 
+## G2.212 Data-Quality Monitor Singleton Implementation
+
+At HEAD `535a6d9c1565b4ced7942cb4082104f2fb0506fd`, PR `#364` is merged and
+G2.211 is accepted.
+
+Implementation result:
+
+| Item | Result |
+|---|---|
+| Lane | G2.212 data-quality monitor singleton/backing API compatibility implementation |
+| Source authority | Yes, path-limited |
+| Source paths | `web/backend/app/services/_data_quality_monitor_singleton.py`, `web/backend/app/services/data_quality_monitor.py` |
+| Focused test | `web/backend/tests/test_data_quality_monitor_singleton_provider.py` |
+| Public imports preserved | `get_data_quality_monitor`, `monitor_data_quality` |
+| Public hooks added | `set_data_quality_monitor_provider`, `reset_data_quality_monitor_provider` |
+| Default singleton fallback | Preserved |
+| Route/adapters/OpenAPI changes | None |
+
+Verification summary:
+
+| Check | Result |
+|---|---|
+| Focused provider seam test | `3 passed` |
+| Authorized non-large regression set | `20 passed` |
+| Large-file split regression record | `35 passed`, `4 failed` existing unrelated baseline issues |
+| Ruff on touched source/test files | Passed |
+| OpenSpec strict validate | Passed |
+
+G2.212 does not close all residual ownership questions. It only gives the
+remaining singleton/backing API surface a compatibility provider hook so future
+lifecycle wiring can depend on an explicit seam instead of directly mutating the
+module-level singleton.
+
 ## Next Gates
 
-- Review G2.211 data-quality monitor singleton/backing API authorization package.
-- If accepted, start G2.212 data-quality monitor singleton/backing API compatibility implementation in a separate source lane.
-- Do not edit routes, adapters, adapter-split constructors, `market_data_adapter.py`, OpenAPI, frontend, config, scripts, or OpenSpec in G2.212.
+- Review G2.212 data-quality monitor singleton/backing API compatibility implementation.
+- If accepted, start G2.213 data-quality monitor singleton/backing API closeout / residual refresh with no source edits.
+- Do not open another source lane before G2.213 classifies remaining residuals and selects a next gate.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/FUNCTION_TREE.md
+++ b/docs/FUNCTION_TREE.md
@@ -125,6 +125,7 @@
 | Backend canonical service adapters | ✅ | backend | `web/backend/app/services/adapters/dashboard_adapter.py` 与 `web/backend/app/services/adapters/data_adapter.py` 接入数据源工厂，并通过 G2.200 支持可注入 data-quality monitor seam |
 | Backend legacy data adapter wrappers | ✅ | backend | `web/backend/app/services/data_adapters/dashboard.py` 与 `web/backend/app/services/data_adapters/data_source.py` 通过 G2.204 保留旧模块路径并重导出 canonical adapters |
 | Backend market data adapter facade | ✅ | backend | `web/backend/app/services/market_data_adapter.py` 通过 G2.208 保留 `MarketDataSourceAdapter(config)` 兼容构造，并支持可注入 data-quality monitor seam |
+| Backend data-quality monitor singleton | ✅ | backend | `web/backend/app/services/_data_quality_monitor_singleton.py` 与 `web/backend/app/services/data_quality_monitor.py` 通过 G2.212 保留默认 singleton fallback，并提供 provider/reset hook |
 
 ### 1.4 K线数据服务 {#domain-01-node-04}
 

--- a/docs/reports/quality/backend-data-quality-monitor-singleton-implementation-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-monitor-singleton-implementation-2026-05-28.md
@@ -1,0 +1,166 @@
+# Backend Data-Quality Monitor Singleton Implementation - 2026-05-28
+
+> **历史文档说明**: 本文件是 G2.212 执行证据快照，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Lane: G2.212 data-quality monitor singleton/backing API compatibility implementation
+- Parent approval: G2.211, PR `#364`, merge commit `535a6d9c1565b4ced7942cb4082104f2fb0506fd`
+- OpenSpec change: `migrate-backend-singletons-to-lifecycle-di`
+- Source authority: approved, path-limited
+- Result: ready for PR review
+
+## Scope
+
+Authorized source paths:
+
+- `web/backend/app/services/_data_quality_monitor_singleton.py`
+- `web/backend/app/services/data_quality_monitor.py`
+
+Authorized test path:
+
+- `web/backend/tests/test_data_quality_monitor_singleton_provider.py`
+
+Explicitly excluded:
+
+- routes
+- canonical adapters
+- `adapter_split`
+- legacy `data_adapters`
+- `market_data_adapter.py`
+- OpenAPI, frontend, config, scripts, and OpenSpec files
+
+## Implementation
+
+G2.212 keeps the existing public singleton API stable:
+
+- `get_data_quality_monitor()`
+- `monitor_data_quality(...)`
+
+It adds two compatibility hooks exported through `app.services.data_quality_monitor`:
+
+- `set_data_quality_monitor_provider(provider)`
+- `reset_data_quality_monitor_provider()`
+
+The default global `DataQualityMonitor()` fallback is still preserved when no provider override is registered.
+
+## GitNexus Pre-Edit Evidence
+
+`get_data_quality_monitor` was checked before editing:
+
+- risk: `CRITICAL`
+- impacted count: `24`
+- direct dependents: `20`
+- affected processes: `7`
+- affected modules: `4`
+
+Disposition: this high-risk root seam was known from G2.210 and explicitly authorized by G2.211 for a compatibility-first, two-source-file implementation only.
+
+`monitor_data_quality` was also checked before editing:
+
+- risk: `LOW`
+- impacted count: `1`
+- direct dependents: `1`
+
+## TDD Evidence
+
+RED:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py -q --no-cov --tb=short
+```
+
+Observed failure before implementation:
+
+- `ImportError: cannot import name 'reset_data_quality_monitor_provider' from 'app.services.data_quality_monitor'`
+
+GREEN:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py -q --no-cov --tb=short
+```
+
+Result:
+
+- `3 passed`
+
+## Verification
+
+Focused provider seam regression:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py -q --no-cov --tb=short
+```
+
+Result:
+
+- `3 passed`
+
+Authorized non-large regression set:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py web/backend/tests/test_data_quality_route_provider_regressions.py web/backend/tests/test_data_quality_canonical_service_adapter_provider.py web/backend/tests/test_adapter_split_data_quality_monitor_provider.py web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short
+```
+
+Result:
+
+- `20 passed`
+
+Large-file split regression record:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_large_file_split_regressions.py -q --no-cov --tb=short || true
+```
+
+Observed result:
+
+- `35 passed`
+- `4 failed`
+
+The four failures are existing unrelated baseline issues outside G2.212 scope:
+
+- missing `src/interfaces/adapters/efinance_adapter/efinance_data_source.py`
+- missing `src/routes/stocks_routes/check_use_mock_data.py`
+- missing `get_stock_search_service` export
+- missing `app.core.exceptions`
+
+Ruff:
+
+```bash
+ruff check web/backend/app/services/_data_quality_monitor_singleton.py web/backend/app/services/data_quality_monitor.py web/backend/tests/test_data_quality_monitor_singleton_provider.py
+```
+
+Result:
+
+- `All checks passed`
+
+OpenSpec:
+
+```bash
+openspec validate migrate-backend-singletons-to-lifecycle-di --strict
+```
+
+Result:
+
+- `Change 'migrate-backend-singletons-to-lifecycle-di' is valid`
+- PostHog connection refusal is telemetry noise only.
+
+## Function Tree
+
+G2.212 updates `domain-01-node-03` / `1.3 多数据源集成` with the data-quality monitor singleton/backing API seam:
+
+- `docs/FUNCTION_TREE.md`
+- `governance/function-tree/catalog.yaml`
+
+## Next Gate
+
+If PR `#365` is accepted, start G2.213 as a no-source closeout / residual refresh package.
+
+G2.213 should:
+
+- record acceptance of the provider hook
+- rescan remaining `get_data_quality_monitor` residuals
+- classify retained residuals
+- decide whether any later source lane is warranted
+
+No new source lane should start before G2.213 classifies the residuals.

--- a/governance/function-tree/catalog.yaml
+++ b/governance/function-tree/catalog.yaml
@@ -59,11 +59,14 @@ domains:
           - "web/backend/app/services/data_adapters/dashboard.py"
           - "web/backend/app/services/data_adapters/data_source.py"
           - "web/backend/app/services/market_data_adapter.py"
+          - "web/backend/app/services/_data_quality_monitor_singleton.py"
+          - "web/backend/app/services/data_quality_monitor.py"
           - "web/backend/app/services/adapters_split/**"
           - "web/backend/tests/test_adapter_split_data_quality_monitor_provider.py"
           - "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py"
           - "web/backend/tests/test_data_quality_legacy_data_adapter_compat.py"
           - "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py"
+          - "web/backend/tests/test_data_quality_monitor_singleton_provider.py"
           - "config/data_sources*"
         entrypoints:
           governance:
@@ -78,11 +81,14 @@ domains:
             - "web/backend/app/services/data_adapters/dashboard.py"
             - "web/backend/app/services/data_adapters/data_source.py"
             - "web/backend/app/services/market_data_adapter.py"
+            - "web/backend/app/services/_data_quality_monitor_singleton.py"
+            - "web/backend/app/services/data_quality_monitor.py"
           tests:
             - "tests/unit/adapters/**"
             - "web/backend/tests/test_data_quality_canonical_service_adapter_provider.py"
             - "web/backend/tests/test_data_quality_legacy_data_adapter_compat.py"
             - "web/backend/tests/test_market_data_adapter_quality_monitor_provider.py"
+            - "web/backend/tests/test_data_quality_monitor_singleton_provider.py"
           operations:
             - "docs/operations/OPS_MANUAL.md"
       - id: "domain-01-node-04"

--- a/governance/mainline/task-cards/pr-365.yaml
+++ b/governance/mainline/task-cards/pr-365.yaml
@@ -1,0 +1,136 @@
+version: "v0.2"
+
+task:
+  id: "pr-365"
+  title: "Implement data-quality monitor singleton provider seam"
+  owner: "codex"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-monitor-singleton-implementation"
+  objective: "add a provider/reset compatibility seam to the data-quality monitor singleton backing API while preserving default singleton fallback"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "feature"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "domain-01"
+  node_id: "domain-01-node-03"
+  affected_entrypoints:
+    - "governance"
+    - "core"
+    - "tests"
+  update_status: "required"
+  secondary_domains: []
+  exemption_reason: "Not exempted; G2.212 updates docs/FUNCTION_TREE.md and governance/function-tree/catalog.yaml for domain-01-node-03."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-monitor-singleton-implementation-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "docs/reports/quality/backend-data-quality-monitor-singleton-implementation-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-365.yaml"
+    - "web/backend/app/services/_data_quality_monitor_singleton.py"
+    - "web/backend/app/services/data_quality_monitor.py"
+    - "web/backend/tests/test_data_quality_monitor_singleton_provider.py"
+  forbidden_paths:
+    - "web/backend/app/api/**"
+    - "web/backend/app/services/adapters/**"
+    - "web/backend/app/services/adapters_split/**"
+    - "web/backend/app/services/data_adapters/**"
+    - "web/backend/app/services/market_data_adapter.py"
+    - "web/backend/app/services/data_adapter.py.backup.20260130"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "route migration"
+  - "adapter or adapter_split migration"
+  - "legacy data_adapters migration"
+  - "market_data_adapter.py edits"
+  - "DataQualityMonitor class internals"
+  - "OpenAPI, frontend, config, script, or OpenSpec edits"
+  - "deleting, renaming, or changing the semantics of get_data_quality_monitor or monitor_data_quality"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py -q --no-cov --tb=short"
+      required: true
+    - id: "authorized-non-large-regression"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py web/backend/tests/test_data_quality_route_provider_regressions.py web/backend/tests/test_data_quality_canonical_service_adapter_provider.py web/backend/tests/test_adapter_split_data_quality_monitor_provider.py web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "large-file-split-regression-record"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_large_file_split_regressions.py -q --no-cov --tb=short || true"
+      required: false
+    - id: "ruff"
+      command: "ruff check web/backend/app/services/_data_quality_monitor_singleton.py web/backend/app/services/data_quality_monitor.py web/backend/tests/test_data_quality_monitor_singleton_provider.py"
+      required: true
+    - id: "json-yaml-parse"
+      command: "python - <<'PY'\nimport json, yaml\nfor path in ['.planning/codebase/generated/data-quality-monitor-singleton-implementation-2026-05-28.json', '.planning/codebase/steward-tree/steward-index.json']:\n    with open(path, encoding='utf-8') as f:\n        json.load(f)\nwith open('governance/mainline/task-cards/pr-365.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-monitor-singleton-implementation-2026-05-28.md docs/FUNCTION_TREE.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-365.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 535a6d9c1565b4ced7942cb4082104f2fb0506fd --head-sha HEAD --report /tmp/pr365-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "get_data_quality_monitor is a CRITICAL impact root; this PR adds only an optional provider hook and preserves default fallback behavior."
+    - "Provider override could leak between tests; reset_data_quality_monitor_provider clears both provider and cached singleton."
+  rollback_plan: "Revert this PR; public singleton imports remain available in the previous implementation."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Add a provider/reset seam to the data-quality monitor singleton backing API."
+    modified_scope: "Two source files, one focused test, and governance/function-tree evidence files."
+    dependency_changes: "None."
+    legacy_logic_impact: "Default DataQualityMonitor singleton fallback and existing public imports are preserved."
+    rollback_ready: "Yes; revert the PR."
+    risk_and_rollback_point: "Do not start another source lane until G2.213 closeout / residual refresh classifies remaining residuals."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "current review thread human maintainer"
+    approved_at: "2026-05-28T22:40:00+08:00"
+    approval_note: "Approved to continue from G2.211 into the G2.212 path-limited source implementation lane after PR #364 merge."
+    secondary_approved: false

--- a/web/backend/app/services/_data_quality_monitor_singleton.py
+++ b/web/backend/app/services/_data_quality_monitor_singleton.py
@@ -2,16 +2,32 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from app.services.data_quality_monitor import DataQualityMonitor
 
 _global_monitor: Optional[DataQualityMonitor] = None
+_monitor_provider: Optional[Callable[[], DataQualityMonitor]] = None
+
+
+def set_data_quality_monitor_provider(provider: Optional[Callable[[], DataQualityMonitor]]) -> None:
+    """Register an explicit monitor provider for lifecycle wiring or tests."""
+    global _monitor_provider
+    _monitor_provider = provider
+
+
+def reset_data_quality_monitor_provider() -> None:
+    """Reset provider override and cached singleton monitor."""
+    global _global_monitor, _monitor_provider
+    _monitor_provider = None
+    _global_monitor = None
 
 
 def get_data_quality_monitor() -> DataQualityMonitor:
     """获取全局数据质量监控实例"""
     global _global_monitor
+    if _monitor_provider is not None:
+        return _monitor_provider()
     if _global_monitor is None:
         _global_monitor = DataQualityMonitor()
     return _global_monitor

--- a/web/backend/app/services/data_quality_monitor.py
+++ b/web/backend/app/services/data_quality_monitor.py
@@ -711,10 +711,16 @@ class DataQualityMonitor:
         """检查监控是否启用"""
         return self.monitoring_enabled
 
-from app.services._data_quality_monitor_singleton import get_data_quality_monitor, monitor_data_quality
+from app.services._data_quality_monitor_singleton import (
+    get_data_quality_monitor,
+    monitor_data_quality,
+    reset_data_quality_monitor_provider,
+    set_data_quality_monitor_provider,
+)
 
 __all__ = [
     "DataQualityLevel", "AlertSeverity", "DataQualityMetric", "DataQualityAlert", "DataSourceQualityMetrics",
     "IDataQualityRule", "SchemaValidationRule", "DataFreshnessRule", "DataConsistencyRule", "DataQualityMonitor",
     "get_data_quality_monitor", "monitor_data_quality",
+    "reset_data_quality_monitor_provider", "set_data_quality_monitor_provider",
 ]

--- a/web/backend/tests/test_data_quality_monitor_singleton_provider.py
+++ b/web/backend/tests/test_data_quality_monitor_singleton_provider.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.data_quality_monitor import (
+    get_data_quality_monitor,
+    monitor_data_quality,
+    reset_data_quality_monitor_provider,
+    set_data_quality_monitor_provider,
+)
+
+
+class FakeQualityMonitor:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def evaluate_data_quality(
+        self,
+        data: dict[str, object],
+        source: str,
+        response_time: float | None = None,
+        success: bool = True,
+    ) -> dict[str, object]:
+        self.calls.append(
+            {
+                "data": data,
+                "source": source,
+                "response_time": response_time,
+                "success": success,
+            }
+        )
+        return {"source": source, "success": success}
+
+
+@pytest.fixture(autouse=True)
+def reset_monitor_provider():
+    reset_data_quality_monitor_provider()
+    yield
+    reset_data_quality_monitor_provider()
+
+
+def test_get_data_quality_monitor_uses_registered_provider():
+    monitor = FakeQualityMonitor()
+
+    set_data_quality_monitor_provider(lambda: monitor)
+
+    assert get_data_quality_monitor() is monitor
+
+
+@pytest.mark.asyncio
+async def test_monitor_data_quality_uses_registered_provider():
+    monitor = FakeQualityMonitor()
+    set_data_quality_monitor_provider(lambda: monitor)
+
+    result = await monitor_data_quality(
+        data={"timestamp": "2026-05-28T00:00:00Z", "status": "ok"},
+        source="unit-test",
+        response_time=12.5,
+        success=True,
+    )
+
+    assert result == {"source": "unit-test", "success": True}
+    assert monitor.calls == [
+        {
+            "data": {"timestamp": "2026-05-28T00:00:00Z", "status": "ok"},
+            "source": "unit-test",
+            "response_time": 12.5,
+            "success": True,
+        }
+    ]
+
+
+def test_reset_data_quality_monitor_provider_restores_default_singleton():
+    monitor = FakeQualityMonitor()
+    set_data_quality_monitor_provider(lambda: monitor)
+    assert get_data_quality_monitor() is monitor
+
+    reset_data_quality_monitor_provider()
+
+    default_monitor = get_data_quality_monitor()
+    assert default_monitor is get_data_quality_monitor()
+    assert default_monitor is not monitor


### PR DESCRIPTION
## Summary
- add provider/reset hooks to the data-quality monitor singleton backing API
- preserve get_data_quality_monitor()/monitor_data_quality public imports and default singleton fallback
- add focused provider-hook regression coverage and update steward/function-tree governance evidence

## Verification
- env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py -q --no-cov --tb=short -> 3 passed
- env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py web/backend/tests/test_data_quality_route_provider_regressions.py web/backend/tests/test_data_quality_canonical_service_adapter_provider.py web/backend/tests/test_adapter_split_data_quality_monitor_provider.py web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short -> 20 passed
- env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_large_file_split_regressions.py -q --no-cov --tb=short || true -> 35 passed / 4 known unrelated baseline failures
- ruff check web/backend/app/services/_data_quality_monitor_singleton.py web/backend/app/services/data_quality_monitor.py web/backend/tests/test_data_quality_monitor_singleton_provider.py -> passed
- python scripts/compliance/markdown_governance_gate.py ... -> errors 0
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict -> valid; PostHog telemetry noise only
- mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-365.yaml ... -> pass=True
- GitNexus detect_changes compare against 535a6d9c... -> medium, 14 files, 1 affected process

## Notes
GitNexus analyze was attempted after commit, but the CLI failed in this linked worktree because .git is a file and the analyzer tried to create .git/info. Staged and compare GitNexus checks were still run against the worktree diff.