### PR TITLE
G2.214 refresh non-Strategy provider queue

### DIFF
--- a/.planning/codebase/generated/nonstrategy-provider-queue-refresh-2026-05-28.json
+++ b/.planning/codebase/generated/nonstrategy-provider-queue-refresh-2026-05-28.json
@@ -1,0 +1,131 @@
+{
+  "schema_version": "2026-05-28.g2-next-candidate-decision.v1",
+  "id": "g2-214-non-strategy-provider-queue-refresh",
+  "generated_at": "2026-05-28T23:28:14+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117",
+  "branch": "g2-214-non-strategy-provider-queue-refresh",
+  "parent_gate": {
+    "id": "g2-213-data-quality-monitor-singleton-closeout-refresh",
+    "github_pr": 366,
+    "merge_commit": "3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117",
+    "accepted_scope": "data-quality monitor singleton/backing API closeout and residual refresh"
+  },
+  "source_edit_authority": false,
+  "openspec": {
+    "change_id": "migrate-backend-singletons-to-lifecycle-di",
+    "approval_status": "approved",
+    "validate_command": "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+  },
+  "queue_scan": {
+    "scope": "web/backend/app/**/*.py",
+    "provider_getter_files": 201,
+    "provider_getter_items": 408,
+    "buckets": {
+      "closed_data_quality_monitor": {
+        "items": 14,
+        "disposition": "closed by G2.213 unless fresh current-HEAD evidence contradicts"
+      },
+      "excluded_strategy": {
+        "items": 44,
+        "disposition": "Strategy residuals closed by G2.183 with retained residuals"
+      },
+      "route_provider_surface": {
+        "items": 131,
+        "disposition": "active route/provider governance surface; not a direct source lane from G2.214"
+      },
+      "realtime_streaming_socket": {
+        "items": 36,
+        "disposition": "previous realtime/socket subtrack evidence exists; do not reopen from token count alone"
+      },
+      "dashboard_tdx": {
+        "items": 11,
+        "disposition": "Dashboard/TDX direct helper debt remains closed; retain until contradictory evidence"
+      },
+      "indicator_data": {
+        "items": 45,
+        "disposition": "requires current-HEAD contradiction review because get_data_service now reports CRITICAL impact"
+      },
+      "adapter_or_factory": {
+        "items": 26,
+        "disposition": "factory/adapter ownership surface; defer behind higher-risk current-head contradiction"
+      },
+      "risk_alert": {
+        "items": 23,
+        "disposition": "risk/alert ownership surface; stop-loss pair already closed, broader alert surfaces deferred"
+      },
+      "other_service_provider": {
+        "items": 78,
+        "disposition": "mixed infra/control-plane/root facade queue; candidate-level decisions required"
+      }
+    }
+  },
+  "candidate_impact_refresh": {
+    "get_data_service": {
+      "file": "web/backend/app/services/data_service.py",
+      "risk": "CRITICAL",
+      "impacted_count": 4,
+      "direct": 3,
+      "processes_affected": 7,
+      "modules_affected": 2,
+      "direct_callers": [
+        "web/backend/app/api/indicators/indicator_cache.py::calculate_indicators",
+        "web/backend/app/api/indicators/indicator_cache.py::_calculate_single_indicator",
+        "web/backend/app/api/v1/strategy/indicators.py::get_technical_indicators"
+      ],
+      "disposition": "selected for G2.215 no-source current-head contradiction / ownership decision"
+    },
+    "get_execution_tracking_evidence_service": {
+      "file": "web/backend/app/api/trade/execution_tracking_routes.py",
+      "risk": "HIGH",
+      "impacted_count": 2,
+      "direct": 2,
+      "processes_affected": 3,
+      "modules_affected": 1,
+      "disposition": "defer behind get_data_service because trade evidence route remains a separate high-risk track"
+    },
+    "get_prewarming_strategy": {
+      "file": "web/backend/app/core/cache_prewarming.py",
+      "risk": "LOW",
+      "impacted_count": 3,
+      "direct": 3,
+      "processes_affected": 0,
+      "modules_affected": 1,
+      "disposition": "defer because current risk is lower and bounded to cache prewarming routes"
+    },
+    "get_unified_data_service": {
+      "file": "web/backend/app/services/unified_data_service.py",
+      "risk": "MEDIUM",
+      "impacted_count": 5,
+      "direct": 5,
+      "processes_affected": 0,
+      "modules_affected": 1,
+      "disposition": "retain as root facade / service self-wrapper pending root-facade ownership decision"
+    }
+  },
+  "decision": {
+    "classification": "no_source_next_candidate_selection",
+    "selected_next_governance_target": "indicator-data-get-data-service-current-head-contradiction-decision",
+    "recommended_next_work_item": "G2.215 indicator/data get_data_service current-HEAD contradiction / ownership decision package",
+    "source_lane_selected": false,
+    "rationale": [
+      "G2.213 closed the data-quality monitor conveyor and returned the broader non-Strategy queue to active triage.",
+      "Fresh GitNexus current-HEAD impact reports get_data_service as CRITICAL, with indicator and strategy-indicator route callers and seven affected processes.",
+      "Older G2.184/G2.186 evidence treated get_data_service as retained or LOW; the current graph is enough to require a no-source contradiction / ownership decision before any implementation authorization.",
+      "Trade execution evidence and cache prewarming remain separate tracks; neither should be batched with indicator/data ownership review."
+    ]
+  },
+  "verification_results": {
+    "json_yaml_parse": "passed",
+    "markdown_governance": "errors 0",
+    "openspec_validate": "valid; PostHog telemetry noise only",
+    "diff_check": "passed"
+  },
+  "next_gate": {
+    "id": "g2-215",
+    "name": "indicator/data get_data_service current-HEAD contradiction / ownership decision",
+    "source_edit_authority": false,
+    "purpose": "Classify whether current get_data_service route callers are retained provider surfaces, route-body direct singleton debt, or a future path-limited authorization candidate."
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T23:11:00+08:00`
-- Base HEAD checked: `e7d9fe63285181f0227661628272487dc63d4e2c`
+- Prepared at: `2026-05-28T23:28:14+08:00`
+- Base HEAD checked: `3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -50,12 +50,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#363` | `g2-210-data-quality-monitor-residual-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `619be9cac1f9516b3df42a41ca362ca9d42d5c9a` | Decision package selecting G2.211 singleton/backing API authorization |
 | `#364` | `g2-211-data-quality-monitor-singleton-authorization` | `wip/root-dirty-20260403` | `MERGED` at `535a6d9c1565b4ced7942cb4082104f2fb0506fd` | Authorization package selecting G2.212 data-quality monitor singleton/backing API implementation |
 | `#365` | `g2-212-data-quality-monitor-singleton-implementation` | `wip/root-dirty-20260403` | `MERGED` at `e7d9fe63285181f0227661628272487dc63d4e2c` | Path-limited singleton/backing API provider seam implementation closed for G2.213 refresh |
+| `#366` | `g2-213-data-quality-monitor-singleton-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117` | No-source closeout selecting G2.214 non-Strategy provider queue refresh |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-213-data-quality-monitor-singleton-closeout-refresh` | `origin/wip/root-dirty-20260403` at `e7d9fe63285181f0227661628272487dc63d4e2c` | Close out data-quality monitor singleton/backing API provider seam and classify remaining residuals | No |
+| `g2-214-non-strategy-provider-queue-refresh` | `origin/wip/root-dirty-20260403` at `3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117` | Refresh broader non-Strategy provider/getter queue and select the next no-source governance target | No |
 
 ## OpenSpec Relationship
 
@@ -71,7 +72,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.213 is a no-source closeout / residual refresh branch after PR `#365` merged
-G2.212. It is limited to governance evidence, steward tree updates, and a task
-card. If accepted, the next gate is G2.214 non-strategy provider governance
-queue refresh / next-candidate selection with no source edits.
+G2.214 is a no-source queue refresh branch after PR `#366` merged G2.213. It is
+limited to governance evidence, steward tree updates, and a task card. If
+accepted, the next gate is G2.215 indicator/data `get_data_service`
+current-HEAD contradiction / ownership decision with no source edits.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T23:11:00+08:00`
-- Base HEAD checked: `e7d9fe63285181f0227661628272487dc63d4e2c`
+- Prepared at: `2026-05-28T23:28:14+08:00`
+- Base HEAD checked: `3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 merged by PR `#363`; G2.211 merged by PR `#364`; G2.212 merged by PR `#365`; G2.213 is the active singleton/backing API closeout / residual refresh |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 merged by PR `#363`; G2.211 merged by PR `#364`; G2.212 merged by PR `#365`; G2.213 merged by PR `#366`; G2.214 is the active broader provider queue refresh |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T23:11:00+08:00`
-- Base HEAD checked: `e7d9fe63285181f0227661628272487dc63d4e2c`
+- Prepared at: `2026-05-28T23:28:14+08:00`
+- Base HEAD checked: `3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.213 data-quality monitor singleton/backing API closeout / residual refresh | G/#79 service lifecycle DI | PR `#365` merged at `e7d9fe63285181f0227661628272487dc63d4e2c`; G2.213 classifies remaining data-quality monitor residuals and selects no new data-quality source lane | If accepted, start G2.214 non-strategy provider governance queue refresh / next-candidate selection with no source edits |
+| P0 | Review G2.214 non-Strategy provider governance queue refresh / next-candidate selection | G/#79 service lifecycle DI | PR `#366` merged at `3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117`; G2.214 selects G2.215 indicator/data `get_data_service` current-HEAD contradiction decision as the next no-source gate | If accepted, start G2.215 no-source ownership decision; do not start source implementation directly |
+| P0 | Preserve G2.213 data-quality monitor singleton/backing API closeout / residual refresh | G/#79 service lifecycle DI | PR `#366` merged; data-quality monitor conveyor selects no new source lane | Do not reopen data-quality monitor source unless fresh current-HEAD evidence contradicts accepted closeout |
 | P0 | Preserve G2.212 data-quality monitor singleton/backing API compatibility implementation | G/#79 service lifecycle DI | PR `#365` merged; provider/reset hook is implemented and default singleton fallback is preserved | Do not reopen data-quality monitor singleton source unless fresh current-HEAD evidence contradicts G2.212/G2.213 |
 | P0 | Preserve G2.211 data-quality monitor singleton/backing API authorization | G/#79 service lifecycle DI | PR `#364` merged; G2.211 authorized a future path-limited G2.212 compatibility implementation | Do not expand G2.212 beyond the two authorized source files and one focused test |
 | P0 | Preserve G2.210 data-quality monitor residual ownership decision | G/#79 service lifecycle DI | PR `#363` merged; singleton/backing API is a high-risk root ownership surface, not a routine cleanup | Use G2.211 authorization before any source lane |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T23:11:00+08:00`
-- Base HEAD checked: `e7d9fe63285181f0227661628272487dc63d4e2c`
+- Prepared at: `2026-05-28T23:28:14+08:00`
+- Base HEAD checked: `3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -87,8 +87,10 @@ state transition.
 | `docs/reports/quality/backend-data-quality-monitor-singleton-authorization-2026-05-28.md` | G2.211 human-readable singleton/backing API authorization report | Accepted by PR `#364`; superseded for implementation evidence by G2.212 |
 | `.planning/codebase/generated/data-quality-monitor-singleton-implementation-2026-05-28.json` | G2.212 data-quality monitor singleton/backing API implementation evidence | Accepted by PR `#365`; superseded for closeout / residual refresh by G2.213 |
 | `docs/reports/quality/backend-data-quality-monitor-singleton-implementation-2026-05-28.md` | G2.212 human-readable singleton/backing API implementation report | Accepted by PR `#365`; superseded for closeout / residual refresh by G2.213 |
-| `.planning/codebase/generated/data-quality-monitor-singleton-closeout-refresh-2026-05-28.json` | G2.213 data-quality monitor singleton/backing API closeout / residual refresh evidence | Current for HEAD `e7d9fe63285181f0227661628272487dc63d4e2c`; review input until PR `#366` is accepted |
-| `docs/reports/quality/backend-data-quality-monitor-singleton-closeout-refresh-2026-05-28.md` | G2.213 human-readable singleton/backing API closeout / residual refresh report | Review input until PR `#366` is accepted |
+| `.planning/codebase/generated/data-quality-monitor-singleton-closeout-refresh-2026-05-28.json` | G2.213 data-quality monitor singleton/backing API closeout / residual refresh evidence | Accepted by PR `#366`; superseded for broader provider queue selection by G2.214 |
+| `docs/reports/quality/backend-data-quality-monitor-singleton-closeout-refresh-2026-05-28.md` | G2.213 human-readable singleton/backing API closeout / residual refresh report | Accepted by PR `#366`; superseded for broader provider queue selection by G2.214 |
+| `.planning/codebase/generated/nonstrategy-provider-queue-refresh-2026-05-28.json` | G2.214 non-Strategy provider queue refresh / next-candidate decision evidence | Current for HEAD `3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117`; review input until PR `#367` is accepted |
+| `docs/reports/quality/backend-nonstrategy-provider-queue-refresh-2026-05-28.md` | G2.214 human-readable non-Strategy provider queue refresh report | Review input until PR `#367` is accepted |
 
 ## External State Inputs
 

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-28T23:11:00+08:00",
+  "generated_at": "2026-05-28T23:28:14+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "e7d9fe63285181f0227661628272487dc63d4e2c",
-  "split_branch": "g2-213-data-quality-monitor-singleton-closeout-refresh",
-  "scope": "data_quality_monitor_singleton_closeout_refresh",
+  "base_head": "3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117",
+  "split_branch": "g2-214-non-strategy-provider-queue-refresh",
+  "scope": "nonstrategy_provider_queue_refresh",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -2212,12 +2212,14 @@
     {
       "id": "g2-213-data-quality-monitor-singleton-closeout-refresh",
       "type": "closeout_refresh",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.212 data-quality monitor singleton/backing API compatibility implementation",
       "source_edit_authority": false,
       "parent_github_pr": 365,
       "parent_merge_commit": "e7d9fe63285181f0227661628272487dc63d4e2c",
+      "github_pr": 366,
+      "merge_commit": "3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117",
       "evidence": [
         ".planning/codebase/generated/data-quality-monitor-singleton-closeout-refresh-2026-05-28.json",
         "docs/reports/quality/backend-data-quality-monitor-singleton-closeout-refresh-2026-05-28.md",
@@ -2261,7 +2263,74 @@
         "current_head_checked": "e7d9fe63285181f0227661628272487dc63d4e2c",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.214 non-strategy provider governance queue refresh / next-candidate selection with no source edits."
+      "next_gate": "Superseded by G2.214 non-Strategy provider governance queue refresh / next-candidate selection."
+    },
+    {
+      "id": "g2-214-non-strategy-provider-queue-refresh",
+      "type": "next_candidate_decision",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.213 data-quality monitor singleton/backing API closeout / residual refresh",
+      "source_edit_authority": false,
+      "parent_github_pr": 366,
+      "parent_merge_commit": "3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117",
+      "evidence": [
+        ".planning/codebase/generated/nonstrategy-provider-queue-refresh-2026-05-28.json",
+        "docs/reports/quality/backend-nonstrategy-provider-queue-refresh-2026-05-28.md",
+        "governance/mainline/task-cards/pr-367.yaml"
+      ],
+      "queue_scan": {
+        "scope": "web/backend/app/**/*.py",
+        "provider_getter_files": 201,
+        "provider_getter_items": 408,
+        "buckets": {
+          "closed_data_quality_monitor": 14,
+          "excluded_strategy": 44,
+          "route_provider_surface": 131,
+          "realtime_streaming_socket": 36,
+          "dashboard_tdx": 11,
+          "indicator_data": 45,
+          "adapter_or_factory": 26,
+          "risk_alert": 23,
+          "other_service_provider": 78
+        }
+      },
+      "candidate_impact_refresh": {
+        "get_data_service": {
+          "risk": "CRITICAL",
+          "direct": 3,
+          "processes_affected": 7,
+          "disposition": "selected for G2.215 no-source current-HEAD contradiction / ownership decision"
+        },
+        "get_execution_tracking_evidence_service": {
+          "risk": "HIGH",
+          "direct": 2,
+          "processes_affected": 3,
+          "disposition": "defer as separate trade evidence route track"
+        },
+        "get_unified_data_service": {
+          "risk": "MEDIUM",
+          "direct": 5,
+          "processes_affected": 0,
+          "disposition": "retain as root facade pending owner-specific decision"
+        },
+        "get_prewarming_strategy": {
+          "risk": "LOW",
+          "direct": 3,
+          "processes_affected": 0,
+          "disposition": "defer as lower-risk cache prewarming route surface"
+        }
+      },
+      "decision": {
+        "selected_next_governance_target": "G2.215 indicator/data get_data_service current-HEAD contradiction / ownership decision",
+        "source_lane_selected": false,
+        "reason": "Fresh current-HEAD GitNexus evidence reports get_data_service as CRITICAL, contradicting older LOW/retained wording enough to require no-source ownership classification before any implementation authorization."
+      },
+      "freshness": {
+        "current_head_checked": "3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117",
+        "stale_if_head_mismatch": true
+      },
+      "next_gate": "If accepted, start G2.215 indicator/data get_data_service current-HEAD contradiction / ownership decision with no source edits."
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -831,10 +831,44 @@ Closeout decision:
 - route API provider residuals remain governed by route/provider governance,
   not by a direct data-quality monitor implementation lane
 
+## G2.214 Non-Strategy Provider Queue Refresh
+
+At HEAD `3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117`, PR `#366` is merged and
+G2.213 is accepted.
+
+Queue refresh:
+
+| Bucket | Items | Current handling |
+|---|---:|---|
+| Closed data-quality monitor | 14 | Closed by G2.213 unless fresh current-HEAD evidence contradicts |
+| Excluded Strategy | 44 | Closed by G2.183 with retained residuals |
+| Route provider surface | 131 | Active route/provider governance surface |
+| Realtime streaming/socket | 36 | Prior realtime/socket subtrack evidence exists; do not reopen from token count alone |
+| Dashboard/TDX | 11 | Direct helper debt remains closed |
+| Indicator/Data | 45 | Requires current-HEAD contradiction review |
+| Adapter/factory | 26 | Defer behind higher-risk current-head contradiction |
+| Risk/alert | 23 | Stop-loss pair closed; broader alert surfaces deferred |
+| Other service/provider | 78 | Mixed infra/control-plane/root facade queue |
+
+Candidate impact refresh:
+
+| Candidate | Current risk | Direct | Processes | Disposition |
+|---|---:|---:|---:|---|
+| `get_data_service` | CRITICAL | 3 | 7 | Select for G2.215 no-source current-HEAD contradiction / ownership decision |
+| `get_execution_tracking_evidence_service` | HIGH | 2 | 3 | Defer as separate trade evidence route track |
+| `get_unified_data_service` | MEDIUM | 5 | 0 | Retain as root facade pending owner-specific decision |
+| `get_prewarming_strategy` | LOW | 3 | 0 | Defer as lower-risk cache prewarming route surface |
+
+G2.214 has no source authority. It does not reopen Indicator/Data source work.
+It records that current GitNexus evidence contradicts older LOW/retained
+wording for `get_data_service`, so the next step must be an ownership decision
+before any source authorization.
+
 ## Next Gates
 
-- Review G2.213 data-quality monitor singleton/backing API closeout / residual refresh.
-- If accepted, start G2.214 non-strategy provider governance queue refresh / next-candidate selection with no source edits.
+- Review G2.214 non-Strategy provider queue refresh / next-candidate selection.
+- If accepted, start G2.215 indicator/data `get_data_service` current-HEAD contradiction / ownership decision with no source edits.
+- Do not start source implementation from G2.214 or G2.215 until a later path-limited authorization package is approved.
 - Do not open another data-quality monitor source lane unless fresh current-HEAD evidence contradicts the accepted closeout.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.

--- a/docs/reports/quality/backend-nonstrategy-provider-queue-refresh-2026-05-28.md
+++ b/docs/reports/quality/backend-nonstrategy-provider-queue-refresh-2026-05-28.md
@@ -1,0 +1,103 @@
+# Backend Non-Strategy Provider Queue Refresh - 2026-05-28
+
+> **历史文档说明**: 本文件是 G2.214 执行证据快照，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Lane: G2.214 non-Strategy provider governance queue refresh / next-candidate selection
+- Parent closeout: G2.213, PR `#366`
+- Parent merge commit: `3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117`
+- OpenSpec change: `migrate-backend-singletons-to-lifecycle-di`
+- Source authority: none
+- Result: ready for review
+
+## Purpose
+
+G2.214 returns from the closed data-quality monitor conveyor to the broader
+non-Strategy provider/getter queue. It refreshes current HEAD evidence and
+selects the next governance target without authorizing source edits.
+
+## Queue Scan
+
+Scope:
+
+- `web/backend/app/**/*.py`
+
+Summary:
+
+| Metric | Count |
+|---|---:|
+| Python files scanned | 575 |
+| Files with provider/getter items | 201 |
+| Provider/getter items | 408 |
+
+Bucket summary:
+
+| Bucket | Items | Disposition |
+|---|---:|---|
+| Closed data-quality monitor | 14 | Closed by G2.213 unless fresh current-HEAD evidence contradicts |
+| Excluded Strategy | 44 | Strategy residuals closed by G2.183 with retained residuals |
+| Route provider surface | 131 | Active route/provider governance surface; not a direct source lane from G2.214 |
+| Realtime streaming/socket | 36 | Prior realtime/socket evidence exists; do not reopen from token count alone |
+| Dashboard/TDX | 11 | Direct helper debt remains closed; retain until contradictory evidence |
+| Indicator/Data | 45 | Requires current-HEAD contradiction review because `get_data_service` now reports CRITICAL impact |
+| Adapter/factory | 26 | Factory/adapter ownership surface; defer behind higher-risk current-head contradiction |
+| Risk/alert | 23 | Stop-loss pair already closed; broader alert surfaces deferred |
+| Other service/provider | 78 | Mixed infra/control-plane/root facade queue; candidate-level decisions required |
+
+## Candidate Impact Refresh
+
+| Candidate | Current risk | Direct | Processes | Disposition |
+|---|---:|---:|---:|---|
+| `get_data_service` | CRITICAL | 3 | 7 | Select for G2.215 no-source contradiction / ownership decision |
+| `get_execution_tracking_evidence_service` | HIGH | 2 | 3 | Defer behind `get_data_service`; trade evidence route is a separate high-risk track |
+| `get_prewarming_strategy` | LOW | 3 | 0 | Defer; current risk is lower and bounded to cache prewarming routes |
+| `get_unified_data_service` | MEDIUM | 5 | 0 | Retain as root facade / service self-wrapper pending a root-facade ownership decision |
+
+`get_data_service` direct callers at current HEAD:
+
+- `web/backend/app/api/indicators/indicator_cache.py::calculate_indicators`
+- `web/backend/app/api/indicators/indicator_cache.py::_calculate_single_indicator`
+- `web/backend/app/api/v1/strategy/indicators.py::get_technical_indicators`
+
+This is a current-HEAD contradiction against the older G2.184/G2.186 wording
+that treated the candidate as LOW or retained route-local provider fallback.
+It does not mean source implementation is authorized. It means the next package
+must decide the ownership and route/provider classification first.
+
+## Decision
+
+Select the next governance target:
+
+`G2.215 indicator/data get_data_service current-HEAD contradiction / ownership decision package`
+
+G2.215 must remain no-source. It should classify whether the current
+`get_data_service` route callers are:
+
+- retained provider surfaces
+- route-body direct singleton debt
+- route-local compatibility fallbacks
+- or a future path-limited authorization candidate
+
+G2.215 must not batch:
+
+- trade execution evidence providers
+- cache prewarming control-plane providers
+- data-quality monitor residuals
+- Strategy residual reopenings
+- realtime/socket ownership
+
+## Verification Results
+
+Governance checks:
+
+- JSON/YAML parse: passed
+- Markdown governance: `errors: 0`
+- OpenSpec strict validate: valid; PostHog connection refusal is telemetry noise only
+- `git diff --check`: passed
+- Mainline scope gate: pending after commit
+
+## Next Gate
+
+If PR `#367` is accepted, start G2.215 as a no-source indicator/data
+`get_data_service` current-HEAD contradiction / ownership decision package.

--- a/governance/mainline/task-cards/pr-367.yaml
+++ b/governance/mainline/task-cards/pr-367.yaml
@@ -1,0 +1,117 @@
+version: "v0.2"
+
+task:
+  id: "pr-367"
+  title: "Refresh non-Strategy provider queue"
+  owner: "codex"
+  created_at: "2026-05-28"
+
+mainline:
+  id: "L1-nonstrategy-provider-queue-refresh"
+  objective: "refresh the non-Strategy provider/getter governance queue after data-quality monitor closeout and select the next no-source decision target"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "Decision-only package; no runtime entrypoint, route, service symbol, public API surface, OpenAPI exposure, PM2 workflow, or frontend behavior is changed."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/nonstrategy-provider-queue-refresh-2026-05-28.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-nonstrategy-provider-queue-refresh-2026-05-28.md"
+    - "governance/mainline/task-cards/pr-367.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "source edits in this PR"
+  - "route/provider migration in this PR"
+  - "opening G2.215 implementation"
+  - "trade execution evidence provider changes"
+  - "cache prewarming provider changes"
+  - "data-quality monitor source reopen"
+  - "Strategy residual reopen"
+  - "OpenAPI, frontend, config, script, or OpenSpec edits"
+  - "GitHub issue label changes"
+
+acceptance:
+  checks:
+    - id: "json-yaml-parse"
+      command: "python - <<'PY'\nimport json, yaml\nfor path in ['.planning/codebase/generated/nonstrategy-provider-queue-refresh-2026-05-28.json', '.planning/codebase/steward-tree/steward-index.json']:\n    with open(path, encoding='utf-8') as f:\n        json.load(f)\nwith open('governance/mainline/task-cards/pr-367.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-nonstrategy-provider-queue-refresh-2026-05-28.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-367.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117 --head-sha HEAD --report /tmp/pr367-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Decision package could be misread as source implementation authority; forbidden paths and next-gate wording prevent that."
+    - "Current impact scan can become stale if route or indicator files change before review."
+    - "Selecting get_data_service from current CRITICAL graph evidence could accidentally reopen unrelated indicator/data work unless G2.215 remains decision-only."
+  rollback_plan: "Revert this governance-only commit; no runtime or source state changes are made."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Refresh the non-Strategy provider queue and select the next no-source decision target."
+    modified_scope: "Only steward tree, generated evidence, quality report, and task-card governance files."
+    dependency_changes: "None."
+    legacy_logic_impact: "No runtime or compatibility behavior changes in this PR."
+    rollback_ready: "Yes; revert the governance commit."
+    risk_and_rollback_point: "Do not start G2.215 as source implementation; it must be a no-source current-HEAD contradiction / ownership decision first."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "current review thread human maintainer"
+    approved_at: "2026-05-28T23:28:14+08:00"
+    approval_note: "Approved to continue from merged PR #366 into G2.214 no-source non-Strategy provider queue refresh / next-candidate selection."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- refresh the broader non-Strategy provider/getter queue after G2.213 data-quality monitor closeout
- classify current provider/getter buckets at HEAD 3d3f8285
- select G2.215 indicator/data get_data_service current-HEAD contradiction / ownership decision as the next no-source gate

## Key Decision
- No source lane is authorized from G2.214.
- Fresh GitNexus impact reports get_data_service as CRITICAL with indicator and strategy-indicator route callers, contradicting older LOW/retained wording enough to require a no-source ownership decision first.
- Trade execution evidence, cache prewarming, data-quality monitor, Strategy, and realtime/socket tracks are not batched into G2.215.

## Verification
- JSON/YAML parse -> passed
- markdown_governance_gate.py -> errors 0
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict -> valid; PostHog telemetry noise only
- git diff --check / git diff --cached --check -> passed
- mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-367.yaml ... -> pass=True
- GitNexus detect_changes staged/compare -> low, 9 files, 0 symbols, 0 affected processes

## Next Gate
If accepted, start G2.215 as a no-source indicator/data get_data_service current-HEAD contradiction / ownership decision package. Do not start source implementation directly.