### PR TITLE
docs(governance): close strategy monitoring db provider lane

### DIFF
--- a/.planning/codebase/generated/strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.json
+++ b/.planning/codebase/generated/strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.json
@@ -1,0 +1,199 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-06-01T01:06:12+08:00",
+  "gate": "G2.279",
+  "title": "Strategy get_monitoring_db provider closeout and residual refresh",
+  "repo": "mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "c5496cab0a4213f74636af1c48772dc96c90bd1b",
+  "worktree": ".worktrees/g2-279-strategy-get-monitoring-db-provider-closeout-refresh",
+  "source_edit_authority": false,
+  "parent": {
+    "gate": "G2.278",
+    "pr": 431,
+    "state": "MERGED",
+    "merged_at": "2026-05-31T16:57:57Z",
+    "merge_commit": "c5496cab0a4213f74636af1c48772dc96c90bd1b",
+    "summary": "Path-limited strategy get_monitoring_db provider implementation accepted and merged."
+  },
+  "static_residual_scan": {
+    "scanned_paths": [
+      "web/backend/app/api/strategy_management/_helpers.py",
+      "web/backend/app/api/strategy_management/_strategy_crud_router.py",
+      "web/backend/app/api/risk/_shared.py",
+      "web/backend/app/api/risk/alerts.py",
+      "web/backend/app/api/risk/metrics.py",
+      "web/backend/app/utils/risk_utils.py"
+    ],
+    "results": {
+      "web/backend/app/api/strategy_management/_helpers.py": {
+        "occurrences": 2,
+        "direct_log_calls": 0,
+        "provider_depends": 0,
+        "provider_defs": 2,
+        "monitoring_db_log_calls": 2,
+        "call_lines": []
+      },
+      "web/backend/app/api/strategy_management/_strategy_crud_router.py": {
+        "occurrences": 1,
+        "direct_log_calls": 0,
+        "provider_depends": 6,
+        "provider_defs": 0,
+        "monitoring_db_log_calls": 4,
+        "call_lines": []
+      },
+      "web/backend/app/api/risk/_shared.py": {
+        "occurrences": 3,
+        "direct_log_calls": 0,
+        "provider_depends": 0,
+        "provider_defs": 2,
+        "monitoring_db_log_calls": 0,
+        "call_lines": []
+      },
+      "web/backend/app/api/risk/alerts.py": {
+        "occurrences": 0,
+        "direct_log_calls": 0,
+        "provider_depends": 1,
+        "provider_defs": 0,
+        "monitoring_db_log_calls": 2,
+        "call_lines": []
+      },
+      "web/backend/app/api/risk/metrics.py": {
+        "occurrences": 0,
+        "direct_log_calls": 0,
+        "provider_depends": 2,
+        "provider_defs": 0,
+        "monitoring_db_log_calls": 4,
+        "call_lines": []
+      },
+      "web/backend/app/utils/risk_utils.py": {
+        "occurrences": 1,
+        "direct_log_calls": 0,
+        "provider_depends": 0,
+        "provider_defs": 1,
+        "monitoring_db_log_calls": 0,
+        "call_lines": []
+      }
+    },
+    "interpretation": {
+      "strategy_direct_get_monitoring_db_log_calls": 0,
+      "strategy_depends_parameters": 6,
+      "risk_route_body_direct_get_monitoring_db_calls": 0,
+      "utility_same_name_helper_status": "deferred utility helper with no active API route-body log calls in this scan",
+      "docstring_or_definition_occurrences_are_not_call_sites": true
+    }
+  },
+  "runtime_openapi_smoke": {
+    "routes": 548,
+    "openapi_paths": 500,
+    "duplicate_operation_ids": 0,
+    "strategy_and_risk_monitoring_db_parameter_leaks": false,
+    "target_operations": {
+      "GET /api/v1/strategy/strategies": {
+        "params": 4,
+        "request_body": false,
+        "monitoring_db_leaks": false,
+        "operation_id": "list_strategies_api_v1_strategy_strategies_get"
+      },
+      "POST /api/v1/strategy/strategies": {
+        "params": 0,
+        "request_body": true,
+        "monitoring_db_leaks": false,
+        "operation_id": "create_strategy_api_v1_strategy_strategies_post"
+      },
+      "POST /api/v1/strategy/{strategy_id}/start": {
+        "params": 1,
+        "request_body": false,
+        "monitoring_db_leaks": false,
+        "operation_id": "start_strategy_api_v1_strategy__strategy_id__start_post"
+      },
+      "POST /api/v1/strategy/{strategy_id}/pause": {
+        "params": 1,
+        "request_body": false,
+        "monitoring_db_leaks": false,
+        "operation_id": "pause_strategy_api_v1_strategy__strategy_id__pause_post"
+      },
+      "POST /api/v1/strategy/{strategy_id}/resume": {
+        "params": 1,
+        "request_body": false,
+        "monitoring_db_leaks": false,
+        "operation_id": "resume_strategy_api_v1_strategy__strategy_id__resume_post"
+      },
+      "POST /api/v1/strategy/{strategy_id}/stop": {
+        "params": 1,
+        "request_body": false,
+        "monitoring_db_leaks": false,
+        "operation_id": "stop_strategy_api_v1_strategy__strategy_id__stop_post"
+      },
+      "GET /api/v1/risk/alerts": {
+        "params": 1,
+        "request_body": false,
+        "monitoring_db_leaks": false,
+        "operation_id": "list_risk_alerts_api_v1_risk_alerts_get"
+      },
+      "POST /api/v1/risk/alerts": {
+        "params": 0,
+        "request_body": true,
+        "monitoring_db_leaks": false,
+        "operation_id": "create_risk_alert_api_v1_risk_alerts_post"
+      },
+      "POST /api/v1/risk/var-cvar": {
+        "params": 0,
+        "request_body": true,
+        "monitoring_db_leaks": false,
+        "operation_id": "calculate_var_cvar_api_v1_risk_var_cvar_post"
+      },
+      "POST /api/v1/risk/beta": {
+        "params": 0,
+        "request_body": true,
+        "monitoring_db_leaks": false,
+        "operation_id": "calculate_beta_api_v1_risk_beta_post"
+      }
+    }
+  },
+  "verification": {
+    "focused_provider_test": {
+      "command": "env PYTHONPATH=web/backend pytest -o addopts= tests/api/file_tests/test_strategy_management_api.py::TestStrategyManagementAPIFile::test_strategy_monitoring_db_uses_route_dependency_provider -q -n 0 --tb=short --no-cov",
+      "result": "1 passed, 1 warning in 2.62s"
+    },
+    "ruff": {
+      "command": "ruff check web/backend/app/api/strategy_management/_helpers.py web/backend/app/api/strategy_management/_strategy_crud_router.py tests/api/file_tests/test_strategy_management_api.py",
+      "result": "All checks passed"
+    },
+    "runtime_openapi": "548 routes, 500 paths, duplicate operation IDs 0, no monitoring_db parameter leaks on target strategy/risk endpoints"
+  },
+  "gitnexus_staged_verification": {
+    "mcp_detect_changes": "Transport closed",
+    "cli_command": "npx gitnexus verify-staged -r mystocks --cwd /opt/claude/mystocks_spec/.worktrees/g2-279-strategy-get-monitoring-db-provider-closeout-refresh --json",
+    "ok": true,
+    "status": "stale",
+    "risk_level": "low",
+    "changed_files": 9,
+    "changed_symbols": 0,
+    "affected_processes": 0,
+    "indexed_commit": "20cb37ace841beeb0079b191a8a564c03029b36a",
+    "current_commit": "c5496cab0a4213f74636af1c48772dc96c90bd1b",
+    "stale_reason": "current_commit_differs_from_indexed_commit",
+    "next_action": "Refresh the GitNexus index before relying on graph freshness."
+  },
+  "decision": {
+    "classification": "closeout-refresh-for-review",
+    "closed_surfaces": [
+      "strategy route-body direct get_monitoring_db().log_operation calls",
+      "risk route-body direct get_monitoring_db().log_operation calls"
+    ],
+    "retained_surfaces": [
+      "strategy route-local provider wrappers",
+      "risk route-local provider wrappers",
+      "utility same-name helper in web/backend/app/utils/risk_utils.py"
+    ],
+    "selected_next_governance_target": "service-lifecycle-residual-candidate-refresh-after-get-monitoring-db",
+    "recommended_next_work_item": "G2.280 no-source service lifecycle residual candidate refresh after get_monitoring_db closeout"
+  },
+  "freshness": {
+    "current_head_checked": "c5496cab0a4213f74636af1c48772dc96c90bd1b",
+    "stale_if_head_or_pr_state_changes": true,
+    "stale_if_route_or_openapi_counts_change": true,
+    "stale_if_strategy_or_risk_get_monitoring_db_call_sites_change": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-06-01T00:37:55+08:00`
-- Base HEAD checked: `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`
+- Prepared at: `2026-06-01T01:06:12+08:00`
+- Base HEAD checked: `c5496cab0a4213f74636af1c48772dc96c90bd1b`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -115,7 +115,8 @@ PRs, change issue labels, or authorize source implementation.
 | `#428` | `g2-275-risk-get-monitoring-db-provider` | `wip/root-dirty-20260403` | `MERGED` at `daa4f22a557b054ab76042d4990b6e91d9faa7a7` | Path-limited risk `get_monitoring_db` provider implementation |
 | `#429` | `g2-276-risk-get-monitoring-db-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `f48ede2ce2202318efa3411fe22fb83a8d4d920b` | No-source risk provider closeout selecting G2.277 strategy authorization |
 | `#430` | `g2-277-strategy-get-monitoring-db-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441` | No-source authorization package for G2.278 strategy `get_monitoring_db` provider implementation |
-| `#431` | `g2-278-strategy-get-monitoring-db-provider` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | Path-limited strategy `get_monitoring_db` provider implementation |
+| `#431` | `g2-278-strategy-get-monitoring-db-provider` | `wip/root-dirty-20260403` | `MERGED` at `c5496cab0a4213f74636af1c48772dc96c90bd1b` | Path-limited strategy `get_monitoring_db` provider implementation selecting G2.279 closeout / residual refresh |
+| `#432` | `g2-279-strategy-get-monitoring-db-provider-closeout-refresh` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | No-source strategy `get_monitoring_db` provider closeout selecting G2.280 residual candidate refresh |
 
 ## Steward Governance Branch
 
@@ -140,6 +141,7 @@ PRs, change issue labels, or authorize source implementation.
 | `g2-276-risk-get-monitoring-db-provider-closeout-refresh` | `origin/wip/root-dirty-20260403` at `daa4f22a557b054ab76042d4990b6e91d9faa7a7` | Close out G2.275 and select strategy-management residual authorization | No |
 | `g2-277-strategy-get-monitoring-db-provider-authorization` | `origin/wip/root-dirty-20260403` at `f48ede2ce2202318efa3411fe22fb83a8d4d920b` | Authorize a future path-limited strategy `get_monitoring_db` route-provider implementation | No |
 | `g2-278-strategy-get-monitoring-db-provider` | `origin/wip/root-dirty-20260403` at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441` | Implement the authorized strategy `get_monitoring_db` route-provider lane | Yes, path-limited |
+| `g2-279-strategy-get-monitoring-db-provider-closeout-refresh` | `origin/wip/root-dirty-20260403` at `c5496cab0a4213f74636af1c48772dc96c90bd1b` | Close out G2.278, refresh `get_monitoring_db` residuals, and select G2.280 no-source residual candidate refresh | No |
 
 ## OpenSpec Relationship
 
@@ -187,4 +189,6 @@ G2.276 is the no-source risk `get_monitoring_db` provider closeout / residual re
 
 G2.277 is the no-source strategy `get_monitoring_db` route-provider authorization after PR `#429` merged G2.276 at `f48ede2ce2202318efa3411fe22fb83a8d4d920b`. It authorizes only a future G2.278 path-limited strategy source lane for `strategy_management/_helpers.py` and `strategy_management/_strategy_crud_router.py` after PR `#430` acceptance. It must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
 
-G2.278 is the path-limited strategy `get_monitoring_db` provider implementation after PR `#430` merged G2.277 at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`. It may touch only `web/backend/app/api/strategy_management/_helpers.py`, `web/backend/app/api/strategy_management/_strategy_crud_router.py`, the focused strategy file test, and governance evidence. It must not edit risk helpers, `web/backend/app/utils/risk_utils.py`, non-strategy routes, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+G2.278 is the path-limited strategy `get_monitoring_db` provider implementation after PR `#430` merged G2.277 at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`. It merged by PR `#431` at `c5496cab0a4213f74636af1c48772dc96c90bd1b`. It may touch only `web/backend/app/api/strategy_management/_helpers.py`, `web/backend/app/api/strategy_management/_strategy_crud_router.py`, the focused strategy file test, and governance evidence. It must not edit risk helpers, `web/backend/app/utils/risk_utils.py`, non-strategy routes, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+
+G2.279 is the no-source strategy `get_monitoring_db` provider closeout / residual refresh after PR `#431` merged G2.278 at `c5496cab0a4213f74636af1c48772dc96c90bd1b`. It records strategy direct `get_monitoring_db().log_operation(...)` calls as `0`, risk route-body direct calls as `0`, runtime/OpenAPI smoke as `548` routes, `500` paths, duplicate operation IDs `0`, and selects `G2.280 no-source service lifecycle residual candidate refresh after get_monitoring_db closeout`. It must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-05-31T23:34:18+08:00`
-- Base HEAD checked: `daa4f22a557b054ab76042d4990b6e91d9faa7a7`
+- Prepared at: `2026-06-01T01:06:12+08:00`
+- Base HEAD checked: `c5496cab0a4213f74636af1c48772dc96c90bd1b`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -19,9 +19,9 @@ exact verification output.
 | Route/OpenAPI and control-plane governance | Established route table, OpenAPI exposure, health/probe taxonomy, and consumer-contract evidence as first-class governance facts | Continue through route/OpenAPI track, not ad hoc route edits |
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
-| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.277 accepted/merged by PR `#430` at `2d1d2c28` | Continue with G2.278 strategy `get_monitoring_db` provider implementation review, then G2.279 no-source closeout only if accepted |
+| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.278 accepted/merged by PR `#431` at `c5496cab0` | Continue with G2.279 strategy `get_monitoring_db` provider closeout / residual refresh review, then G2.280 no-source residual candidate refresh only if accepted |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.277 have progressed through PR `#337`-`#430`; current review target is G2.278 strategy implementation in future PR `#431` |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.278 have progressed through PR `#337`-`#431`; current review target is G2.279 closeout / residual refresh in future PR `#432` |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Recent Closeouts
@@ -41,6 +41,7 @@ exact verification output.
 | G2.275 risk get_monitoring_db provider implementation | PR `#428` merged at `daa4f22a557b054ab76042d4990b6e91d9faa7a7`; direct risk route-body calls are `0` and route/OpenAPI contracts stayed stable | G2.276 records closeout and selects the strategy-management residual for a no-source authorization gate |
 | G2.276 risk get_monitoring_db provider closeout / residual refresh | PR `#429` merged at `f48ede2ce2202318efa3411fe22fb83a8d4d920b`; risk lane closed and strategy-management residual selected | G2.277 authorizes only the strategy-management route/helper surface before any G2.278 implementation |
 | G2.277 strategy get_monitoring_db provider authorization | PR `#430` merged at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`; path-limited strategy source lane authorized | G2.278 implements only the two authorized strategy source files and focused strategy test |
+| G2.278 strategy get_monitoring_db provider implementation | PR `#431` merged at `c5496cab0a4213f74636af1c48772dc96c90bd1b`; direct strategy target calls are `0`, dependency parameters are `6`, route/OpenAPI contracts stayed stable | G2.279 records closeout, confirms risk route-body calls remain closed, and selects the next no-source residual candidate refresh |
 
 ## Closeout Rule
 

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-06-01T00:37:55+08:00`
-- Base HEAD checked: `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`
+- Prepared at: `2026-06-01T01:06:12+08:00`
+- Base HEAD checked: `c5496cab0a4213f74636af1c48772dc96c90bd1b`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.278 strategy `get_monitoring_db` route-provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#430` merged at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`; G2.278 moves strategy-management logging to `Depends(get_strategy_monitoring_db)` in the authorized path-limited source files while preserving route/OpenAPI shape | Review PR `#431` when opened; if accepted, start `G2.279 no-source strategy get_monitoring_db provider closeout / residual refresh`; do not expand into risk, utility helper, route registration, docs/api, frontend, OpenSpec, PM2, or broader backend source |
+| P0 | Review G2.279 strategy `get_monitoring_db` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#431` merged at `c5496cab0a4213f74636af1c48772dc96c90bd1b`; G2.279 records strategy direct `get_monitoring_db().log_operation(...)` calls as `0`, risk route-body direct calls as `0`, runtime/OpenAPI as `548/500/0`, and leaves the utility same-name helper deferred | Review PR `#432` when opened; if accepted, start `G2.280 no-source service lifecycle residual candidate refresh after get_monitoring_db closeout`; do not start source implementation from G2.279 |
+| P0 | Preserve G2.278 strategy `get_monitoring_db` route-provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#431` merged at `c5496cab0a4213f74636af1c48772dc96c90bd1b`; strategy-management logging moved to `Depends(get_strategy_monitoring_db)` in the authorized path-limited source files while preserving route/OpenAPI shape | Do not use G2.278 as authority for risk helper changes, utility helper changes, route registration, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or broader backend source |
 | P0 | Preserve G2.277 strategy `get_monitoring_db` route-provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#430` merged at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`; G2.277 authorized only `_helpers.py`, `_strategy_crud_router.py`, and focused strategy tests for G2.278 | Do not use G2.277 as authority for risk helper edits, utility helper edits, non-strategy migrations, route registration, OpenAPI artifact edits, frontend, config, scripts, OpenSpec, PM2, or source retirement |
 | P0 | Preserve G2.276 risk `get_monitoring_db` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#429` merged at `f48ede2ce2202318efa3411fe22fb83a8d4d920b`; risk route-body `get_monitoring_db()` calls remain closed at `0`, strategy-management residual selected for no-source authorization | Do not use G2.276 as authority for backend source edits, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state |
 | P0 | Preserve G2.275 risk `get_monitoring_db` route-provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#428` merged at `daa4f22a557b054ab76042d4990b6e91d9faa7a7`; G2.275 moved `create_risk_alert`, `calculate_var_cvar`, and `calculate_beta` to `Depends(get_risk_monitoring_db)` | Do not use G2.275 as authority for strategy-management helper changes, utility helper changes, route registration, OpenAPI artifact edits, frontend, config, scripts, OpenSpec, PM2, or broader backend source |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-06-01T00:37:55+08:00`
-- Base HEAD checked: `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`
+- Prepared at: `2026-06-01T01:06:12+08:00`
+- Base HEAD checked: `c5496cab0a4213f74636af1c48772dc96c90bd1b`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -16,9 +16,12 @@ state transition.
 
 | Evidence | Role | Freshness policy |
 |---|---|---|
-| `.planning/codebase/generated/strategy-get-monitoring-db-provider-implementation-2026-06-01.json` | G2.278 strategy `get_monitoring_db` provider implementation evidence | Review input for future PR `#431`; path-limited source implementation |
-| `docs/reports/quality/backend-strategy-get-monitoring-db-provider-implementation-2026-06-01.md` | G2.278 human-readable implementation report | Review input for future PR `#431`; records TDD, source/test verification, OpenAPI smoke, and known strategy file-test debt |
-| `governance/mainline/task-cards/pr-431.yaml` | Path-limited implementation task card for G2.278 | Review input; allows only two strategy source files, focused tests, steward tree, generated evidence, report, and task card updates |
+| `.planning/codebase/generated/strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.json` | G2.279 strategy `get_monitoring_db` provider closeout / residual-refresh evidence | Review input for future PR `#432`; no-source closeout and next-gate selection |
+| `docs/reports/quality/backend-strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.md` | G2.279 human-readable closeout / residual-refresh report | Review input for future PR `#432`; records PR `#431` accepted/merged, current residual scan, OpenAPI smoke, and G2.280 recommendation |
+| `governance/mainline/task-cards/pr-432.yaml` | No-source governance task card for G2.279 | Review input; allows only steward tree, generated evidence, report, and task card updates |
+| `.planning/codebase/generated/strategy-get-monitoring-db-provider-implementation-2026-06-01.json` | G2.278 strategy `get_monitoring_db` provider implementation evidence | Accepted by PR `#431`, merged at `c5496cab0a4213f74636af1c48772dc96c90bd1b`; path-limited source implementation |
+| `docs/reports/quality/backend-strategy-get-monitoring-db-provider-implementation-2026-06-01.md` | G2.278 human-readable implementation report | Accepted by PR `#431`; records TDD, source/test verification, OpenAPI smoke, and known strategy file-test debt |
+| `governance/mainline/task-cards/pr-431.yaml` | Path-limited implementation task card for G2.278 | Accepted by PR `#431`; allowed only two strategy source files, focused tests, steward tree, generated evidence, report, and task card updates |
 | `.planning/codebase/generated/strategy-get-monitoring-db-provider-authorization-2026-05-31.json` | G2.277 strategy `get_monitoring_db` provider authorization evidence | Accepted by PR `#430`, merged at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`; no-source authorization package only |
 | `docs/reports/quality/backend-strategy-get-monitoring-db-provider-authorization-2026-05-31.md` | G2.277 human-readable authorization report | Accepted by PR `#430`; authorizes only a future strategy-management source lane after acceptance |
 | `governance/mainline/task-cards/pr-430.yaml` | Path-limited governance task card for G2.277 | Accepted by PR `#430`; allowed only steward tree, generated evidence, report, and task card updates |

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-06-01T00:37:55+08:00",
+  "generated_at": "2026-06-01T01:06:12+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441",
-  "split_branch": "g2-278-strategy-get-monitoring-db-provider",
+  "base_head": "c5496cab0a4213f74636af1c48772dc96c90bd1b",
+  "split_branch": "g2-279-strategy-get-monitoring-db-provider-closeout-refresh",
   "scope": "strategy_get_monitoring_db_provider_implementation",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
@@ -8007,15 +8007,17 @@
     {
       "id": "g2-278-strategy-get-monitoring-db-provider-implementation",
       "type": "implementation_package",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.277 strategy get_monitoring_db route-provider authorization",
       "source_edit_authority": true,
       "github_pr": {
         "number": 431,
         "url": "https://github.com/chengjon/mystocks/pull/431",
-        "state": "PLANNED_FOR_REVIEW",
-        "head_ref": "g2-278-strategy-get-monitoring-db-provider"
+        "state": "MERGED",
+        "head_ref": "g2-278-strategy-get-monitoring-db-provider",
+        "merge_commit": "c5496cab0a4213f74636af1c48772dc96c90bd1b",
+        "merged_at": "2026-05-31T16:57:57Z"
       },
       "evidence": [
         ".planning/codebase/generated/strategy-get-monitoring-db-provider-implementation-2026-06-01.json",
@@ -8111,12 +8113,90 @@
         "recommended_next_work_item": "G2.279 no-source strategy get_monitoring_db provider closeout / residual refresh"
       },
       "freshness": {
-        "current_head_checked": "2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441",
+        "current_head_checked": "c5496cab0a4213f74636af1c48772dc96c90bd1b",
         "stale_if_head_or_pr_state_changes": true,
         "stale_if_route_or_openapi_counts_change": true,
         "stale_if_strategy_get_monitoring_db_call_sites_change": true
       },
-      "next_gate": "If accepted, start G2.279 no-source strategy get_monitoring_db provider closeout / residual refresh."
+      "next_gate": "Superseded by G2.279 no-source strategy get_monitoring_db provider closeout / residual refresh."
+    },
+    {
+      "id": "g2-279-strategy-get-monitoring-db-provider-closeout-refresh",
+      "type": "closeout_refresh",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.278 strategy get_monitoring_db provider implementation",
+      "source_edit_authority": false,
+      "github_pr": {
+        "number": 432,
+        "url": "https://github.com/chengjon/mystocks/pull/432",
+        "state": "PLANNED_FOR_REVIEW",
+        "head_ref": "g2-279-strategy-get-monitoring-db-provider-closeout-refresh"
+      },
+      "evidence": [
+        ".planning/codebase/generated/strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.json",
+        "docs/reports/quality/backend-strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.md",
+        "governance/mainline/task-cards/pr-432.yaml"
+      ],
+      "closed_parent": {
+        "pr": 431,
+        "state": "MERGED",
+        "merge_commit": "c5496cab0a4213f74636af1c48772dc96c90bd1b",
+        "merged_at": "2026-05-31T16:57:57Z"
+      },
+      "allowed_scope": [
+        ".planning/codebase/generated/strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.md",
+        "governance/mainline/task-cards/pr-432.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "tests/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "closeout_result": {
+        "strategy_direct_get_monitoring_db_log_calls": 0,
+        "strategy_depends_parameters": 6,
+        "risk_route_body_direct_get_monitoring_db_calls": 0,
+        "utility_same_name_helper_status": "deferred utility helper with no active API route-body log calls in this scan",
+        "runtime_routes": 548,
+        "openapi_paths": 500,
+        "duplicate_operation_ids": 0,
+        "monitoring_db_parameter_leaks": false
+      },
+      "verification": {
+        "focused_strategy_provider_test": "1 passed, 1 warning",
+        "ruff": "All checks passed on touched strategy source/test files",
+        "runtime_openapi": "548 routes, 500 paths, duplicate operation IDs 0, no monitoring_db parameter leaks on target endpoints",
+        "gitnexus_staged": "MCP detect_changes returned Transport closed; CLI fallback ok=true, status=stale, risk=low, changed symbols 0, affected processes 0"
+      },
+      "decision": {
+        "classification": "closeout-refresh-for-review",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-279",
+        "selected_next_governance_target": "service-lifecycle-residual-candidate-refresh-after-get-monitoring-db",
+        "recommended_next_work_item": "G2.280 no-source service lifecycle residual candidate refresh after get_monitoring_db closeout"
+      },
+      "freshness": {
+        "current_head_checked": "c5496cab0a4213f74636af1c48772dc96c90bd1b",
+        "stale_if_head_or_pr_state_changes": true,
+        "stale_if_route_or_openapi_counts_change": true,
+        "stale_if_strategy_or_risk_get_monitoring_db_call_sites_change": true
+      },
+      "next_gate": "If accepted, start G2.280 no-source service lifecycle residual candidate refresh after get_monitoring_db closeout."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -2954,7 +2954,7 @@ Status: accepted/merged by PR `#430` at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d044
 
 ## G2.278 Strategy get_monitoring_db Provider Implementation
 
-Status: for review in future PR `#431`.
+Status: accepted/merged by PR `#431` at `c5496cab0a4213f74636af1c48772dc96c90bd1b`.
 
 - Parent PR `#430` merged at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`.
 - GitNexus MCP impact/context returned `Transport closed`; CLI fallback reported LOW risk for `get_monitoring_db`, `list_strategies`, `create_strategy`, and `_handle_strategy_lifecycle_action`, with `0` affected processes.
@@ -2967,3 +2967,16 @@ Status: for review in future PR `#431`.
 - Runtime/OpenAPI smoke with placeholder import-time environment values recorded `548` FastAPI routes, `500` OpenAPI paths, `0` duplicate operation IDs, and no `monitoring_db` parameter leak on target strategy endpoints.
 - Next gate after acceptance: G2.279 no-source strategy `get_monitoring_db` provider closeout / residual refresh.
 - G2.278 must not be used as authority for risk helper changes, `web/backend/app/utils/risk_utils.py`, route registration, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or broader backend source.
+
+## G2.279 Strategy get_monitoring_db Provider Closeout / Residual Refresh
+
+Status: for review in future PR `#432`.
+
+- Parent PR `#431` merged at `c5496cab0a4213f74636af1c48772dc96c90bd1b`.
+- Strategy direct `get_monitoring_db().log_operation(...)` calls in the target files are `0`; active strategy dependency parameters remain `6`; `monitoring_db.log_operation(...)` calls remain `6`.
+- Risk route-body direct `get_monitoring_db().log_operation(...)` calls remain closed at `0`; risk provider wrappers remain retained.
+- `web/backend/app/utils/risk_utils.py` remains a deferred utility same-name helper with `0` active API route-body log calls in this scan.
+- Runtime/OpenAPI smoke with placeholder import-time environment values recorded `548` FastAPI routes, `500` OpenAPI paths, `0` duplicate operation IDs, and no `monitoring_db` parameter leak on target strategy/risk endpoints.
+- Focused strategy provider test remains green at `1/1`; touched strategy ruff remains clean.
+- Selected next gate after acceptance: G2.280 no-source service lifecycle residual candidate refresh after `get_monitoring_db` closeout.
+- G2.279 must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.

--- a/docs/reports/quality/backend-strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.md
+++ b/docs/reports/quality/backend-strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.md
@@ -1,0 +1,149 @@
+# Backend Strategy get_monitoring_db Provider Closeout Refresh
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Gate: `G2.279`
+- Status: for review
+- Prepared at: `2026-06-01T01:06:12+08:00`
+- Base HEAD checked: `c5496cab0a4213f74636af1c48772dc96c90bd1b`
+- Parent PR: `#431`
+- Parent merge commit: `c5496cab0a4213f74636af1c48772dc96c90bd1b`
+- Source edit authority: no
+
+Boundary note: this report records closeout and next-gate evidence only. It does
+not authorize backend source edits, route registration changes, generated
+OpenAPI artifact edits, frontend/config/script edits, OpenSpec changes, PM2
+commands, or runtime state changes.
+
+## Parent Closeout
+
+PR `#431` merged G2.278 at
+`c5496cab0a4213f74636af1c48772dc96c90bd1b`.
+
+G2.278 implemented only the G2.277-authorized strategy surface:
+
+- `web/backend/app/api/strategy_management/_helpers.py`
+- `web/backend/app/api/strategy_management/_strategy_crud_router.py`
+- focused strategy provider test coverage
+- governance evidence and task-card updates
+
+The G2.278 implementation moved the active strategy CRUD/lifecycle route
+logging surface behind `Depends(get_strategy_monitoring_db)` while preserving
+route paths, OpenAPI path count, response contracts, and handler behavior.
+
+## Current Residual Scan
+
+| Path | Direct `get_monitoring_db().log_operation(...)` calls | Provider depends params | Provider definitions | Notes |
+|---|---:|---:|---:|---|
+| `web/backend/app/api/strategy_management/_helpers.py` | 0 | 0 | 2 | Contains backing provider definitions and helper-level `monitoring_db.log_operation(...)` calls |
+| `web/backend/app/api/strategy_management/_strategy_crud_router.py` | 0 | 6 | 0 | Active strategy handlers now receive `monitoring_db` through dependency parameters |
+| `web/backend/app/api/risk/_shared.py` | 0 | 0 | 2 | Risk provider backing remains retained from G2.275 |
+| `web/backend/app/api/risk/alerts.py` | 0 | 1 | 0 | Risk route-body direct calls remain closed |
+| `web/backend/app/api/risk/metrics.py` | 0 | 2 | 0 | Risk route-body direct calls remain closed |
+| `web/backend/app/utils/risk_utils.py` | 0 | 0 | 1 | Utility same-name helper remains deferred; no active API route-body log call in this scan |
+
+Interpretation:
+
+- Strategy direct route/helper target calls are closed at `0`.
+- Strategy active handler dependency parameters are `6`.
+- Risk direct route-body calls remain closed at `0`.
+- `web/backend/app/utils/risk_utils.py` is not promoted into a source lane by
+  this closeout; it remains a deferred utility same-name helper.
+- Name occurrences from definitions or historical docstrings are not counted as
+  active route-body calls.
+
+## Runtime / OpenAPI Smoke
+
+Runtime/OpenAPI smoke with placeholder import-time environment values recorded:
+
+- FastAPI routes: `548`
+- OpenAPI paths: `500`
+- Duplicate operation IDs: `0`
+- Target strategy/risk endpoints leaked `monitoring_db` request parameters: `false`
+
+Checked target endpoints:
+
+| Endpoint | Params | Request body | `monitoring_db` leak |
+|---|---:|---|---|
+| `GET /api/v1/strategy/strategies` | 4 | false | false |
+| `POST /api/v1/strategy/strategies` | 0 | true | false |
+| `POST /api/v1/strategy/{strategy_id}/start` | 1 | false | false |
+| `POST /api/v1/strategy/{strategy_id}/pause` | 1 | false | false |
+| `POST /api/v1/strategy/{strategy_id}/resume` | 1 | false | false |
+| `POST /api/v1/strategy/{strategy_id}/stop` | 1 | false | false |
+| `GET /api/v1/risk/alerts` | 1 | false | false |
+| `POST /api/v1/risk/alerts` | 0 | true | false |
+| `POST /api/v1/risk/var-cvar` | 0 | true | false |
+| `POST /api/v1/risk/beta` | 0 | true | false |
+
+## Focused Verification
+
+| Check | Result |
+|---|---|
+| Focused strategy provider test | `1 passed, 1 warning in 2.62s` |
+| Touched strategy ruff check | `All checks passed` |
+| Runtime/OpenAPI smoke | `548` routes, `500` paths, duplicate operation IDs `0` |
+| GitNexus staged verification | MCP `detect_changes` returned `Transport closed`; CLI fallback returned `ok=true`, `risk_level=low`, changed symbols `0`, affected processes `0`, with stale-index warning |
+
+Focused provider test:
+
+```bash
+env PYTHONPATH=web/backend pytest -o addopts= tests/api/file_tests/test_strategy_management_api.py::TestStrategyManagementAPIFile::test_strategy_monitoring_db_uses_route_dependency_provider -q -n 0 --tb=short --no-cov
+```
+
+Ruff check:
+
+```bash
+ruff check web/backend/app/api/strategy_management/_helpers.py web/backend/app/api/strategy_management/_strategy_crud_router.py tests/api/file_tests/test_strategy_management_api.py
+```
+
+GitNexus staged verification:
+
+```bash
+npx gitnexus verify-staged -r mystocks --cwd /opt/claude/mystocks_spec/.worktrees/g2-279-strategy-get-monitoring-db-provider-closeout-refresh --json
+```
+
+The CLI fallback reported a stale index:
+
+- indexed commit: `20cb37ace841beeb0079b191a8a564c03029b36a`
+- current commit: `c5496cab0a4213f74636af1c48772dc96c90bd1b`
+- stale reason: `current_commit_differs_from_indexed_commit`
+
+Use this as scope-risk evidence only after noting the stale-index warning; refresh
+the GitNexus index before relying on graph freshness.
+
+## Decision
+
+G2.279 records the strategy `get_monitoring_db` provider lane as closed for the
+authorized target surface.
+
+Accepted facts for review:
+
+- PR `#431` is merged at
+  `c5496cab0a4213f74636af1c48772dc96c90bd1b`.
+- Strategy direct `get_monitoring_db().log_operation(...)` calls in the target
+  files are `0`.
+- Risk direct route-body `get_monitoring_db().log_operation(...)` calls remain
+  `0`.
+- Runtime/OpenAPI shape remains stable at `548` routes, `500` OpenAPI paths,
+  and duplicate operation IDs `0`.
+
+Recommended next gate after review acceptance:
+
+`G2.280 no-source service lifecycle residual candidate refresh after get_monitoring_db closeout`
+
+G2.280 should refresh the remaining service lifecycle queue before any new
+authorization or source lane. It should not start backend source implementation
+directly from this G2.279 closeout.
+
+## Stale Policy
+
+This report is stale if any of these change before review:
+
+- current HEAD differs from
+  `c5496cab0a4213f74636af1c48772dc96c90bd1b`
+- PR `#431` merge state or merge commit changes
+- runtime route count or OpenAPI path count changes
+- target strategy/risk `get_monitoring_db` call-site scan changes

--- a/governance/mainline/task-cards/pr-432.yaml
+++ b/governance/mainline/task-cards/pr-432.yaml
@@ -1,0 +1,126 @@
+version: "v0.2"
+
+task:
+  id: "pr-432"
+  title: "Close strategy get_monitoring_db provider lane"
+  owner: "codex"
+  created_at: "2026-06-01"
+
+mainline:
+  id: "L1-strategy-get-monitoring-db-provider-closeout-refresh"
+  objective: "record G2.278 acceptance, close the strategy get_monitoring_db provider lane, and select the next no-source residual refresh gate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "G2.279 is a no-source governance closeout and residual refresh. It changes no runtime entrypoint, route path, route registration, generated OpenAPI artifact, frontend route, or FUNCTION_TREE catalog entry."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.md"
+    - "governance/mainline/task-cards/pr-432.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits"
+  - "test edits"
+  - "route registration changes"
+  - "route path, method, response model, or generated OpenAPI artifact changes"
+  - "docs/api artifact edits"
+  - "frontend/config/script changes"
+  - "OpenSpec proposal or spec edits"
+  - "PM2 commands or stateful runtime gates"
+  - "source retirement"
+
+acceptance:
+  checks:
+    - id: "pr431-merged"
+      command: "gh pr view 431 confirms MERGED at c5496cab0a4213f74636af1c48772dc96c90bd1b"
+      required: true
+    - id: "static-residual-scan"
+      command: "current HEAD scan records strategy direct get_monitoring_db().log_operation calls at 0 and risk route-body direct calls at 0"
+      required: true
+    - id: "runtime-openapi-smoke"
+      command: "app.main route/OpenAPI smoke records 548 routes, 500 paths, duplicate operation IDs 0, and no monitoring_db parameter leak on target endpoints"
+      required: true
+    - id: "focused-provider-test"
+      command: "env PYTHONPATH=web/backend pytest -o addopts= tests/api/file_tests/test_strategy_management_api.py::TestStrategyManagementAPIFile::test_strategy_monitoring_db_uses_route_dependency_provider -q -n 0 --tb=short --no-cov"
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/api/strategy_management/_helpers.py web/backend/app/api/strategy_management/_strategy_crud_router.py tests/api/file_tests/test_strategy_management_api.py"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-432.yaml --base-sha c5496cab0a4213f74636af1c48772dc96c90bd1b --head-sha HEAD --report /tmp/pr432-mainline-governance-report.json"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "gitnexus-detect-changes"
+      command: "GitNexus staged verification attempted before commit; stale-index warning recorded if present"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "A future worker may treat this closeout as source implementation authorization; the report and steward tree explicitly forbid that."
+    - "Utility same-name helper in web/backend/app/utils/risk_utils.py remains deferred and must not be removed from G2.279."
+  rollback_plan: "Revert PR #432; this removes only governance evidence and restores the previous steward tree state."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Close the accepted strategy get_monitoring_db provider lane."
+    modified_scope: "Governance evidence, steward tree indexes, human-readable report, and task card only."
+    dependency_changes: "No dependency changes."
+    legacy_logic_impact: "No runtime, route, OpenAPI, frontend, config, script, or OpenSpec changes."
+    rollback_ready: "Revert PR #432."
+    risk_and_rollback_point: "No-source closeout; rollback is single-PR revert."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-01T01:06:12+08:00"
+    approval_note: "Human maintainer approved continuing after PR #431 acceptance into G2.279 no-source closeout / residual refresh. Scope remains limited to governance artifacts."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records PR #431 as merged at c5496cab0a4213f74636af1c48772dc96c90bd1b
- closes the strategy get_monitoring_db provider lane with direct target calls at 0 and Depends params at 6
- refreshes residual state and selects G2.280 no-source service lifecycle residual candidate refresh after get_monitoring_db closeout

## Boundary
- no backend source edits
- no test edits
- no route/OpenAPI artifact edits
- no frontend/config/script/OpenSpec/PM2 changes

## Verification
- JSON parse: ok
- markdown governance gate: 6 checked, 0 errors
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: valid
- mainline scope gate: pass
- git diff --check and staged/postcommit diff check: pass
- GitNexus MCP detect_changes: Transport closed; CLI fallback ok=true, status=stale, risk=low, changed symbols 0, affected processes 0