### PR TITLE
docs(governance): authorize strategy monitoring db provider

### DIFF
--- a/.planning/codebase/generated/strategy-get-monitoring-db-provider-authorization-2026-05-31.json
+++ b/.planning/codebase/generated/strategy-get-monitoring-db-provider-authorization-2026-05-31.json
@@ -1,0 +1,217 @@
+{
+  "id": "g2-277-strategy-get-monitoring-db-provider-authorization",
+  "type": "authorization_package",
+  "prepared_at": "2026-06-01T00:01:42+08:00",
+  "base_head": "f48ede2ce2202318efa3411fe22fb83a8d4d920b",
+  "parent": {
+    "id": "g2-276-risk-get-monitoring-db-provider-closeout-refresh",
+    "github_pr": 429,
+    "merge_commit": "f48ede2ce2202318efa3411fe22fb83a8d4d920b",
+    "decision": "risk get_monitoring_db route-provider lane closed; strategy-management residual selected for no-source authorization"
+  },
+  "scope": {
+    "source_edit_authority": false,
+    "changed_runtime": false,
+    "changed_routes": false,
+    "changed_openapi": false,
+    "authorization_only": true
+  },
+  "gitnexus": {
+    "mcp_context": "tool call failed: Transport closed",
+    "mcp_impact": "tool call failed: Transport closed",
+    "cli_impact_uid": {
+      "target_uid": "Function:web/backend/app/api/strategy_management/_helpers.py:get_monitoring_db",
+      "direction": "upstream",
+      "risk": "LOW",
+      "impacted_count": 7,
+      "direct": 3,
+      "processes_affected": 0,
+      "modules_affected": 1,
+      "affected_module": "Strategy_management",
+      "direct_symbols": [
+        "Function:web/backend/app/api/strategy_management/_helpers.py:_handle_strategy_lifecycle_action",
+        "Function:web/backend/app/api/strategy_management/_strategy_crud_router.py:list_strategies",
+        "Function:web/backend/app/api/strategy_management/_strategy_crud_router.py:create_strategy"
+      ],
+      "depth_2_symbols": [
+        "Function:web/backend/app/api/strategy_management/_strategy_execution_router.py:start_strategy",
+        "Function:web/backend/app/api/strategy_management/_strategy_execution_router.py:pause_strategy",
+        "Function:web/backend/app/api/strategy_management/_strategy_execution_router.py:resume_strategy",
+        "Function:web/backend/app/api/strategy_management/_strategy_execution_router.py:stop_strategy"
+      ],
+      "index_status": {
+        "stale": true,
+        "commits_behind": 0,
+        "has_embeddings": false
+      }
+    }
+  },
+  "strategy_surface": {
+    "definition": "web/backend/app/api/strategy_management/_helpers.py:420",
+    "candidate_files": {
+      "web/backend/app/api/strategy_management/_helpers.py": {
+        "occurrences": 3,
+        "direct_log_calls": 2,
+        "direct_call_sites": [
+          "line 393 in _handle_strategy_lifecycle_action",
+          "line 409 in _handle_strategy_lifecycle_action"
+        ],
+        "classification": "strategy helper owns lifecycle log_operation calls behind helper-level action handling"
+      },
+      "web/backend/app/api/strategy_management/_strategy_crud_router.py": {
+        "occurrences": 4,
+        "direct_log_calls": 4,
+        "import_line": 20,
+        "direct_call_sites": [
+          "line 157 in list_strategies",
+          "line 174 in list_strategies",
+          "line 254 in create_strategy",
+          "line 271 in create_strategy"
+        ],
+        "classification": "active route-body residual candidate for future route-provider implementation"
+      },
+      "web/backend/app/utils/risk_utils.py": {
+        "definitions": 1,
+        "active_api_route_body_calls": 0,
+        "classification": "deferred utility same-name helper; not authorized by G2.277"
+      }
+    },
+    "target_handlers": [
+      "_handle_strategy_lifecycle_action",
+      "list_strategies",
+      "create_strategy"
+    ]
+  },
+  "route_openapi": {
+    "command_context": "app.main import with temporary placeholder environment values; no PM2 or stateful database gate",
+    "routes": 548,
+    "openapi_paths": 500,
+    "duplicate_operation_ids": 0,
+    "target_routes": [
+      {
+        "path": "/api/v1/strategy/strategies",
+        "method": "GET",
+        "endpoint": "list_strategies",
+        "module": "app.api.strategy_management._strategy_crud_router",
+        "include_in_schema": true,
+        "parameter_count": 4,
+        "request_body": false,
+        "response_codes": [
+          "200",
+          "400",
+          "404",
+          "422",
+          "500"
+        ]
+      },
+      {
+        "path": "/api/v1/strategy/strategies",
+        "method": "POST",
+        "endpoint": "create_strategy",
+        "module": "app.api.strategy_management._strategy_crud_router",
+        "include_in_schema": true,
+        "parameter_count": 0,
+        "request_body": true,
+        "response_codes": [
+          "200",
+          "400",
+          "404",
+          "422",
+          "500"
+        ]
+      },
+      {
+        "path": "/api/v1/strategy/strategies/{strategy_id}",
+        "method": "GET",
+        "endpoint": "get_strategy",
+        "module": "app.api.strategy_management._strategy_crud_router",
+        "include_in_schema": true,
+        "parameter_count": 1,
+        "request_body": false,
+        "response_codes": [
+          "200",
+          "400",
+          "404",
+          "422",
+          "500"
+        ]
+      }
+    ]
+  },
+  "test_inventory": {
+    "focused_test_attempt": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= tests/api/file_tests/test_strategy_management_api.py -q -n 0 --tb=short --no-cov",
+      "result": "3 failed, 7 passed, 1 warning",
+      "classification": "existing strategy file-test drift; not caused by G2.277 no-source authorization",
+      "failures": [
+        "test_router_registers_expected_strategy_routes expects router.prefix /api/v1/strategy but current package router prefix is empty",
+        "test_router_contains_expected_number_of_route_method_pairs expects 16 route/method pairs but current count is 23",
+        "test_chart_data_function_is_exported_but_not_wired_into_package_router expects chart-data path to be unwired but current router includes it"
+      ]
+    },
+    "focused_future_test_paths": [
+      "tests/api/file_tests/test_strategy_management_api.py",
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "known_debt_not_authorized_for_edit_by_g2_277": [
+      "strategy file-test route count and router prefix expectations",
+      "strategy chart-data wiring expectation drift"
+    ]
+  },
+  "governance_verification": {
+    "gitnexus_verify_staged": {
+      "ok": true,
+      "status": "stale",
+      "changed_files": 9,
+      "changed_symbols": 0,
+      "affected_processes": 0,
+      "risk_level": "low",
+      "indexed_commit": "39c8a3b2d7ca4a85f66ccaacb17894f52451602e",
+      "current_commit": "f48ede2ce2202318efa3411fe22fb83a8d4d920b",
+      "stale_reason": "current_commit_differs_from_indexed_commit"
+    }
+  },
+  "authorization": {
+    "selected_next_gate": "G2.278 path-limited strategy get_monitoring_db route-provider implementation",
+    "authorized_after_acceptance_only": true,
+    "authorized_future_source_paths": [
+      "web/backend/app/api/strategy_management/_helpers.py",
+      "web/backend/app/api/strategy_management/_strategy_crud_router.py"
+    ],
+    "authorized_future_test_paths": [
+      "tests/api/file_tests/test_strategy_management_api.py",
+      "web/backend/tests/test_health_route_conflicts.py"
+    ],
+    "future_lane_allowed_actions": [
+      "add a strategy-management-local dependency provider or equivalent route-provider seam for the strategy monitoring database helper",
+      "move list_strategies and create_strategy away from direct route-body get_monitoring_db().log_operation(...) calls",
+      "route _handle_strategy_lifecycle_action logging through the same explicit strategy monitoring database seam where practical without changing public route contracts",
+      "preserve current MonitoringDatabase fallback and log_operation behavior",
+      "add focused assertions that no FastAPI dependency parameter leaks into OpenAPI for the target strategy endpoints"
+    ],
+    "future_lane_forbidden_actions": [
+      "risk helper or risk route edits",
+      "web/backend/app/utils/risk_utils.py edits",
+      "non-strategy route/provider migrations",
+      "route path/method/response shape changes",
+      "OpenAPI artifact edits",
+      "frontend/config/script/OpenSpec edits",
+      "PM2 or stateful runtime gates",
+      "source retirement"
+    ],
+    "acceptance_for_future_lane": [
+      "GitNexus impact re-run before source edits using the strategy helper UID",
+      "focused TDD red/green or equivalent regression proof for strategy route-provider usage",
+      "targeted strategy API/file tests either pass or record pre-existing route expectation drift without widening scope",
+      "ruff passes for touched backend files",
+      "app.openapi() remains 500 paths with duplicate operation IDs 0",
+      "target endpoint parameter counts do not gain dependency artifacts"
+    ]
+  },
+  "freshness": {
+    "current_head_checked": "f48ede2ce2202318efa3411fe22fb83a8d4d920b",
+    "stale_if_head_or_pr_state_changes": true,
+    "stale_if_route_or_openapi_counts_change": true,
+    "stale_if_strategy_get_monitoring_db_call_sites_change": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-05-31T20:39:29+08:00`
-- Base HEAD checked: `0de77f3d05b1b6242515f2b86fce03c0eba37aaa`
+- Prepared at: `2026-06-01T00:01:42+08:00`
+- Base HEAD checked: `f48ede2ce2202318efa3411fe22fb83a8d4d920b`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -111,6 +111,10 @@ PRs, change issue labels, or authorize source implementation.
 | `#424` | `g2-271-pool-monitoring-control-plane-ownership` | `wip/root-dirty-20260403` | `MERGED` at `8e0fcd6738c4e3a889b4851d058f8121f32b8ce8` | No-source pool monitoring control-plane ownership decision selecting G2.272 residual candidate refresh |
 | `#425` | `g2-272-service-lifecycle-residual-candidate-refresh` | `wip/root-dirty-20260403` | `MERGED` at `bcf28e4668391f91ea97ee252b4da4eea64faf74` | No-source residual candidate refresh selecting G2.273 `get_monitoring_db` ownership decision |
 | `#426` | `g2-273-get-monitoring-db-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `0de77f3d05b1b6242515f2b86fce03c0eba37aaa` | No-source ownership decision selecting G2.274 risk `get_monitoring_db` authorization |
+| `#427` | `g2-274-risk-get-monitoring-db-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `16df80c30eb4fceec78a13630e40167f0e4037ca` | No-source authorization package for G2.275 risk `get_monitoring_db` provider implementation |
+| `#428` | `g2-275-risk-get-monitoring-db-provider` | `wip/root-dirty-20260403` | `MERGED` at `daa4f22a557b054ab76042d4990b6e91d9faa7a7` | Path-limited risk `get_monitoring_db` provider implementation |
+| `#429` | `g2-276-risk-get-monitoring-db-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `f48ede2ce2202318efa3411fe22fb83a8d4d920b` | No-source risk provider closeout selecting G2.277 strategy authorization |
+| `#430` | `g2-277-strategy-get-monitoring-db-provider-authorization` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | No-source authorization package for future G2.278 strategy `get_monitoring_db` provider implementation |
 
 ## Steward Governance Branch
 
@@ -131,6 +135,9 @@ PRs, change issue labels, or authorize source implementation.
 | `g2-272-service-lifecycle-residual-candidate-refresh` | `origin/wip/root-dirty-20260403` at `8e0fcd6738c4e3a889b4851d058f8121f32b8ce8` | Refresh service lifecycle residual candidates after pool-monitoring deferral | No |
 | `g2-273-get-monitoring-db-ownership-decision` | `origin/wip/root-dirty-20260403` at `bcf28e4668391f91ea97ee252b4da4eea64faf74` | Decide split `get_monitoring_db` ownership before any route-provider authorization | No |
 | `g2-274-risk-get-monitoring-db-provider-authorization` | `origin/wip/root-dirty-20260403` at `0de77f3d05b1b6242515f2b86fce03c0eba37aaa` | Authorize a future path-limited risk `get_monitoring_db` route-provider implementation | No |
+| `g2-275-risk-get-monitoring-db-provider` | `origin/wip/root-dirty-20260403` at `16df80c30eb4fceec78a13630e40167f0e4037ca` | Implement the authorized risk `get_monitoring_db` route-provider lane | Yes, path-limited |
+| `g2-276-risk-get-monitoring-db-provider-closeout-refresh` | `origin/wip/root-dirty-20260403` at `daa4f22a557b054ab76042d4990b6e91d9faa7a7` | Close out G2.275 and select strategy-management residual authorization | No |
+| `g2-277-strategy-get-monitoring-db-provider-authorization` | `origin/wip/root-dirty-20260403` at `f48ede2ce2202318efa3411fe22fb83a8d4d920b` | Authorize a future path-limited strategy `get_monitoring_db` route-provider implementation | No |
 
 ## OpenSpec Relationship
 
@@ -175,3 +182,5 @@ G2.274 is the no-source risk `get_monitoring_db` route-provider authorization af
 G2.275 is the path-limited risk `get_monitoring_db` route-provider implementation after PR `#427` merged G2.274 at `16df80c30eb4fceec78a13630e40167f0e4037ca`. It may touch only `web/backend/app/api/risk/_shared.py`, `web/backend/app/api/risk/alerts.py`, `web/backend/app/api/risk/metrics.py`, the focused risk file test, and governance evidence. It must not edit strategy-management helpers, `web/backend/app/utils/risk_utils.py`, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
 
 G2.276 is the no-source risk `get_monitoring_db` provider closeout / residual refresh after PR `#428` merged G2.275 at `daa4f22a557b054ab76042d4990b6e91d9faa7a7`. It records the risk route-provider lane as closed, refreshes remaining strategy-management and utility same-name helper residuals, and selects G2.277 no-source strategy authorization. It must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+
+G2.277 is the no-source strategy `get_monitoring_db` route-provider authorization after PR `#429` merged G2.276 at `f48ede2ce2202318efa3411fe22fb83a8d4d920b`. It authorizes only a future G2.278 path-limited strategy source lane for `strategy_management/_helpers.py` and `strategy_management/_strategy_crud_router.py` after PR `#430` acceptance. It must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -19,9 +19,9 @@ exact verification output.
 | Route/OpenAPI and control-plane governance | Established route table, OpenAPI exposure, health/probe taxonomy, and consumer-contract evidence as first-class governance facts | Continue through route/OpenAPI track, not ad hoc route edits |
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
-| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.275 accepted/merged by PR `#428` at `daa4f22a` | Continue with G2.276 risk `get_monitoring_db` provider closeout / residual refresh review, then G2.277 no-source strategy authorization if accepted |
+| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.276 accepted/merged by PR `#429` at `f48ede2c` | Continue with G2.277 strategy `get_monitoring_db` provider authorization review, then G2.278 path-limited strategy implementation only if accepted |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.275 have progressed through PR `#337`-`#428`; current review target is G2.276 risk closeout / residual refresh in future PR `#429` |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.276 have progressed through PR `#337`-`#429`; current review target is G2.277 strategy authorization in future PR `#430` |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Recent Closeouts
@@ -39,6 +39,7 @@ exact verification output.
 | G2.273 get_monitoring_db ownership decision | PR `#426` merged at `0de77f3d05b1b6242515f2b86fce03c0eba37aaa`; ownership split confirmed across risk, strategy, and utility helpers | G2.274 authorizes only the risk surface before any implementation |
 | G2.274 risk get_monitoring_db provider authorization | PR `#427` merged at `16df80c30eb4fceec78a13630e40167f0e4037ca`; path-limited risk source lane authorized | G2.275 implements only the three authorized risk handlers and focused provider test |
 | G2.275 risk get_monitoring_db provider implementation | PR `#428` merged at `daa4f22a557b054ab76042d4990b6e91d9faa7a7`; direct risk route-body calls are `0` and route/OpenAPI contracts stayed stable | G2.276 records closeout and selects the strategy-management residual for a no-source authorization gate |
+| G2.276 risk get_monitoring_db provider closeout / residual refresh | PR `#429` merged at `f48ede2ce2202318efa3411fe22fb83a8d4d920b`; risk lane closed and strategy-management residual selected | G2.277 authorizes only the strategy-management route/helper surface before any G2.278 implementation |
 
 ## Closeout Rule
 

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-05-31T23:34:18+08:00`
-- Base HEAD checked: `daa4f22a557b054ab76042d4990b6e91d9faa7a7`
+- Prepared at: `2026-06-01T00:01:42+08:00`
+- Base HEAD checked: `f48ede2ce2202318efa3411fe22fb83a8d4d920b`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.276 risk `get_monitoring_db` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#428` merged at `daa4f22a557b054ab76042d4990b6e91d9faa7a7`; G2.276 records risk route-body `get_monitoring_db()` calls as `0` and selects strategy-management `get_monitoring_db` as the next no-source authorization target | Review PR `#429` when opened; if accepted, start `G2.277 no-source strategy get_monitoring_db route-provider authorization`; do not start strategy source implementation from G2.276 |
+| P0 | Review G2.277 strategy `get_monitoring_db` route-provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#429` merged at `f48ede2ce2202318efa3411fe22fb83a8d4d920b`; G2.277 records strategy-management `_helpers.py` / `_strategy_crud_router.py` as the next path-limited candidate and keeps risk plus utility helpers out of scope | Review PR `#430` when opened; if accepted, start `G2.278 path-limited strategy get_monitoring_db route-provider implementation`; do not start strategy source implementation from G2.277 before acceptance |
+| P0 | Preserve G2.276 risk `get_monitoring_db` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#429` merged at `f48ede2ce2202318efa3411fe22fb83a8d4d920b`; risk route-body `get_monitoring_db()` calls remain closed at `0`, strategy-management residual selected for no-source authorization | Do not use G2.276 as authority for backend source edits, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state |
 | P0 | Preserve G2.275 risk `get_monitoring_db` route-provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#428` merged at `daa4f22a557b054ab76042d4990b6e91d9faa7a7`; G2.275 moved `create_risk_alert`, `calculate_var_cvar`, and `calculate_beta` to `Depends(get_risk_monitoring_db)` | Do not use G2.275 as authority for strategy-management helper changes, utility helper changes, route registration, OpenAPI artifact edits, frontend, config, scripts, OpenSpec, PM2, or broader backend source |
 | P0 | Preserve G2.274 risk `get_monitoring_db` route-provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#427` merged at `16df80c30eb4fceec78a13630e40167f0e4037ca`; G2.274 authorized only the three risk source files plus focused tests for G2.275 | Do not use G2.274 as authority for strategy-management helper changes, utility helper changes, route registration, OpenAPI artifact edits, frontend, config, scripts, OpenSpec, PM2, or broader backend source |
 | P0 | Preserve G2.273 `get_monitoring_db` ownership / route-provider decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#426` merged at `0de77f3d05b1b6242515f2b86fce03c0eba37aaa`; `get_monitoring_db` is split across risk helper, strategy helper, and utility same-name helper surfaces | Do not use G2.273 as authority for backend source edits, combined risk/strategy migration, route registration, source retirement, tests, docs/api, frontend, OpenSpec, config, scripts, or PM2 |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-05-31T23:34:18+08:00`
-- Base HEAD checked: `daa4f22a557b054ab76042d4990b6e91d9faa7a7`
+- Prepared at: `2026-06-01T00:01:42+08:00`
+- Base HEAD checked: `f48ede2ce2202318efa3411fe22fb83a8d4d920b`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -16,9 +16,12 @@ state transition.
 
 | Evidence | Role | Freshness policy |
 |---|---|---|
-| `.planning/codebase/generated/risk-get-monitoring-db-provider-closeout-refresh-2026-05-31.json` | G2.276 risk `get_monitoring_db` provider closeout / residual-refresh evidence | Review input for future PR `#429`; no-source closeout and next-gate selection |
-| `docs/reports/quality/backend-risk-get-monitoring-db-provider-closeout-refresh-2026-05-31.md` | G2.276 human-readable closeout / residual-refresh report | Review input for future PR `#429`; records PR `#428` accepted/merged and selects G2.277 |
-| `governance/mainline/task-cards/pr-429.yaml` | Path-limited governance task card for G2.276 | Review input; allows only steward tree, generated evidence, report, and task card updates |
+| `.planning/codebase/generated/strategy-get-monitoring-db-provider-authorization-2026-05-31.json` | G2.277 strategy `get_monitoring_db` provider authorization evidence | Review input for future PR `#430`; no-source authorization package only |
+| `docs/reports/quality/backend-strategy-get-monitoring-db-provider-authorization-2026-05-31.md` | G2.277 human-readable authorization report | Review input for future PR `#430`; authorizes only a future strategy-management source lane after acceptance |
+| `governance/mainline/task-cards/pr-430.yaml` | Path-limited governance task card for G2.277 | Review input; allows only steward tree, generated evidence, report, and task card updates |
+| `.planning/codebase/generated/risk-get-monitoring-db-provider-closeout-refresh-2026-05-31.json` | G2.276 risk `get_monitoring_db` provider closeout / residual-refresh evidence | Accepted by PR `#429`, merged at `f48ede2ce2202318efa3411fe22fb83a8d4d920b`; no-source closeout and next-gate selection |
+| `docs/reports/quality/backend-risk-get-monitoring-db-provider-closeout-refresh-2026-05-31.md` | G2.276 human-readable closeout / residual-refresh report | Accepted by PR `#429`; records PR `#428` accepted/merged and selects G2.277 |
+| `governance/mainline/task-cards/pr-429.yaml` | Path-limited governance task card for G2.276 | Accepted by PR `#429`; allowed only steward tree, generated evidence, report, and task card updates |
 | `.planning/codebase/generated/risk-get-monitoring-db-provider-implementation-2026-05-31.json` | G2.275 risk `get_monitoring_db` provider implementation evidence | Accepted by PR `#428`, merged at `daa4f22a557b054ab76042d4990b6e91d9faa7a7`; path-limited source implementation |
 | `docs/reports/quality/backend-risk-get-monitoring-db-provider-implementation-2026-05-31.md` | G2.275 human-readable implementation report | Accepted by PR `#428`; records TDD, source/test verification, OpenAPI smoke, and known week1 risk test debt |
 | `governance/mainline/task-cards/pr-428.yaml` | Path-limited implementation task card for G2.275 | Accepted by PR `#428`; allowed only three risk source files, focused provider test, steward tree, generated evidence, report, and task card updates |

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-05-31T23:34:18+08:00",
+  "generated_at": "2026-06-01T00:01:42+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "daa4f22a557b054ab76042d4990b6e91d9faa7a7",
-  "split_branch": "g2-276-risk-get-monitoring-db-provider-closeout-refresh",
-  "scope": "risk_get_monitoring_db_provider_closeout_refresh",
+  "base_head": "f48ede2ce2202318efa3411fe22fb83a8d4d920b",
+  "split_branch": "g2-277-strategy-get-monitoring-db-provider-authorization",
+  "scope": "strategy_get_monitoring_db_provider_authorization",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -7806,15 +7806,17 @@
     {
       "id": "g2-276-risk-get-monitoring-db-provider-closeout-refresh",
       "type": "closeout_refresh",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.275 risk get_monitoring_db route-provider implementation",
       "source_edit_authority": false,
       "github_pr": {
         "number": 429,
         "url": "https://github.com/chengjon/mystocks/pull/429",
-        "state": "PLANNED_FOR_REVIEW",
-        "head_ref": "g2-276-risk-get-monitoring-db-provider-closeout-refresh"
+        "state": "MERGED",
+        "merged_at": "2026-05-31T15:51:40Z",
+        "head_ref": "g2-276-risk-get-monitoring-db-provider-closeout-refresh",
+        "merge_commit": "f48ede2ce2202318efa3411fe22fb83a8d4d920b"
       },
       "evidence": [
         ".planning/codebase/generated/risk-get-monitoring-db-provider-closeout-refresh-2026-05-31.json",
@@ -7893,12 +7895,112 @@
         "openspec/specs/**"
       ],
       "freshness": {
-        "current_head_checked": "daa4f22a557b054ab76042d4990b6e91d9faa7a7",
+        "current_head_checked": "f48ede2ce2202318efa3411fe22fb83a8d4d920b",
         "stale_if_head_or_pr_state_changes": true,
         "stale_if_route_or_openapi_counts_change": true,
         "stale_if_get_monitoring_db_call_sites_change": true
       },
-      "next_gate": "If accepted, start G2.277 no-source strategy get_monitoring_db route-provider authorization."
+      "next_gate": "Superseded by G2.277 no-source strategy get_monitoring_db route-provider authorization."
+    },
+    {
+      "id": "g2-277-strategy-get-monitoring-db-provider-authorization",
+      "type": "authorization_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.276 risk get_monitoring_db provider closeout / residual refresh",
+      "source_edit_authority": false,
+      "future_source_edit_authority_if_accepted": true,
+      "github_pr": {
+        "number": 430,
+        "url": "https://github.com/chengjon/mystocks/pull/430",
+        "state": "PLANNED_FOR_REVIEW",
+        "head_ref": "g2-277-strategy-get-monitoring-db-provider-authorization"
+      },
+      "evidence": [
+        ".planning/codebase/generated/strategy-get-monitoring-db-provider-authorization-2026-05-31.json",
+        "docs/reports/quality/backend-strategy-get-monitoring-db-provider-authorization-2026-05-31.md",
+        "governance/mainline/task-cards/pr-430.yaml"
+      ],
+      "gitnexus_evidence": {
+        "mcp": "Transport closed for context / impact",
+        "cli_uid": "Function:web/backend/app/api/strategy_management/_helpers.py:get_monitoring_db",
+        "risk": "LOW",
+        "impacted_count": 7,
+        "direct": 3,
+        "processes_affected": 0,
+        "modules_affected": 1,
+        "affected_module": "Strategy_management"
+      },
+      "authorization_scope": {
+        "future_lane": "G2.278 path-limited strategy get_monitoring_db route-provider implementation",
+        "allowed_source_paths": [
+          "web/backend/app/api/strategy_management/_helpers.py",
+          "web/backend/app/api/strategy_management/_strategy_crud_router.py"
+        ],
+        "allowed_test_paths": [
+          "tests/api/file_tests/test_strategy_management_api.py",
+          "web/backend/tests/test_health_route_conflicts.py"
+        ],
+        "forbidden_paths": [
+          "web/backend/app/api/risk/**",
+          "web/backend/app/utils/risk_utils.py",
+          "non-strategy route/provider migrations",
+          "web/frontend/**",
+          "docs/api/**",
+          "openspec/changes/**",
+          "openspec/specs/**",
+          "config/**",
+          "scripts/**"
+        ]
+      },
+      "strategy_surface": {
+        "helper_file": {
+          "path": "web/backend/app/api/strategy_management/_helpers.py",
+          "definition_line": 420,
+          "helper_level_log_calls": 2,
+          "target_function": "_handle_strategy_lifecycle_action"
+        },
+        "crud_router_file": {
+          "path": "web/backend/app/api/strategy_management/_strategy_crud_router.py",
+          "route_body_direct_log_calls": 4,
+          "target_handlers": [
+            "list_strategies",
+            "create_strategy"
+          ]
+        },
+        "deferred_utility_same_name_helper": {
+          "path": "web/backend/app/utils/risk_utils.py",
+          "active_api_route_body_calls": 0
+        }
+      },
+      "route_openapi": {
+        "routes": 548,
+        "openapi_paths": 500,
+        "duplicate_operation_ids": 0,
+        "target_endpoint_parameter_counts": {
+          "GET /api/v1/strategy/strategies": 4,
+          "POST /api/v1/strategy/strategies": 0,
+          "GET /api/v1/strategy/strategies/{strategy_id}": 1
+        }
+      },
+      "known_test_debt": {
+        "focused_command": "env PYTHONPATH=web/backend pytest -o addopts= tests/api/file_tests/test_strategy_management_api.py -q -n 0 --tb=short --no-cov",
+        "result": "3 failed, 7 passed, 1 warning",
+        "classification": "existing strategy file-test route expectation drift"
+      },
+      "decision": {
+        "classification": "authorization-package-for-review",
+        "source_lane_recommendation": "do-not-start-source-implementation-before-pr-430-acceptance",
+        "selected_next_governance_target": "strategy-get-monitoring-db-route-provider-implementation",
+        "recommended_next_work_item": "G2.278 path-limited strategy get_monitoring_db route-provider implementation"
+      },
+      "freshness": {
+        "current_head_checked": "f48ede2ce2202318efa3411fe22fb83a8d4d920b",
+        "stale_if_head_or_pr_state_changes": true,
+        "stale_if_route_or_openapi_counts_change": true,
+        "stale_if_strategy_get_monitoring_db_call_sites_change": true
+      },
+      "next_gate": "If accepted, start G2.278 path-limited strategy get_monitoring_db route-provider implementation."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -2925,7 +2925,7 @@ Status: accepted/merged by PR `#428` at `daa4f22a557b054ab76042d4990b6e91d9faa7a
 
 ## G2.276 Risk get_monitoring_db Provider Closeout / Residual Refresh
 
-Status: for review in future PR `#429`.
+Status: accepted/merged by PR `#429` at `f48ede2ce2202318efa3411fe22fb83a8d4d920b`.
 
 - Parent PR `#428` merged at `daa4f22a557b054ab76042d4990b6e91d9faa7a7`.
 - Risk route-body `get_monitoring_db()` calls are closed: `risk/alerts.py` and `risk/metrics.py` both have `0`; risk provider backing call remains in `_shared.py`.
@@ -2935,3 +2935,19 @@ Status: for review in future PR `#429`.
 - Focused risk provider test remains green at `1/1`; ruff remains clean on the G2.275 touched risk source/test paths.
 - Selected next gate after acceptance: G2.277 no-source strategy `get_monitoring_db` route-provider authorization.
 - G2.276 must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+
+## G2.277 Strategy get_monitoring_db Provider Authorization
+
+Status: for review in future PR `#430`.
+
+- Parent PR `#429` merged at `f48ede2ce2202318efa3411fe22fb83a8d4d920b`.
+- GitNexus MCP context / impact returned `Transport closed`; CLI fallback using `Function:web/backend/app/api/strategy_management/_helpers.py:get_monitoring_db` returned LOW risk with `7` impacted symbols, `3` direct symbols, and `0` affected processes.
+- Direct affected symbols are `_handle_strategy_lifecycle_action`, `list_strategies`, and `create_strategy`.
+- Strategy target files are `web/backend/app/api/strategy_management/_helpers.py` and `web/backend/app/api/strategy_management/_strategy_crud_router.py`.
+- Current strategy call sites are `2` helper-level lifecycle log calls in `_helpers.py` and `4` active route-body log calls in `_strategy_crud_router.py`.
+- `web/backend/app/utils/risk_utils.py` remains a deferred utility same-name helper with `0` active API route-body calls in this scan.
+- Runtime/OpenAPI smoke with placeholder import-time environment values recorded `548` FastAPI routes, `500` OpenAPI paths, and `0` duplicate operation IDs.
+- Focused strategy file-test attempt currently reports `3 failed, 7 passed, 1 warning`; failures are existing route prefix/count/chart-data wiring expectation drift and are not caused by this no-source authorization package.
+- Authorized next gate after acceptance: G2.278 path-limited strategy `get_monitoring_db` route-provider implementation.
+- Future G2.278 may touch only the two strategy-management source paths plus focused strategy tests named in the authorization report.
+- G2.277 must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.

--- a/docs/reports/quality/backend-strategy-get-monitoring-db-provider-authorization-2026-05-31.md
+++ b/docs/reports/quality/backend-strategy-get-monitoring-db-provider-authorization-2026-05-31.md
@@ -1,0 +1,219 @@
+# Backend Strategy get_monitoring_db Provider Authorization
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Workline: G2.277
+- Type: no-source authorization package
+- Prepared at: `2026-06-01T00:01:42+08:00`
+- Base HEAD checked: `f48ede2ce2202318efa3411fe22fb83a8d4d920b`
+- Parent gate: G2.276 risk `get_monitoring_db` provider closeout / residual refresh
+- Parent PR: `#429`, merged at `f48ede2ce2202318efa3411fe22fb83a8d4d920b`
+
+This package is authorization-only. It does not edit backend source, tests,
+route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2,
+or runtime state.
+
+## Authorization Decision
+
+If accepted, G2.277 authorizes only a future G2.278 path-limited implementation
+for the strategy-management route/helper surface:
+
+- `web/backend/app/api/strategy_management/_helpers.py`
+- `web/backend/app/api/strategy_management/_strategy_crud_router.py`
+
+The future implementation target is to move the active strategy route-body
+`get_monitoring_db().log_operation(...)` calls, and the related helper-level
+lifecycle logging seam where practical, onto an explicit strategy monitoring
+database provider while preserving current fallback behavior and API contracts.
+
+G2.277 does not authorize risk helper changes, utility helper changes,
+non-strategy route/provider migrations, source retirement, route registration
+changes, or OpenAPI artifact edits.
+
+## GitNexus Evidence
+
+MCP context / impact for `get_monitoring_db` returned `Transport closed`.
+
+The CLI fallback with the disambiguated UID succeeded:
+
+```text
+target_uid: Function:web/backend/app/api/strategy_management/_helpers.py:get_monitoring_db
+risk: LOW
+impacted_count: 7
+direct: 3
+processes_affected: 0
+modules_affected: 1
+affected_module: Strategy_management
+```
+
+Direct affected symbols:
+
+| Symbol | Path |
+|---|---|
+| `_handle_strategy_lifecycle_action` | `web/backend/app/api/strategy_management/_helpers.py` |
+| `list_strategies` | `web/backend/app/api/strategy_management/_strategy_crud_router.py` |
+| `create_strategy` | `web/backend/app/api/strategy_management/_strategy_crud_router.py` |
+
+Depth-2 symbols observed by the CLI fallback:
+
+- `start_strategy`
+- `pause_strategy`
+- `resume_strategy`
+- `stop_strategy`
+
+GitNexus index status is still a stale warning with `commits_behind=0` and
+`has_embeddings=false`. A future source lane must re-run impact before editing
+and must stop if the risk level changes to HIGH or CRITICAL outside the exact
+authorized target files.
+
+## Strategy Surface Evidence
+
+Definition:
+
+- `web/backend/app/api/strategy_management/_helpers.py:420`
+
+Current call sites:
+
+| File | Line | Function | Classification |
+|---|---:|---|---|
+| `web/backend/app/api/strategy_management/_helpers.py` | 393 | `_handle_strategy_lifecycle_action` | helper-level lifecycle log call |
+| `web/backend/app/api/strategy_management/_helpers.py` | 409 | `_handle_strategy_lifecycle_action` | helper-level lifecycle log call |
+| `web/backend/app/api/strategy_management/_strategy_crud_router.py` | 157 | `list_strategies` | active route-body log call |
+| `web/backend/app/api/strategy_management/_strategy_crud_router.py` | 174 | `list_strategies` | active route-body log call |
+| `web/backend/app/api/strategy_management/_strategy_crud_router.py` | 254 | `create_strategy` | active route-body log call |
+| `web/backend/app/api/strategy_management/_strategy_crud_router.py` | 271 | `create_strategy` | active route-body log call |
+
+Deferred same-name helper:
+
+- `web/backend/app/utils/risk_utils.py` defines another `get_monitoring_db()`
+  helper, but the scoped scan found `0` active API route-body calls for that
+  utility surface. It remains outside G2.277.
+
+Decision: do not create a combined risk/strategy/utility implementation lane.
+Risk is closed by G2.275/G2.276. Strategy-management should be handled by a
+separate path-limited implementation only after this authorization package is
+accepted.
+
+## Route / OpenAPI Evidence
+
+The route/OpenAPI smoke used temporary placeholder environment values only to
+satisfy import-time settings validation. It did not run PM2 or a stateful
+database workflow.
+
+| Metric | Value |
+|---|---:|
+| FastAPI route count | 548 |
+| OpenAPI path count | 500 |
+| Duplicate operation IDs | 0 |
+
+Target endpoints:
+
+| Path | Method | Endpoint | Parameter count | Request body | Response codes |
+|---|---|---|---:|---|---|
+| `/api/v1/strategy/strategies` | `GET` | `list_strategies` | 4 | no | `200`, `400`, `404`, `422`, `500` |
+| `/api/v1/strategy/strategies` | `POST` | `create_strategy` | 0 | yes | `200`, `400`, `404`, `422`, `500` |
+| `/api/v1/strategy/strategies/{strategy_id}` | `GET` | `get_strategy` | 1 | no | `200`, `400`, `404`, `422`, `500` |
+
+Future G2.278 must preserve route paths, methods, response contracts, and
+OpenAPI parameter counts. If a dependency provider parameter leaks into
+OpenAPI, the implementation must be corrected before review.
+
+## Focused Test Inventory
+
+Focused command attempted:
+
+```text
+env PYTHONPATH=web/backend pytest -o addopts= tests/api/file_tests/test_strategy_management_api.py -q -n 0 --tb=short --no-cov
+```
+
+Result:
+
+```text
+3 failed, 7 passed, 1 warning
+```
+
+Failure classification: existing strategy file-test drift, not a G2.277
+no-source authorization regression.
+
+Observed failures:
+
+- `test_router_registers_expected_strategy_routes` expects
+  `strategy_module.router.prefix == "/api/v1/strategy"`, but the current package
+  router prefix is empty.
+- `test_router_contains_expected_number_of_route_method_pairs` expects `16`
+  route/method pairs, while current code exposes `23`.
+- `test_chart_data_function_is_exported_but_not_wired_into_package_router`
+  expects chart-data to be unwired, but current router includes it.
+
+Authorized future test paths:
+
+- `tests/api/file_tests/test_strategy_management_api.py`
+- `web/backend/tests/test_health_route_conflicts.py`
+
+G2.277 does not authorize broad strategy test cleanup. If G2.278 needs to edit
+the file-test expectations, it must keep those edits directly tied to provider
+injection verification and record the pre-existing route expectation drift.
+
+## Governance Verification
+
+GitNexus staged verification for this no-source package:
+
+```text
+ok: true
+status: stale
+changed_files: 9
+changed_symbols: 0
+affected_processes: 0
+risk_level: low
+indexed_commit: 39c8a3b2d7ca4a85f66ccaacb17894f52451602e
+current_commit: f48ede2ce2202318efa3411fe22fb83a8d4d920b
+```
+
+The stale warning is recorded as an index freshness warning, not a source
+impact finding. This branch changes only governance files.
+
+## Future G2.278 Authorized Shape
+
+Only after G2.277 is accepted, G2.278 may:
+
+- Add a strategy-management-local dependency provider or equivalent
+  route-provider seam for the strategy monitoring database helper.
+- Replace direct route-body
+  `get_monitoring_db().log_operation(...)` calls in `list_strategies` and
+  `create_strategy` with dependency-supplied monitoring database object usage.
+- Route `_handle_strategy_lifecycle_action` logging through the same explicit
+  strategy monitoring database seam where practical without changing public
+  route contracts.
+- Preserve existing `MonitoringDatabase` fallback behavior.
+- Add or update focused tests in the authorized test paths.
+
+## Future G2.278 Forbidden Scope
+
+- `web/backend/app/api/risk/**`
+- `web/backend/app/utils/risk_utils.py`
+- non-strategy route/provider migrations
+- route registration changes
+- route path, method, response shape, or OpenAPI artifact changes
+- frontend, config, scripts, OpenSpec, PM2, or runtime state
+- source retirement or compatibility deletion
+
+## Required Future Verification
+
+G2.278 must provide fresh evidence for:
+
+- GitNexus impact before source edits using
+  `Function:web/backend/app/api/strategy_management/_helpers.py:get_monitoring_db`.
+- TDD red/green or equivalent regression proof for the route-provider behavior.
+- Targeted strategy tests or a precise record of pre-existing strategy file-test
+  drift.
+- Ruff on touched backend files.
+- `app.openapi()` remains `500` paths with duplicate operation IDs `0`.
+- Target endpoint OpenAPI parameter counts remain unchanged.
+
+## Evidence Artifacts
+
+- `.planning/codebase/generated/strategy-get-monitoring-db-provider-authorization-2026-05-31.json`
+- `docs/reports/quality/backend-strategy-get-monitoring-db-provider-authorization-2026-05-31.md`
+- `governance/mainline/task-cards/pr-430.yaml`

--- a/governance/mainline/task-cards/pr-430.yaml
+++ b/governance/mainline/task-cards/pr-430.yaml
@@ -1,0 +1,132 @@
+version: "v0.2"
+
+task:
+  id: "pr-430"
+  title: "Authorize strategy get_monitoring_db provider lane"
+  owner: "codex"
+  created_at: "2026-05-31"
+
+mainline:
+  id: "L1-strategy-get-monitoring-db-provider-authorization"
+  objective: "authorize a future strategy-only route-provider implementation lane for get_monitoring_db"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "G2.277 updates only steward tree state, generated evidence, a quality report, and this task card. It changes no runtime entrypoints, route paths, backend source, tests, frontend, OpenAPI generation code, or FUNCTION_TREE catalog entries."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/strategy-get-monitoring-db-provider-authorization-2026-05-31.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-strategy-get-monitoring-db-provider-authorization-2026-05-31.md"
+    - "governance/mainline/task-cards/pr-430.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits"
+  - "provider injection implementation"
+  - "risk helper or route changes"
+  - "utility helper changes"
+  - "non-strategy route/provider migrations"
+  - "route registration changes"
+  - "source retirement or archive"
+  - "test contract edits"
+  - "OpenAPI artifact edits"
+  - "frontend/config/script changes"
+  - "OpenSpec proposal or spec edits"
+  - "PM2 commands"
+
+acceptance:
+  checks:
+    - id: "pr429-merged"
+      command: "gh pr view 429 confirms MERGED at f48ede2ce2202318efa3411fe22fb83a8d4d920b"
+      required: true
+    - id: "gitnexus-strategy-impact"
+      command: "GitNexus CLI impact for Function:web/backend/app/api/strategy_management/_helpers.py:get_monitoring_db records LOW risk, 3 direct symbols, and 0 affected processes after MCP Transport closed"
+      required: true
+    - id: "authorization-scope"
+      command: "Authorization names only future strategy-management source paths and focused test paths; risk and utility helper surfaces remain deferred"
+      required: true
+    - id: "route-openapi-smoke"
+      command: "app.main route/OpenAPI smoke records 548 routes, 500 paths, duplicate operation IDs 0, and target endpoint parameter counts"
+      required: true
+    - id: "known-test-debt-recorded"
+      command: "Focused strategy file-test drift is recorded as existing debt and not treated as G2.277 no-source regression"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-strategy-get-monitoring-db-provider-authorization-2026-05-31.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-430.yaml --base-sha f48ede2ce2202318efa3411fe22fb83a8d4d920b --head-sha HEAD --report /tmp/pr430-mainline-governance-report.json"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "gitnexus-detect-changes"
+      command: "GitNexus staged verification attempted before commit; stale-index warning recorded if present"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "G2.277 must not be mistaken for backend source implementation authorization before PR #430 is accepted."
+    - "Future source work must not include risk helpers, utility helper, non-strategy routes, route registration, OpenAPI artifact, or PM2 changes."
+  rollback_plan: "Revert PR #430; this restores the steward tree to the immediate post-PR #429 state."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Authorize a future strategy-only get_monitoring_db provider lane."
+    modified_scope: "Steward tree, generated evidence, quality report, and task card only."
+    dependency_changes: "No dependency changes."
+    legacy_logic_impact: "No runtime or backend behavior changes."
+    rollback_ready: "Revert PR #430."
+    risk_and_rollback_point: "Pure governance authorization; rollback is single-PR revert."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-01T00:01:42+08:00"
+    approval_note: "Human maintainer approved continuing after PR #429 merge into G2.277 no-source strategy get_monitoring_db route-provider authorization. No source implementation is performed in PR #430."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records G2.276 / PR #429 as merged and advances the steward tree to G2.277
- adds the no-source strategy get_monitoring_db route-provider authorization package
- authorizes only a future G2.278 path-limited strategy implementation after review acceptance

## Scope
- governance docs, generated evidence, steward-tree state, and pr-430 task card only
- no backend source, tests, route contracts, OpenAPI artifacts, frontend, config, scripts, PM2, or OpenSpec spec/proposal edits

## Verification
- JSON parse: OK
- markdown governance gate: 6 checked files, 0 errors
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: valid
- git diff --cached --check: pass
- mainline_scope_gate: pass
- GitNexus staged verification / detect-changes: low risk, 9 files, 0 changed symbols, 0 affected processes; stale index warning recorded