### PR TITLE
docs(governance): refresh monitoring db residual candidates

### DIFF
--- a/.planning/codebase/generated/service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.json
+++ b/.planning/codebase/generated/service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.json
@@ -1,0 +1,229 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-06-01T01:32:16+08:00",
+  "gate": "G2.280",
+  "title": "Service lifecycle residual candidate refresh after get_monitoring_db closeout",
+  "repo": "mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "fcead56344110e33041319271c122e71d2b763a0",
+  "worktree": ".worktrees/g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db",
+  "source_edit_authority": false,
+  "parent": {
+    "gate": "G2.279",
+    "pr": 432,
+    "state": "MERGED",
+    "merged_at": "2026-05-31T17:26:19Z",
+    "merge_commit": "fcead56344110e33041319271c122e71d2b763a0",
+    "summary": "No-source strategy get_monitoring_db provider closeout accepted and merged."
+  },
+  "scan": {
+    "roots": [
+      "web/backend/app/api",
+      "web/backend/app/services"
+    ],
+    "python_files_scanned": 371,
+    "getter_names_seen": 572,
+    "active_interesting_candidates": 31,
+    "method_calls_excluded": true,
+    "known_closed_surfaces_excluded": [
+      "get_monitoring_db",
+      "get_risk_monitoring_db",
+      "get_strategy_monitoring_db",
+      "get_monitoring_portfolio_optimizer",
+      "get_monitoring_analysis_postgres_async",
+      "get_monitoring_watchlists_postgres_async",
+      "get_signal_history_postgres_async",
+      "get_monitoring_postgres_async",
+      "get_data_service_dependency",
+      "get_config_manager_dependency",
+      "get_calculator_factory",
+      "get_prewarming_strategy",
+      "get_execution_tracking_evidence_service",
+      "get_unified_data_service",
+      "get_stop_loss_service",
+      "get_data_quality_monitor",
+      "get_data_adapter",
+      "get_strategy_service",
+      "get_strategy_adapter",
+      "get_postgres_async",
+      "get_mock_data_manager"
+    ],
+    "top_candidates": [
+      {
+        "name": "get_integrated_services",
+        "api_bare_calls": 0,
+        "service_bare_calls": 7,
+        "defs": 1,
+        "files": [
+          "web/backend/app/services/__init__.py"
+        ],
+        "classification": "root facade compatibility surface",
+        "disposition": "defer to separate root facade compatibility decision"
+      },
+      {
+        "name": "get_indicator_registry",
+        "api_bare_calls": 0,
+        "service_bare_calls": 5,
+        "defs": 2,
+        "files": [
+          "web/backend/app/services/indicator_calculator.py",
+          "web/backend/app/services/indicator_registry.py",
+          "web/backend/app/services/indicators/talib_adapter.py",
+          "web/backend/app/services/indicators/indicator_registry.py",
+          "web/backend/app/services/indicators/defaults.py"
+        ],
+        "classification": "ambiguous registry surface",
+        "disposition": "defer until registry ownership is disambiguated"
+      },
+      {
+        "name": "get_lineage_tracker",
+        "api_bare_calls": 5,
+        "service_bare_calls": 0,
+        "defs": 1,
+        "files": [
+          "web/backend/app/api/data_lineage.py"
+        ],
+        "classification": "bounded active API route helper / provider candidate",
+        "disposition": "selected for next no-source ownership / route-provider decision"
+      },
+      {
+        "name": "get_postgres_connection",
+        "api_bare_calls": 5,
+        "service_bare_calls": 0,
+        "defs": 1,
+        "files": [
+          "web/backend/app/api/governance_dashboard.py"
+        ],
+        "classification": "control-plane DB connection helper",
+        "disposition": "defer to control-plane route/OpenAPI ownership decision"
+      },
+      {
+        "name": "get_redis_client",
+        "api_bare_calls": 0,
+        "service_bare_calls": 4,
+        "defs": 0,
+        "files": [
+          "web/backend/app/services/system_resource_metrics.py",
+          "web/backend/app/services/redis/redis_pubsub.py",
+          "web/backend/app/services/redis/redis_lock.py",
+          "web/backend/app/services/redis/redis_cache.py"
+        ],
+        "classification": "infrastructure cache/client helper",
+        "disposition": "defer to infrastructure/cache ownership lane"
+      },
+      {
+        "name": "get_cache_integration",
+        "api_bare_calls": 0,
+        "service_bare_calls": 4,
+        "defs": 0,
+        "files": [
+          "web/backend/app/services/unified_data_service.py",
+          "web/backend/app/services/market_data_service/market_data_service_methods/part1.py",
+          "web/backend/app/services/data_service_enhanced.py",
+          "web/backend/app/services/data_service.py"
+        ],
+        "classification": "cache integration infrastructure surface",
+        "disposition": "defer to infrastructure/cache ownership lane"
+      },
+      {
+        "name": "get_cache_manager",
+        "api_bare_calls": 1,
+        "service_bare_calls": 0,
+        "defs": 1,
+        "provider_like": 6,
+        "files": [
+          "web/backend/app/api/dashboard.py",
+          "web/backend/app/api/_cache_basic_routes.py",
+          "web/backend/app/api/cache.py"
+        ],
+        "classification": "ambiguous dashboard/cache helper",
+        "disposition": "defer until dashboard/core cache ownership is disambiguated"
+      }
+    ]
+  },
+  "gitnexus_evidence": {
+    "mcp": {
+      "get_integrated_services_context": "Transport closed"
+    },
+    "cli": {
+      "index_status": "stale warning on sampled candidates",
+      "sampled_candidates": [
+        {
+          "name": "get_integrated_services",
+          "risk": "MEDIUM",
+          "impacted_count": 13,
+          "direct": 13,
+          "processes_affected": 0,
+          "disposition": "defer as root facade compatibility surface"
+        },
+        {
+          "name": "get_indicator_registry",
+          "risk": "UNKNOWN",
+          "status": "ambiguous",
+          "candidates": [
+            "web/backend/app/services/indicator_registry.py",
+            "web/backend/app/services/indicators/indicator_registry.py"
+          ],
+          "disposition": "defer until disambiguated"
+        },
+        {
+          "name": "get_lineage_tracker",
+          "risk": "MEDIUM",
+          "impacted_count": 5,
+          "direct": 5,
+          "processes_affected": 0,
+          "disposition": "selected for next no-source decision"
+        },
+        {
+          "name": "get_postgres_connection",
+          "risk": "MEDIUM",
+          "impacted_count": 6,
+          "direct": 5,
+          "processes_affected": 0,
+          "disposition": "defer to control-plane route/OpenAPI ownership"
+        },
+        {
+          "name": "get_cache_manager",
+          "risk": "UNKNOWN",
+          "status": "ambiguous",
+          "candidates": [
+            "web/backend/app/api/dashboard.py",
+            "web/backend/app/core/cache_manager.py"
+          ],
+          "disposition": "defer until dashboard/core cache ownership is disambiguated"
+        }
+      ]
+    }
+  },
+  "runtime_openapi_smoke": {
+    "routes": 548,
+    "openapi_paths": 500,
+    "duplicate_operation_ids": 0
+  },
+  "gitnexus_staged_verification": {
+    "mcp_detect_changes": "Transport closed",
+    "cli_command": "npx gitnexus verify-staged -r mystocks --cwd /opt/claude/mystocks_spec/.worktrees/g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db --json",
+    "ok": true,
+    "status": "stale",
+    "risk_level": "low",
+    "changed_files": 9,
+    "changed_symbols": 0,
+    "affected_processes": 0,
+    "indexed_commit": "13321ab73166afc0990b097503294a883842a941",
+    "current_commit": "fcead56344110e33041319271c122e71d2b763a0",
+    "stale_reason": "current_commit_differs_from_indexed_commit",
+    "next_action": "Refresh the GitNexus index before relying on graph freshness."
+  },
+  "decision": {
+    "classification": "residual-candidate-refresh-complete-no-source-lane",
+    "source_lane_recommendation": "do-not-start-source-implementation-from-g2-280",
+    "selected_next_governance_target": "G2.281 no-source data_lineage get_lineage_tracker ownership / route-provider decision",
+    "reason": "get_lineage_tracker is the most bounded active API route helper candidate after get_monitoring_db closeout: five active bare calls in one route module, non-ambiguous GitNexus target, MEDIUM sampled risk, and zero affected processes. Broader root facade, registry, control-plane DB, and cache candidates require separate ownership decisions before any source authorization."
+  },
+  "freshness": {
+    "current_head_checked": "fcead56344110e33041319271c122e71d2b763a0",
+    "stale_if_head_or_pr_state_changes": true,
+    "stale_if_route_or_openapi_counts_change": true,
+    "stale_if_candidate_scan_changes": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-06-01T01:06:12+08:00`
-- Base HEAD checked: `c5496cab0a4213f74636af1c48772dc96c90bd1b`
+- Prepared at: `2026-06-01T01:32:16+08:00`
+- Base HEAD checked: `fcead56344110e33041319271c122e71d2b763a0`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -116,7 +116,8 @@ PRs, change issue labels, or authorize source implementation.
 | `#429` | `g2-276-risk-get-monitoring-db-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `f48ede2ce2202318efa3411fe22fb83a8d4d920b` | No-source risk provider closeout selecting G2.277 strategy authorization |
 | `#430` | `g2-277-strategy-get-monitoring-db-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441` | No-source authorization package for G2.278 strategy `get_monitoring_db` provider implementation |
 | `#431` | `g2-278-strategy-get-monitoring-db-provider` | `wip/root-dirty-20260403` | `MERGED` at `c5496cab0a4213f74636af1c48772dc96c90bd1b` | Path-limited strategy `get_monitoring_db` provider implementation selecting G2.279 closeout / residual refresh |
-| `#432` | `g2-279-strategy-get-monitoring-db-provider-closeout-refresh` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | No-source strategy `get_monitoring_db` provider closeout selecting G2.280 residual candidate refresh |
+| `#432` | `g2-279-strategy-get-monitoring-db-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `fcead56344110e33041319271c122e71d2b763a0` | No-source strategy `get_monitoring_db` provider closeout selecting G2.280 residual candidate refresh |
+| `#433` | `g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | No-source residual candidate refresh selecting G2.281 data_lineage `get_lineage_tracker` decision |
 
 ## Steward Governance Branch
 
@@ -142,6 +143,7 @@ PRs, change issue labels, or authorize source implementation.
 | `g2-277-strategy-get-monitoring-db-provider-authorization` | `origin/wip/root-dirty-20260403` at `f48ede2ce2202318efa3411fe22fb83a8d4d920b` | Authorize a future path-limited strategy `get_monitoring_db` route-provider implementation | No |
 | `g2-278-strategy-get-monitoring-db-provider` | `origin/wip/root-dirty-20260403` at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441` | Implement the authorized strategy `get_monitoring_db` route-provider lane | Yes, path-limited |
 | `g2-279-strategy-get-monitoring-db-provider-closeout-refresh` | `origin/wip/root-dirty-20260403` at `c5496cab0a4213f74636af1c48772dc96c90bd1b` | Close out G2.278, refresh `get_monitoring_db` residuals, and select G2.280 no-source residual candidate refresh | No |
+| `g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db` | `origin/wip/root-dirty-20260403` at `fcead56344110e33041319271c122e71d2b763a0` | Refresh service lifecycle residual candidates after `get_monitoring_db` closeout and select G2.281 no-source `get_lineage_tracker` decision | No |
 
 ## OpenSpec Relationship
 
@@ -191,4 +193,6 @@ G2.277 is the no-source strategy `get_monitoring_db` route-provider authorizatio
 
 G2.278 is the path-limited strategy `get_monitoring_db` provider implementation after PR `#430` merged G2.277 at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`. It merged by PR `#431` at `c5496cab0a4213f74636af1c48772dc96c90bd1b`. It may touch only `web/backend/app/api/strategy_management/_helpers.py`, `web/backend/app/api/strategy_management/_strategy_crud_router.py`, the focused strategy file test, and governance evidence. It must not edit risk helpers, `web/backend/app/utils/risk_utils.py`, non-strategy routes, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
 
-G2.279 is the no-source strategy `get_monitoring_db` provider closeout / residual refresh after PR `#431` merged G2.278 at `c5496cab0a4213f74636af1c48772dc96c90bd1b`. It records strategy direct `get_monitoring_db().log_operation(...)` calls as `0`, risk route-body direct calls as `0`, runtime/OpenAPI smoke as `548` routes, `500` paths, duplicate operation IDs `0`, and selects `G2.280 no-source service lifecycle residual candidate refresh after get_monitoring_db closeout`. It must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+G2.279 is the no-source strategy `get_monitoring_db` provider closeout / residual refresh after PR `#431` merged G2.278 at `c5496cab0a4213f74636af1c48772dc96c90bd1b`. It merged by PR `#432` at `fcead56344110e33041319271c122e71d2b763a0`. It records strategy direct `get_monitoring_db().log_operation(...)` calls as `0`, risk route-body direct calls as `0`, runtime/OpenAPI smoke as `548` routes, `500` paths, duplicate operation IDs `0`, and selects `G2.280 no-source service lifecycle residual candidate refresh after get_monitoring_db closeout`. It must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+
+G2.280 is the no-source service lifecycle residual candidate refresh after PR `#432` merged G2.279 at `fcead56344110e33041319271c122e71d2b763a0`. It scans `371` API/service Python files, records `31` active interesting residual candidates after known-closed exclusions, defers root facade / registry / control-plane / cache surfaces, and selects `G2.281 no-source data_lineage get_lineage_tracker ownership / route-provider decision`. It must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-06-01T01:06:12+08:00`
-- Base HEAD checked: `c5496cab0a4213f74636af1c48772dc96c90bd1b`
+- Prepared at: `2026-06-01T01:32:16+08:00`
+- Base HEAD checked: `fcead56344110e33041319271c122e71d2b763a0`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -19,9 +19,9 @@ exact verification output.
 | Route/OpenAPI and control-plane governance | Established route table, OpenAPI exposure, health/probe taxonomy, and consumer-contract evidence as first-class governance facts | Continue through route/OpenAPI track, not ad hoc route edits |
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
-| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.278 accepted/merged by PR `#431` at `c5496cab0` | Continue with G2.279 strategy `get_monitoring_db` provider closeout / residual refresh review, then G2.280 no-source residual candidate refresh only if accepted |
+| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.279 accepted/merged by PR `#432` at `fcead563` | Continue with G2.280 service lifecycle residual candidate refresh review, then G2.281 no-source data_lineage `get_lineage_tracker` decision only if accepted |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.278 have progressed through PR `#337`-`#431`; current review target is G2.279 closeout / residual refresh in future PR `#432` |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.279 have progressed through PR `#337`-`#432`; current review target is G2.280 candidate refresh in future PR `#433` |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Recent Closeouts
@@ -42,6 +42,7 @@ exact verification output.
 | G2.276 risk get_monitoring_db provider closeout / residual refresh | PR `#429` merged at `f48ede2ce2202318efa3411fe22fb83a8d4d920b`; risk lane closed and strategy-management residual selected | G2.277 authorizes only the strategy-management route/helper surface before any G2.278 implementation |
 | G2.277 strategy get_monitoring_db provider authorization | PR `#430` merged at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`; path-limited strategy source lane authorized | G2.278 implements only the two authorized strategy source files and focused strategy test |
 | G2.278 strategy get_monitoring_db provider implementation | PR `#431` merged at `c5496cab0a4213f74636af1c48772dc96c90bd1b`; direct strategy target calls are `0`, dependency parameters are `6`, route/OpenAPI contracts stayed stable | G2.279 records closeout, confirms risk route-body calls remain closed, and selects the next no-source residual candidate refresh |
+| G2.279 strategy get_monitoring_db provider closeout / residual refresh | PR `#432` merged at `fcead56344110e33041319271c122e71d2b763a0`; strategy/risk direct calls remain closed and utility helper remains deferred | G2.280 refreshes residual candidates before any new authorization or source lane |
 
 ## Closeout Rule
 

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-06-01T01:06:12+08:00`
-- Base HEAD checked: `c5496cab0a4213f74636af1c48772dc96c90bd1b`
+- Prepared at: `2026-06-01T01:32:16+08:00`
+- Base HEAD checked: `fcead56344110e33041319271c122e71d2b763a0`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.279 strategy `get_monitoring_db` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#431` merged at `c5496cab0a4213f74636af1c48772dc96c90bd1b`; G2.279 records strategy direct `get_monitoring_db().log_operation(...)` calls as `0`, risk route-body direct calls as `0`, runtime/OpenAPI as `548/500/0`, and leaves the utility same-name helper deferred | Review PR `#432` when opened; if accepted, start `G2.280 no-source service lifecycle residual candidate refresh after get_monitoring_db closeout`; do not start source implementation from G2.279 |
+| P0 | Review G2.280 service lifecycle residual candidate refresh after `get_monitoring_db` | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#432` merged at `fcead56344110e33041319271c122e71d2b763a0`; G2.280 scans `371` API/service Python files, records `31` active interesting residual candidates, keeps root facade / registry / control-plane / cache surfaces deferred, and selects `get_lineage_tracker` only for no-source ownership / route-provider decision | Review PR `#433` when opened; if accepted, start `G2.281 no-source data_lineage get_lineage_tracker ownership / route-provider decision`; do not start source implementation from G2.280 |
+| P0 | Preserve G2.279 strategy `get_monitoring_db` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#432` merged at `fcead56344110e33041319271c122e71d2b763a0`; strategy direct `get_monitoring_db().log_operation(...)` calls are `0`, risk route-body direct calls are `0`, runtime/OpenAPI remains `548/500/0`, utility helper remains deferred | Do not use G2.279 as authority for backend source edits, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state |
 | P0 | Preserve G2.278 strategy `get_monitoring_db` route-provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#431` merged at `c5496cab0a4213f74636af1c48772dc96c90bd1b`; strategy-management logging moved to `Depends(get_strategy_monitoring_db)` in the authorized path-limited source files while preserving route/OpenAPI shape | Do not use G2.278 as authority for risk helper changes, utility helper changes, route registration, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or broader backend source |
 | P0 | Preserve G2.277 strategy `get_monitoring_db` route-provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#430` merged at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`; G2.277 authorized only `_helpers.py`, `_strategy_crud_router.py`, and focused strategy tests for G2.278 | Do not use G2.277 as authority for risk helper edits, utility helper edits, non-strategy migrations, route registration, OpenAPI artifact edits, frontend, config, scripts, OpenSpec, PM2, or source retirement |
 | P0 | Preserve G2.276 risk `get_monitoring_db` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#429` merged at `f48ede2ce2202318efa3411fe22fb83a8d4d920b`; risk route-body `get_monitoring_db()` calls remain closed at `0`, strategy-management residual selected for no-source authorization | Do not use G2.276 as authority for backend source edits, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-06-01T01:06:12+08:00`
-- Base HEAD checked: `c5496cab0a4213f74636af1c48772dc96c90bd1b`
+- Prepared at: `2026-06-01T01:32:16+08:00`
+- Base HEAD checked: `fcead56344110e33041319271c122e71d2b763a0`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -16,9 +16,12 @@ state transition.
 
 | Evidence | Role | Freshness policy |
 |---|---|---|
-| `.planning/codebase/generated/strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.json` | G2.279 strategy `get_monitoring_db` provider closeout / residual-refresh evidence | Review input for future PR `#432`; no-source closeout and next-gate selection |
-| `docs/reports/quality/backend-strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.md` | G2.279 human-readable closeout / residual-refresh report | Review input for future PR `#432`; records PR `#431` accepted/merged, current residual scan, OpenAPI smoke, and G2.280 recommendation |
-| `governance/mainline/task-cards/pr-432.yaml` | No-source governance task card for G2.279 | Review input; allows only steward tree, generated evidence, report, and task card updates |
+| `.planning/codebase/generated/service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.json` | G2.280 service lifecycle residual candidate refresh evidence | Review input for future PR `#433`; no-source candidate refresh and next-gate selection |
+| `docs/reports/quality/backend-service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.md` | G2.280 human-readable residual candidate refresh report | Review input for future PR `#433`; records PR `#432` accepted/merged, current candidate scan, GitNexus sampling, OpenAPI smoke, and G2.281 recommendation |
+| `governance/mainline/task-cards/pr-433.yaml` | No-source governance task card for G2.280 | Review input; allows only steward tree, generated evidence, report, and task card updates |
+| `.planning/codebase/generated/strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.json` | G2.279 strategy `get_monitoring_db` provider closeout / residual-refresh evidence | Accepted by PR `#432`, merged at `fcead56344110e33041319271c122e71d2b763a0`; no-source closeout and next-gate selection |
+| `docs/reports/quality/backend-strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.md` | G2.279 human-readable closeout / residual-refresh report | Accepted by PR `#432`; records PR `#431` accepted/merged, current residual scan, OpenAPI smoke, and G2.280 recommendation |
+| `governance/mainline/task-cards/pr-432.yaml` | No-source governance task card for G2.279 | Accepted by PR `#432`; allowed only steward tree, generated evidence, report, and task card updates |
 | `.planning/codebase/generated/strategy-get-monitoring-db-provider-implementation-2026-06-01.json` | G2.278 strategy `get_monitoring_db` provider implementation evidence | Accepted by PR `#431`, merged at `c5496cab0a4213f74636af1c48772dc96c90bd1b`; path-limited source implementation |
 | `docs/reports/quality/backend-strategy-get-monitoring-db-provider-implementation-2026-06-01.md` | G2.278 human-readable implementation report | Accepted by PR `#431`; records TDD, source/test verification, OpenAPI smoke, and known strategy file-test debt |
 | `governance/mainline/task-cards/pr-431.yaml` | Path-limited implementation task card for G2.278 | Accepted by PR `#431`; allowed only two strategy source files, focused tests, steward tree, generated evidence, report, and task card updates |

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-06-01T01:06:12+08:00",
+  "generated_at": "2026-06-01T01:32:16+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "c5496cab0a4213f74636af1c48772dc96c90bd1b",
-  "split_branch": "g2-279-strategy-get-monitoring-db-provider-closeout-refresh",
+  "base_head": "fcead56344110e33041319271c122e71d2b763a0",
+  "split_branch": "g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db",
   "scope": "strategy_get_monitoring_db_provider_implementation",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
@@ -8123,15 +8123,17 @@
     {
       "id": "g2-279-strategy-get-monitoring-db-provider-closeout-refresh",
       "type": "closeout_refresh",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.278 strategy get_monitoring_db provider implementation",
       "source_edit_authority": false,
       "github_pr": {
         "number": 432,
         "url": "https://github.com/chengjon/mystocks/pull/432",
-        "state": "PLANNED_FOR_REVIEW",
-        "head_ref": "g2-279-strategy-get-monitoring-db-provider-closeout-refresh"
+        "state": "MERGED",
+        "head_ref": "g2-279-strategy-get-monitoring-db-provider-closeout-refresh",
+        "merge_commit": "fcead56344110e33041319271c122e71d2b763a0",
+        "merged_at": "2026-05-31T17:26:19Z"
       },
       "evidence": [
         ".planning/codebase/generated/strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.json",
@@ -8191,12 +8193,106 @@
         "recommended_next_work_item": "G2.280 no-source service lifecycle residual candidate refresh after get_monitoring_db closeout"
       },
       "freshness": {
-        "current_head_checked": "c5496cab0a4213f74636af1c48772dc96c90bd1b",
+        "current_head_checked": "fcead56344110e33041319271c122e71d2b763a0",
         "stale_if_head_or_pr_state_changes": true,
         "stale_if_route_or_openapi_counts_change": true,
         "stale_if_strategy_or_risk_get_monitoring_db_call_sites_change": true
       },
-      "next_gate": "If accepted, start G2.280 no-source service lifecycle residual candidate refresh after get_monitoring_db closeout."
+      "next_gate": "Superseded by G2.280 no-source service lifecycle residual candidate refresh after get_monitoring_db closeout."
+    },
+    {
+      "id": "g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db",
+      "type": "candidate_refresh",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.279 strategy get_monitoring_db provider closeout / residual refresh",
+      "source_edit_authority": false,
+      "github_pr": {
+        "number": 433,
+        "url": "https://github.com/chengjon/mystocks/pull/433",
+        "state": "PLANNED_FOR_REVIEW",
+        "head_ref": "g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db"
+      },
+      "evidence": [
+        ".planning/codebase/generated/service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.json",
+        "docs/reports/quality/backend-service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.md",
+        "governance/mainline/task-cards/pr-433.yaml"
+      ],
+      "closed_parent": {
+        "pr": 432,
+        "state": "MERGED",
+        "merge_commit": "fcead56344110e33041319271c122e71d2b763a0",
+        "merged_at": "2026-05-31T17:26:19Z"
+      },
+      "allowed_scope": [
+        ".planning/codebase/generated/service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.md",
+        "governance/mainline/task-cards/pr-433.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "tests/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "scan": {
+        "python_files_scanned": 371,
+        "getter_names_seen": 572,
+        "active_interesting_candidates": 31,
+        "runtime_routes": 548,
+        "openapi_paths": 500,
+        "duplicate_operation_ids": 0
+      },
+      "candidate_disposition": {
+        "selected_next": "get_lineage_tracker",
+        "selected_next_reason": "bounded active API route helper: five bare calls in one data_lineage route module, MEDIUM sampled risk, zero affected processes",
+        "deferred": [
+          "get_integrated_services root facade compatibility",
+          "get_indicator_registry ambiguous registry surface",
+          "get_postgres_connection control-plane DB helper",
+          "get_redis_client infrastructure cache/client helper",
+          "get_cache_integration cache integration infrastructure surface",
+          "get_cache_manager ambiguous dashboard/cache helper"
+        ]
+      },
+      "gitnexus_evidence": {
+        "mcp": "Transport closed for get_integrated_services context",
+        "cli": "sampled impact checks used; stale-index warning recorded",
+        "staged": "MCP detect_changes returned Transport closed; CLI fallback ok=true, status=stale, risk=low, changed symbols 0, affected processes 0",
+        "selected_candidate": {
+          "name": "get_lineage_tracker",
+          "risk": "MEDIUM",
+          "impacted_count": 5,
+          "direct": 5,
+          "processes_affected": 0
+        }
+      },
+      "decision": {
+        "classification": "residual-candidate-refresh-for-review",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-280",
+        "selected_next_governance_target": "data_lineage-get-lineage-tracker-ownership-route-provider-decision",
+        "recommended_next_work_item": "G2.281 no-source data_lineage get_lineage_tracker ownership / route-provider decision"
+      },
+      "freshness": {
+        "current_head_checked": "fcead56344110e33041319271c122e71d2b763a0",
+        "stale_if_head_or_pr_state_changes": true,
+        "stale_if_route_or_openapi_counts_change": true,
+        "stale_if_candidate_scan_changes": true
+      },
+      "next_gate": "If accepted, start G2.281 no-source data_lineage get_lineage_tracker ownership / route-provider decision."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -2970,7 +2970,7 @@ Status: accepted/merged by PR `#431` at `c5496cab0a4213f74636af1c48772dc96c90bd1
 
 ## G2.279 Strategy get_monitoring_db Provider Closeout / Residual Refresh
 
-Status: for review in future PR `#432`.
+Status: accepted/merged by PR `#432` at `fcead56344110e33041319271c122e71d2b763a0`.
 
 - Parent PR `#431` merged at `c5496cab0a4213f74636af1c48772dc96c90bd1b`.
 - Strategy direct `get_monitoring_db().log_operation(...)` calls in the target files are `0`; active strategy dependency parameters remain `6`; `monitoring_db.log_operation(...)` calls remain `6`.
@@ -2980,3 +2980,17 @@ Status: for review in future PR `#432`.
 - Focused strategy provider test remains green at `1/1`; touched strategy ruff remains clean.
 - Selected next gate after acceptance: G2.280 no-source service lifecycle residual candidate refresh after `get_monitoring_db` closeout.
 - G2.279 must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+
+## G2.280 Service Lifecycle Residual Candidate Refresh After get_monitoring_db
+
+Status: for review in future PR `#433`.
+
+- Parent PR `#432` merged at `fcead56344110e33041319271c122e71d2b763a0`.
+- Current scan covered `371` Python files under `web/backend/app/api` and `web/backend/app/services`.
+- The scan found `572` getter-like names and `31` active interesting candidates after excluding method calls and known-closed surfaces.
+- Runtime/OpenAPI smoke with placeholder import-time environment values recorded `548` FastAPI routes, `500` OpenAPI paths, and `0` duplicate operation IDs.
+- Highest service-only candidate is `get_integrated_services`, classified as root facade compatibility and deferred to a separate root facade decision.
+- `get_indicator_registry` and `get_cache_manager` are ambiguous and deferred until ownership is disambiguated.
+- `get_postgres_connection` is a control-plane DB helper and deferred to route/OpenAPI/control-plane ownership.
+- Selected next gate after acceptance: G2.281 no-source data_lineage `get_lineage_tracker` ownership / route-provider decision.
+- G2.280 must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.

--- a/docs/reports/quality/backend-service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.md
+++ b/docs/reports/quality/backend-service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.md
@@ -1,0 +1,124 @@
+# Backend Service Lifecycle Residual Candidate Refresh After get_monitoring_db
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Gate: `G2.280`
+- Status: for review
+- Prepared at: `2026-06-01T01:32:16+08:00`
+- Base HEAD checked: `fcead56344110e33041319271c122e71d2b763a0`
+- Parent PR: `#432`
+- Parent merge commit: `fcead56344110e33041319271c122e71d2b763a0`
+- Source edit authority: no
+
+Boundary note: this report records residual candidate selection only. It does
+not authorize backend source edits, test edits, route registration changes,
+generated OpenAPI artifact edits, frontend/config/script edits, OpenSpec
+changes, PM2 commands, or runtime state changes.
+
+## Parent Closeout
+
+PR `#432` merged G2.279 at
+`fcead56344110e33041319271c122e71d2b763a0`.
+
+G2.279 closed the `get_monitoring_db` route-provider sequence for the current
+risk and strategy surfaces:
+
+- strategy target direct `get_monitoring_db().log_operation(...)` calls: `0`
+- strategy route dependency parameters: `6`
+- risk route-body direct `get_monitoring_db().log_operation(...)` calls: `0`
+- utility same-name helper in `web/backend/app/utils/risk_utils.py`: retained
+  and deferred
+
+## Scan Summary
+
+The G2.280 scan covered:
+
+- `web/backend/app/api`
+- `web/backend/app/services`
+
+Results:
+
+- Python files scanned: `371`
+- Getter-like names seen: `572`
+- Active interesting candidates after known-closed exclusions: `31`
+- Runtime/OpenAPI smoke: `548` routes, `500` OpenAPI paths, duplicate
+  operation IDs `0`
+
+The scan excluded method calls such as `object.get_data(...)` from provider
+candidate ranking. It also excluded previously closed or retained surfaces such
+as `get_monitoring_db`, `get_postgres_async`, `get_mock_data_manager`,
+`get_calculator_factory`, `get_unified_data_service`, `get_strategy_service`,
+and route-local provider wrappers created by recent G2 lanes.
+
+## Candidate Triage
+
+| Candidate | Active API calls | Service calls | Files | Classification | Disposition |
+|---|---:|---:|---:|---|---|
+| `get_integrated_services` | 0 | 7 | 1 | root facade compatibility surface | Defer to separate root facade compatibility decision |
+| `get_indicator_registry` | 0 | 5 | 5 | ambiguous registry surface | Defer until registry ownership is disambiguated |
+| `get_lineage_tracker` | 5 | 0 | 1 | bounded active API route helper / provider candidate | Select for next no-source ownership / route-provider decision |
+| `get_postgres_connection` | 5 | 0 | 1 | control-plane DB connection helper | Defer to control-plane route/OpenAPI ownership decision |
+| `get_redis_client` | 0 | 4 | 4 | infrastructure cache/client helper | Defer to infrastructure/cache ownership lane |
+| `get_cache_integration` | 0 | 4 | 4 | cache integration infrastructure surface | Defer to infrastructure/cache ownership lane |
+| `get_cache_manager` | 1 | 0 | 3 | ambiguous dashboard/cache helper | Defer until dashboard/core cache ownership is disambiguated |
+
+## GitNexus Evidence
+
+GitNexus MCP `context` for `get_integrated_services` returned `Transport closed`.
+CLI fallback was used for sampled impact checks.
+
+| Candidate | CLI result | Disposition |
+|---|---|---|
+| `get_integrated_services` | MEDIUM, impacted count `13`, direct `13`, processes affected `0` | Broad root facade; defer |
+| `get_indicator_registry` | UNKNOWN / ambiguous across two registry definitions | Defer until disambiguated |
+| `get_lineage_tracker` | MEDIUM, impacted count `5`, direct `5`, processes affected `0` | Select for next decision gate |
+| `get_postgres_connection` | MEDIUM, impacted count `6`, direct `5`, processes affected `0` | Control-plane route/OpenAPI ownership; defer |
+| `get_cache_manager` | UNKNOWN / ambiguous across API dashboard and core cache manager definitions | Defer until disambiguated |
+
+The sampled CLI impact reports had a stale-index warning. Use them as
+candidate-shaping evidence only; refresh the GitNexus index before relying on
+graph freshness for implementation authorization.
+
+Staged verification before commit:
+
+- MCP `detect_changes`: `Transport closed`
+- CLI fallback: `ok=true`, `status=stale`, `risk_level=low`
+- changed files: `9`
+- changed symbols: `0`
+- affected processes: `0`
+- indexed commit: `13321ab73166afc0990b097503294a883842a941`
+- current commit: `fcead56344110e33041319271c122e71d2b763a0`
+- stale reason: `current_commit_differs_from_indexed_commit`
+
+## Decision
+
+G2.280 recommends:
+
+`G2.281 no-source data_lineage get_lineage_tracker ownership / route-provider decision`
+
+Rationale:
+
+- `get_lineage_tracker` is the most bounded active API route helper candidate
+  after `get_monitoring_db` closeout.
+- It has `5` active bare calls in one active route module:
+  `web/backend/app/api/data_lineage.py`.
+- GitNexus CLI sampling found a non-ambiguous target with MEDIUM risk and `0`
+  affected processes.
+- It is a better next governance step than opening a broad root facade,
+  registry, cache, or control-plane DB helper lane.
+
+G2.281 should decide ownership and future route-provider strategy only. It must
+not perform source implementation unless a later authorization package is
+reviewed and accepted.
+
+## Stale Policy
+
+This report is stale if any of these change before review:
+
+- current HEAD differs from
+  `fcead56344110e33041319271c122e71d2b763a0`
+- PR `#432` merge state or merge commit changes
+- runtime route count or OpenAPI path count changes
+- residual candidate scan output changes

--- a/governance/mainline/task-cards/pr-433.yaml
+++ b/governance/mainline/task-cards/pr-433.yaml
@@ -1,0 +1,120 @@
+version: "v0.2"
+
+task:
+  id: "pr-433"
+  title: "Refresh service lifecycle residual candidates after get_monitoring_db"
+  owner: "codex"
+  created_at: "2026-06-01"
+
+mainline:
+  id: "L1-service-lifecycle-residual-candidate-refresh-after-monitoring-db"
+  objective: "record G2.279 acceptance, refresh remaining service lifecycle residual candidates, and select the next no-source decision gate"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "G2.280 is a no-source governance candidate refresh. It changes no runtime entrypoint, route path, route registration, generated OpenAPI artifact, frontend route, or FUNCTION_TREE catalog entry."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.md"
+    - "governance/mainline/task-cards/pr-433.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits"
+  - "test edits"
+  - "route registration changes"
+  - "route path, method, response model, or generated OpenAPI artifact changes"
+  - "docs/api artifact edits"
+  - "frontend/config/script changes"
+  - "OpenSpec proposal or spec edits"
+  - "PM2 commands or stateful runtime gates"
+  - "source retirement"
+
+acceptance:
+  checks:
+    - id: "pr432-merged"
+      command: "gh pr view 432 confirms MERGED at fcead56344110e33041319271c122e71d2b763a0"
+      required: true
+    - id: "candidate-scan"
+      command: "current HEAD residual scan covers web/backend/app/api and web/backend/app/services, records 371 Python files, and selects G2.281 no-source get_lineage_tracker ownership / route-provider decision"
+      required: true
+    - id: "runtime-openapi-smoke"
+      command: "app.main route/OpenAPI smoke records 548 routes, 500 paths, duplicate operation IDs 0"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-433.yaml --base-sha fcead56344110e33041319271c122e71d2b763a0 --head-sha HEAD --report /tmp/pr433-mainline-governance-report.json"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "gitnexus-detect-changes"
+      command: "GitNexus staged verification attempted before commit; stale-index warning recorded if present"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "A future worker may treat G2.280 candidate selection as source authorization; the report and steward tree explicitly forbid that."
+    - "Root facade, registry, cache, and control-plane candidates remain deferred and must not be bundled into G2.281."
+  rollback_plan: "Revert PR #433; this removes only governance evidence and restores the previous steward tree state."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Refresh service lifecycle residual candidates after get_monitoring_db closeout."
+    modified_scope: "Governance evidence, steward tree indexes, human-readable report, and task card only."
+    dependency_changes: "No dependency changes."
+    legacy_logic_impact: "No runtime, route, OpenAPI, frontend, config, script, or OpenSpec changes."
+    rollback_ready: "Revert PR #433."
+    risk_and_rollback_point: "No-source candidate refresh; rollback is single-PR revert."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-01T01:32:16+08:00"
+    approval_note: "Human maintainer approved continuing after PR #432 acceptance into G2.280 no-source service lifecycle residual candidate refresh. Scope remains limited to governance artifacts."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records PR #432 as merged at fcead56344110e33041319271c122e71d2b763a0
- refreshes service lifecycle residual candidates after get_monitoring_db closeout
- selects G2.281 no-source data_lineage get_lineage_tracker ownership / route-provider decision

## Boundary
- no backend source edits
- no test edits
- no route/OpenAPI artifact edits
- no frontend/config/script/OpenSpec/PM2 changes

## Verification
- JSON parse: ok
- markdown governance gate: 6 checked, 0 errors
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: valid
- mainline scope gate: pass
- runtime/OpenAPI smoke: 548 routes, 500 paths, duplicate operation IDs 0
- git diff --check and staged/postcommit diff check: pass
- GitNexus MCP detect_changes: Transport closed; CLI fallback ok=true, status=stale, risk=low, changed symbols 0, affected processes 0