### PR TITLE
G2.218 close DataService provider seam

### DIFF
--- a/.planning/codebase/generated/data-service-provider-closeout-refresh-2026-05-29.json
+++ b/.planning/codebase/generated/data-service-provider-closeout-refresh-2026-05-29.json
@@ -1,0 +1,128 @@
+{
+  "schema_version": "2026-05-29.data-service-provider-closeout-refresh.v1",
+  "generated_at": "2026-05-29T01:22:32+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "branch": "g2-218-data-service-provider-closeout-refresh",
+  "base_head": "4d2b69e449975d145976e10c8af965e16dc60a1e",
+  "openspec_lane": "migrate-backend-singletons-to-lifecycle-di",
+  "source_edit_authority": false,
+  "parent": {
+    "g2": "G2.217",
+    "github_pr": 370,
+    "state": "MERGED",
+    "merge_commit": "4d2b69e449975d145976e10c8af965e16dc60a1e",
+    "head_commit": "9e8504a82b5d5c57a0e046be2d3ddde13027a3d3",
+    "summary": "DataService provider/reset seam implementation accepted into wip/root-dirty-20260403"
+  },
+  "verification": {
+    "import_smoke": {
+      "command": "env PYTHONPATH=web/backend python -c '<DataService provider/reset smoke>'",
+      "exit": 0,
+      "result": "import_smoke=pass provider_override=pass reset_default=pass",
+      "note": "Default fallback smoke initializes DataService and emits existing TDengine/MyStocksUnifiedManager startup logs."
+    },
+    "pytest": [
+      {
+        "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_service_singleton_provider.py -q --no-cov --tb=short",
+        "result": "2 passed in 1.64s"
+      },
+      {
+        "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short",
+        "result": "6 passed in 2.63s"
+      }
+    ],
+    "ruff": {
+      "command": "ruff check web/backend/app/services/data_service.py web/backend/tests/test_data_service_singleton_provider.py",
+      "result": "All checks passed!"
+    },
+    "openspec": {
+      "command": "openspec validate migrate-backend-singletons-to-lifecycle-di --strict",
+      "result": "Change 'migrate-backend-singletons-to-lifecycle-di' is valid",
+      "telemetry_note": "PostHog network flush failure is telemetry noise."
+    }
+  },
+  "data_service_static_refresh": {
+    "token_hits_in_web_backend_app": 5,
+    "rg_source_call_lines": 7,
+    "singleton_import_call_files": [
+      {
+        "file": "web/backend/app/api/indicators/indicator_cache.py",
+        "line": 49,
+        "role": "route-local provider wrapper",
+        "text": "return get_data_service()"
+      },
+      {
+        "file": "web/backend/app/api/v1/strategy/indicators.py",
+        "line": 30,
+        "role": "route-local provider wrapper",
+        "text": "return get_data_service()"
+      }
+    ],
+    "non_residual_token_hits": [
+      {
+        "file": "web/backend/app/services/data_service.py",
+        "role": "canonical provider function definition"
+      },
+      {
+        "file": "web/backend/app/api/v1/strategy/ml_runtime_helpers.py",
+        "role": "imports DataService symbol but does not call get_data_service() directly"
+      },
+      {
+        "file": "web/backend/app/api/v1/system/health.py",
+        "role": "local EnhancedDataService helper named _get_data_service, not app.services.data_service.get_data_service"
+      }
+    ],
+    "decision": "Keep the two route-local provider wrappers; do not reopen DataService source from token-only matches."
+  },
+  "residual_candidate_refresh": {
+    "get_data_service": {
+      "state": "closed_by_g2_217",
+      "next_action": "Do not reopen unless current HEAD contradicts provider/reset seam evidence."
+    },
+    "get_execution_tracking_evidence_service": {
+      "file_count": 2,
+      "call_count": 3,
+      "primary_file": "web/backend/app/api/trade/execution_tracking_routes.py",
+      "classification": "trade evidence route-local provider surface",
+      "recommended_next_gate": "G2.219 no-source ownership decision package"
+    },
+    "get_unified_data_service": {
+      "file_count": 1,
+      "call_count": 6,
+      "primary_file": "web/backend/app/services/unified_data_service.py",
+      "classification": "root facade / compatibility surface",
+      "recommended_next_gate": "defer behind trade evidence ownership decision"
+    },
+    "get_prewarming_strategy": {
+      "file_count": 3,
+      "call_count": 6,
+      "primary_file": "web/backend/app/api/_cache_prewarming_routes.py",
+      "classification": "cache prewarming route/provider surface",
+      "recommended_next_gate": "defer behind higher-risk trade evidence and root facade decisions"
+    }
+  },
+  "next_gate": {
+    "g2": "G2.219",
+    "title": "trade execution tracking evidence provider ownership decision",
+    "source_edit_authority": false,
+    "scope": [
+      "regenerate current ownership evidence for get_execution_tracking_evidence_service",
+      "decide whether it remains a route-local provider seam or needs a later authorization package",
+      "do not edit web/backend source in the decision package"
+    ]
+  },
+  "forbidden_scope": [
+    "web/backend/**",
+    "web/frontend/**",
+    "src/**",
+    "tests/**",
+    "docs/api/**",
+    "docs/FUNCTION_TREE.md",
+    "governance/function-tree/catalog.yaml",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**"
+  ]
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-28T23:28:14+08:00`
-- Base HEAD checked: `3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117`
+- Prepared at: `2026-05-29T01:22:32+08:00`
+- Base HEAD checked: `4d2b69e449975d145976e10c8af965e16dc60a1e`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -54,12 +54,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#367` | `g2-214-non-strategy-provider-queue-refresh` | `wip/root-dirty-20260403` | `MERGED` at `a508fb263173b2014d307c4baec3b1eca0f42340` | No-source queue refresh selecting G2.215 indicator/data `get_data_service` ownership decision |
 | `#368` | `g2-215-indicator-data-get-data-service-decision` | `wip/root-dirty-20260403` | `MERGED` at `cec3f727534008d2a48221c656c22f82f351e3d7` | No-source ownership decision selecting G2.216 indicator/data `DataService` provider authorization |
 | `#369` | `g2-216-indicator-data-service-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `68ba10829b89095f8b907d249f59198995543ebc` | No-source authorization selecting G2.217 `DataService` provider/reset seam implementation |
+| `#370` | `g2-217-data-service-provider-reset-seam` | `wip/root-dirty-20260403` | `MERGED` at `4d2b69e449975d145976e10c8af965e16dc60a1e` | Path-limited implementation adding `DataService` provider/reset seam while preserving default singleton fallback |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-217-data-service-provider-reset-seam` | `origin/wip/root-dirty-20260403` at `68ba10829b89095f8b907d249f59198995543ebc` | Implement the approved path-limited `DataService` provider/reset seam while preserving default singleton fallback | Yes |
+| `g2-218-data-service-provider-closeout-refresh` | `origin/wip/root-dirty-20260403` at `4d2b69e449975d145976e10c8af965e16dc60a1e` | Close out the merged `DataService` provider/reset seam and refresh residual provider/getter queue | No |
 
 ## OpenSpec Relationship
 
@@ -75,7 +76,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.217 is a path-limited implementation branch after PR `#369` merged G2.216. It
-is limited to `web/backend/app/services/data_service.py`, a focused provider
-test, governance evidence, steward tree updates, and a task card. If accepted,
-the next gate is G2.218 closeout / residual refresh with no source edits.
+G2.218 is a no-source closeout branch after PR `#370` merged G2.217. It is
+limited to governance evidence, steward tree updates, and a task card. If
+accepted, the next gate is G2.219 `get_execution_tracking_evidence_service`
+ownership decision, also with no source edits.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-28T23:28:14+08:00`
-- Base HEAD checked: `3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117`
+- Prepared at: `2026-05-29T01:22:32+08:00`
+- Base HEAD checked: `4d2b69e449975d145976e10c8af965e16dc60a1e`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 merged by PR `#363`; G2.211 merged by PR `#364`; G2.212 merged by PR `#365`; G2.213 merged by PR `#366`; G2.214 merged by PR `#367`; G2.215 merged by PR `#368`; G2.216 merged by PR `#369`; G2.217 is the active `DataService` provider/reset seam implementation |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 merged by PR `#363`; G2.211 merged by PR `#364`; G2.212 merged by PR `#365`; G2.213 merged by PR `#366`; G2.214 merged by PR `#367`; G2.215 merged by PR `#368`; G2.216 merged by PR `#369`; G2.217 merged by PR `#370`; G2.218 is the active no-source `DataService` provider/reset seam closeout / residual refresh |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-28T23:51:14+08:00`
-- Base HEAD checked: `a508fb263173b2014d307c4baec3b1eca0f42340`
+- Prepared at: `2026-05-29T01:22:32+08:00`
+- Base HEAD checked: `4d2b69e449975d145976e10c8af965e16dc60a1e`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,7 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.217 indicator/data `DataService` provider/reset seam implementation | G/#79 service lifecycle DI | PR `#369` merged at `68ba10829b89095f8b907d249f59198995543ebc`; G2.217 adds `set_data_service_provider()` / `reset_data_service_provider()` while preserving `get_data_service()` fallback | If accepted, start G2.218 no-source closeout / residual refresh; do not start another source lane directly |
+| P0 | Review G2.218 `DataService` provider/reset seam closeout / residual refresh | G/#79 service lifecycle DI | PR `#370` merged at `4d2b69e449975d145976e10c8af965e16dc60a1e`; G2.218 refreshes merged verification, closes the `get_data_service` implementation lane, and selects G2.219 trade execution tracking evidence provider ownership decision | If accepted, start G2.219 no-source ownership decision for `get_execution_tracking_evidence_service`; do not start another source lane directly |
 | P0 | Preserve G2.214 non-Strategy provider governance queue refresh / next-candidate selection | G/#79 service lifecycle DI | PR `#367` merged; G2.214 selected G2.215 indicator/data `get_data_service` current-HEAD contradiction decision as the next no-source gate | Do not reopen other non-Strategy candidates from G2.214 without fresh current-HEAD contradiction evidence |
 | P0 | Preserve G2.213 data-quality monitor singleton/backing API closeout / residual refresh | G/#79 service lifecycle DI | PR `#366` merged; data-quality monitor conveyor selects no new source lane | Do not reopen data-quality monitor source unless fresh current-HEAD evidence contradicts accepted closeout |
 | P0 | Preserve G2.212 data-quality monitor singleton/backing API compatibility implementation | G/#79 service lifecycle DI | PR `#365` merged; provider/reset hook is implemented and default singleton fallback is preserved | Do not reopen data-quality monitor singleton source unless fresh current-HEAD evidence contradicts G2.212/G2.213 |
@@ -57,9 +57,9 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.217 preserve `get_data_service()` as the public default singleton fallback?
-- Does `reset_data_service_provider()` clear both provider override and cached singleton state?
-- Do indicator route provider regressions remain green without route/OpenAPI edits?
-- Does G2.217 keep Strategy, data-quality, trade, cache, realtime, and adapter surfaces out of scope?
-- Is G2.218 correctly positioned as a no-source closeout / residual refresh before another implementation lane?
+- Does G2.218 correctly treat PR `#370` as merged and accepted into `wip/root-dirty-20260403`?
+- Does the merged `DataService` provider/reset seam still pass import smoke and focused regressions at `4d2b69e449975d145976e10c8af965e16dc60a1e`?
+- Does the residual refresh separate the two direct route-local `get_data_service()` wrapper calls from unrelated token hits?
+- Does G2.218 keep all backend source, tests, route/OpenAPI contracts, OpenSpec changes, and issue label changes out of scope?
+- Is G2.219 correctly positioned as a no-source ownership decision for `get_execution_tracking_evidence_service` before any implementation lane?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-28T23:28:14+08:00`
-- Base HEAD checked: `3d3f8285f3a83cb4dda60d9b7eb8cf36fdf77117`
+- Prepared at: `2026-05-29T01:22:32+08:00`
+- Base HEAD checked: `4d2b69e449975d145976e10c8af965e16dc60a1e`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -95,8 +95,10 @@ state transition.
 | `docs/reports/quality/backend-indicator-data-get-data-service-ownership-decision-2026-05-28.md` | G2.215 human-readable ownership decision report | Accepted by PR `#368`; superseded for provider/reset authorization by G2.216 |
 | `.planning/codebase/generated/indicator-data-service-provider-authorization-2026-05-29.json` | G2.216 indicator/data `DataService` provider/reset seam authorization evidence | Accepted by PR `#369`; superseded for implementation evidence by G2.217 |
 | `docs/reports/quality/backend-indicator-data-service-provider-authorization-2026-05-29.md` | G2.216 human-readable provider authorization report | Accepted by PR `#369`; superseded for implementation evidence by G2.217 |
-| `.planning/codebase/generated/data-service-provider-reset-seam-implementation-2026-05-29.json` | G2.217 `DataService` provider/reset seam implementation evidence | Review input until PR `#370` is accepted |
-| `docs/reports/quality/backend-data-service-provider-reset-seam-implementation-2026-05-29.md` | G2.217 human-readable implementation report | Review input until PR `#370` is accepted |
+| `.planning/codebase/generated/data-service-provider-reset-seam-implementation-2026-05-29.json` | G2.217 `DataService` provider/reset seam implementation evidence | Accepted by PR `#370`; superseded for closeout evidence by G2.218 |
+| `docs/reports/quality/backend-data-service-provider-reset-seam-implementation-2026-05-29.md` | G2.217 human-readable implementation report | Accepted by PR `#370`; superseded for closeout evidence by G2.218 |
+| `.planning/codebase/generated/data-service-provider-closeout-refresh-2026-05-29.json` | G2.218 `DataService` provider/reset seam closeout and residual refresh evidence | Review input until PR `#371` is accepted |
+| `docs/reports/quality/backend-data-service-provider-closeout-refresh-2026-05-29.md` | G2.218 human-readable closeout / residual refresh report | Review input until PR `#371` is accepted |
 
 ## External State Inputs
 

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-29T00:46:30+08:00",
+  "generated_at": "2026-05-29T01:22:32+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "68ba10829b89095f8b907d249f59198995543ebc",
-  "split_branch": "g2-217-data-service-provider-reset-seam",
-  "scope": "indicator_data_data_service_provider_reset_implementation",
-  "source_edit_authority": true,
+  "base_head": "4d2b69e449975d145976e10c8af965e16dc60a1e",
+  "split_branch": "g2-218-data-service-provider-closeout-refresh",
+  "scope": "data_service_provider_closeout_refresh",
+  "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -1218,12 +1218,12 @@
       "verification": {
         "tdd_red": "failed on missing quality_monitor constructor parameter",
         "focused_pytest": "1 passed",
-      "ruff": "All checks passed",
-      "import_smoke": "passed with minimal dummy required env",
-      "openspec_validate": "valid; PostHog network flush noise only",
-      "mainline_scope_gate": "passed",
-      "gitnexus_detect_changes_staged": "low risk; 18 changed files, 84 changed symbols, 0 affected processes"
-    },
+        "ruff": "All checks passed",
+        "import_smoke": "passed with minimal dummy required env",
+        "openspec_validate": "valid; PostHog network flush noise only",
+        "mainline_scope_gate": "passed",
+        "gitnexus_detect_changes_staged": "low risk; 18 changed files, 84 changed symbols, 0 affected processes"
+      },
       "freshness": {
         "current_head_checked": "e4245ebe54c5ad6d2aebf4802d165d59700c9eeb",
         "stale_if_head_mismatch": true
@@ -2487,7 +2487,7 @@
     {
       "id": "g2-217-data-service-provider-reset-seam",
       "type": "implementation",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.216 indicator/data DataService provider authorization package",
       "source_edit_authority": true,
@@ -2543,10 +2543,81 @@
         "interpretation": "File-level attribution marks existing data_service.py methods as modified; cached source diff is localized to typing import, provider/reset helpers, and get_data_service provider branch."
       },
       "freshness": {
-        "current_head_checked": "68ba10829b89095f8b907d249f59198995543ebc",
+        "current_head_checked": "4d2b69e449975d145976e10c8af965e16dc60a1e",
         "stale_if_head_mismatch": true
       },
-      "next_gate": "If accepted, start G2.218 no-source DataService provider/reset seam closeout and residual refresh."
+      "next_gate": "Superseded by G2.218 DataService provider/reset seam closeout and residual refresh.",
+      "github_pr": 370,
+      "head_ref": "g2-217-data-service-provider-reset-seam",
+      "merge_commit": "4d2b69e449975d145976e10c8af965e16dc60a1e"
+    },
+    {
+      "id": "g2-218-data-service-provider-closeout-refresh",
+      "type": "closeout_refresh",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI",
+      "parent": "G2.217 DataService provider/reset seam implementation",
+      "source_edit_authority": false,
+      "parent_github_pr": 370,
+      "parent_merge_commit": "4d2b69e449975d145976e10c8af965e16dc60a1e",
+      "evidence": [
+        ".planning/codebase/generated/data-service-provider-closeout-refresh-2026-05-29.json",
+        "docs/reports/quality/backend-data-service-provider-closeout-refresh-2026-05-29.md",
+        "governance/mainline/task-cards/pr-371.yaml"
+      ],
+      "verification": {
+        "import_smoke": "import_smoke=pass provider_override=pass reset_default=pass",
+        "focused_provider_test": "web/backend/tests/test_data_service_singleton_provider.py: 2 passed",
+        "route_provider_regressions": "web/backend/tests/test_indicator_registry_route_provider.py + web/backend/tests/test_v1_indicators_regressions.py: 6 passed",
+        "ruff": "passed",
+        "openspec_validate": "valid"
+      },
+      "data_service_residuals": {
+        "direct_singleton_wrapper_calls": [
+          "web/backend/app/api/indicators/indicator_cache.py:49",
+          "web/backend/app/api/v1/strategy/indicators.py:30"
+        ],
+        "decision": "retain route-local provider wrappers; do not reopen DataService source from token-only matches"
+      },
+      "residual_candidate_refresh": {
+        "closed": [
+          "get_data_service"
+        ],
+        "selected_next_gate": "get_execution_tracking_evidence_service",
+        "deferred": [
+          "get_unified_data_service",
+          "get_prewarming_strategy"
+        ]
+      },
+      "next_gate": "If accepted, start G2.219 no-source ownership decision for get_execution_tracking_evidence_service; do not start source implementation directly.",
+      "allowed_scope": [
+        ".planning/codebase/generated/data-service-provider-closeout-refresh-2026-05-29.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-data-service-provider-closeout-refresh-2026-05-29.md",
+        "governance/mainline/task-cards/pr-371.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "tests/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "freshness": {
+        "current_head_checked": "4d2b69e449975d145976e10c8af965e16dc60a1e",
+        "stale_if_head_mismatch": true
+      }
     },
     {
       "id": "core-batch2-reconciliation",

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -976,11 +976,47 @@ G2.217 does not edit route wrappers, route/OpenAPI contracts, Strategy residuals
 data-quality monitor source, trade/cache/realtime providers, `adapter_split`, or
 `market_data_adapter.py`.
 
+## G2.218 DataService Provider/Reset Seam Closeout / Residual Refresh
+
+G2.218 closes the accepted G2.217 source lane after PR `#370` merged at
+`4d2b69e449975d145976e10c8af965e16dc60a1e`. This is a no-source closeout and
+residual refresh package.
+
+Current evidence:
+
+| Check | Result |
+|---|---|
+| Import smoke | `import_smoke=pass provider_override=pass reset_default=pass` |
+| Focused provider test | `2 passed` |
+| Indicator route provider regressions | `6 passed` |
+| Ruff | passed |
+| OpenSpec strict validate | valid |
+
+`get_data_service` residual classification:
+
+| Surface | Current state | Decision |
+|---|---|---|
+| Direct singleton wrapper calls | 2 route-local provider wrappers in `indicator_cache.py` and `v1/strategy/indicators.py` | Retain as provider wrappers |
+| Canonical function definition | `web/backend/app/services/data_service.py` | Closed by G2.217 provider/reset seam |
+| Local helper names / imports | `ml_runtime_helpers.py`, `v1/system/health.py` | Not `app.services.data_service.get_data_service()` residuals |
+
+Residual queue after closing `get_data_service`:
+
+| Candidate | Current scan | Classification | Disposition |
+|---|---:|---|---|
+| `get_execution_tracking_evidence_service` | 3 calls in 2 files | trade evidence route-local provider surface | Select G2.219 no-source ownership decision |
+| `get_unified_data_service` | 6 calls in 1 file | root facade / compatibility surface | Defer behind trade evidence ownership decision |
+| `get_prewarming_strategy` | 6 calls in 3 files | cache prewarming route/provider surface | Defer behind higher-risk trade/root-facade decisions |
+
+G2.218 does not authorize backend source edits, test edits, OpenSpec changes,
+route/OpenAPI changes, issue label changes, or direct implementation for the
+next candidate.
+
 ## Next Gates
 
-- Review G2.217 indicator/data `DataService` provider/reset seam implementation.
-- If accepted, start G2.218 no-source closeout / residual refresh before selecting another source lane.
-- Do not start another source implementation directly from G2.217.
+- Review G2.218 `DataService` provider/reset seam closeout / residual refresh.
+- If accepted, start G2.219 no-source ownership decision for `get_execution_tracking_evidence_service`.
+- Do not start another source implementation directly from G2.218 or G2.219.
 - Do not open another data-quality monitor source lane unless fresh current-HEAD evidence contradicts the accepted closeout.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.

--- a/docs/reports/quality/backend-data-service-provider-closeout-refresh-2026-05-29.md
+++ b/docs/reports/quality/backend-data-service-provider-closeout-refresh-2026-05-29.md
@@ -1,0 +1,96 @@
+# Backend DataService Provider/Reset Seam Closeout Refresh - 2026-05-29
+
+> **历史文档说明**: 本文件是 G2.218 执行证据快照，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Branch: `g2-218-data-service-provider-closeout-refresh`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `4d2b69e449975d145976e10c8af965e16dc60a1e`
+- Prepared at: `2026-05-29T01:22:32+08:00`
+- OpenSpec lane: `migrate-backend-singletons-to-lifecycle-di`
+- Source authority: none
+
+## Parent Merge
+
+| Item | State |
+|---|---|
+| Parent implementation | G2.217 `DataService` provider/reset seam |
+| GitHub PR | `#370` |
+| PR state | `MERGED` |
+| Merge commit | `4d2b69e449975d145976e10c8af965e16dc60a1e` |
+| Head commit | `9e8504a82b5d5c57a0e046be2d3ddde13027a3d3` |
+
+G2.217 is accepted into `wip/root-dirty-20260403`. This closeout refresh does not reopen source implementation.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Import smoke | `import_smoke=pass provider_override=pass reset_default=pass` |
+| Focused provider test | `2 passed in 1.64s` |
+| Indicator route provider regressions | `6 passed in 2.63s` |
+| Ruff | `All checks passed!` |
+| OpenSpec strict validate | `Change 'migrate-backend-singletons-to-lifecycle-di' is valid` |
+
+Notes:
+
+- The default fallback import smoke initializes `DataService` and emits existing TDengine / `MyStocksUnifiedManager` startup logs.
+- OpenSpec validation still emits PostHog network flush noise after reporting the change as valid.
+
+## DataService Residual Refresh
+
+Static scan found five `get_data_service` token files under `web/backend/app`.
+Only two are direct calls to `app.services.data_service.get_data_service()`:
+
+| Caller | File | Role |
+|---|---|---|
+| `return get_data_service()` | `web/backend/app/api/indicators/indicator_cache.py:49` | route-local provider wrapper |
+| `return get_data_service()` | `web/backend/app/api/v1/strategy/indicators.py:30` | route-local provider wrapper |
+
+Non-residual token hits:
+
+| File | Classification |
+|---|---|
+| `web/backend/app/services/data_service.py` | canonical provider function definition |
+| `web/backend/app/api/v1/strategy/ml_runtime_helpers.py` | imports `DataService` but does not directly call `get_data_service()` |
+| `web/backend/app/api/v1/system/health.py` | local `EnhancedDataService` helper named `_get_data_service`, not `app.services.data_service.get_data_service` |
+
+Decision: keep the two route-local provider wrappers. Do not reopen DataService source from token-only matches unless current HEAD contradicts this closeout evidence.
+
+## Residual Candidate Queue
+
+| Candidate | Current scan | Classification | Disposition |
+|---|---:|---|---|
+| `get_data_service` | 2 direct singleton wrapper calls | closed by G2.217 provider/reset seam | Do not reopen without current-HEAD contradiction |
+| `get_execution_tracking_evidence_service` | 3 calls in 2 files | trade evidence route-local provider surface | Select G2.219 no-source ownership decision |
+| `get_unified_data_service` | 6 calls in 1 file | root facade / compatibility surface | Defer behind trade evidence ownership decision |
+| `get_prewarming_strategy` | 6 calls in 3 files | cache prewarming route/provider surface | Defer behind higher-risk trade/root-facade decisions |
+
+## Next Gate
+
+Start G2.219 as a no-source ownership decision package for `get_execution_tracking_evidence_service`.
+
+G2.219 should:
+
+- Regenerate current evidence for `web/backend/app/api/trade/execution_tracking_routes.py`.
+- Decide whether the getter remains a route-local provider seam or needs a later path-limited authorization package.
+- Preserve the separation between decision, authorization, implementation, and closeout.
+- Avoid all backend source edits unless a later authorization package is accepted.
+
+## Not Changed
+
+- No backend source edits.
+- No tests changed.
+- No route/OpenAPI contracts changed.
+- No OpenSpec proposal or spec files changed.
+- No GitHub issue or PR labels changed.
+- No Strategy, data-quality monitor, realtime/socket, cache prewarming, root facade, `adapter_split`, or `market_data_adapter.py` source work opened.
+
+## Evidence Artifacts
+
+| Artifact | Purpose |
+|---|---|
+| `.planning/codebase/generated/data-service-provider-closeout-refresh-2026-05-29.json` | Machine-readable G2.218 closeout and residual refresh evidence |
+| `docs/reports/quality/backend-data-service-provider-closeout-refresh-2026-05-29.md` | Human-readable G2.218 closeout report |
+| `governance/mainline/task-cards/pr-371.yaml` | Mainline governance task card |

--- a/governance/mainline/task-cards/pr-371.yaml
+++ b/governance/mainline/task-cards/pr-371.yaml
@@ -1,0 +1,133 @@
+version: "v0.2"
+
+task:
+  id: "pr-371"
+  title: "Close DataService provider seam and refresh residual queue"
+  owner: "codex"
+  created_at: "2026-05-29"
+
+mainline:
+  id: "L1-data-service-provider-closeout-refresh"
+  objective: "close out merged PR #370 evidence and refresh the remaining provider/getter governance queue without source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "G2.218 is a no-source closeout and residual queue refresh after merged PR #370. It changes no runtime route entrypoint, public HTTP API, OpenAPI exposure, PM2 workflow, frontend behavior, source code, or tests."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-service-provider-closeout-refresh-2026-05-29.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-service-provider-closeout-refresh-2026-05-29.md"
+    - "governance/mainline/task-cards/pr-371.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits"
+  - "test edits"
+  - "route/OpenAPI contract changes"
+  - "route provider wrapper edits"
+  - "Strategy getter residual reopen"
+  - "data-quality monitor source reopen"
+  - "trade execution evidence provider implementation"
+  - "cache prewarming provider implementation"
+  - "root facade compatibility implementation"
+  - "realtime streaming/socket provider changes"
+  - "adapter_split or market_data_adapter changes"
+  - "GitHub issue or PR label changes"
+  - "OpenSpec proposal or spec creation"
+
+acceptance:
+  checks:
+    - id: "import-smoke"
+      command: "env PYTHONPATH=web/backend python -c '<DataService provider/reset smoke>'"
+      required: true
+    - id: "focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_data_service_singleton_provider.py -q --no-cov --tb=short"
+      required: true
+    - id: "route-provider-regressions"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_indicator_registry_route_provider.py web/backend/tests/test_v1_indicators_regressions.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/services/data_service.py web/backend/tests/test_data_service_singleton_provider.py"
+      required: true
+    - id: "json-yaml-parse"
+      command: "python - <<'PY'\nimport json, yaml\nfor path in ['.planning/codebase/generated/data-service-provider-closeout-refresh-2026-05-29.json', '.planning/codebase/steward-tree/steward-index.json']:\n    with open(path, encoding='utf-8') as f:\n        json.load(f)\nwith open('governance/mainline/task-cards/pr-371.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-service-provider-closeout-refresh-2026-05-29.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-371.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha 4d2b69e449975d145976e10c8af965e16dc60a1e --head-sha HEAD --report /tmp/pr371-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "No-source closeout may be misread as source implementation authority; task card forbids backend, frontend, tests, OpenSpec, config, and scripts edits."
+    - "Token-only scans can overcount get_data_service residuals; report separates direct singleton wrapper calls from local helper definitions and unrelated helper names."
+    - "Selecting G2.219 could be misread as implementation; next gate is explicitly no-source ownership decision only."
+  rollback_plan: "Revert this PR; no runtime source or test changes are present."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Close out merged PR #370 and refresh the residual provider/getter queue."
+    modified_scope: "Governance reports, generated evidence, steward tree, and task card only."
+    dependency_changes: "None."
+    legacy_logic_impact: "None; no source or test files are modified."
+    rollback_ready: "Yes; revert the PR."
+    risk_and_rollback_point: "Do not start G2.219 implementation; G2.219 is no-source ownership decision only."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "current review thread human maintainer"
+    approved_at: "2026-05-29T01:22:32+08:00"
+    approval_note: "Approved to continue from merged PR #370 into the G2.218 no-source DataService provider/reset seam closeout and residual refresh lane."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- close out merged PR #370 DataService provider/reset seam evidence
- refresh DataService residual classification and keep the two route-local wrapper calls retained
- select G2.219 get_execution_tracking_evidence_service ownership decision as the next no-source gate

## Verification
- import smoke: provider override and reset-to-default passed
- pytest: web/backend/tests/test_data_service_singleton_provider.py => 2 passed
- pytest: web/backend/tests/test_indicator_registry_route_provider.py + web/backend/tests/test_v1_indicators_regressions.py => 6 passed
- ruff check: passed
- markdown governance: 6 checked files, 0 errors
- OpenSpec strict validate: valid (PostHog telemetry noise only)
- mainline scope gate: pass=True
- GitNexus staged/compare: low risk, 0 symbols, 0 affected processes

## Boundary
No source, test, route/OpenAPI, OpenSpec, config, script, frontend, or issue-label changes. G2.219 is a no-source ownership decision only, not implementation.