### PR TITLE
G2.219 classify execution tracking evidence provider

### DIFF
--- a/.planning/codebase/generated/execution-tracking-evidence-provider-ownership-decision-2026-05-29.json
+++ b/.planning/codebase/generated/execution-tracking-evidence-provider-ownership-decision-2026-05-29.json
@@ -1,0 +1,141 @@
+{
+  "schema_version": "2026-05-29.execution-tracking-evidence-provider-ownership-decision.v1",
+  "generated_at": "2026-05-29T01:42:47+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "branch": "g2-219-execution-tracking-evidence-provider-decision",
+  "base_head": "d4ee917ad642939c4c60000998b8bea5ca7c9a65",
+  "openspec_lane": "migrate-backend-singletons-to-lifecycle-di",
+  "source_edit_authority": false,
+  "parent": {
+    "g2": "G2.218",
+    "github_pr": 371,
+    "state": "MERGED",
+    "merge_commit": "d4ee917ad642939c4c60000998b8bea5ca7c9a65",
+    "summary": "DataService provider/reset seam closeout accepted into wip/root-dirty-20260403"
+  },
+  "target": {
+    "symbol": "get_execution_tracking_evidence_service",
+    "file": "web/backend/app/api/trade/execution_tracking_routes.py",
+    "definition_line": 289,
+    "classification": "trade evidence route-local provider surface"
+  },
+  "gitnexus_impact": {
+    "repo": "mystocks_spec",
+    "risk": "HIGH",
+    "impacted_count": 2,
+    "direct_callers": 2,
+    "processes_affected": 3,
+    "modules_affected": 1,
+    "direct_callers_list": [
+      "_load_execution_records",
+      "get_execution_tracking_detail"
+    ],
+    "affected_processes": [
+      "Get_execution_tracking_detail -> Strip",
+      "Get_execution_tracking_detail -> _as_int",
+      "Get_execution_tracking_detail -> _broker_state_for"
+    ],
+    "affected_module": "Trade"
+  },
+  "static_inventory": {
+    "route_file_line_count": 563,
+    "test_file_line_count": 221,
+    "route_decorators": [
+      {
+        "line": 435,
+        "method": "GET",
+        "role": "list execution tracking"
+      },
+      {
+        "line": 469,
+        "method": "POST",
+        "role": "record external execution trigger"
+      },
+      {
+        "line": 533,
+        "method": "GET",
+        "role": "get execution tracking detail"
+      }
+    ],
+    "provider_lines": [
+      {
+        "line": 289,
+        "text": "def get_execution_tracking_evidence_service() -> ExecutionTrackingEvidenceService:"
+      },
+      {
+        "line": 364,
+        "text": "for record in get_execution_tracking_evidence_service().load_records("
+      },
+      {
+        "line": 542,
+        "text": "evidence_service = get_execution_tracking_evidence_service()"
+      }
+    ],
+    "depends_usage": 0,
+    "test_count": 4,
+    "test_seam": "web/backend/tests/test_trade_execution_tracking_routes.py monkeypatches get_execution_tracking_evidence_service at line 78"
+  },
+  "verification": {
+    "pytest": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_trade_execution_tracking_routes.py -q --no-cov --tb=short",
+      "result": "4 passed in 3.30s"
+    },
+    "ruff": {
+      "command": "ruff check web/backend/app/api/trade/execution_tracking_routes.py web/backend/tests/test_trade_execution_tracking_routes.py",
+      "result": "All checks passed!"
+    },
+    "openspec": {
+      "command": "openspec validate migrate-backend-singletons-to-lifecycle-di --strict",
+      "result": "Change 'migrate-backend-singletons-to-lifecycle-di' is valid",
+      "telemetry_note": "PostHog network flush failure is telemetry noise."
+    },
+    "openapi_smoke": {
+      "command": "env PYTHONPATH=web/backend python -c '<app.main route/OpenAPI smoke>'",
+      "result": "blocked_by_environment",
+      "missing_environment": [
+        "POSTGRESQL_HOST",
+        "POSTGRESQL_USER",
+        "POSTGRESQL_PASSWORD",
+        "JWT_SECRET_KEY",
+        "BACKEND_PORT",
+        "BACKEND_BACKUP_PORT"
+      ]
+    }
+  },
+  "decision": {
+    "state": "ownership_decision_for_review",
+    "result": "Do not treat get_execution_tracking_evidence_service as a generic service singleton cleanup. It belongs to the trade execution tracking route/provider ownership surface.",
+    "rationale": [
+      "The provider is defined inside the trade route module and constructs ExecutionTrackingEvidenceService on demand.",
+      "It is called by both list loading and detail lookup, so a blind source edit has HIGH graph impact.",
+      "Existing tests already use a route-module monkeypatch seam, but FastAPI Depends is not yet used.",
+      "Current route/OpenAPI verification is environment-blocked, so source implementation should not start from this decision package."
+    ],
+    "selected_next_gate": "G2.220 trade execution tracking evidence provider authorization package",
+    "source_implementation_allowed_now": false
+  },
+  "next_gate": {
+    "g2": "G2.220",
+    "title": "trade execution tracking evidence provider authorization",
+    "source_edit_authority": false,
+    "scope": [
+      "define whether a later path-limited source lane should convert direct provider calls to route dependency/provider injection",
+      "require current app.main/OpenAPI smoke or explicit environment-blocker disposition before source implementation",
+      "keep route contracts, response models, miniQMT evidence semantics, and tests stable"
+    ]
+  },
+  "forbidden_scope": [
+    "web/backend/**",
+    "web/frontend/**",
+    "src/**",
+    "tests/**",
+    "docs/api/**",
+    "docs/FUNCTION_TREE.md",
+    "governance/function-tree/catalog.yaml",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**"
+  ]
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-29T01:22:32+08:00`
-- Base HEAD checked: `4d2b69e449975d145976e10c8af965e16dc60a1e`
+- Prepared at: `2026-05-29T01:42:47+08:00`
+- Base HEAD checked: `d4ee917ad642939c4c60000998b8bea5ca7c9a65`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -55,12 +55,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#368` | `g2-215-indicator-data-get-data-service-decision` | `wip/root-dirty-20260403` | `MERGED` at `cec3f727534008d2a48221c656c22f82f351e3d7` | No-source ownership decision selecting G2.216 indicator/data `DataService` provider authorization |
 | `#369` | `g2-216-indicator-data-service-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `68ba10829b89095f8b907d249f59198995543ebc` | No-source authorization selecting G2.217 `DataService` provider/reset seam implementation |
 | `#370` | `g2-217-data-service-provider-reset-seam` | `wip/root-dirty-20260403` | `MERGED` at `4d2b69e449975d145976e10c8af965e16dc60a1e` | Path-limited implementation adding `DataService` provider/reset seam while preserving default singleton fallback |
+| `#371` | `g2-218-data-service-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `d4ee917ad642939c4c60000998b8bea5ca7c9a65` | No-source closeout selecting G2.219 `get_execution_tracking_evidence_service` ownership decision |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-218-data-service-provider-closeout-refresh` | `origin/wip/root-dirty-20260403` at `4d2b69e449975d145976e10c8af965e16dc60a1e` | Close out the merged `DataService` provider/reset seam and refresh residual provider/getter queue | No |
+| `g2-219-execution-tracking-evidence-provider-decision` | `origin/wip/root-dirty-20260403` at `d4ee917ad642939c4c60000998b8bea5ca7c9a65` | Classify `get_execution_tracking_evidence_service` ownership and select the next no-source authorization gate | No |
 
 ## OpenSpec Relationship
 
@@ -76,7 +77,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.218 is a no-source closeout branch after PR `#370` merged G2.217. It is
-limited to governance evidence, steward tree updates, and a task card. If
-accepted, the next gate is G2.219 `get_execution_tracking_evidence_service`
-ownership decision, also with no source edits.
+G2.219 is a no-source ownership decision branch after PR `#371` merged G2.218.
+It is limited to governance evidence, steward tree updates, and a task card. If
+accepted, the next gate is G2.220 trade execution tracking evidence provider
+authorization, also with no source edits.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-29T01:22:32+08:00`
-- Base HEAD checked: `4d2b69e449975d145976e10c8af965e16dc60a1e`
+- Prepared at: `2026-05-29T01:42:47+08:00`
+- Base HEAD checked: `d4ee917ad642939c4c60000998b8bea5ca7c9a65`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 merged by PR `#363`; G2.211 merged by PR `#364`; G2.212 merged by PR `#365`; G2.213 merged by PR `#366`; G2.214 merged by PR `#367`; G2.215 merged by PR `#368`; G2.216 merged by PR `#369`; G2.217 merged by PR `#370`; G2.218 is the active no-source `DataService` provider/reset seam closeout / residual refresh |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 merged by PR `#363`; G2.211 merged by PR `#364`; G2.212 merged by PR `#365`; G2.213 merged by PR `#366`; G2.214 merged by PR `#367`; G2.215 merged by PR `#368`; G2.216 merged by PR `#369`; G2.217 merged by PR `#370`; G2.218 merged by PR `#371`; G2.219 is the active no-source `get_execution_tracking_evidence_service` ownership decision |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-29T01:22:32+08:00`
-- Base HEAD checked: `4d2b69e449975d145976e10c8af965e16dc60a1e`
+- Prepared at: `2026-05-29T01:42:47+08:00`
+- Base HEAD checked: `d4ee917ad642939c4c60000998b8bea5ca7c9a65`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,7 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.218 `DataService` provider/reset seam closeout / residual refresh | G/#79 service lifecycle DI | PR `#370` merged at `4d2b69e449975d145976e10c8af965e16dc60a1e`; G2.218 refreshes merged verification, closes the `get_data_service` implementation lane, and selects G2.219 trade execution tracking evidence provider ownership decision | If accepted, start G2.219 no-source ownership decision for `get_execution_tracking_evidence_service`; do not start another source lane directly |
+| P0 | Review G2.219 trade execution tracking evidence provider ownership decision | G/#79 service lifecycle DI + trade route/provider governance | PR `#371` merged at `d4ee917ad642939c4c60000998b8bea5ca7c9a65`; G2.219 classifies `get_execution_tracking_evidence_service` as a high-impact trade route/provider surface, not a generic singleton cleanup | If accepted, start G2.220 no-source authorization package; do not start source implementation directly |
 | P0 | Preserve G2.214 non-Strategy provider governance queue refresh / next-candidate selection | G/#79 service lifecycle DI | PR `#367` merged; G2.214 selected G2.215 indicator/data `get_data_service` current-HEAD contradiction decision as the next no-source gate | Do not reopen other non-Strategy candidates from G2.214 without fresh current-HEAD contradiction evidence |
 | P0 | Preserve G2.213 data-quality monitor singleton/backing API closeout / residual refresh | G/#79 service lifecycle DI | PR `#366` merged; data-quality monitor conveyor selects no new source lane | Do not reopen data-quality monitor source unless fresh current-HEAD evidence contradicts accepted closeout |
 | P0 | Preserve G2.212 data-quality monitor singleton/backing API compatibility implementation | G/#79 service lifecycle DI | PR `#365` merged; provider/reset hook is implemented and default singleton fallback is preserved | Do not reopen data-quality monitor singleton source unless fresh current-HEAD evidence contradicts G2.212/G2.213 |
@@ -57,9 +57,9 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.218 correctly treat PR `#370` as merged and accepted into `wip/root-dirty-20260403`?
-- Does the merged `DataService` provider/reset seam still pass import smoke and focused regressions at `4d2b69e449975d145976e10c8af965e16dc60a1e`?
-- Does the residual refresh separate the two direct route-local `get_data_service()` wrapper calls from unrelated token hits?
-- Does G2.218 keep all backend source, tests, route/OpenAPI contracts, OpenSpec changes, and issue label changes out of scope?
-- Is G2.219 correctly positioned as a no-source ownership decision for `get_execution_tracking_evidence_service` before any implementation lane?
+- Does G2.219 correctly treat PR `#371` as merged and accepted into `wip/root-dirty-20260403`?
+- Does the GitNexus `HIGH` impact on `get_execution_tracking_evidence_service` remain visible as a stop sign for direct implementation?
+- Does G2.219 classify the target as trade route/provider ownership rather than a generic singleton cleanup?
+- Does G2.219 keep all backend source, tests, route/OpenAPI contracts, OpenSpec changes, and issue label changes out of scope?
+- Is G2.220 correctly positioned as a no-source authorization package before any implementation lane?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-29T01:22:32+08:00`
-- Base HEAD checked: `4d2b69e449975d145976e10c8af965e16dc60a1e`
+- Prepared at: `2026-05-29T01:42:47+08:00`
+- Base HEAD checked: `d4ee917ad642939c4c60000998b8bea5ca7c9a65`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -97,8 +97,10 @@ state transition.
 | `docs/reports/quality/backend-indicator-data-service-provider-authorization-2026-05-29.md` | G2.216 human-readable provider authorization report | Accepted by PR `#369`; superseded for implementation evidence by G2.217 |
 | `.planning/codebase/generated/data-service-provider-reset-seam-implementation-2026-05-29.json` | G2.217 `DataService` provider/reset seam implementation evidence | Accepted by PR `#370`; superseded for closeout evidence by G2.218 |
 | `docs/reports/quality/backend-data-service-provider-reset-seam-implementation-2026-05-29.md` | G2.217 human-readable implementation report | Accepted by PR `#370`; superseded for closeout evidence by G2.218 |
-| `.planning/codebase/generated/data-service-provider-closeout-refresh-2026-05-29.json` | G2.218 `DataService` provider/reset seam closeout and residual refresh evidence | Review input until PR `#371` is accepted |
-| `docs/reports/quality/backend-data-service-provider-closeout-refresh-2026-05-29.md` | G2.218 human-readable closeout / residual refresh report | Review input until PR `#371` is accepted |
+| `.planning/codebase/generated/data-service-provider-closeout-refresh-2026-05-29.json` | G2.218 `DataService` provider/reset seam closeout and residual refresh evidence | Accepted by PR `#371`; superseded for next ownership evidence by G2.219 |
+| `docs/reports/quality/backend-data-service-provider-closeout-refresh-2026-05-29.md` | G2.218 human-readable closeout / residual refresh report | Accepted by PR `#371`; superseded for next ownership evidence by G2.219 |
+| `.planning/codebase/generated/execution-tracking-evidence-provider-ownership-decision-2026-05-29.json` | G2.219 `get_execution_tracking_evidence_service` ownership decision evidence | Review input until PR `#372` is accepted |
+| `docs/reports/quality/backend-execution-tracking-evidence-provider-ownership-decision-2026-05-29.md` | G2.219 human-readable ownership decision report | Review input until PR `#372` is accepted |
 
 ## External State Inputs
 

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-29T01:22:32+08:00",
+  "generated_at": "2026-05-29T01:42:47+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "4d2b69e449975d145976e10c8af965e16dc60a1e",
-  "split_branch": "g2-218-data-service-provider-closeout-refresh",
-  "scope": "data_service_provider_closeout_refresh",
+  "base_head": "d4ee917ad642939c4c60000998b8bea5ca7c9a65",
+  "split_branch": "g2-219-execution-tracking-evidence-provider-decision",
+  "scope": "execution_tracking_evidence_provider_ownership_decision",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -2554,7 +2554,7 @@
     {
       "id": "g2-218-data-service-provider-closeout-refresh",
       "type": "closeout_refresh",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI",
       "parent": "G2.217 DataService provider/reset seam implementation",
       "source_edit_authority": false,
@@ -2589,7 +2589,10 @@
           "get_prewarming_strategy"
         ]
       },
-      "next_gate": "If accepted, start G2.219 no-source ownership decision for get_execution_tracking_evidence_service; do not start source implementation directly.",
+      "next_gate": "Superseded by G2.219 trade execution tracking evidence provider ownership decision.",
+      "github_pr": 371,
+      "head_ref": "g2-218-data-service-provider-closeout-refresh",
+      "merge_commit": "d4ee917ad642939c4c60000998b8bea5ca7c9a65",
       "allowed_scope": [
         ".planning/codebase/generated/data-service-provider-closeout-refresh-2026-05-29.json",
         ".planning/codebase/steward-tree/current-next-gates.md",
@@ -2615,7 +2618,76 @@
         "openspec/specs/**"
       ],
       "freshness": {
-        "current_head_checked": "4d2b69e449975d145976e10c8af965e16dc60a1e",
+        "current_head_checked": "d4ee917ad642939c4c60000998b8bea5ca7c9a65",
+        "stale_if_head_mismatch": true
+      }
+    },
+    {
+      "id": "g2-219-execution-tracking-evidence-provider-decision",
+      "type": "decision_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + trade route/provider governance",
+      "parent": "G2.218 DataService provider/reset seam closeout / residual refresh",
+      "source_edit_authority": false,
+      "parent_github_pr": 371,
+      "parent_merge_commit": "d4ee917ad642939c4c60000998b8bea5ca7c9a65",
+      "evidence": [
+        ".planning/codebase/generated/execution-tracking-evidence-provider-ownership-decision-2026-05-29.json",
+        "docs/reports/quality/backend-execution-tracking-evidence-provider-ownership-decision-2026-05-29.md",
+        "governance/mainline/task-cards/pr-372.yaml"
+      ],
+      "target": {
+        "symbol": "get_execution_tracking_evidence_service",
+        "file": "web/backend/app/api/trade/execution_tracking_routes.py",
+        "definition_line": 289,
+        "classification": "trade evidence route-local provider surface"
+      },
+      "gitnexus_impact": {
+        "risk": "HIGH",
+        "impacted_count": 2,
+        "direct_callers": 2,
+        "processes_affected": 3,
+        "modules_affected": 1,
+        "affected_module": "Trade"
+      },
+      "verification": {
+        "focused_trade_route_tests": "web/backend/tests/test_trade_execution_tracking_routes.py: 4 passed",
+        "ruff": "passed",
+        "openspec_validate": "valid",
+        "openapi_smoke": "blocked_by_missing_required_environment"
+      },
+      "decision": {
+        "result": "classify as trade route/provider ownership surface, not generic singleton cleanup",
+        "source_implementation_allowed_now": false,
+        "selected_next_gate": "G2.220 trade execution tracking evidence provider authorization package"
+      },
+      "next_gate": "If accepted, start G2.220 no-source authorization package; do not start source implementation directly.",
+      "allowed_scope": [
+        ".planning/codebase/generated/execution-tracking-evidence-provider-ownership-decision-2026-05-29.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-execution-tracking-evidence-provider-ownership-decision-2026-05-29.md",
+        "governance/mainline/task-cards/pr-372.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "tests/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "freshness": {
+        "current_head_checked": "d4ee917ad642939c4c60000998b8bea5ca7c9a65",
         "stale_if_head_mismatch": true
       }
     },

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -1012,11 +1012,46 @@ G2.218 does not authorize backend source edits, test edits, OpenSpec changes,
 route/OpenAPI changes, issue label changes, or direct implementation for the
 next candidate.
 
+## G2.219 Trade Execution Tracking Evidence Provider Ownership
+
+G2.219 is a no-source ownership decision package after PR `#371` merged at
+`d4ee917ad642939c4c60000998b8bea5ca7c9a65`.
+
+Target:
+
+| Item | Value |
+|---|---|
+| Symbol | `get_execution_tracking_evidence_service` |
+| File | `web/backend/app/api/trade/execution_tracking_routes.py:289` |
+| Current shape | route-local factory for `ExecutionTrackingEvidenceService` |
+| Current injection style | direct route-module helper calls; no FastAPI `Depends` usage |
+
+Current evidence:
+
+| Check | Result |
+|---|---|
+| GitNexus impact | `HIGH`, 2 direct callers, 3 affected processes, Trade module |
+| Focused trade execution route tests | `4 passed` |
+| Ruff on route/test files | passed |
+| OpenSpec strict validate | valid |
+| app.main/OpenAPI smoke | environment-blocked by missing required env vars |
+
+Ownership decision:
+
+`get_execution_tracking_evidence_service` is a trade execution tracking
+route/provider ownership surface, not a generic service singleton cleanup
+candidate. The existing route-local helper and test monkeypatch seam are
+evidence for possible injection, not implementation authorization.
+
+G2.219 selects G2.220 as a no-source authorization package to define whether a
+later path-limited implementation should convert list/detail direct provider
+calls to explicit route dependency/provider injection.
+
 ## Next Gates
 
-- Review G2.218 `DataService` provider/reset seam closeout / residual refresh.
-- If accepted, start G2.219 no-source ownership decision for `get_execution_tracking_evidence_service`.
-- Do not start another source implementation directly from G2.218 or G2.219.
+- Review G2.219 trade execution tracking evidence provider ownership decision.
+- If accepted, start G2.220 no-source trade execution tracking evidence provider authorization.
+- Do not start source implementation directly from G2.219 or G2.220.
 - Do not open another data-quality monitor source lane unless fresh current-HEAD evidence contradicts the accepted closeout.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.

--- a/docs/reports/quality/backend-execution-tracking-evidence-provider-ownership-decision-2026-05-29.md
+++ b/docs/reports/quality/backend-execution-tracking-evidence-provider-ownership-decision-2026-05-29.md
@@ -1,0 +1,137 @@
+# Backend Execution Tracking Evidence Provider Ownership Decision - 2026-05-29
+
+> **历史文档说明**: 本文件是 G2.219 执行证据快照，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Branch: `g2-219-execution-tracking-evidence-provider-decision`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `d4ee917ad642939c4c60000998b8bea5ca7c9a65`
+- Prepared at: `2026-05-29T01:42:47+08:00`
+- OpenSpec lane: `migrate-backend-singletons-to-lifecycle-di`
+- Source authority: none
+
+## Parent Merge
+
+| Item | State |
+|---|---|
+| Parent closeout | G2.218 `DataService` provider/reset seam closeout / residual refresh |
+| GitHub PR | `#371` |
+| PR state | `MERGED` |
+| Merge commit | `d4ee917ad642939c4c60000998b8bea5ca7c9a65` |
+
+G2.219 starts from the accepted G2.218 decision to inspect `get_execution_tracking_evidence_service` next. This package does not authorize source implementation.
+
+## Target
+
+| Item | Value |
+|---|---|
+| Symbol | `get_execution_tracking_evidence_service` |
+| File | `web/backend/app/api/trade/execution_tracking_routes.py:289` |
+| Current shape | route-local factory for `ExecutionTrackingEvidenceService` |
+| Current injection style | direct route-module helper calls; no FastAPI `Depends` usage |
+| Existing test seam | `test_trade_execution_tracking_routes.py` monkeypatches the helper |
+
+## GitNexus Impact
+
+| Metric | Value |
+|---|---:|
+| Risk | `HIGH` |
+| Direct callers | 2 |
+| Impacted symbols | 2 |
+| Affected processes | 3 |
+| Affected modules | 1 |
+
+Direct callers:
+
+| Caller | File |
+|---|---|
+| `_load_execution_records` | `web/backend/app/api/trade/execution_tracking_routes.py` |
+| `get_execution_tracking_detail` | `web/backend/app/api/trade/execution_tracking_routes.py` |
+
+Affected process names:
+
+- `Get_execution_tracking_detail -> Strip`
+- `Get_execution_tracking_detail -> _as_int`
+- `Get_execution_tracking_detail -> _broker_state_for`
+
+## Static Inventory
+
+| Evidence | Value |
+|---|---|
+| Route file line count | 563 |
+| Test file line count | 221 |
+| Route decorators in file | 3 |
+| Provider definition line | 289 |
+| Provider call lines | 364, 542 |
+| Direct `Depends` usage for provider | 0 |
+| Focused route tests | 4 |
+
+Route surfaces in the file:
+
+| Line | Method | Role |
+|---:|---|---|
+| 435 | `GET` | list execution tracking |
+| 469 | `POST` | record external execution trigger |
+| 533 | `GET` | get execution tracking detail |
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `web/backend/tests/test_trade_execution_tracking_routes.py` | `4 passed in 3.30s` |
+| Ruff on route and test files | `All checks passed!` |
+| OpenSpec strict validate | `Change 'migrate-backend-singletons-to-lifecycle-di' is valid` |
+
+OpenAPI app smoke is currently environment-blocked, not source-blocked. Importing
+`app.main` exits with missing required environment variables:
+
+- `POSTGRESQL_HOST`
+- `POSTGRESQL_USER`
+- `POSTGRESQL_PASSWORD`
+- `JWT_SECRET_KEY`
+- `BACKEND_PORT`
+- `BACKEND_BACKUP_PORT`
+
+Do not treat the blocked OpenAPI smoke as implementation authority. A later source lane should either run the app/OpenAPI smoke with a valid environment or explicitly record the environment blocker disposition.
+
+## Decision
+
+`get_execution_tracking_evidence_service` is not a generic service singleton cleanup candidate. It is a trade execution tracking route/provider ownership surface.
+
+Current disposition:
+
+- Keep the existing route-local provider helper unchanged.
+- Do not edit `web/backend/app/api/trade/execution_tracking_routes.py` in G2.219.
+- Do not convert direct calls to `Depends` in this decision package.
+- Do not change route contracts, response models, miniQMT evidence semantics, or tests from this package.
+- Use the existing test monkeypatch seam as evidence that injection is possible, not as permission to start implementation.
+
+## Next Gate
+
+Start G2.220 as a no-source authorization package for the trade execution tracking evidence provider.
+
+G2.220 should decide the exact future implementation boundary before any source edit:
+
+- Whether to convert list/detail direct provider calls to explicit route dependency/provider injection.
+- Whether `_load_execution_records` should accept an injected evidence service from the route handler or keep calling the helper.
+- Which focused tests must prove behavior stays stable.
+- How to handle app.main/OpenAPI smoke when required environment variables are absent.
+- The precise allowed source and test paths for any later implementation lane.
+
+## Not Changed
+
+- No backend source edits.
+- No tests changed.
+- No route/OpenAPI contracts changed.
+- No OpenSpec proposal or spec files changed.
+- No GitHub issue or PR labels changed.
+- No DataService, Strategy, data-quality monitor, realtime/socket, cache prewarming, root facade, `adapter_split`, or `market_data_adapter.py` work opened.
+
+## Evidence Artifacts
+
+| Artifact | Purpose |
+|---|---|
+| `.planning/codebase/generated/execution-tracking-evidence-provider-ownership-decision-2026-05-29.json` | Machine-readable G2.219 ownership decision evidence |
+| `docs/reports/quality/backend-execution-tracking-evidence-provider-ownership-decision-2026-05-29.md` | Human-readable G2.219 decision report |
+| `governance/mainline/task-cards/pr-372.yaml` | Mainline governance task card |

--- a/governance/mainline/task-cards/pr-372.yaml
+++ b/governance/mainline/task-cards/pr-372.yaml
@@ -1,0 +1,124 @@
+version: "v0.2"
+
+task:
+  id: "pr-372"
+  title: "Classify execution tracking evidence provider ownership"
+  owner: "codex"
+  created_at: "2026-05-29"
+
+mainline:
+  id: "L1-execution-tracking-evidence-provider-ownership"
+  objective: "classify get_execution_tracking_evidence_service ownership and select the next no-source authorization gate without source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "G2.219 is a no-source ownership decision package. It changes no runtime route entrypoint, public HTTP API, OpenAPI exposure, PM2 workflow, frontend behavior, source code, or tests."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/execution-tracking-evidence-provider-ownership-decision-2026-05-29.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-execution-tracking-evidence-provider-ownership-decision-2026-05-29.md"
+    - "governance/mainline/task-cards/pr-372.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits"
+  - "test edits"
+  - "route/OpenAPI contract changes"
+  - "route provider wrapper implementation"
+  - "FastAPI Depends conversion"
+  - "ExecutionTrackingEvidenceService implementation changes"
+  - "miniQMT evidence semantic changes"
+  - "DataService, Strategy, data-quality, realtime/socket, cache, root-facade, adapter_split, or market_data_adapter changes"
+  - "GitHub issue or PR label changes"
+  - "OpenSpec proposal or spec creation"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_trade_execution_tracking_routes.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/api/trade/execution_tracking_routes.py web/backend/tests/test_trade_execution_tracking_routes.py"
+      required: true
+    - id: "json-yaml-parse"
+      command: "python - <<'PY'\nimport json, yaml\nfor path in ['.planning/codebase/generated/execution-tracking-evidence-provider-ownership-decision-2026-05-29.json', '.planning/codebase/steward-tree/steward-index.json']:\n    with open(path, encoding='utf-8') as f:\n        json.load(f)\nwith open('governance/mainline/task-cards/pr-372.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-execution-tracking-evidence-provider-ownership-decision-2026-05-29.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-372.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha d4ee917ad642939c4c60000998b8bea5ca7c9a65 --head-sha HEAD --report /tmp/pr372-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "The target has HIGH GitNexus impact, so this package deliberately stops at ownership classification."
+    - "OpenAPI app smoke is environment-blocked; source implementation must not start until a later gate disposes of that blocker."
+    - "The existing monkeypatch seam could be mistaken for implementation authorization; this card keeps it evidence-only."
+  rollback_plan: "Revert this PR; no runtime source or test changes are present."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Classify get_execution_tracking_evidence_service ownership and choose the next gate."
+    modified_scope: "Governance reports, generated evidence, steward tree, and task card only."
+    dependency_changes: "None."
+    legacy_logic_impact: "None; no source or test files are modified."
+    rollback_ready: "Yes; revert the PR."
+    risk_and_rollback_point: "Do not start source implementation; G2.220 must first authorize exact route/provider scope."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "current review thread human maintainer"
+    approved_at: "2026-05-29T01:42:47+08:00"
+    approval_note: "Approved to continue from merged PR #371 into the G2.219 no-source get_execution_tracking_evidence_service ownership decision lane."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- merge-forward from accepted PR #371 and classify get_execution_tracking_evidence_service ownership
- record GitNexus HIGH impact: 2 direct callers, 3 affected processes, Trade module
- classify the target as a trade route/provider ownership surface, not a generic singleton cleanup
- select G2.220 no-source authorization package before any route/provider implementation

## Verification
- pytest: web/backend/tests/test_trade_execution_tracking_routes.py => 4 passed
- ruff: execution_tracking_routes.py + test_trade_execution_tracking_routes.py passed
- markdown governance: 6 checked files, 0 errors
- OpenSpec strict validate: valid (PostHog telemetry noise only)
- mainline scope gate: pass=True
- GitNexus staged/compare: low risk, 0 changed symbols, 0 affected processes

## Boundary
No source, test, route/OpenAPI, OpenSpec, config, script, frontend, or issue-label changes. OpenAPI app smoke is environment-blocked by missing required env vars and is recorded as a blocker for any later source lane.