### PR TITLE
docs(governance): decide lineage tracker ownership

### DIFF
--- a/.planning/codebase/generated/data-lineage-tracker-ownership-decision-2026-06-01.json
+++ b/.planning/codebase/generated/data-lineage-tracker-ownership-decision-2026-06-01.json
@@ -1,0 +1,146 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-06-01T01:56:44+08:00",
+  "gate": "G2.281",
+  "title": "data_lineage get_lineage_tracker ownership / route-provider decision",
+  "repo": "mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "1707284bceeef8992641290d86790c1699975f5a",
+  "worktree": ".worktrees/g2-281-data-lineage-tracker-ownership-decision",
+  "source_edit_authority": false,
+  "autopilot_status": "stop_at_pr_review_gate",
+  "autopilot_stop_reason": "GitNexus sampled impact for get_lineage_tracker is MEDIUM. This triggers the maintainer's limited-autopilot stop rule even though affected processes are 0.",
+  "parent": {
+    "gate": "G2.280",
+    "pr": 433,
+    "state": "MERGED",
+    "merged_at": "2026-05-31T17:53:44Z",
+    "merge_commit": "1707284bceeef8992641290d86790c1699975f5a",
+    "summary": "No-source service lifecycle residual candidate refresh accepted and merged."
+  },
+  "surface": {
+    "route_module": "web/backend/app/api/data_lineage.py",
+    "line_count": 567,
+    "provider_candidate": {
+      "name": "get_lineage_tracker",
+      "definition_line": 92,
+      "returns": [
+        "LineageTracker",
+        "_AsyncpgLineageConnectionAdapter"
+      ],
+      "creates_raw_connection": true,
+      "uses_asyncpg_connect": true,
+      "uses_settings_postgresql_config": true
+    },
+    "route_handlers": [
+      {
+        "name": "record_lineage",
+        "line": 129,
+        "method": "POST",
+        "path": "/api/v1/lineage/record",
+        "call_line": 149
+      },
+      {
+        "name": "get_upstream_lineage",
+        "line": 204,
+        "method": "GET",
+        "path": "/api/v1/lineage/{node_id}/upstream",
+        "call_line": 226
+      },
+      {
+        "name": "get_downstream_lineage",
+        "line": 314,
+        "method": "GET",
+        "path": "/api/v1/lineage/{node_id}/downstream",
+        "call_line": 336
+      },
+      {
+        "name": "get_lineage_graph",
+        "line": 401,
+        "method": "POST",
+        "path": "/api/v1/lineage/graph",
+        "call_line": 424
+      },
+      {
+        "name": "analyze_impact",
+        "line": 517,
+        "method": "POST",
+        "path": "/api/v1/lineage/impact",
+        "call_line": 540
+      }
+    ],
+    "active_bare_calls": 5,
+    "files_touched_if_future_provider_lane": [
+      "web/backend/app/api/data_lineage.py",
+      "focused data_lineage file tests if an existing or new focused test path is authorized later"
+    ]
+  },
+  "route_openapi_smoke": {
+    "routes": 548,
+    "openapi_paths": 500,
+    "duplicate_operation_ids": 0,
+    "lineage_paths": [
+      "/api/v1/lineage/graph",
+      "/api/v1/lineage/impact",
+      "/api/v1/lineage/record",
+      "/api/v1/lineage/{node_id}/downstream",
+      "/api/v1/lineage/{node_id}/upstream",
+      "/api/v1/governance/lineage/stats"
+    ],
+    "known_log_noise": "mock backtest NotImplementedError during app import smoke"
+  },
+  "gitnexus_evidence": {
+    "mcp": "not relied on for this gate; prior MCP detect/context calls have been returning Transport closed",
+    "cli_context": {
+      "status": "found",
+      "uid": "Function:web/backend/app/api/data_lineage.py:get_lineage_tracker",
+      "incoming_calls": [
+        "record_lineage",
+        "get_upstream_lineage",
+        "get_downstream_lineage",
+        "get_lineage_graph",
+        "analyze_impact"
+      ],
+      "processes": [],
+      "index_status": "stale warning"
+    },
+    "cli_impact": {
+      "risk": "MEDIUM",
+      "impacted_count": 5,
+      "direct": 5,
+      "processes_affected": 0,
+      "modules_affected": 1,
+      "affected_module": "Api",
+      "index_status": "stale warning"
+    }
+  },
+  "gitnexus_staged_verification": {
+    "mcp_detect_changes": "Transport closed",
+    "cli_command": "npx gitnexus verify-staged -r mystocks --cwd /opt/claude/mystocks_spec/.worktrees/g2-281-data-lineage-tracker-ownership-decision --json",
+    "ok": true,
+    "status": "stale",
+    "risk_level": "low",
+    "changed_files": 9,
+    "changed_symbols": 0,
+    "affected_processes": 0,
+    "indexed_commit": "bf65ba60483469d5a973543a3ed3b421434ae1da",
+    "current_commit": "1707284bceeef8992641290d86790c1699975f5a",
+    "stale_reason": "current_commit_differs_from_indexed_commit",
+    "next_action": "Refresh the GitNexus index before relying on graph freshness."
+  },
+  "decision": {
+    "classification": "bounded-active-api-route-helper",
+    "ownership": "data_lineage route module owns current helper; it is not a cross-module service facade and not a control-plane route registry issue",
+    "route_provider_recommendation": "A future lane may convert the five direct await get_lineage_tracker() calls into a route-local provider/dependency seam, but only after human review because GitNexus risk is MEDIUM.",
+    "recommended_next_governance_target": "G2.282 no-source data_lineage get_lineage_tracker provider authorization package",
+    "source_lane_authorized_now": false,
+    "autopilot_continue_allowed": false
+  },
+  "freshness": {
+    "current_head_checked": "1707284bceeef8992641290d86790c1699975f5a",
+    "stale_if_head_or_pr_state_changes": true,
+    "stale_if_route_or_openapi_counts_change": true,
+    "stale_if_data_lineage_call_sites_change": true,
+    "stale_if_gitnexus_risk_changes": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-06-01T01:32:16+08:00`
-- Base HEAD checked: `fcead56344110e33041319271c122e71d2b763a0`
+- Prepared at: `2026-06-01T01:56:44+08:00`
+- Base HEAD checked: `1707284bceeef8992641290d86790c1699975f5a`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -117,7 +117,8 @@ PRs, change issue labels, or authorize source implementation.
 | `#430` | `g2-277-strategy-get-monitoring-db-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441` | No-source authorization package for G2.278 strategy `get_monitoring_db` provider implementation |
 | `#431` | `g2-278-strategy-get-monitoring-db-provider` | `wip/root-dirty-20260403` | `MERGED` at `c5496cab0a4213f74636af1c48772dc96c90bd1b` | Path-limited strategy `get_monitoring_db` provider implementation selecting G2.279 closeout / residual refresh |
 | `#432` | `g2-279-strategy-get-monitoring-db-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `fcead56344110e33041319271c122e71d2b763a0` | No-source strategy `get_monitoring_db` provider closeout selecting G2.280 residual candidate refresh |
-| `#433` | `g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | No-source residual candidate refresh selecting G2.281 data_lineage `get_lineage_tracker` decision |
+| `#433` | `g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db` | `wip/root-dirty-20260403` | `MERGED` at `1707284bceeef8992641290d86790c1699975f5a` | No-source residual candidate refresh selecting G2.281 data_lineage `get_lineage_tracker` decision |
+| `#434` | `g2-281-data-lineage-tracker-ownership-decision` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | No-source data_lineage `get_lineage_tracker` ownership decision; auto-merge paused due GitNexus MEDIUM risk |
 
 ## Steward Governance Branch
 
@@ -144,6 +145,7 @@ PRs, change issue labels, or authorize source implementation.
 | `g2-278-strategy-get-monitoring-db-provider` | `origin/wip/root-dirty-20260403` at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441` | Implement the authorized strategy `get_monitoring_db` route-provider lane | Yes, path-limited |
 | `g2-279-strategy-get-monitoring-db-provider-closeout-refresh` | `origin/wip/root-dirty-20260403` at `c5496cab0a4213f74636af1c48772dc96c90bd1b` | Close out G2.278, refresh `get_monitoring_db` residuals, and select G2.280 no-source residual candidate refresh | No |
 | `g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db` | `origin/wip/root-dirty-20260403` at `fcead56344110e33041319271c122e71d2b763a0` | Refresh service lifecycle residual candidates after `get_monitoring_db` closeout and select G2.281 no-source `get_lineage_tracker` decision | No |
+| `g2-281-data-lineage-tracker-ownership-decision` | `origin/wip/root-dirty-20260403` at `1707284bceeef8992641290d86790c1699975f5a` | Decide data_lineage `get_lineage_tracker` ownership / route-provider disposition; stop auto-merge due GitNexus MEDIUM risk | No |
 
 ## OpenSpec Relationship
 
@@ -195,4 +197,6 @@ G2.278 is the path-limited strategy `get_monitoring_db` provider implementation 
 
 G2.279 is the no-source strategy `get_monitoring_db` provider closeout / residual refresh after PR `#431` merged G2.278 at `c5496cab0a4213f74636af1c48772dc96c90bd1b`. It merged by PR `#432` at `fcead56344110e33041319271c122e71d2b763a0`. It records strategy direct `get_monitoring_db().log_operation(...)` calls as `0`, risk route-body direct calls as `0`, runtime/OpenAPI smoke as `548` routes, `500` paths, duplicate operation IDs `0`, and selects `G2.280 no-source service lifecycle residual candidate refresh after get_monitoring_db closeout`. It must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
 
-G2.280 is the no-source service lifecycle residual candidate refresh after PR `#432` merged G2.279 at `fcead56344110e33041319271c122e71d2b763a0`. It scans `371` API/service Python files, records `31` active interesting residual candidates after known-closed exclusions, defers root facade / registry / control-plane / cache surfaces, and selects `G2.281 no-source data_lineage get_lineage_tracker ownership / route-provider decision`. It must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+G2.280 is the no-source service lifecycle residual candidate refresh after PR `#432` merged G2.279 at `fcead56344110e33041319271c122e71d2b763a0`. It merged by PR `#433` at `1707284bceeef8992641290d86790c1699975f5a`. It scans `371` API/service Python files, records `31` active interesting residual candidates after known-closed exclusions, defers root facade / registry / control-plane / cache surfaces, and selects `G2.281 no-source data_lineage get_lineage_tracker ownership / route-provider decision`. It must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+
+G2.281 is the no-source data_lineage `get_lineage_tracker` ownership / route-provider decision after PR `#433` merged G2.280 at `1707284bceeef8992641290d86790c1699975f5a`. It classifies `get_lineage_tracker` as a bounded active API route helper with five direct callers in `web/backend/app/api/data_lineage.py`, records runtime/OpenAPI smoke as `548` routes, `500` paths, duplicate operation IDs `0`, and recommends a possible G2.282 no-source authorization package only after human review. Limited autopilot must stop at this PR because GitNexus CLI sampled impact is MEDIUM. It must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-06-01T01:32:16+08:00`
-- Base HEAD checked: `fcead56344110e33041319271c122e71d2b763a0`
+- Prepared at: `2026-06-01T01:56:44+08:00`
+- Base HEAD checked: `1707284bceeef8992641290d86790c1699975f5a`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -19,9 +19,9 @@ exact verification output.
 | Route/OpenAPI and control-plane governance | Established route table, OpenAPI exposure, health/probe taxonomy, and consumer-contract evidence as first-class governance facts | Continue through route/OpenAPI track, not ad hoc route edits |
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
-| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.279 accepted/merged by PR `#432` at `fcead563` | Continue with G2.280 service lifecycle residual candidate refresh review, then G2.281 no-source data_lineage `get_lineage_tracker` decision only if accepted |
+| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.280 accepted/merged by PR `#433` at `1707284b` | Continue with G2.281 data_lineage `get_lineage_tracker` decision review; auto-merge is paused because GitNexus risk is MEDIUM |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.279 have progressed through PR `#337`-`#432`; current review target is G2.280 candidate refresh in future PR `#433` |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.280 have progressed through PR `#337`-`#433`; current review target is G2.281 decision in future PR `#434` |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Recent Closeouts
@@ -43,6 +43,7 @@ exact verification output.
 | G2.277 strategy get_monitoring_db provider authorization | PR `#430` merged at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`; path-limited strategy source lane authorized | G2.278 implements only the two authorized strategy source files and focused strategy test |
 | G2.278 strategy get_monitoring_db provider implementation | PR `#431` merged at `c5496cab0a4213f74636af1c48772dc96c90bd1b`; direct strategy target calls are `0`, dependency parameters are `6`, route/OpenAPI contracts stayed stable | G2.279 records closeout, confirms risk route-body calls remain closed, and selects the next no-source residual candidate refresh |
 | G2.279 strategy get_monitoring_db provider closeout / residual refresh | PR `#432` merged at `fcead56344110e33041319271c122e71d2b763a0`; strategy/risk direct calls remain closed and utility helper remains deferred | G2.280 refreshes residual candidates before any new authorization or source lane |
+| G2.280 service lifecycle residual candidate refresh after get_monitoring_db | PR `#433` merged at `1707284bceeef8992641290d86790c1699975f5a`; `371` files scanned, `31` active interesting candidates recorded, and `get_lineage_tracker` selected | G2.281 decides data_lineage ownership but must stop at review because GitNexus risk is MEDIUM |
 
 ## Closeout Rule
 

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-06-01T01:32:16+08:00`
-- Base HEAD checked: `fcead56344110e33041319271c122e71d2b763a0`
+- Prepared at: `2026-06-01T01:56:44+08:00`
+- Base HEAD checked: `1707284bceeef8992641290d86790c1699975f5a`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.280 service lifecycle residual candidate refresh after `get_monitoring_db` | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#432` merged at `fcead56344110e33041319271c122e71d2b763a0`; G2.280 scans `371` API/service Python files, records `31` active interesting residual candidates, keeps root facade / registry / control-plane / cache surfaces deferred, and selects `get_lineage_tracker` only for no-source ownership / route-provider decision | Review PR `#433` when opened; if accepted, start `G2.281 no-source data_lineage get_lineage_tracker ownership / route-provider decision`; do not start source implementation from G2.280 |
+| P0 | Review G2.281 data_lineage `get_lineage_tracker` ownership / route-provider decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#433` merged at `1707284bceeef8992641290d86790c1699975f5a`; G2.281 classifies `get_lineage_tracker` as a bounded active API route helper with five direct callers in `data_lineage.py`; GitNexus CLI sampled impact is MEDIUM, direct callers `5`, affected processes `0` | Review PR `#434` when opened; do not auto-merge under limited-autopilot because GitNexus risk is MEDIUM; if human-accepted, decide whether to start G2.282 no-source authorization package |
+| P0 | Preserve G2.280 service lifecycle residual candidate refresh after `get_monitoring_db` | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#433` merged at `1707284bceeef8992641290d86790c1699975f5a`; G2.280 scanned `371` API/service Python files, recorded `31` active interesting residual candidates, deferred root facade / registry / control-plane / cache surfaces, and selected `get_lineage_tracker` only for no-source ownership / route-provider decision | Do not use G2.280 as authority for backend source edits, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state |
 | P0 | Preserve G2.279 strategy `get_monitoring_db` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#432` merged at `fcead56344110e33041319271c122e71d2b763a0`; strategy direct `get_monitoring_db().log_operation(...)` calls are `0`, risk route-body direct calls are `0`, runtime/OpenAPI remains `548/500/0`, utility helper remains deferred | Do not use G2.279 as authority for backend source edits, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state |
 | P0 | Preserve G2.278 strategy `get_monitoring_db` route-provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#431` merged at `c5496cab0a4213f74636af1c48772dc96c90bd1b`; strategy-management logging moved to `Depends(get_strategy_monitoring_db)` in the authorized path-limited source files while preserving route/OpenAPI shape | Do not use G2.278 as authority for risk helper changes, utility helper changes, route registration, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or broader backend source |
 | P0 | Preserve G2.277 strategy `get_monitoring_db` route-provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#430` merged at `2d1d2c28fe59bd7b98f63a41b9a0ff4c343d0441`; G2.277 authorized only `_helpers.py`, `_strategy_crud_router.py`, and focused strategy tests for G2.278 | Do not use G2.277 as authority for risk helper edits, utility helper edits, non-strategy migrations, route registration, OpenAPI artifact edits, frontend, config, scripts, OpenSpec, PM2, or source retirement |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-06-01T01:32:16+08:00`
-- Base HEAD checked: `fcead56344110e33041319271c122e71d2b763a0`
+- Prepared at: `2026-06-01T01:56:44+08:00`
+- Base HEAD checked: `1707284bceeef8992641290d86790c1699975f5a`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -16,9 +16,12 @@ state transition.
 
 | Evidence | Role | Freshness policy |
 |---|---|---|
-| `.planning/codebase/generated/service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.json` | G2.280 service lifecycle residual candidate refresh evidence | Review input for future PR `#433`; no-source candidate refresh and next-gate selection |
-| `docs/reports/quality/backend-service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.md` | G2.280 human-readable residual candidate refresh report | Review input for future PR `#433`; records PR `#432` accepted/merged, current candidate scan, GitNexus sampling, OpenAPI smoke, and G2.281 recommendation |
-| `governance/mainline/task-cards/pr-433.yaml` | No-source governance task card for G2.280 | Review input; allows only steward tree, generated evidence, report, and task card updates |
+| `.planning/codebase/generated/data-lineage-tracker-ownership-decision-2026-06-01.json` | G2.281 data_lineage `get_lineage_tracker` ownership / route-provider decision evidence | Review input for future PR `#434`; no-source decision package; limited-autopilot must stop because GitNexus risk is MEDIUM |
+| `docs/reports/quality/backend-data-lineage-tracker-ownership-decision-2026-06-01.md` | G2.281 human-readable ownership decision report | Review input for future PR `#434`; records PR `#433` accepted/merged, route helper surface, GitNexus MEDIUM risk, OpenAPI smoke, and G2.282 recommendation |
+| `governance/mainline/task-cards/pr-434.yaml` | No-source governance task card for G2.281 | Review input; allows only steward tree, generated evidence, report, and task card updates; no auto-merge |
+| `.planning/codebase/generated/service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.json` | G2.280 service lifecycle residual candidate refresh evidence | Accepted by PR `#433`, merged at `1707284bceeef8992641290d86790c1699975f5a`; no-source candidate refresh and next-gate selection |
+| `docs/reports/quality/backend-service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.md` | G2.280 human-readable residual candidate refresh report | Accepted by PR `#433`; records PR `#432` accepted/merged, current candidate scan, GitNexus sampling, OpenAPI smoke, and G2.281 recommendation |
+| `governance/mainline/task-cards/pr-433.yaml` | No-source governance task card for G2.280 | Accepted by PR `#433`; allowed only steward tree, generated evidence, report, and task card updates |
 | `.planning/codebase/generated/strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.json` | G2.279 strategy `get_monitoring_db` provider closeout / residual-refresh evidence | Accepted by PR `#432`, merged at `fcead56344110e33041319271c122e71d2b763a0`; no-source closeout and next-gate selection |
 | `docs/reports/quality/backend-strategy-get-monitoring-db-provider-closeout-refresh-2026-06-01.md` | G2.279 human-readable closeout / residual-refresh report | Accepted by PR `#432`; records PR `#431` accepted/merged, current residual scan, OpenAPI smoke, and G2.280 recommendation |
 | `governance/mainline/task-cards/pr-432.yaml` | No-source governance task card for G2.279 | Accepted by PR `#432`; allowed only steward tree, generated evidence, report, and task card updates |

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-06-01T01:32:16+08:00",
+  "generated_at": "2026-06-01T01:56:44+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "fcead56344110e33041319271c122e71d2b763a0",
-  "split_branch": "g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db",
+  "base_head": "1707284bceeef8992641290d86790c1699975f5a",
+  "split_branch": "g2-281-data-lineage-tracker-ownership-decision",
   "scope": "strategy_get_monitoring_db_provider_implementation",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
@@ -8203,15 +8203,17 @@
     {
       "id": "g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db",
       "type": "candidate_refresh",
-      "state": "for_review",
+      "state": "merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.279 strategy get_monitoring_db provider closeout / residual refresh",
       "source_edit_authority": false,
       "github_pr": {
         "number": 433,
         "url": "https://github.com/chengjon/mystocks/pull/433",
-        "state": "PLANNED_FOR_REVIEW",
-        "head_ref": "g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db"
+        "state": "MERGED",
+        "head_ref": "g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db",
+        "merge_commit": "1707284bceeef8992641290d86790c1699975f5a",
+        "merged_at": "2026-05-31T17:53:44Z"
       },
       "evidence": [
         ".planning/codebase/generated/service-lifecycle-residual-candidate-refresh-after-monitoring-db-2026-06-01.json",
@@ -8287,12 +8289,106 @@
         "recommended_next_work_item": "G2.281 no-source data_lineage get_lineage_tracker ownership / route-provider decision"
       },
       "freshness": {
-        "current_head_checked": "fcead56344110e33041319271c122e71d2b763a0",
+        "current_head_checked": "1707284bceeef8992641290d86790c1699975f5a",
         "stale_if_head_or_pr_state_changes": true,
         "stale_if_route_or_openapi_counts_change": true,
         "stale_if_candidate_scan_changes": true
       },
-      "next_gate": "If accepted, start G2.281 no-source data_lineage get_lineage_tracker ownership / route-provider decision."
+      "next_gate": "Superseded by G2.281 no-source data_lineage get_lineage_tracker ownership / route-provider decision."
+    },
+    {
+      "id": "g2-281-data-lineage-tracker-ownership-decision",
+      "type": "ownership_decision",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.280 service lifecycle residual candidate refresh after get_monitoring_db",
+      "source_edit_authority": false,
+      "autopilot_status": "stop_at_pr_review_gate",
+      "autopilot_stop_reason": "GitNexus sampled impact for get_lineage_tracker is MEDIUM",
+      "github_pr": {
+        "number": 434,
+        "url": "https://github.com/chengjon/mystocks/pull/434",
+        "state": "PLANNED_FOR_REVIEW",
+        "head_ref": "g2-281-data-lineage-tracker-ownership-decision"
+      },
+      "evidence": [
+        ".planning/codebase/generated/data-lineage-tracker-ownership-decision-2026-06-01.json",
+        "docs/reports/quality/backend-data-lineage-tracker-ownership-decision-2026-06-01.md",
+        "governance/mainline/task-cards/pr-434.yaml"
+      ],
+      "closed_parent": {
+        "pr": 433,
+        "state": "MERGED",
+        "merge_commit": "1707284bceeef8992641290d86790c1699975f5a",
+        "merged_at": "2026-05-31T17:53:44Z"
+      },
+      "allowed_scope": [
+        ".planning/codebase/generated/data-lineage-tracker-ownership-decision-2026-06-01.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-data-lineage-tracker-ownership-decision-2026-06-01.md",
+        "governance/mainline/task-cards/pr-434.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "tests/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "surface": {
+        "module": "web/backend/app/api/data_lineage.py",
+        "helper": "get_lineage_tracker",
+        "definition_line": 92,
+        "active_direct_calls": 5,
+        "route_handlers": [
+          "record_lineage",
+          "get_upstream_lineage",
+          "get_downstream_lineage",
+          "get_lineage_graph",
+          "analyze_impact"
+        ],
+        "runtime_routes": 548,
+        "openapi_paths": 500,
+        "duplicate_operation_ids": 0
+      },
+      "gitnexus_evidence": {
+        "cli_context": "found one Function:web/backend/app/api/data_lineage.py:get_lineage_tracker symbol with five incoming calls",
+        "staged": "MCP detect_changes returned Transport closed; CLI fallback ok=true, status=stale, risk=low, changed symbols 0, affected processes 0",
+        "cli_impact": {
+          "risk": "MEDIUM",
+          "impacted_count": 5,
+          "direct": 5,
+          "processes_affected": 0,
+          "index_status": "stale warning"
+        }
+      },
+      "decision": {
+        "classification": "bounded-active-api-route-helper",
+        "ownership": "data_lineage route module owns current helper",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-281",
+        "autopilot_continue_allowed": false,
+        "selected_next_governance_target": "data_lineage-get-lineage-tracker-provider-authorization-package",
+        "recommended_next_work_item": "G2.282 no-source data_lineage get_lineage_tracker provider authorization package only after human review"
+      },
+      "freshness": {
+        "current_head_checked": "1707284bceeef8992641290d86790c1699975f5a",
+        "stale_if_head_or_pr_state_changes": true,
+        "stale_if_route_or_openapi_counts_change": true,
+        "stale_if_data_lineage_call_sites_change": true,
+        "stale_if_gitnexus_risk_changes": true
+      },
+      "next_gate": "Stop for human review. If accepted, decide whether to start G2.282 no-source data_lineage get_lineage_tracker provider authorization package."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -2983,7 +2983,7 @@ Status: accepted/merged by PR `#432` at `fcead56344110e33041319271c122e71d2b763a
 
 ## G2.280 Service Lifecycle Residual Candidate Refresh After get_monitoring_db
 
-Status: for review in future PR `#433`.
+Status: accepted/merged by PR `#433` at `1707284bceeef8992641290d86790c1699975f5a`.
 
 - Parent PR `#432` merged at `fcead56344110e33041319271c122e71d2b763a0`.
 - Current scan covered `371` Python files under `web/backend/app/api` and `web/backend/app/services`.
@@ -2994,3 +2994,16 @@ Status: for review in future PR `#433`.
 - `get_postgres_connection` is a control-plane DB helper and deferred to route/OpenAPI/control-plane ownership.
 - Selected next gate after acceptance: G2.281 no-source data_lineage `get_lineage_tracker` ownership / route-provider decision.
 - G2.280 must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+
+## G2.281 data_lineage get_lineage_tracker Ownership / Route-Provider Decision
+
+Status: for review in future PR `#434`.
+
+- Parent PR `#433` merged at `1707284bceeef8992641290d86790c1699975f5a`.
+- `get_lineage_tracker` is defined in `web/backend/app/api/data_lineage.py` and returns a `LineageTracker` plus connection adapter created from an `asyncpg` raw connection.
+- Active direct callers are `record_lineage`, `get_upstream_lineage`, `get_downstream_lineage`, `get_lineage_graph`, and `analyze_impact`.
+- Runtime/OpenAPI smoke with placeholder import-time environment values recorded `548` FastAPI routes, `500` OpenAPI paths, `0` duplicate operation IDs, and the five `/api/v1/lineage` paths present.
+- GitNexus CLI context found one symbol and five incoming calls; impact is MEDIUM with `5` impacted / direct callers and `0` affected processes.
+- Limited autopilot must stop at this PR review gate because GitNexus risk is MEDIUM.
+- Recommended next gate after human acceptance: decide whether to create `G2.282 no-source data_lineage get_lineage_tracker provider authorization package`.
+- G2.281 must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.

--- a/docs/reports/quality/backend-data-lineage-tracker-ownership-decision-2026-06-01.md
+++ b/docs/reports/quality/backend-data-lineage-tracker-ownership-decision-2026-06-01.md
@@ -1,0 +1,137 @@
+# Backend data_lineage get_lineage_tracker Ownership Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Gate: `G2.281`
+- Status: for review
+- Prepared at: `2026-06-01T01:56:44+08:00`
+- Base HEAD checked: `1707284bceeef8992641290d86790c1699975f5a`
+- Parent PR: `#433`
+- Parent merge commit: `1707284bceeef8992641290d86790c1699975f5a`
+- Source edit authority: no
+- Autopilot status: stop at PR review gate
+
+Boundary note: this report records an ownership and route-provider decision
+only. It does not authorize backend source edits, test edits, route registration
+changes, generated OpenAPI artifact edits, frontend/config/script edits,
+OpenSpec changes, PM2 commands, or runtime state changes.
+
+## Autopilot Stop Reason
+
+The maintainer's limited-autopilot rule allows automatic merging only when
+GitNexus risk remains low and no new affected symbols or processes appear.
+
+For `get_lineage_tracker`, GitNexus CLI impact reports:
+
+- risk: `MEDIUM`
+- impacted count: `5`
+- direct callers: `5`
+- affected processes: `0`
+- affected module: `Api`
+- index status: stale warning
+
+Staged verification for this governance-only PR reports:
+
+- MCP `detect_changes`: `Transport closed`
+- CLI fallback: `ok=true`, `status=stale`, `risk_level=low`
+- changed files: `9`
+- changed symbols: `0`
+- affected processes: `0`
+- indexed commit: `bf65ba60483469d5a973543a3ed3b421434ae1da`
+- current commit: `1707284bceeef8992641290d86790c1699975f5a`
+
+Because the risk is `MEDIUM`, this G2.281 PR must stop at human review. Codex
+must not auto-merge this PR or start a follow-up source implementation lane.
+
+## Parent State
+
+PR `#433` merged G2.280 at
+`1707284bceeef8992641290d86790c1699975f5a`.
+
+G2.280 selected `get_lineage_tracker` as the next bounded no-source decision
+target after the `get_monitoring_db` sequence closed.
+
+## Surface Summary
+
+Current owner surface:
+
+- route module: `web/backend/app/api/data_lineage.py`
+- helper: `get_lineage_tracker`
+- definition line: `92`
+- active direct calls: `5`
+- active route handlers: `5`
+- cross-module incoming calls: none found by GitNexus CLI context
+
+Current helper behavior:
+
+- creates an `asyncpg` raw connection from PostgreSQL settings
+- creates `LineageStorage`
+- creates `LineageTracker`
+- returns `(tracker, connection_adapter)`
+
+Active callers:
+
+| Handler | Route | Method | Direct call line |
+|---|---|---|---:|
+| `record_lineage` | `/api/v1/lineage/record` | POST | 149 |
+| `get_upstream_lineage` | `/api/v1/lineage/{node_id}/upstream` | GET | 226 |
+| `get_downstream_lineage` | `/api/v1/lineage/{node_id}/downstream` | GET | 336 |
+| `get_lineage_graph` | `/api/v1/lineage/graph` | POST | 424 |
+| `analyze_impact` | `/api/v1/lineage/impact` | POST | 540 |
+
+## Route / OpenAPI Smoke
+
+Runtime/OpenAPI smoke with placeholder import-time environment values recorded:
+
+- FastAPI routes: `548`
+- OpenAPI paths: `500`
+- duplicate operation IDs: `0`
+
+Lineage paths present:
+
+- `/api/v1/lineage/graph`
+- `/api/v1/lineage/impact`
+- `/api/v1/lineage/record`
+- `/api/v1/lineage/{node_id}/downstream`
+- `/api/v1/lineage/{node_id}/upstream`
+- `/api/v1/governance/lineage/stats`
+
+Known smoke log noise: app import emitted the existing mock backtest
+`NotImplementedError` log. The smoke still completed and produced route/OpenAPI
+counts.
+
+## Decision
+
+Classification:
+
+`get_lineage_tracker` is a bounded active API route helper / provider candidate.
+
+Ownership:
+
+The current helper belongs to the `data_lineage.py` route module. It is not a
+root service facade, not a registry surface, and not a route-registration or
+OpenAPI exposure issue.
+
+Recommended next gate:
+
+`G2.282 no-source data_lineage get_lineage_tracker provider authorization package`
+
+Important boundary:
+
+G2.281 does not authorize source implementation. A future G2.282 may draft a
+path-limited authorization package for a route-local provider/dependency seam,
+but that authorization must be reviewed because the current GitNexus sampled
+risk is `MEDIUM`.
+
+## Stale Policy
+
+This report is stale if any of these change before review:
+
+- current HEAD differs from
+  `1707284bceeef8992641290d86790c1699975f5a`
+- PR `#433` merge state or merge commit changes
+- runtime route count or OpenAPI path count changes
+- `data_lineage.py` `get_lineage_tracker` call sites change
+- GitNexus risk or affected symbol/process counts change

--- a/governance/mainline/task-cards/pr-434.yaml
+++ b/governance/mainline/task-cards/pr-434.yaml
@@ -1,0 +1,123 @@
+version: "v0.2"
+
+task:
+  id: "pr-434"
+  title: "Decide data_lineage get_lineage_tracker ownership"
+  owner: "codex"
+  created_at: "2026-06-01"
+
+mainline:
+  id: "L1-data-lineage-tracker-ownership-decision"
+  objective: "record G2.280 acceptance and decide ownership / route-provider disposition for data_lineage get_lineage_tracker"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "G2.281 is a no-source governance decision. It changes no runtime entrypoint, route path, route registration, generated OpenAPI artifact, frontend route, or FUNCTION_TREE catalog entry."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-lineage-tracker-ownership-decision-2026-06-01.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-lineage-tracker-ownership-decision-2026-06-01.md"
+    - "governance/mainline/task-cards/pr-434.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits"
+  - "test edits"
+  - "route registration changes"
+  - "route path, method, response model, or generated OpenAPI artifact changes"
+  - "docs/api artifact edits"
+  - "frontend/config/script changes"
+  - "OpenSpec proposal or spec edits"
+  - "PM2 commands or stateful runtime gates"
+  - "source implementation authorization by automation"
+
+acceptance:
+  checks:
+    - id: "pr433-merged"
+      command: "gh pr view 433 confirms MERGED at 1707284bceeef8992641290d86790c1699975f5a"
+      required: true
+    - id: "data-lineage-surface-scan"
+      command: "current HEAD scan records get_lineage_tracker definition and five direct route-handler calls in web/backend/app/api/data_lineage.py"
+      required: true
+    - id: "gitnexus-impact"
+      command: "GitNexus CLI context/impact records get_lineage_tracker as MEDIUM risk with 5 direct callers and 0 affected processes; autopilot must stop at PR review"
+      required: true
+    - id: "runtime-openapi-smoke"
+      command: "app.main route/OpenAPI smoke records 548 routes, 500 paths, duplicate operation IDs 0, and lineage paths present"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-434.yaml --base-sha 1707284bceeef8992641290d86790c1699975f5a --head-sha HEAD --report /tmp/pr434-mainline-governance-report.json"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "gitnexus-detect-changes"
+      command: "GitNexus staged verification attempted before commit; stale-index warning recorded if present"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "GitNexus impact for get_lineage_tracker is MEDIUM, so this PR must not be auto-merged under the limited-autopilot rule."
+    - "A future worker may treat this decision as source authorization; the report and steward tree explicitly forbid that."
+  rollback_plan: "Revert PR #434; this removes only governance evidence and restores the previous steward tree state."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Decide ownership for data_lineage get_lineage_tracker."
+    modified_scope: "Governance evidence, steward tree indexes, human-readable report, and task card only."
+    dependency_changes: "No dependency changes."
+    legacy_logic_impact: "No runtime, route, OpenAPI, frontend, config, script, or OpenSpec changes."
+    rollback_ready: "Revert PR #434."
+    risk_and_rollback_point: "No-source decision; rollback is single-PR revert."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer-limited-autopilot"
+    approved_at: "2026-06-01T01:56:44+08:00"
+    approval_note: "Limited autopilot authorized no-source governance execution, but this PR must stop at human review because GitNexus sampled risk is MEDIUM."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- records PR #433 as merged at 1707284bceeef8992641290d86790c1699975f5a
- classifies data_lineage get_lineage_tracker as a bounded active API route helper / provider candidate
- recommends a possible G2.282 no-source provider authorization package after human review

## Autopilot stop
- GitNexus CLI impact for get_lineage_tracker is MEDIUM
- impacted count: 5
- direct callers: 5
- affected processes: 0
- per maintainer limited-autopilot rules, this PR must stop at human review and must not be auto-merged

## Boundary
- no backend source edits
- no test edits
- no route/OpenAPI artifact edits
- no frontend/config/script/OpenSpec/PM2 changes

## Verification
- JSON parse: ok
- markdown governance gate: 6 checked, 0 errors
- openspec validate migrate-backend-singletons-to-lifecycle-di --strict: valid
- mainline scope gate: pass
- runtime/OpenAPI smoke: 548 routes, 500 paths, duplicate operation IDs 0, lineage paths present
- git diff --check and staged/postcommit diff check: pass
- GitNexus staged verification: MCP Transport closed; CLI fallback ok=true, status=stale, risk=low, changed symbols 0, affected processes 0