### PR TITLE
G2.220 authorize execution tracking evidence provider seam

### DIFF
--- a/.planning/codebase/generated/execution-tracking-evidence-provider-authorization-2026-05-29.json
+++ b/.planning/codebase/generated/execution-tracking-evidence-provider-authorization-2026-05-29.json
@@ -1,0 +1,140 @@
+{
+  "schema_version": "2026-05-29.execution-tracking-evidence-provider-authorization.v1",
+  "generated_at": "2026-05-29T02:01:47+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "branch": "g2-220-execution-tracking-evidence-provider-authorization",
+  "base_head": "b51256b775f7b4c6e5baad8c82a7f86446c0151b",
+  "openspec_lane": "migrate-backend-singletons-to-lifecycle-di",
+  "source_edit_authority": false,
+  "parent": {
+    "g2": "G2.219",
+    "github_pr": 372,
+    "state": "MERGED",
+    "merge_commit": "b51256b775f7b4c6e5baad8c82a7f86446c0151b",
+    "summary": "Execution tracking evidence provider ownership decision accepted into wip/root-dirty-20260403"
+  },
+  "target": {
+    "symbol": "get_execution_tracking_evidence_service",
+    "file": "web/backend/app/api/trade/execution_tracking_routes.py",
+    "definition_line": 289,
+    "classification": "trade execution tracking route/provider seam"
+  },
+  "current_shape": {
+    "provider_definition": "def get_execution_tracking_evidence_service() -> ExecutionTrackingEvidenceService",
+    "provider_factory_line": 290,
+    "direct_call_lines": [
+      364,
+      542
+    ],
+    "load_helper": "_load_execution_records",
+    "list_route": "get_execution_tracking",
+    "detail_route": "get_execution_tracking_detail",
+    "trigger_route_scope": "out_of_scope"
+  },
+  "fresh_impact": {
+    "gitnexus_repo": "mystocks_spec",
+    "risk": "HIGH",
+    "impacted_count": 2,
+    "direct_callers": [
+      "_load_execution_records",
+      "get_execution_tracking_detail"
+    ],
+    "processes_affected": 3,
+    "modules_affected": [
+      "Trade"
+    ]
+  },
+  "authorization_decision": {
+    "state": "authorized_for_future_implementation_after_acceptance",
+    "authorized_future_g2": "G2.221",
+    "source_implementation_allowed_in_this_package": false,
+    "future_source_authority_if_g2_220_accepted": true,
+    "allowed_future_source_paths": [
+      "web/backend/app/api/trade/execution_tracking_routes.py"
+    ],
+    "allowed_future_test_paths": [
+      "web/backend/tests/test_trade_execution_tracking_routes.py"
+    ],
+    "forbidden_future_source_paths": [
+      "web/backend/app/api/trade/** except execution_tracking_routes.py",
+      "web/backend/app/services/**",
+      "web/backend/app/api/** outside web/backend/app/api/trade/execution_tracking_routes.py",
+      "web/backend/tests/** outside web/backend/tests/test_trade_execution_tracking_routes.py",
+      "web/frontend/**",
+      "src/**",
+      "docs/api/**",
+      "openspec/changes/**",
+      "openspec/specs/**"
+    ],
+    "authorized_future_pattern": [
+      "preserve get_execution_tracking_evidence_service as the default provider factory",
+      "add route dependency/provider injection for list and detail execution tracking flows",
+      "pass the injected evidence service into _load_execution_records instead of calling the provider helper inside the helper",
+      "inject the evidence service into get_execution_tracking_detail instead of calling the provider helper in the route body",
+      "leave trigger_external_execution out of scope",
+      "update focused tests to use FastAPI dependency override or equivalent explicit injection seam"
+    ],
+    "contract_invariants": [
+      "no path changes",
+      "no response_model changes",
+      "no UnifiedResponse shape changes",
+      "no request schema changes",
+      "no miniQMT evidence semantic changes",
+      "no broker_state or bridge evidence interpretation changes"
+    ],
+    "pre_implementation_gate": [
+      "run GitNexus impact before source edits",
+      "rerun app.main/OpenAPI smoke before claiming the later source implementation complete",
+      "run focused trade execution tracking tests before and after implementation",
+      "run ruff on the changed route/test files"
+    ]
+  },
+  "verification": {
+    "pytest": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_trade_execution_tracking_routes.py -q --no-cov --tb=short",
+      "result": "4 passed in 2.13s"
+    },
+    "ruff": {
+      "command": "ruff check web/backend/app/api/trade/execution_tracking_routes.py web/backend/tests/test_trade_execution_tracking_routes.py",
+      "result": "All checks passed!"
+    },
+    "openspec": {
+      "command": "openspec validate migrate-backend-singletons-to-lifecycle-di --strict",
+      "result": "Change 'migrate-backend-singletons-to-lifecycle-di' is valid",
+      "telemetry_note": "PostHog network flush failure is telemetry noise."
+    },
+    "openapi_smoke": {
+      "command": "python -c import app.main and app.openapi() with transient runtime environment",
+      "result": "passed",
+      "verified_at": "2026-05-29T02:24:28+08:00",
+      "route_count": 548,
+      "openapi_paths": 500,
+      "secret_handling": "required environment keys were supplied transiently; secret values were not persisted or recorded",
+      "required_rerun_for_g2_221": true
+    }
+  },
+  "next_gate": {
+    "g2": "G2.221",
+    "title": "trade execution tracking evidence provider route injection implementation",
+    "source_edit_authority": "conditional_on_accepting_g2_220",
+    "scope": [
+      "path-limited implementation in execution_tracking_routes.py",
+      "focused test updates in test_trade_execution_tracking_routes.py",
+      "governance evidence and task card only"
+    ]
+  },
+  "forbidden_scope_this_package": [
+    "web/backend/**",
+    "web/frontend/**",
+    "src/**",
+    "tests/**",
+    "docs/api/**",
+    "docs/FUNCTION_TREE.md",
+    "governance/function-tree/catalog.yaml",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**"
+  ]
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-29T01:42:47+08:00`
-- Base HEAD checked: `d4ee917ad642939c4c60000998b8bea5ca7c9a65`
+- Prepared at: `2026-05-29T02:01:47+08:00`
+- Base HEAD checked: `b51256b775f7b4c6e5baad8c82a7f86446c0151b`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -56,12 +56,13 @@ PRs, change issue labels, or authorize source implementation.
 | `#369` | `g2-216-indicator-data-service-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `68ba10829b89095f8b907d249f59198995543ebc` | No-source authorization selecting G2.217 `DataService` provider/reset seam implementation |
 | `#370` | `g2-217-data-service-provider-reset-seam` | `wip/root-dirty-20260403` | `MERGED` at `4d2b69e449975d145976e10c8af965e16dc60a1e` | Path-limited implementation adding `DataService` provider/reset seam while preserving default singleton fallback |
 | `#371` | `g2-218-data-service-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `d4ee917ad642939c4c60000998b8bea5ca7c9a65` | No-source closeout selecting G2.219 `get_execution_tracking_evidence_service` ownership decision |
+| `#372` | `g2-219-execution-tracking-evidence-provider-decision` | `wip/root-dirty-20260403` | `MERGED` at `b51256b775f7b4c6e5baad8c82a7f86446c0151b` | No-source ownership decision selecting G2.220 trade execution tracking evidence provider authorization |
 
 ## Steward Governance Branch
 
 | Branch | Base | Purpose | Source authority |
 |---|---|---|---|
-| `g2-219-execution-tracking-evidence-provider-decision` | `origin/wip/root-dirty-20260403` at `d4ee917ad642939c4c60000998b8bea5ca7c9a65` | Classify `get_execution_tracking_evidence_service` ownership and select the next no-source authorization gate | No |
+| `g2-220-execution-tracking-evidence-provider-authorization` | `origin/wip/root-dirty-20260403` at `b51256b775f7b4c6e5baad8c82a7f86446c0151b` | Authorize the exact future route/provider injection boundary for `get_execution_tracking_evidence_service` | No |
 
 ## OpenSpec Relationship
 
@@ -77,7 +78,7 @@ owning OpenSpec branch or an approved implementation authorization package.
 
 ## Merge Ordering Note
 
-G2.219 is a no-source ownership decision branch after PR `#371` merged G2.218.
-It is limited to governance evidence, steward tree updates, and a task card. If
-accepted, the next gate is G2.220 trade execution tracking evidence provider
-authorization, also with no source edits.
+G2.220 is a no-source authorization branch after PR `#372` merged G2.219. It is
+limited to governance evidence, steward tree updates, and a task card. If
+accepted, the next gate is G2.221 path-limited implementation in the trade
+execution tracking route/test pair.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-29T01:42:47+08:00`
-- Base HEAD checked: `d4ee917ad642939c4c60000998b8bea5ca7c9a65`
+- Prepared at: `2026-05-29T02:01:47+08:00`
+- Base HEAD checked: `b51256b775f7b4c6e5baad8c82a7f86446c0151b`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -21,7 +21,7 @@ exact verification output.
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
 | Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, and closeout pattern across multiple services | Continue with path-limited source lanes only after authorization |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 merged by PR `#363`; G2.211 merged by PR `#364`; G2.212 merged by PR `#365`; G2.213 merged by PR `#366`; G2.214 merged by PR `#367`; G2.215 merged by PR `#368`; G2.216 merged by PR `#369`; G2.217 merged by PR `#370`; G2.218 merged by PR `#371`; G2.219 is the active no-source `get_execution_tracking_evidence_service` ownership decision |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184 merged by PR `#337`; G2.185 merged by PR `#338`; G2.186 merged by PR `#339`; G2.187 merged by PR `#340`; G2.188 merged by PR `#341`; G2.189 merged by PR `#342`; G2.190 merged by PR `#343`; G2.191 merged by PR `#344`; G2.192 merged by PR `#345`; G2.193 merged by PR `#346`; G2.194 merged by PR `#347`; G2.195 merged by PR `#348`; G2.196 merged by PR `#349`; G2.197 merged by PR `#350`; G2.198 merged by PR `#351`; G2.199 merged by PR `#352`; G2.200 merged by PR `#353`; G2.201 merged by PR `#354`; G2.202 merged by PR `#355`; G2.203 merged by PR `#356`; G2.204 merged by PR `#357`; G2.205 merged by PR `#358`; G2.206 merged by PR `#359`; G2.207 merged by PR `#360`; G2.208 merged by PR `#361`; G2.209 merged by PR `#362`; G2.210 merged by PR `#363`; G2.211 merged by PR `#364`; G2.212 merged by PR `#365`; G2.213 merged by PR `#366`; G2.214 merged by PR `#367`; G2.215 merged by PR `#368`; G2.216 merged by PR `#369`; G2.217 merged by PR `#370`; G2.218 merged by PR `#371`; G2.219 merged by PR `#372`; G2.220 is the active no-source trade execution tracking evidence provider authorization |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Closeout Rule

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-29T01:42:47+08:00`
-- Base HEAD checked: `d4ee917ad642939c4c60000998b8bea5ca7c9a65`
+- Prepared at: `2026-05-29T02:01:47+08:00`
+- Base HEAD checked: `b51256b775f7b4c6e5baad8c82a7f86446c0151b`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,7 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.219 trade execution tracking evidence provider ownership decision | G/#79 service lifecycle DI + trade route/provider governance | PR `#371` merged at `d4ee917ad642939c4c60000998b8bea5ca7c9a65`; G2.219 classifies `get_execution_tracking_evidence_service` as a high-impact trade route/provider surface, not a generic singleton cleanup | If accepted, start G2.220 no-source authorization package; do not start source implementation directly |
+| P0 | Review G2.220 trade execution tracking evidence provider authorization | G/#79 service lifecycle DI + trade route/provider governance | PR `#372` merged at `b51256b775f7b4c6e5baad8c82a7f86446c0151b`; G2.220 authorizes a future path-limited G2.221 route/provider injection lane, but makes no source change itself | If accepted, start G2.221 implementation limited to `execution_tracking_routes.py`, `test_trade_execution_tracking_routes.py`, and governance evidence |
 | P0 | Preserve G2.214 non-Strategy provider governance queue refresh / next-candidate selection | G/#79 service lifecycle DI | PR `#367` merged; G2.214 selected G2.215 indicator/data `get_data_service` current-HEAD contradiction decision as the next no-source gate | Do not reopen other non-Strategy candidates from G2.214 without fresh current-HEAD contradiction evidence |
 | P0 | Preserve G2.213 data-quality monitor singleton/backing API closeout / residual refresh | G/#79 service lifecycle DI | PR `#366` merged; data-quality monitor conveyor selects no new source lane | Do not reopen data-quality monitor source unless fresh current-HEAD evidence contradicts accepted closeout |
 | P0 | Preserve G2.212 data-quality monitor singleton/backing API compatibility implementation | G/#79 service lifecycle DI | PR `#365` merged; provider/reset hook is implemented and default singleton fallback is preserved | Do not reopen data-quality monitor singleton source unless fresh current-HEAD evidence contradicts G2.212/G2.213 |
@@ -57,9 +57,9 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 ## Immediate Review Questions
 
-- Does G2.219 correctly treat PR `#371` as merged and accepted into `wip/root-dirty-20260403`?
-- Does the GitNexus `HIGH` impact on `get_execution_tracking_evidence_service` remain visible as a stop sign for direct implementation?
-- Does G2.219 classify the target as trade route/provider ownership rather than a generic singleton cleanup?
-- Does G2.219 keep all backend source, tests, route/OpenAPI contracts, OpenSpec changes, and issue label changes out of scope?
-- Is G2.220 correctly positioned as a no-source authorization package before any implementation lane?
+- Does G2.220 correctly treat PR `#372` as merged and accepted into `wip/root-dirty-20260403`?
+- Does G2.220 preserve the GitNexus `HIGH` impact as a path-limit and pre-edit impact gate for G2.221?
+- Does G2.220 authorize only the route/test pair needed for provider injection and keep all other source out of scope?
+- Does G2.220 preserve route paths, response models, `UnifiedResponse`, request schemas, and miniQMT semantics as invariants?
+- Is G2.221 correctly positioned as the first source implementation lane after this authorization, not before?
 - Are implementation, authorization, decision, and evidence lanes still distinct?

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-29T01:42:47+08:00`
-- Base HEAD checked: `d4ee917ad642939c4c60000998b8bea5ca7c9a65`
+- Prepared at: `2026-05-29T02:01:47+08:00`
+- Base HEAD checked: `b51256b775f7b4c6e5baad8c82a7f86446c0151b`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -99,8 +99,10 @@ state transition.
 | `docs/reports/quality/backend-data-service-provider-reset-seam-implementation-2026-05-29.md` | G2.217 human-readable implementation report | Accepted by PR `#370`; superseded for closeout evidence by G2.218 |
 | `.planning/codebase/generated/data-service-provider-closeout-refresh-2026-05-29.json` | G2.218 `DataService` provider/reset seam closeout and residual refresh evidence | Accepted by PR `#371`; superseded for next ownership evidence by G2.219 |
 | `docs/reports/quality/backend-data-service-provider-closeout-refresh-2026-05-29.md` | G2.218 human-readable closeout / residual refresh report | Accepted by PR `#371`; superseded for next ownership evidence by G2.219 |
-| `.planning/codebase/generated/execution-tracking-evidence-provider-ownership-decision-2026-05-29.json` | G2.219 `get_execution_tracking_evidence_service` ownership decision evidence | Review input until PR `#372` is accepted |
-| `docs/reports/quality/backend-execution-tracking-evidence-provider-ownership-decision-2026-05-29.md` | G2.219 human-readable ownership decision report | Review input until PR `#372` is accepted |
+| `.planning/codebase/generated/execution-tracking-evidence-provider-ownership-decision-2026-05-29.json` | G2.219 `get_execution_tracking_evidence_service` ownership decision evidence | Accepted by PR `#372`; superseded for authorization evidence by G2.220 |
+| `docs/reports/quality/backend-execution-tracking-evidence-provider-ownership-decision-2026-05-29.md` | G2.219 human-readable ownership decision report | Accepted by PR `#372`; superseded for authorization evidence by G2.220 |
+| `.planning/codebase/generated/execution-tracking-evidence-provider-authorization-2026-05-29.json` | G2.220 trade execution tracking evidence provider authorization evidence | Review input until PR `#373` is accepted |
+| `docs/reports/quality/backend-execution-tracking-evidence-provider-authorization-2026-05-29.md` | G2.220 human-readable authorization report | Review input until PR `#373` is accepted |
 
 ## External State Inputs
 
@@ -132,7 +134,8 @@ state transition.
 | GitHub PR `#358` | `MERGED` | G2.205 legacy adapter wrapper closeout / residual refresh merged by commit `44909f5d048700115da6a9eb9345957b8af3d077` |
 | GitHub PR `#359` | `MERGED` | G2.206 `market_data_adapter.py` ownership decision merged by commit `ded789ee5d49d6ddcce5d8a69af1901a8481d1f0` |
 | GitHub PR `#360` | `MERGED` | G2.207 `market_data_adapter.py` provider seam authorization merged by commit `b4b34375eef0186b81be9a24491328dab72c2e21` |
-| `origin/wip/root-dirty-20260403` | `b4b34375eef0186b81be9a24491328dab72c2e21` | Base used for this implementation branch |
+| GitHub PR `#372` | `MERGED` | G2.219 `get_execution_tracking_evidence_service` ownership decision merged by commit `b51256b775f7b4c6e5baad8c82a7f86446c0151b` |
+| `origin/wip/root-dirty-20260403` | `b51256b775f7b4c6e5baad8c82a7f86446c0151b` | Base used for this authorization branch |
 | Root worktree | Dirty/stale relative to remote | Not used as the edit surface for this split |
 
 ## Evidence Recording Rules

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-29T01:42:47+08:00",
+  "generated_at": "2026-05-29T02:01:47+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "d4ee917ad642939c4c60000998b8bea5ca7c9a65",
-  "split_branch": "g2-219-execution-tracking-evidence-provider-decision",
-  "scope": "execution_tracking_evidence_provider_ownership_decision",
+  "base_head": "b51256b775f7b4c6e5baad8c82a7f86446c0151b",
+  "split_branch": "g2-220-execution-tracking-evidence-provider-authorization",
+  "scope": "execution_tracking_evidence_provider_authorization",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -2625,10 +2625,13 @@
     {
       "id": "g2-219-execution-tracking-evidence-provider-decision",
       "type": "decision_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI + trade route/provider governance",
       "parent": "G2.218 DataService provider/reset seam closeout / residual refresh",
       "source_edit_authority": false,
+      "github_pr": 372,
+      "head_ref": "g2-219-execution-tracking-evidence-provider-decision",
+      "merge_commit": "b51256b775f7b4c6e5baad8c82a7f86446c0151b",
       "parent_github_pr": 371,
       "parent_merge_commit": "d4ee917ad642939c4c60000998b8bea5ca7c9a65",
       "evidence": [
@@ -2661,7 +2664,7 @@
         "source_implementation_allowed_now": false,
         "selected_next_gate": "G2.220 trade execution tracking evidence provider authorization package"
       },
-      "next_gate": "If accepted, start G2.220 no-source authorization package; do not start source implementation directly.",
+      "next_gate": "Superseded by G2.220 trade execution tracking evidence provider authorization.",
       "allowed_scope": [
         ".planning/codebase/generated/execution-tracking-evidence-provider-ownership-decision-2026-05-29.json",
         ".planning/codebase/steward-tree/current-next-gates.md",
@@ -2687,7 +2690,99 @@
         "openspec/specs/**"
       ],
       "freshness": {
-        "current_head_checked": "d4ee917ad642939c4c60000998b8bea5ca7c9a65",
+        "current_head_checked": "b51256b775f7b4c6e5baad8c82a7f86446c0151b",
+        "stale_if_head_mismatch": true
+      }
+    },
+    {
+      "id": "g2-220-execution-tracking-evidence-provider-authorization",
+      "type": "authorization_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + trade route/provider governance",
+      "parent": "G2.219 get_execution_tracking_evidence_service ownership decision",
+      "source_edit_authority": false,
+      "parent_github_pr": 372,
+      "parent_merge_commit": "b51256b775f7b4c6e5baad8c82a7f86446c0151b",
+      "evidence": [
+        ".planning/codebase/generated/execution-tracking-evidence-provider-authorization-2026-05-29.json",
+        "docs/reports/quality/backend-execution-tracking-evidence-provider-authorization-2026-05-29.md",
+        "governance/mainline/task-cards/pr-373.yaml"
+      ],
+      "target": {
+        "symbol": "get_execution_tracking_evidence_service",
+        "file": "web/backend/app/api/trade/execution_tracking_routes.py",
+        "definition_line": 289,
+        "classification": "trade evidence route-local provider surface",
+        "direct_callers": [
+          "_load_execution_records",
+          "get_execution_tracking_detail"
+        ]
+      },
+      "gitnexus_impact": {
+        "risk": "HIGH",
+        "impacted_count": 2,
+        "direct_callers": 2,
+        "processes_affected": 3,
+        "modules_affected": 1,
+        "affected_module": "Trade"
+      },
+      "future_authorized_scope": {
+        "implementation_lane": "G2.221 path-limited execution tracking provider injection",
+        "allowed_source_paths": [
+          "web/backend/app/api/trade/execution_tracking_routes.py"
+        ],
+        "allowed_test_paths": [
+          "web/backend/tests/test_trade_execution_tracking_routes.py"
+        ],
+        "allowed_pattern": [
+          "preserve get_execution_tracking_evidence_service as default provider factory",
+          "inject the evidence service into execution tracking list/detail routes",
+          "pass the injected service into _load_execution_records",
+          "update focused tests with explicit dependency override or equivalent injection seam"
+        ],
+        "invariants": [
+          "no route path changes",
+          "no response_model changes",
+          "no UnifiedResponse envelope changes",
+          "no request schema changes",
+          "no miniQMT evidence semantic changes",
+          "no broker_state or bridge evidence interpretation changes",
+          "trigger_external_execution remains out of scope"
+        ]
+      },
+      "verification": {
+        "focused_trade_route_tests": "web/backend/tests/test_trade_execution_tracking_routes.py: required before and after future implementation",
+        "ruff": "required on the authorized route/test pair",
+        "openspec_validate": "required for migrate-backend-singletons-to-lifecycle-di",
+        "openapi_smoke": "G2.220 baseline passed with transient runtime environment: route_count=548, openapi_paths=500; rerun after future G2.221 source edits"
+      },
+      "next_gate": "If accepted, start G2.221 path-limited implementation; do not expand beyond execution_tracking_routes.py, test_trade_execution_tracking_routes.py, and governance evidence.",
+      "allowed_scope": [
+        ".planning/codebase/generated/execution-tracking-evidence-provider-authorization-2026-05-29.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-execution-tracking-evidence-provider-authorization-2026-05-29.md",
+        "governance/mainline/task-cards/pr-373.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "tests/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "freshness": {
+        "current_head_checked": "b51256b775f7b4c6e5baad8c82a7f86446c0151b",
         "stale_if_head_mismatch": true
       }
     },

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -1047,11 +1047,56 @@ G2.219 selects G2.220 as a no-source authorization package to define whether a
 later path-limited implementation should convert list/detail direct provider
 calls to explicit route dependency/provider injection.
 
+## G2.220 Trade Execution Tracking Evidence Provider Authorization
+
+G2.220 is a no-source authorization package after PR `#372` merged at
+`b51256b775f7b4c6e5baad8c82a7f86446c0151b`.
+
+Authorization decision:
+
+| Item | Value |
+|---|---|
+| G2.220 source authority | none |
+| Conditional next implementation | G2.221 only after review acceptance |
+| Allowed implementation source path | `web/backend/app/api/trade/execution_tracking_routes.py` |
+| Allowed implementation test path | `web/backend/tests/test_trade_execution_tracking_routes.py` |
+| Out of scope | `trigger_external_execution`, miniQMT semantics, response contracts, request schemas |
+
+Authorized future G2.221 pattern, if this package is accepted:
+
+- preserve `get_execution_tracking_evidence_service` as the default provider factory
+- add explicit route dependency/provider injection for execution tracking list/detail flows
+- pass the injected evidence service into `_load_execution_records`
+- inject the evidence service into `get_execution_tracking_detail`
+- update focused tests to use FastAPI dependency override or an equivalent explicit injection seam
+
+Contract invariants:
+
+- no route path changes
+- no `response_model` changes
+- no `UnifiedResponse` envelope changes
+- no request schema changes
+- no miniQMT evidence semantic changes
+- no `broker_state` or bridge evidence interpretation changes
+
+Pre-implementation gates for a later G2.221 lane:
+
+- rerun GitNexus impact before source edits
+- rerun app.main/OpenAPI smoke after source edits before claiming implementation complete
+- run focused execution tracking route tests before and after edits
+- run ruff on the touched route/test pair
+- keep staged scope limited to the authorized route/test pair plus governance evidence
+
+G2.220 baseline app.main/OpenAPI smoke passed with transient runtime
+environment: `route_count=548`, `openapi_paths=500`. Secret values were not
+persisted in repository files or recorded in this track summary.
+
 ## Next Gates
 
-- Review G2.219 trade execution tracking evidence provider ownership decision.
-- If accepted, start G2.220 no-source trade execution tracking evidence provider authorization.
-- Do not start source implementation directly from G2.219 or G2.220.
+- Review G2.220 trade execution tracking evidence provider authorization.
+- If accepted, start G2.221 path-limited implementation for the execution tracking route/test pair.
+- Do not expand G2.221 beyond `execution_tracking_routes.py`,
+  `test_trade_execution_tracking_routes.py`, and governance evidence.
 - Do not open another data-quality monitor source lane unless fresh current-HEAD evidence contradicts the accepted closeout.
 - Do not batch service adapters, legacy adapters, `market_data_adapter.py`, or
   singleton-wrapper migration with `adapter_split` constructor migration.

--- a/docs/reports/quality/backend-execution-tracking-evidence-provider-authorization-2026-05-29.md
+++ b/docs/reports/quality/backend-execution-tracking-evidence-provider-authorization-2026-05-29.md
@@ -1,0 +1,126 @@
+# Backend Execution Tracking Evidence Provider Authorization - 2026-05-29
+
+> **历史文档说明**: 本文件是 G2.220 执行证据快照，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Branch: `g2-220-execution-tracking-evidence-provider-authorization`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD checked: `b51256b775f7b4c6e5baad8c82a7f86446c0151b`
+- Prepared at: `2026-05-29T02:01:47+08:00`
+- OpenSpec lane: `migrate-backend-singletons-to-lifecycle-di`
+- Source authority in this package: none
+
+## Parent Merge
+
+| Item | State |
+|---|---|
+| Parent decision | G2.219 `get_execution_tracking_evidence_service` ownership decision |
+| GitHub PR | `#372` |
+| PR state | `MERGED` |
+| Merge commit | `b51256b775f7b4c6e5baad8c82a7f86446c0151b` |
+
+G2.220 starts from the accepted G2.219 classification. It authorizes a future implementation lane only after this package is reviewed and accepted.
+
+## Current Shape
+
+| Item | Value |
+|---|---|
+| Provider helper | `get_execution_tracking_evidence_service` |
+| Provider definition | `web/backend/app/api/trade/execution_tracking_routes.py:289` |
+| Provider factory | line 290 |
+| Direct provider call lines | 364, 542 |
+| List route | `get_execution_tracking` |
+| Detail route | `get_execution_tracking_detail` |
+| Trigger route | out of scope |
+| Current dependency style | direct helper calls, no FastAPI `Depends` for this provider |
+
+GitNexus impact remains a stop sign for broad edits:
+
+| Metric | Value |
+|---|---:|
+| Risk | `HIGH` |
+| Direct callers | 2 |
+| Affected processes | 3 |
+| Affected modules | 1 |
+
+Direct callers:
+
+- `_load_execution_records`
+- `get_execution_tracking_detail`
+
+## Authorization
+
+If G2.220 is accepted, G2.221 may proceed as a path-limited source implementation lane.
+
+Authorized future source paths:
+
+| Path | Scope |
+|---|---|
+| `web/backend/app/api/trade/execution_tracking_routes.py` | convert the execution tracking evidence provider access to route dependency/provider injection |
+| `web/backend/tests/test_trade_execution_tracking_routes.py` | update or add focused tests for the injection seam |
+
+Authorized future implementation pattern:
+
+- Preserve `get_execution_tracking_evidence_service` as the default provider factory.
+- Add route dependency/provider injection for the list and detail execution tracking flows.
+- Pass the injected evidence service into `_load_execution_records` instead of calling the provider helper inside that helper.
+- Inject the evidence service into `get_execution_tracking_detail` instead of calling the provider helper in the route body.
+- Leave `trigger_external_execution` out of scope.
+- Update focused tests to use FastAPI dependency override or an equivalent explicit injection seam.
+
+Contract invariants for any future implementation:
+
+- No path changes.
+- No `response_model` changes.
+- No `UnifiedResponse` shape changes.
+- No request schema changes.
+- No miniQMT evidence semantic changes.
+- No `broker_state` or bridge evidence interpretation changes.
+
+## Pre-Implementation Gate For G2.221
+
+Before editing source in G2.221:
+
+- Run GitNexus impact on `get_execution_tracking_evidence_service`.
+- Rerun app.main/OpenAPI smoke before claiming the later source implementation complete.
+- Run `web/backend/tests/test_trade_execution_tracking_routes.py` as the focused baseline.
+- Run ruff on the route and test files.
+- Keep staged scope limited to the authorized source/test paths plus governance evidence.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| `web/backend/tests/test_trade_execution_tracking_routes.py` | `4 passed in 2.13s` |
+| Ruff on route and test files | `All checks passed!` |
+| OpenSpec strict validate | `Change 'migrate-backend-singletons-to-lifecycle-di' is valid` |
+| app.main/OpenAPI smoke | passed with transient runtime environment; `route_count=548`, `openapi_paths=500` |
+
+The G2.220 app.main/OpenAPI smoke used transient environment values only. Secret
+values were not persisted in repository files or recorded in this report. G2.221
+must rerun this smoke after the future source implementation before claiming the
+implementation complete.
+
+## Not Changed
+
+- No backend source edits.
+- No tests changed.
+- No route/OpenAPI contracts changed.
+- No OpenSpec proposal or spec files changed.
+- No GitHub issue or PR labels changed.
+- No DataService, Strategy, data-quality monitor, realtime/socket, cache prewarming, root facade, `adapter_split`, or `market_data_adapter.py` work opened.
+
+## Next Gate
+
+If this authorization package is accepted, start G2.221 as the path-limited trade execution tracking evidence provider route injection implementation lane.
+
+G2.221 should not expand beyond the two authorized implementation paths and the governance evidence required for the PR.
+
+## Evidence Artifacts
+
+| Artifact | Purpose |
+|---|---|
+| `.planning/codebase/generated/execution-tracking-evidence-provider-authorization-2026-05-29.json` | Machine-readable G2.220 authorization evidence |
+| `docs/reports/quality/backend-execution-tracking-evidence-provider-authorization-2026-05-29.md` | Human-readable G2.220 authorization report |
+| `governance/mainline/task-cards/pr-373.yaml` | Mainline governance task card |

--- a/governance/mainline/task-cards/pr-373.yaml
+++ b/governance/mainline/task-cards/pr-373.yaml
@@ -1,0 +1,123 @@
+version: "v0.2"
+
+task:
+  id: "pr-373"
+  title: "Authorize execution tracking evidence provider injection"
+  owner: "codex"
+  created_at: "2026-05-29"
+
+mainline:
+  id: "L1-execution-tracking-evidence-provider-authorization"
+  objective: "authorize the exact future route/provider injection boundary for get_execution_tracking_evidence_service without source edits"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "G2.220 is a no-source authorization package. It changes no runtime route entrypoint, public HTTP API, OpenAPI exposure, PM2 workflow, frontend behavior, source code, or tests."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/execution-tracking-evidence-provider-authorization-2026-05-29.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-execution-tracking-evidence-provider-authorization-2026-05-29.md"
+    - "governance/mainline/task-cards/pr-373.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits in this PR"
+  - "test edits in this PR"
+  - "route/OpenAPI contract changes"
+  - "ExecutionTrackingEvidenceService implementation changes"
+  - "miniQMT evidence semantic changes"
+  - "DataService, Strategy, data-quality, realtime/socket, cache, root-facade, adapter_split, or market_data_adapter changes"
+  - "GitHub issue or PR label changes"
+  - "OpenSpec proposal or spec creation"
+
+acceptance:
+  checks:
+    - id: "focused-pytest"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_trade_execution_tracking_routes.py -q --no-cov --tb=short"
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/api/trade/execution_tracking_routes.py web/backend/tests/test_trade_execution_tracking_routes.py"
+      required: true
+    - id: "json-yaml-parse"
+      command: "python - <<'PY'\nimport json, yaml\nfor path in ['.planning/codebase/generated/execution-tracking-evidence-provider-authorization-2026-05-29.json', '.planning/codebase/steward-tree/steward-index.json']:\n    with open(path, encoding='utf-8') as f:\n        json.load(f)\nwith open('governance/mainline/task-cards/pr-373.yaml', encoding='utf-8') as f:\n    yaml.safe_load(f)\nPY"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-execution-tracking-evidence-provider-authorization-2026-05-29.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "diff-check"
+      command: "git diff --check"
+      required: true
+    - id: "cached-diff-check"
+      command: "git diff --cached --check"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-373.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha b51256b775f7b4c6e5baad8c82a7f86446c0151b --head-sha HEAD --report /tmp/pr373-mainline-governance-report.json"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "This package authorizes a future source lane but does not itself edit source; reviewers must not treat it as implementation."
+    - "The target has HIGH GitNexus impact, so the future source lane must remain path-limited."
+    - "If accepted, G2.221 may edit only web/backend/app/api/trade/execution_tracking_routes.py and web/backend/tests/test_trade_execution_tracking_routes.py, plus governance evidence."
+    - "G2.220 app.main/OpenAPI smoke passed with transient runtime environment; G2.221 must rerun smoke after source edits before claiming implementation complete."
+  rollback_plan: "Revert this PR; no runtime source or test changes are present."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Authorize exact future implementation boundaries for execution tracking evidence provider injection."
+    modified_scope: "Governance reports, generated evidence, steward tree, and task card only."
+    dependency_changes: "None."
+    legacy_logic_impact: "None; no source or test files are modified."
+    rollback_ready: "Yes; revert the PR."
+    risk_and_rollback_point: "If accepted, G2.221 may edit only the authorized route and test files plus governance evidence."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "current review thread human maintainer"
+    approved_at: "2026-05-29T02:01:47+08:00"
+    approval_note: "Approved to continue from merged PR #372 into the G2.220 no-source trade execution tracking evidence provider authorization lane."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Adds the G2.220 no-source authorization package for `get_execution_tracking_evidence_service`.
- Marks PR #372 / G2.219 as merged and superseded by G2.220 authorization evidence.
- Defines the conditional future G2.221 path-limited implementation boundary for `execution_tracking_routes.py` and `test_trade_execution_tracking_routes.py`.
- Records G2.220 app.main/OpenAPI baseline smoke as passing with transient runtime environment: route_count=548, openapi_paths=500.

## Boundary
- No backend source edits.
- No test edits.
- No route/OpenAPI contract changes.
- No OpenSpec/spec creation.
- Future implementation remains blocked until this authorization package is reviewed and accepted.
- G2.221 must rerun app.main/OpenAPI smoke after source edits before claiming implementation complete.

## Verification
- `env PYTHONPATH=web/backend pytest -o addopts= web/backend/tests/test_trade_execution_tracking_routes.py -q --no-cov --tb=short` -> 4 passed.
- `ruff check web/backend/app/api/trade/execution_tracking_routes.py web/backend/tests/test_trade_execution_tracking_routes.py` -> passed.
- app.main/OpenAPI smoke with transient runtime env -> app import passed, OpenAPI passed, route_count=548, openapi_paths=500.
- `openspec validate migrate-backend-singletons-to-lifecycle-di --strict` -> valid; PostHog telemetry flush still reports ECONNREFUSED noise.
- Mainline scope gate -> pass=True.
- Markdown governance -> 6 checked files, 0 errors.
- GitNexus compare from `b51256b775f7b4c6e5baad8c82a7f86446c0151b` -> low, 0 changed symbols, 0 affected processes.

## Secret Handling
- Runtime configuration was supplied only to smoke commands.
- Secret values were not persisted into repository files or PR text.
