### PR TITLE
G2.213 close data-quality monitor provider seam

### DIFF
--- a/.planning/codebase/generated/data-quality-monitor-singleton-closeout-refresh-2026-05-28.json
+++ b/.planning/codebase/generated/data-quality-monitor-singleton-closeout-refresh-2026-05-28.json
@@ -1,0 +1,128 @@
+{
+  "schema_version": "2026-05-28.g2-closeout-refresh-evidence.v1",
+  "id": "g2-213-data-quality-monitor-singleton-closeout-refresh",
+  "generated_at": "2026-05-28T23:11:00+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "e7d9fe63285181f0227661628272487dc63d4e2c",
+  "branch": "g2-213-data-quality-monitor-singleton-closeout-refresh",
+  "parent_gate": {
+    "id": "g2-212-data-quality-monitor-singleton-implementation",
+    "github_pr": 365,
+    "merge_commit": "e7d9fe63285181f0227661628272487dc63d4e2c",
+    "accepted_scope": "provider/reset hook implementation for the data-quality monitor singleton/backing API"
+  },
+  "source_edit_authority": false,
+  "openspec": {
+    "change_id": "migrate-backend-singletons-to-lifecycle-di",
+    "approval_status": "approved",
+    "validate_command": "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+  },
+  "scan": {
+    "scope": "web/backend/app/**/*.py",
+    "term": "get_data_quality_monitor",
+    "active_files": 7,
+    "active_occurrences": 29,
+    "active_calls": 7,
+    "generated_at_head": "e7d9fe63285181f0227661628272487dc63d4e2c",
+    "classification": [
+      {
+        "bucket": "singleton_backing_api",
+        "disposition": "closed by G2.212; retain provider/reset seam and default singleton fallback",
+        "files": [
+          {
+            "path": "web/backend/app/services/_data_quality_monitor_singleton.py",
+            "occurrences": 2,
+            "calls": 2,
+            "imports": 0
+          },
+          {
+            "path": "web/backend/app/services/data_quality_monitor.py",
+            "occurrences": 2,
+            "calls": 0,
+            "imports": 0
+          }
+        ]
+      },
+      {
+        "bucket": "route_api_provider_surface",
+        "disposition": "retained active FastAPI dependency/provider surface; not a direct implementation candidate in this lane",
+        "files": [
+          {
+            "path": "web/backend/app/api/data_quality.py",
+            "occurrences": 17,
+            "calls": 1,
+            "imports": 1
+          }
+        ]
+      },
+      {
+        "bucket": "closed_canonical_service_adapter_fallbacks",
+        "disposition": "closed by G2.200/G2.201; retain default fallback unless fresh current-HEAD evidence contradicts",
+        "files": [
+          {
+            "path": "web/backend/app/services/adapters/dashboard_adapter.py",
+            "occurrences": 2,
+            "calls": 1,
+            "imports": 1
+          },
+          {
+            "path": "web/backend/app/services/adapters/data_adapter.py",
+            "occurrences": 2,
+            "calls": 1,
+            "imports": 1
+          }
+        ]
+      },
+      {
+        "bucket": "closed_market_data_adapter_facade_fallback",
+        "disposition": "closed by G2.208/G2.209; retain compatibility facade fallback unless fresh current-HEAD evidence contradicts",
+        "files": [
+          {
+            "path": "web/backend/app/services/market_data_adapter.py",
+            "occurrences": 2,
+            "calls": 1,
+            "imports": 1
+          }
+        ]
+      },
+      {
+        "bucket": "closed_adapter_split_base_fallback",
+        "disposition": "closed by G2.196/G2.197; retain BaseAdapter fallback unless fresh current-HEAD evidence contradicts",
+        "files": [
+          {
+            "path": "web/backend/app/services/adapters_split/base_adapter.py",
+            "occurrences": 2,
+            "calls": 1,
+            "imports": 1
+          }
+        ]
+      }
+    ]
+  },
+  "closeout_decision": {
+    "data_quality_monitor_conveyor_state": "closed_after_review",
+    "new_source_lane_selected": false,
+    "reason": "All remaining active get_data_quality_monitor surfaces are either the accepted singleton/backing API seam, retained route provider surface, or previously closed fallback surfaces.",
+    "do_not_reopen_without": "fresh current-HEAD evidence contradicting G2.196/G2.197, G2.200/G2.201, G2.208/G2.209, or G2.212 verification"
+  },
+  "verification_plan": {
+    "focused_pytest": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py -q --no-cov --tb=short",
+    "authorized_non_large_regression": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py web/backend/tests/test_data_quality_route_provider_regressions.py web/backend/tests/test_data_quality_canonical_service_adapter_provider.py web/backend/tests/test_adapter_split_data_quality_monitor_provider.py web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short",
+    "openspec": "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+  },
+  "verification_results": {
+    "focused_pytest": "3 passed",
+    "authorized_non_large_regression": "20 passed",
+    "json_yaml_parse": "passed",
+    "markdown_governance": "errors 0",
+    "openspec_validate": "valid; PostHog telemetry noise only",
+    "diff_check": "passed"
+  },
+  "next_gate": {
+    "id": "g2-214",
+    "name": "non-strategy provider governance queue refresh / next candidate selection",
+    "source_edit_authority": false,
+    "purpose": "Return from the data-quality monitor conveyor to the broader non-strategy provider queue and select any next candidate through a no-source governance decision first."
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T22:40:00+08:00`
-- Base HEAD checked: `535a6d9c1565b4ced7942cb4082104f2fb0506fd`
+- Prepared at: `2026-05-28T23:11:00+08:00`
+- Base HEAD checked: `e7d9fe63285181f0227661628272487dc63d4e2c`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -49,12 +49,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#362` | `g2-209-data-quality-market-data-adapter-provider-closeout` | `wip/root-dirty-20260403` | `MERGED` at `33b6ace2f68e23bcf07a12f53511d1f7b9fb8230` | Governance closeout selecting G2.210 data-quality monitor residual ownership decision |
 | `#363` | `g2-210-data-quality-monitor-residual-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `619be9cac1f9516b3df42a41ca362ca9d42d5c9a` | Decision package selecting G2.211 singleton/backing API authorization |
 | `#364` | `g2-211-data-quality-monitor-singleton-authorization` | `wip/root-dirty-20260403` | `MERGED` at `535a6d9c1565b4ced7942cb4082104f2fb0506fd` | Authorization package selecting G2.212 data-quality monitor singleton/backing API implementation |
+| `#365` | `g2-212-data-quality-monitor-singleton-implementation` | `wip/root-dirty-20260403` | `MERGED` at `e7d9fe63285181f0227661628272487dc63d4e2c` | Path-limited singleton/backing API provider seam implementation closed for G2.213 refresh |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-212-data-quality-monitor-singleton-implementation` | `origin/wip/root-dirty-20260403` at `535a6d9c1565b4ced7942cb4082104f2fb0506fd` | Implement data-quality monitor singleton/backing API provider/reset hook while preserving default singleton fallback | Yes, limited to the authorized singleton/backing API paths and focused test |
+| `g2-213-data-quality-monitor-singleton-closeout-refresh` | `origin/wip/root-dirty-20260403` at `e7d9fe63285181f0227661628272487dc63d4e2c` | Close out data-quality monitor singleton/backing API provider seam and classify remaining residuals | No |
 
 ## OpenSpec Relationship
 
@@ -70,7 +71,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.212 is the source implementation branch after PR `#364` merged G2.211. It is
-limited to the authorized singleton/backing API paths plus one focused test and
-governance evidence. If accepted, the next gate is G2.213 closeout / residual
-refresh with no source edits.
+G2.213 is a no-source closeout / residual refresh branch after PR `#365` merged
+G2.212. It is limited to governance evidence, steward tree updates, and a task
+card. If accepted, the next gate is G2.214 non-strategy provider governance
+queue refresh / next-candidate selection with no source edits.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T22:40:00+08:00`
-- Base HEAD checked: `535a6d9c1565b4ced7942cb4082104f2fb0506fd`
+- Prepared at: `2026-05-28T23:11:00+08:00`
+- Base HEAD checked: `e7d9fe63285181f0227661628272487dc63d4e2c`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 merged by PR `#363`; G2.211 merged by PR `#364`; G2.212 is the active singleton/backing API implementation review |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 merged by PR `#363`; G2.211 merged by PR `#364`; G2.212 merged by PR `#365`; G2.213 is the active singleton/backing API closeout / residual refresh |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T22:40:00+08:00`
-- Base HEAD checked: `535a6d9c1565b4ced7942cb4082104f2fb0506fd`
+- Prepared at: `2026-05-28T23:11:00+08:00`
+- Base HEAD checked: `e7d9fe63285181f0227661628272487dc63d4e2c`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.212 data-quality monitor singleton/backing API compatibility implementation | G/#79 service lifecycle DI | PR `#364` merged at `535a6d9c1565b4ced7942cb4082104f2fb0506fd`; G2.212 adds a provider/reset hook while preserving default singleton fallback | If accepted, start G2.213 closeout / residual refresh with no source edits |
+| P0 | Review G2.213 data-quality monitor singleton/backing API closeout / residual refresh | G/#79 service lifecycle DI | PR `#365` merged at `e7d9fe63285181f0227661628272487dc63d4e2c`; G2.213 classifies remaining data-quality monitor residuals and selects no new data-quality source lane | If accepted, start G2.214 non-strategy provider governance queue refresh / next-candidate selection with no source edits |
+| P0 | Preserve G2.212 data-quality monitor singleton/backing API compatibility implementation | G/#79 service lifecycle DI | PR `#365` merged; provider/reset hook is implemented and default singleton fallback is preserved | Do not reopen data-quality monitor singleton source unless fresh current-HEAD evidence contradicts G2.212/G2.213 |
 | P0 | Preserve G2.211 data-quality monitor singleton/backing API authorization | G/#79 service lifecycle DI | PR `#364` merged; G2.211 authorized a future path-limited G2.212 compatibility implementation | Do not expand G2.212 beyond the two authorized source files and one focused test |
 | P0 | Preserve G2.210 data-quality monitor residual ownership decision | G/#79 service lifecycle DI | PR `#363` merged; singleton/backing API is a high-risk root ownership surface, not a routine cleanup | Use G2.211 authorization before any source lane |
 | P0 | Preserve G2.209 data-quality `market_data_adapter.py` provider seam closeout / residual refresh | G/#79 service lifecycle DI | PR `#362` merged; `market_data_adapter.py` is closed and remaining monitor residuals are routed to G2.210 ownership decision | Do not reopen closed G2.208/G2.209 source scope without contradictory current HEAD evidence |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T22:18:21+08:00`
-- Base HEAD checked: `619be9cac1f9516b3df42a41ca362ca9d42d5c9a`
+- Prepared at: `2026-05-28T23:11:00+08:00`
+- Base HEAD checked: `e7d9fe63285181f0227661628272487dc63d4e2c`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -85,8 +85,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-monitor-residual-ownership-decision-2026-05-28.md` | G2.210 human-readable residual ownership decision report | Accepted by PR `#363`; superseded for singleton/backing API authorization by G2.211 |
 | `.planning/codebase/generated/data-quality-monitor-singleton-authorization-2026-05-28.json` | G2.211 data-quality monitor singleton/backing API authorization evidence | Accepted by PR `#364`; superseded for implementation evidence by G2.212 |
 | `docs/reports/quality/backend-data-quality-monitor-singleton-authorization-2026-05-28.md` | G2.211 human-readable singleton/backing API authorization report | Accepted by PR `#364`; superseded for implementation evidence by G2.212 |
-| `.planning/codebase/generated/data-quality-monitor-singleton-implementation-2026-05-28.json` | G2.212 data-quality monitor singleton/backing API implementation evidence | Current for HEAD `535a6d9c1565b4ced7942cb4082104f2fb0506fd`; review input until PR `#365` is accepted |
-| `docs/reports/quality/backend-data-quality-monitor-singleton-implementation-2026-05-28.md` | G2.212 human-readable singleton/backing API implementation report | Review input until PR `#365` is accepted |
+| `.planning/codebase/generated/data-quality-monitor-singleton-implementation-2026-05-28.json` | G2.212 data-quality monitor singleton/backing API implementation evidence | Accepted by PR `#365`; superseded for closeout / residual refresh by G2.213 |
+| `docs/reports/quality/backend-data-quality-monitor-singleton-implementation-2026-05-28.md` | G2.212 human-readable singleton/backing API implementation report | Accepted by PR `#365`; superseded for closeout / residual refresh by G2.213 |
+| `.planning/codebase/generated/data-quality-monitor-singleton-closeout-refresh-2026-05-28.json` | G2.213 data-quality monitor singleton/backing API closeout / residual refresh evidence | Current for HEAD `e7d9fe63285181f0227661628272487dc63d4e2c`; review input until PR `#366` is accepted |
+| `docs/reports/quality/backend-data-quality-monitor-singleton-closeout-refresh-2026-05-28.md` | G2.213 human-readable singleton/backing API closeout / residual refresh report | Review input until PR `#366` is accepted |
 
 ## External State Inputs
 

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T22:40:00+08:00",
+  "generated_at": "2026-05-28T23:11:00+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "535a6d9c1565b4ced7942cb4082104f2fb0506fd",
-  "split_branch": "g2-212-data-quality-monitor-singleton-implementation",
-  "scope": "data_quality_monitor_singleton_implementation",
-  "source_edit_authority": true,
+  "base_head": "e7d9fe63285181f0227661628272487dc63d4e2c",
+  "split_branch": "g2-213-data-quality-monitor-singleton-closeout-refresh",
+  "scope": "data_quality_monitor_singleton_closeout_refresh",
+  "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -2156,12 +2156,14 @@
     {
       "id": "g2-212-data-quality-monitor-singleton-implementation",
       "type": "implementation",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.211 data-quality monitor singleton/backing API authorization",
       "source_edit_authority": true,
       "parent_github_pr": 364,
       "parent_merge_commit": "535a6d9c1565b4ced7942cb4082104f2fb0506fd",
+      "github_pr": 365,
+      "merge_commit": "e7d9fe63285181f0227661628272487dc63d4e2c",
       "evidence": [
         ".planning/codebase/generated/data-quality-monitor-singleton-implementation-2026-05-28.json",
         "docs/reports/quality/backend-data-quality-monitor-singleton-implementation-2026-05-28.md",
@@ -2205,7 +2207,61 @@
         "current_head_checked": "535a6d9c1565b4ced7942cb4082104f2fb0506fd",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.213 data-quality monitor singleton/backing API closeout / residual refresh with no source edits."
+      "next_gate": "Superseded by G2.213 data-quality monitor singleton/backing API closeout / residual refresh."
+    },
+    {
+      "id": "g2-213-data-quality-monitor-singleton-closeout-refresh",
+      "type": "closeout_refresh",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.212 data-quality monitor singleton/backing API compatibility implementation",
+      "source_edit_authority": false,
+      "parent_github_pr": 365,
+      "parent_merge_commit": "e7d9fe63285181f0227661628272487dc63d4e2c",
+      "evidence": [
+        ".planning/codebase/generated/data-quality-monitor-singleton-closeout-refresh-2026-05-28.json",
+        "docs/reports/quality/backend-data-quality-monitor-singleton-closeout-refresh-2026-05-28.md",
+        "governance/mainline/task-cards/pr-366.yaml"
+      ],
+      "residual_scan": {
+        "term": "get_data_quality_monitor",
+        "scope": "web/backend/app/**/*.py",
+        "active_files": 7,
+        "active_occurrences": 29,
+        "active_calls": 7,
+        "classification": {
+          "singleton_backing_api": {
+            "files": 2,
+            "disposition": "closed by G2.212; retain provider/reset seam and default singleton fallback"
+          },
+          "route_api_provider_surface": {
+            "files": 1,
+            "disposition": "retained active FastAPI dependency/provider surface"
+          },
+          "closed_canonical_service_adapter_fallbacks": {
+            "files": 2,
+            "disposition": "closed by G2.200/G2.201"
+          },
+          "closed_market_data_adapter_facade_fallback": {
+            "files": 1,
+            "disposition": "closed by G2.208/G2.209"
+          },
+          "closed_adapter_split_base_fallback": {
+            "files": 1,
+            "disposition": "closed by G2.196/G2.197"
+          }
+        }
+      },
+      "closeout_decision": {
+        "new_data_quality_monitor_source_lane_selected": false,
+        "data_quality_monitor_conveyor_state": "closed_after_review",
+        "route_provider_residuals_remain_under_route_provider_governance": true
+      },
+      "freshness": {
+        "current_head_checked": "e7d9fe63285181f0227661628272487dc63d4e2c",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.214 non-strategy provider governance queue refresh / next-candidate selection with no source edits."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -799,11 +799,43 @@ remaining singleton/backing API surface a compatibility provider hook so future
 lifecycle wiring can depend on an explicit seam instead of directly mutating the
 module-level singleton.
 
+## G2.213 Data-Quality Monitor Singleton Closeout / Residual Refresh
+
+At HEAD `e7d9fe63285181f0227661628272487dc63d4e2c`, PR `#365` is merged and
+G2.212 is accepted.
+
+Residual scan:
+
+| Metric | Count |
+|---|---:|
+| Active `get_data_quality_monitor` files | 7 |
+| Active occurrences | 29 |
+| Active calls | 7 |
+
+Residual classification:
+
+| Bucket | Files | Disposition |
+|---|---:|---|
+| Singleton/backing API seam | 2 | Closed by G2.212; retain provider/reset seam and default fallback |
+| Route API provider surface | 1 | Retained active FastAPI dependency/provider surface |
+| Closed canonical service adapter fallbacks | 2 | Closed by G2.200/G2.201 |
+| Closed `market_data_adapter.py` facade fallback | 1 | Closed by G2.208/G2.209 |
+| Closed `adapter_split` base fallback | 1 | Closed by G2.196/G2.197 |
+
+Closeout decision:
+
+- no new data-quality monitor source lane is selected from this refresh
+- do not reopen the data-quality monitor source conveyor unless fresh
+  current-HEAD evidence contradicts accepted G2.196/G2.197, G2.200/G2.201,
+  G2.208/G2.209, or G2.212 evidence
+- route API provider residuals remain governed by route/provider governance,
+  not by a direct data-quality monitor implementation lane
+
 ## Next Gates
 
-- Review G2.212 data-quality monitor singleton/backing API compatibility implementation.
-- If accepted, start G2.213 data-quality monitor singleton/backing API closeout / residual refresh with no source edits.
-- Do not open another source lane before G2.213 classifies remaining residuals and selects a next gate.
+- Review G2.213 data-quality monitor singleton/backing API closeout / residual refresh.
+- If accepted, start G2.214 non-strategy provider governance queue refresh / next-candidate selection with no source edits.
+- Do not open another data-quality monitor source lane unless fresh current-HEAD evidence contradicts the accepted closeout.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.
 - Do not expand into alerts resolver fixes, legacy `app.api.risk_management`

--- a/docs/reports/quality/backend-data-quality-monitor-singleton-closeout-refresh-2026-05-28.md
+++ b/docs/reports/quality/backend-data-quality-monitor-singleton-closeout-refresh-2026-05-28.md
@@ -1,0 +1,124 @@
+# Backend Data-Quality Monitor Singleton Closeout / Residual Refresh - 2026-05-28
+
+> **历史文档说明**: 本文件是 G2.213 执行证据快照，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Lane: G2.213 data-quality monitor singleton/backing API closeout / residual refresh
+- Parent implementation: G2.212, PR `#365`
+- Parent merge commit: `e7d9fe63285181f0227661628272487dc63d4e2c`
+- OpenSpec change: `migrate-backend-singletons-to-lifecycle-di`
+- Source authority: none
+- Result: ready for review
+
+## Purpose
+
+G2.213 does not edit backend source. It closes the G2.212 implementation lane by:
+
+- recording that PR `#365` was accepted
+- refreshing active `get_data_quality_monitor` residuals at current HEAD
+- classifying every remaining residual into retained or previously closed buckets
+- deciding whether another data-quality monitor source lane is warranted
+
+## Residual Scan
+
+Scope:
+
+- `web/backend/app/**/*.py`
+
+Term:
+
+- `get_data_quality_monitor`
+
+Current HEAD:
+
+- `e7d9fe63285181f0227661628272487dc63d4e2c`
+
+Summary:
+
+| Metric | Count |
+|---|---:|
+| Active files | 7 |
+| Active occurrences | 29 |
+| Active calls | 7 |
+
+## Residual Classification
+
+| Bucket | Files | Disposition |
+|---|---:|---|
+| Singleton/backing API seam | 2 | Closed by G2.212; retain provider/reset seam and default singleton fallback |
+| Route API provider surface | 1 | Retained active FastAPI dependency/provider surface; not a direct implementation candidate in this lane |
+| Closed canonical service adapter fallbacks | 2 | Closed by G2.200/G2.201; retain default fallback unless fresh current-HEAD evidence contradicts |
+| Closed `market_data_adapter.py` facade fallback | 1 | Closed by G2.208/G2.209; retain compatibility facade fallback unless fresh current-HEAD evidence contradicts |
+| Closed `adapter_split` base fallback | 1 | Closed by G2.196/G2.197; retain `BaseAdapter` fallback unless fresh current-HEAD evidence contradicts |
+
+File-level evidence:
+
+| Path | Occurrences | Calls | Imports | Classification |
+|---|---:|---:|---:|---|
+| `web/backend/app/services/_data_quality_monitor_singleton.py` | 2 | 2 | 0 | Singleton/backing API seam |
+| `web/backend/app/services/data_quality_monitor.py` | 2 | 0 | 0 | Singleton/backing API facade exports |
+| `web/backend/app/api/data_quality.py` | 17 | 1 | 1 | Route API provider surface |
+| `web/backend/app/services/adapters/dashboard_adapter.py` | 2 | 1 | 1 | Closed canonical service adapter fallback |
+| `web/backend/app/services/adapters/data_adapter.py` | 2 | 1 | 1 | Closed canonical service adapter fallback |
+| `web/backend/app/services/market_data_adapter.py` | 2 | 1 | 1 | Closed market data adapter facade fallback |
+| `web/backend/app/services/adapters_split/base_adapter.py` | 2 | 1 | 1 | Closed adapter split base fallback |
+
+## Decision
+
+No new data-quality monitor source lane is selected from this refresh.
+
+Reason:
+
+- the singleton/backing API surface now has the G2.212 provider/reset seam
+- route API provider residuals remain active route contract surfaces and should stay under route/provider governance
+- canonical service adapter fallbacks, `market_data_adapter.py`, and `adapter_split` base fallback were already closed by prior accepted lanes
+
+The data-quality monitor conveyor should be treated as closed after PR `#366` review unless fresh current-HEAD evidence contradicts the accepted G2.196/G2.197, G2.200/G2.201, G2.208/G2.209, or G2.212 evidence.
+
+## Verification Results
+
+Because G2.213 is no-source, verification focuses on current HEAD consistency.
+
+Focused provider seam regression:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py -q --no-cov --tb=short
+```
+
+Result:
+
+- `3 passed`
+
+Authorized non-large regression:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py web/backend/tests/test_data_quality_route_provider_regressions.py web/backend/tests/test_data_quality_canonical_service_adapter_provider.py web/backend/tests/test_adapter_split_data_quality_monitor_provider.py web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short
+```
+
+Result:
+
+- `20 passed`
+
+OpenSpec:
+
+```bash
+openspec validate migrate-backend-singletons-to-lifecycle-di --strict
+```
+
+Result:
+
+- `Change 'migrate-backend-singletons-to-lifecycle-di' is valid`
+- PostHog connection refusal is telemetry noise only.
+
+Governance checks:
+
+- JSON/YAML parse: passed
+- Markdown governance: `errors: 0`
+- `git diff --check`: passed
+
+## Next Gate
+
+If PR `#366` is accepted, start G2.214 as a no-source non-strategy provider governance queue refresh / next-candidate selection.
+
+G2.214 should not open a source lane directly. It should first decide whether any remaining non-strategy provider candidate is eligible for an authorization package.

--- a/governance/mainline/task-cards/pr-366.yaml
+++ b/governance/mainline/task-cards/pr-366.yaml
@@ -1,0 +1,120 @@
+version: "v0.2"
+
+task:
+  id: "pr-366"
+  title: "Close out data-quality monitor singleton provider seam"
+  owner: "codex"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-data-quality-monitor-singleton-closeout-refresh"
+  objective: "close out the G2.212 data-quality monitor singleton provider seam and classify remaining residuals without source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Closeout-only package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-quality-monitor-singleton-closeout-refresh-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-quality-monitor-singleton-closeout-refresh-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-366.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "source edits in this PR"
+  - "route/provider migration in this PR"
+  - "adapter, adapter_split, legacy data_adapters, or market_data_adapter.py edits"
+  - "function-tree semantic expansion"
+  - "OpenAPI, frontend, config, script, or OpenSpec edits"
+  - "starting G2.214 implementation"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py -q --no-cov --tb=short"
+      required: true
+    - id: "authorized-non-large-regression"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py web/backend/tests/test_data_quality_route_provider_regressions.py web/backend/tests/test_data_quality_canonical_service_adapter_provider.py web/backend/tests/test_adapter_split_data_quality_monitor_provider.py web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "json-yaml-parse"
+      command: "python - <<'PY'\nimport json, yaml\nfor path in ['.planning/codebase/generated/data-quality-monitor-singleton-closeout-refresh-2026-05-28.json', '.planning/codebase/steward-tree/steward-index.json']:\n    with open(path, encoding='utf-8') as f:\n        json.load(f)\nwith open('governance/mainline/task-cards/pr-366.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-quality-monitor-singleton-closeout-refresh-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-366.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha e7d9fe63285181f0227661628272487dc63d4e2c --head-sha HEAD --report /tmp/pr366-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Closeout package could be misread as implementation authority; forbidden paths and next-gate wording prevent that."
+    - "Residual counts are snapshot evidence and must be refreshed if HEAD changes before review."
+  rollback_plan: "Revert this governance-only commit; no runtime or source state changes are made."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Close out the data-quality monitor singleton provider seam and classify remaining residuals."
+    modified_scope: "Only steward tree, generated evidence, quality report, and task-card governance files."
+    dependency_changes: "None."
+    legacy_logic_impact: "No runtime or compatibility behavior changes in this PR."
+    rollback_ready: "Yes; revert the governance commit."
+    risk_and_rollback_point: "Do not start G2.214 as source implementation; it must be a no-source next-candidate governance refresh first."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "current review thread human maintainer"
+    approved_at: "2026-05-28T23:11:00+08:00"
+    approval_note: "Approved to continue from merged PR #365 into G2.213 no-source closeout / residual refresh."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- close out the accepted G2.212 data-quality monitor singleton provider seam
- refresh current get_data_quality_monitor residuals at HEAD e7d9fe632
- classify remaining residuals as retained route provider surface or previously closed fallback seams; select no new data-quality monitor source lane

## Verification
- env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py -q --no-cov --tb=short -> 3 passed
- env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_quality_monitor_singleton_provider.py web/backend/tests/test_data_quality_route_provider_regressions.py web/backend/tests/test_data_quality_canonical_service_adapter_provider.py web/backend/tests/test_adapter_split_data_quality_monitor_provider.py web/backend/tests/test_market_data_adapter_quality_monitor_provider.py web/backend/tests/test_logging_noise_regressions.py -q --no-cov --tb=short -> 20 passed
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict -> valid; PostHog telemetry noise only
- markdown_governance_gate.py -> errors 0
- mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-366.yaml ... -> pass=True
- GitNexus detect_changes staged/compare -> low, 9 files, 0 symbols, 0 affected processes

## Next Gate
If accepted, start G2.214 as no-source non-strategy provider governance queue refresh / next-candidate selection. Do not open a source implementation lane directly.