### PR TITLE
G2.291: inject data_source_registry manager provider

### DIFF
--- a/.planning/codebase/generated/data-source-registry-manager-provider-implementation-2026-06-01.json
+++ b/.planning/codebase/generated/data-source-registry-manager-provider-implementation-2026-06-01.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": "2026-06-01.g2-provider-implementation.v1",
+  "generated_at": "2026-06-01T11:08:00+08:00",
+  "workline": "G2 service lifecycle / provider governance",
+  "node": {
+    "id": "G2.291",
+    "title": "data_source_registry get_manager provider implementation",
+    "state": "for_review",
+    "source_edit_authority": true,
+    "autopilot_allowed_to_merge": false,
+    "stop_reason": "backend source/tests changed and target GitNexus impact is MEDIUM with one affected process"
+  },
+  "parent": {
+    "id": "G2.290",
+    "pr": 443,
+    "state": "MERGED",
+    "merge_commit": "e517163385e96a6c7115e14b77fb89819b4cead4",
+    "merged_at": "2026-06-01T02:53:05Z"
+  },
+  "planned_pr": {
+    "number": 444,
+    "branch": "g2-291-data-source-registry-manager-provider-implementation",
+    "base": "wip/root-dirty-20260403"
+  },
+  "scope": {
+    "source_paths": [
+      "web/backend/app/api/data_source_registry.py"
+    ],
+    "test_paths": [
+      "web/backend/tests/test_data_source_registry_manager_provider.py",
+      "tests/unit/test_data_source_metrics_integration.py"
+    ],
+    "governance_paths": [
+      ".planning/codebase/steward-tree/current-next-gates.md",
+      ".planning/codebase/steward-tree/evidence-index.md",
+      ".planning/codebase/steward-tree/completed-ledger.md",
+      ".planning/codebase/steward-tree/branch-register.md",
+      ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+      ".planning/codebase/steward-tree/steward-index.json",
+      ".planning/codebase/generated/data-source-registry-manager-provider-implementation-2026-06-01.json",
+      "docs/reports/quality/backend-data-source-registry-manager-provider-implementation-2026-06-01.md",
+      "governance/mainline/task-cards/pr-444.yaml"
+    ],
+    "forbidden_paths": [
+      "web/backend/app/api/data_source_config.py",
+      "src/core/data_source/**",
+      "src/core/data_source_manager_v2.py",
+      "docs/api/**",
+      "web/frontend/**",
+      "config/**",
+      "scripts/**",
+      "openspec/changes/**",
+      "openspec/specs/**",
+      "PM2/runtime state"
+    ]
+  },
+  "implementation": {
+    "module": "web/backend/app/api/data_source_registry.py",
+    "helper": "get_manager",
+    "provider": "get_data_source_registry_manager",
+    "provider_behavior": "delegates to get_manager()",
+    "compatibility_seam": "get_manager remains public/backing monkeypatch seam",
+    "fresh_manager_semantics": "preserved through get_manager() returning DataSourceManagerV2()",
+    "route_handlers": [
+      "search_data_sources",
+      "get_category_stats",
+      "get_data_source",
+      "update_data_source",
+      "test_data_source",
+      "health_check_data_source",
+      "health_check_all_data_sources"
+    ],
+    "direct_route_body_get_manager_calls_after": 0,
+    "provider_backing_get_manager_calls_after": 1,
+    "depends_provider_bindings_after": 7
+  },
+  "contract_snapshot": {
+    "runtime_routes": 548,
+    "openapi_paths": 500,
+    "duplicate_operation_ids": 0,
+    "data_source_runtime_routes": 16,
+    "route_registration_changed": false,
+    "generated_openapi_artifact_changed": false
+  },
+  "gitnexus": {
+    "mcp_context": "Transport closed",
+    "mcp_impact": "Transport closed",
+    "cli_context": "found Function:web/backend/app/api/data_source_registry.py:get_manager with seven incoming calls",
+    "cli_impact": {
+      "risk": "MEDIUM",
+      "impacted_count": 7,
+      "direct": 7,
+      "processes_affected": 1,
+      "modules_affected": 1,
+      "index_status": "stale warning"
+    }
+  },
+  "verification": {
+    "tdd_red": "web/backend/tests/test_data_source_registry_manager_provider.py: 3 failed before implementation",
+    "tdd_green": "web/backend/tests/test_data_source_registry_manager_provider.py: 3 passed after implementation",
+    "focused_tests": "34 passed in 11.95s",
+    "focused_test_command": "PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov web/backend/tests/test_data_source_registry_manager_provider.py tests/api/file_tests/test_data_source_registry_api.py web/backend/tests/test_data_source_registry_error_contract.py web/backend/tests/test_data_source_auth_hardening.py tests/unit/test_data_source_metrics_integration.py",
+    "ruff": "All checks passed",
+    "route_openapi": "548 routes, 500 paths, duplicate operation IDs 0, data-source runtime routes 16",
+    "openspec": "migrate-backend-singletons-to-lifecycle-di valid; PostHog telemetry noise only",
+    "git_diff_check": "passed"
+  },
+  "next_gate": {
+    "if_pr_444_accepted": "G2.292 no-source data_source_registry.get_manager provider closeout / residual refresh",
+    "if_pr_444_rejected": "revert PR #444 branch changes or revise implementation inside the same path-limited envelope"
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-06-01T01:56:44+08:00`
-- Base HEAD checked: `1707284bceeef8992641290d86790c1699975f5a`
+- Prepared at: `2026-06-01T11:08:00+08:00`
+- Base HEAD checked: `e517163385e96a6c7115e14b77fb89819b4cead4`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -120,7 +120,8 @@ PRs, change issue labels, or authorize source implementation.
 | `#433` | `g2-280-service-lifecycle-residual-candidate-refresh-after-monitoring-db` | `wip/root-dirty-20260403` | `MERGED` at `1707284bceeef8992641290d86790c1699975f5a` | No-source residual candidate refresh selecting G2.281 data_lineage `get_lineage_tracker` decision |
 | `#441` | `g2-288-governance-dashboard-postgres-provider-closeout` | `wip/root-dirty-20260403` | `MERGED` at `75ce550ceaf9f77b7659193b9cbd3c9ab2181c37` | No-source governance dashboard provider closeout selecting G2.289 data_source_registry ownership decision |
 | `#442` | `g2-289-data-source-registry-manager-ownership` | `wip/root-dirty-20260403` | `MERGED` at `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf` | No-source data_source_registry `get_manager` ownership decision selecting G2.290 provider authorization |
-| `#443` | `g2-290-data-source-registry-manager-provider-authorization` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | No-source provider authorization for future G2.291 data_source_registry implementation; auto-merge paused because it authorizes future source work and target risk is MEDIUM |
+| `#443` | `g2-290-data-source-registry-manager-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `e517163385e96a6c7115e14b77fb89819b4cead4` | No-source provider authorization for future G2.291 data_source_registry implementation |
+| `#444` | `g2-291-data-source-registry-manager-provider-implementation` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | Path-limited data_source_registry manager provider implementation; auto-merge paused because it changes backend source/tests and target risk is MEDIUM |
 
 ## Steward Governance Branch
 
@@ -157,6 +158,7 @@ PRs, change issue labels, or authorize source implementation.
 | `g2-288-governance-dashboard-postgres-provider-closeout` | `origin/wip/root-dirty-20260403` at `67ef9b9d8f9dd420de80995f624fa54e41493415` | Close out governance_dashboard provider implementation and select G2.289 data_source_registry ownership decision | No |
 | `g2-289-data-source-registry-manager-ownership` | `origin/wip/root-dirty-20260403` at `75ce550ceaf9f77b7659193b9cbd3c9ab2181c37` | Decide data_source_registry `get_manager` ownership / route-provider disposition; stop auto-merge due GitNexus MEDIUM risk and one affected process | No |
 | `g2-290-data-source-registry-manager-provider-authorization` | `origin/wip/root-dirty-20260403` at `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf` | Authorize a future path-limited data_source_registry `get_manager` route-provider implementation | No |
+| `g2-291-data-source-registry-manager-provider-implementation` | `origin/wip/root-dirty-20260403` at `e517163385e96a6c7115e14b77fb89819b4cead4` | Implement path-limited data_source_registry manager provider injection and focused tests | Yes |
 
 ## OpenSpec Relationship
 
@@ -228,4 +230,6 @@ G2.288 is the no-source `governance_dashboard.get_postgres_connection` provider 
 
 G2.289 is the no-source `data_source_registry.get_manager` ownership / route-provider decision after PR `#441` merged G2.288 at `75ce550ceaf9f77b7659193b9cbd3c9ab2181c37`. It merged by PR `#442` at `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf`. It classifies `get_manager` as a bounded active data-source registry route helper with `7` direct route-body callers, runtime/OpenAPI `548/500/0`, and GitNexus MEDIUM impact with one affected process. It must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
 
-G2.290 is the no-source `data_source_registry.get_manager` provider authorization after PR `#442` merged G2.289 at `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf`. It authorizes only a future G2.291 path-limited source lane for `web/backend/app/api/data_source_registry.py` plus focused data-source registry tests after PR `#443` human acceptance. It must not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state in the authorization PR.
+G2.290 is the no-source `data_source_registry.get_manager` provider authorization after PR `#442` merged G2.289 at `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf`. It merged by PR `#443` at `e517163385e96a6c7115e14b77fb89819b4cead4`. It authorized only the G2.291 path-limited source lane for `web/backend/app/api/data_source_registry.py` plus focused data-source registry tests. It must not be used to expand scope beyond that implementation envelope.
+
+G2.291 is the path-limited `data_source_registry.get_manager` provider implementation after PR `#443` merged G2.290 at `e517163385e96a6c7115e14b77fb89819b4cead4`. It adds `get_data_source_registry_manager`, keeps `get_manager()` as backing compatibility / monkeypatch seam, moves seven target handlers to `Depends(get_data_source_registry_manager)`, preserves runtime/OpenAPI `548/500/0`, and records focused tests `34/34`. It edits backend source/tests and must stop at future PR `#444` review; if accepted, the next gate is G2.292 no-source provider closeout / residual refresh.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-06-01T08:49:27+08:00`
-- Base HEAD checked: `67ef9b9d8f9dd420de80995f624fa54e41493415`
+- Prepared at: `2026-06-01T11:08:00+08:00`
+- Base HEAD checked: `e517163385e96a6c7115e14b77fb89819b4cead4`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -19,15 +19,16 @@ exact verification output.
 | Route/OpenAPI and control-plane governance | Established route table, OpenAPI exposure, health/probe taxonomy, and consumer-contract evidence as first-class governance facts | Continue through route/OpenAPI track, not ad hoc route edits |
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
-| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.289 accepted/merged by PR `#442` at `1f0a9093` | Continue with G2.290 `data_source_registry.get_manager` provider authorization review; do not auto-merge because it authorizes future source work and the target impact is MEDIUM |
+| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.290 accepted/merged by PR `#443` at `e5171633` | Continue with G2.291 `data_source_registry.get_manager` provider implementation review; do not auto-merge because it changes backend source/tests and the target impact is MEDIUM |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.289 have progressed through PR `#337`-`#442`; current review target is G2.290 provider authorization in future PR `#443` |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.290 have progressed through PR `#337`-`#443`; current review target is G2.291 provider implementation in future PR `#444` |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Recent Closeouts
 
 | Item | Accepted evidence | Follow-up |
 |---|---|---|
+| G2.290 data_source_registry get_manager provider authorization | PR `#443` merged at `e517163385e96a6c7115e14b77fb89819b4cead4`; authorized only a path-limited G2.291 implementation lane | G2.291 implements the provider injection and must stop at future PR `#444` review |
 | G2.265 signal statistics stale contract cleanup | PR `#418` merged at `2b53352d6869f66147ce3892b1b0a7174ba064b4`; targeted tests `2/2`; runtime OpenAPI target paths `0` | G2.266 records closeout and selects `G2.267 no-source monitoring/signal residual provider classification refresh` |
 | G2.266 signal statistics dormant contract closeout | PR `#419` merged at `eec68bb47a4ee98508480ef0ac2cdd3716e04b05`; stale contract branch closed | G2.267 classifies monitoring/signal residuals and selects G2.268 no-source authorization |
 | G2.267 monitoring/signal residual classification | PR `#420` merged at `772e4a3ac8e05edaa243d660d67c7e5df18158f9`; active portfolio optimizer route-body candidate selected | G2.268 authorizes a future path-limited portfolio optimizer provider implementation lane |

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-06-01T10:36:04+08:00`
-- Base HEAD checked: `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf`
+- Prepared at: `2026-06-01T11:08:00+08:00`
+- Base HEAD checked: `e517163385e96a6c7115e14b77fb89819b4cead4`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.290 `data_source_registry.get_manager` provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#442` merged at `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf`; G2.290 authorizes only a future G2.291 path-limited source lane after human acceptance, with future source limited to `data_source_registry.py` plus focused data-source registry tests | Review future PR `#443`; do not auto-merge because it authorizes future backend source implementation and the target has GitNexus MEDIUM impact with one affected process |
+| P0 | Review G2.291 `data_source_registry.get_manager` provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#443` merged at `e517163385e96a6c7115e14b77fb89819b4cead4`; G2.291 adds route-local `get_data_source_registry_manager`, moves 7 target handlers to `Depends(...)`, keeps `get_manager()` as compatibility/backing seam, and preserves runtime/OpenAPI `548/500/0` | Review future PR `#444`; do not auto-merge because it changes backend source/tests and the target has GitNexus MEDIUM impact with one affected process |
+| P0 | Preserve G2.290 `data_source_registry.get_manager` provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#443` merged at `e517163385e96a6c7115e14b77fb89819b4cead4`; G2.290 authorized only the path-limited G2.291 source lane now represented by this worktree | Do not use G2.290 to expand scope beyond `web/backend/app/api/data_source_registry.py` plus focused data-source registry tests |
 | P0 | Preserve G2.289 `data_source_registry.get_manager` ownership / route-provider decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#442` merged at `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf`; G2.289 classified `get_manager` as a bounded active data-source registry route helper with `7` direct route-body callers, runtime/OpenAPI `548/500/0`, and GitNexus MEDIUM impact with one affected process | Do not use G2.289 as source implementation authorization; use G2.290 only as no-source provider authorization after review |
 | P0 | Preserve G2.288 `governance_dashboard.get_postgres_connection` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#441` merged at `75ce550ceaf9f77b7659193b9cbd3c9ab2181c37`; G2.288 closed the governance dashboard provider lane, confirmed direct route-body calls `0`, manual close calls `0`, provider bindings `5`, and selected `data_source_registry.get_manager` only for no-source ownership / route-provider decision | Do not use G2.288 as source implementation authorization; use G2.289 only for no-source ownership / route-provider decision |
 | P0 | Preserve G2.287 `governance_dashboard.get_postgres_connection` provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#440` merged at `67ef9b9d8f9dd420de80995f624fa54e41493415`; G2.287 moved five governance dashboard handlers to `Depends(get_governance_dashboard_postgres_connection)` and preserved runtime/OpenAPI `548/500/0` | Do not use G2.287 as authority for non-governance-dashboard source edits, route registration, route/OpenAPI contract changes, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-06-01T10:36:04+08:00`
-- Base HEAD checked: `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf`
+- Prepared at: `2026-06-01T11:08:00+08:00`
+- Base HEAD checked: `e517163385e96a6c7115e14b77fb89819b4cead4`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -16,9 +16,12 @@ state transition.
 
 | Evidence | Role | Freshness policy |
 |---|---|---|
-| `.planning/codebase/generated/data-source-registry-manager-provider-authorization-2026-06-01.json` | G2.290 `data_source_registry.get_manager` provider authorization evidence | Review input for future PR `#443`; no-source authorization package; must stop because it authorizes future source work and the target has GitNexus MEDIUM impact with one affected process |
-| `docs/reports/quality/backend-data-source-registry-manager-provider-authorization-2026-06-01.md` | G2.290 human-readable provider authorization report | Review input for future PR `#443`; records PR `#442` accepted/merged, future path-limited implementation envelope, tests, and stop rule |
-| `governance/mainline/task-cards/pr-443.yaml` | No-source governance task card for G2.290 | Review input; allows only steward tree, generated evidence, report, and task card updates; no auto-merge because it authorizes future source work |
+| `.planning/codebase/generated/data-source-registry-manager-provider-implementation-2026-06-01.json` | G2.291 `data_source_registry.get_manager` provider implementation evidence | Review input for future PR `#444`; path-limited source implementation package; must stop because it changes backend source/tests and the target has GitNexus MEDIUM impact with one affected process |
+| `docs/reports/quality/backend-data-source-registry-manager-provider-implementation-2026-06-01.md` | G2.291 human-readable provider implementation report | Review input for future PR `#444`; records PR `#443` accepted/merged, implementation envelope, tests, and stop rule |
+| `governance/mainline/task-cards/pr-444.yaml` | Governance task card for G2.291 source implementation | Review input; allows only steward tree, generated evidence, report, source file, and focused test updates; no auto-merge because it changes backend source work |
+| `.planning/codebase/generated/data-source-registry-manager-provider-authorization-2026-06-01.json` | G2.290 `data_source_registry.get_manager` provider authorization evidence | Accepted by PR `#443`; historical no-source authorization package that led to the current source implementation lane |
+| `docs/reports/quality/backend-data-source-registry-manager-provider-authorization-2026-06-01.md` | G2.290 human-readable provider authorization report | Accepted by PR `#443`; records PR `#442` accepted/merged and the future path-limited implementation envelope |
+| `governance/mainline/task-cards/pr-443.yaml` | Governance task card for G2.290 | Accepted by PR `#443`; historical no-source authorization record |
 | `.planning/codebase/generated/data-source-registry-manager-ownership-decision-2026-06-01.json` | G2.289 `data_source_registry.get_manager` ownership / route-provider decision evidence | Accepted by PR `#442`, merged at `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf`; no-source decision package; superseded for authorization by G2.290 |
 | `docs/reports/quality/backend-data-source-registry-manager-ownership-decision-2026-06-01.md` | G2.289 human-readable ownership / route-provider decision report | Accepted by PR `#442`; records PR `#441` accepted/merged, seven route-body consumers, OpenAPI smoke, GitNexus fallback, and G2.290 recommendation |
 | `governance/mainline/task-cards/pr-442.yaml` | No-source governance task card for G2.289 | Accepted by PR `#442`; allowed only steward tree, generated evidence, report, and task card updates |

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-06-01T10:36:04+08:00",
+  "generated_at": "2026-06-01T11:08:00+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "1f0a909355f5db9002cfc2d0fcbba21e366dc0bf",
-  "split_branch": "g2-288-governance-dashboard-postgres-provider-closeout",
-  "scope": "governance_dashboard_postgres_provider_closeout_refresh",
-  "source_edit_authority": false,
+  "base_head": "e517163385e96a6c7115e14b77fb89819b4cead4",
+  "split_branch": "g2-291-data-source-registry-manager-provider-implementation",
+  "scope": "data_source_registry_manager_provider_implementation",
+  "source_edit_authority": true,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -9228,7 +9228,7 @@
     {
       "id": "g2-290-data-source-registry-manager-provider-authorization",
       "type": "authorization_package",
-      "state": "for_review",
+      "state": "accepted_merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.289 data_source_registry get_manager ownership / route-provider decision",
       "source_edit_authority": false,
@@ -9238,8 +9238,10 @@
       "github_pr": {
         "number": 443,
         "url": "https://github.com/chengjon/mystocks/pull/443",
-        "state": "PLANNED_FOR_REVIEW",
-        "head_ref": "g2-290-data-source-registry-manager-provider-authorization"
+        "state": "MERGED",
+        "merged_at": "2026-06-01T02:53:05Z",
+        "head_ref": "g2-290-data-source-registry-manager-provider-authorization",
+        "merge_commit": "e517163385e96a6c7115e14b77fb89819b4cead4"
       },
       "evidence": [
         ".planning/codebase/generated/data-source-registry-manager-provider-authorization-2026-06-01.json",
@@ -9352,7 +9354,120 @@
         "stale_if_gitnexus_risk_changes": true,
         "stale_if_test_inventory_changes": true
       },
-      "next_gate": "Stop for human review in PR #443. If accepted, start G2.291 path-limited source implementation; do not edit source from G2.290."
+      "next_gate": "Superseded by G2.291 path-limited data_source_registry get_manager route-provider implementation."
+    },
+    {
+      "id": "g2-291-data-source-registry-manager-provider-implementation",
+      "type": "implementation_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.290 data_source_registry get_manager provider authorization",
+      "source_edit_authority": true,
+      "autopilot_status": "stop_at_pr_review_gate",
+      "autopilot_stop_reason": "G2.291 changes backend source/tests and the target has GitNexus MEDIUM impact with one affected process",
+      "github_pr": {
+        "number": 444,
+        "url": "https://github.com/chengjon/mystocks/pull/444",
+        "state": "PLANNED_FOR_REVIEW",
+        "head_ref": "g2-291-data-source-registry-manager-provider-implementation"
+      },
+      "evidence": [
+        ".planning/codebase/generated/data-source-registry-manager-provider-implementation-2026-06-01.json",
+        "docs/reports/quality/backend-data-source-registry-manager-provider-implementation-2026-06-01.md",
+        "governance/mainline/task-cards/pr-444.yaml"
+      ],
+      "closed_parent": {
+        "pr": 443,
+        "state": "MERGED",
+        "merge_commit": "e517163385e96a6c7115e14b77fb89819b4cead4",
+        "merged_at": "2026-06-01T02:53:05Z"
+      },
+      "allowed_scope": [
+        "web/backend/app/api/data_source_registry.py",
+        "web/backend/tests/test_data_source_registry_manager_provider.py",
+        "tests/unit/test_data_source_metrics_integration.py",
+        ".planning/codebase/generated/data-source-registry-manager-provider-implementation-2026-06-01.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-data-source-registry-manager-provider-implementation-2026-06-01.md",
+        "governance/mainline/task-cards/pr-444.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/app/api/data_source_config.py",
+        "src/core/data_source/**",
+        "src/core/data_source_manager_v2.py",
+        "docs/api/**",
+        "web/frontend/**",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**",
+        "PM2/runtime state"
+      ],
+      "surface": {
+        "module": "web/backend/app/api/data_source_registry.py",
+        "helper": "get_manager",
+        "provider": "get_data_source_registry_manager",
+        "route_handlers": [
+          "search_data_sources",
+          "get_category_stats",
+          "get_data_source",
+          "update_data_source",
+          "test_data_source",
+          "health_check_data_source",
+          "health_check_all_data_sources"
+        ],
+        "direct_route_body_calls_after": 0,
+        "provider_backing_calls_after": 1,
+        "depends_provider_bindings_after": 7,
+        "runtime_routes": 548,
+        "openapi_paths": 500,
+        "duplicate_operation_ids": 0,
+        "target_runtime_route_count": 7,
+        "data_source_runtime_routes": 16
+      },
+      "gitnexus_evidence": {
+        "mcp_context": "tool call failed: Transport closed",
+        "mcp_impact": "tool call failed: Transport closed",
+        "cli_context": "found Function:web/backend/app/api/data_source_registry.py:get_manager with seven incoming calls",
+        "cli_impact_uid": {
+          "risk": "MEDIUM",
+          "impacted_count": 7,
+          "direct": 7,
+          "processes_affected": 1,
+          "modules_affected": 1,
+          "index_status": "stale warning"
+        }
+      },
+      "verification": {
+        "tdd_red": "3 failed before implementation",
+        "tdd_green": "3 passed after implementation",
+        "focused_data_source_registry_tests": "34 passed in 11.95s",
+        "ruff": "All checks passed",
+        "route_openapi": "548 routes, 500 paths, duplicate operation IDs 0, data-source runtime routes 16",
+        "openspec": "migrate-backend-singletons-to-lifecycle-di valid; PostHog telemetry noise only"
+      },
+      "decision": {
+        "classification": "provider-implementation-for-review",
+        "source_lane_recommendation": "stop-at-pr-444-human-review",
+        "autopilot_continue_allowed": false,
+        "selected_next_governance_target": "data-source-registry-manager-provider-closeout-refresh",
+        "recommended_next_work_item": "G2.292 no-source data_source_registry.get_manager provider closeout / residual refresh after PR #444 human acceptance"
+      },
+      "freshness": {
+        "current_head_checked": "e517163385e96a6c7115e14b77fb89819b4cead4",
+        "stale_if_head_or_pr_state_changes": true,
+        "stale_if_route_or_openapi_counts_change": true,
+        "stale_if_data_source_registry_call_sites_change": true,
+        "stale_if_data_source_manager_contract_changes": true,
+        "stale_if_gitnexus_risk_changes": true,
+        "stale_if_test_inventory_changes": true
+      },
+      "next_gate": "Stop for human review in PR #444. If accepted, start G2.292 no-source provider closeout / residual refresh."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-05-31T23:34:18+08:00`
-- Base HEAD checked: `daa4f22a557b054ab76042d4990b6e91d9faa7a7`
+- Prepared at: `2026-06-01T11:08:00+08:00`
+- Base HEAD checked: `e517163385e96a6c7115e14b77fb89819b4cead4`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -3138,4 +3138,18 @@ Status: for review in future PR `#443`.
 - Current route/OpenAPI smoke with repo `.env` loaded into the subprocess records `548` FastAPI routes, `500` OpenAPI paths, `0` duplicate operation IDs, and `7` data-source registry runtime routes.
 - GitNexus MCP returned `Transport closed`; CLI fallback reports MEDIUM risk, `7` impacted symbols, `7` direct callers, `1` affected process, `1` affected module, and stale-index warning.
 - PR `#443` must stop for human review and must not auto-merge because it authorizes future source work and the target has GitNexus MEDIUM impact with one affected process.
-- G2.290 is superseded only after a reviewed G2.291 implementation lane is accepted.
+- G2.290 is superseded by G2.291 path-limited implementation.
+
+## G2.291 data_source_registry get_manager Provider Implementation
+
+- PR state: planned future PR `#444` for review.
+- Parent state: PR `#443` merged G2.290 at `e517163385e96a6c7115e14b77fb89819b4cead4`.
+- G2.291 is a path-limited source implementation package. It edits only `web/backend/app/api/data_source_registry.py`, focused data-source registry tests, steward evidence, this track, and the PR task card.
+- Implementation shape: add route-local provider `get_data_source_registry_manager` delegating to existing `get_manager()`, keep `get_manager()` as backing compatibility / monkeypatch seam, and move the seven active data-source registry handlers to `Depends(get_data_source_registry_manager)`.
+- Result: direct route-body `get_manager()` calls are `0`, provider backing calls are `1`, and `Depends(get_data_source_registry_manager)` bindings are `7`.
+- Compatibility: direct unit-call compatibility is retained through `_resolve_data_source_registry_manager` so tests that monkeypatch `data_source_registry.get_manager` remain valid.
+- Route/OpenAPI: runtime routes `548`, OpenAPI paths `500`, duplicate operation IDs `0`, data-source runtime route count `16`.
+- Verification: TDD red `3 failed`, TDD green `3 passed`, focused data-source registry suite `34 passed`, ruff changed files `All checks passed`, OpenSpec strict valid with PostHog telemetry noise only.
+- GitNexus: MCP `context` and `impact` returned `Transport closed`; CLI fallback reports MEDIUM risk, `7` direct callers, `7` impacted symbols, `1` affected process, and stale-index warning for `Function:web/backend/app/api/data_source_registry.py:get_manager`.
+- Stop rule: PR `#444` must stop for human review because it changes backend source/tests and the target has GitNexus MEDIUM impact with one affected process.
+- Recommended next gate after human acceptance and merge: G2.292 no-source `data_source_registry.get_manager` provider closeout / residual refresh.

--- a/docs/reports/quality/backend-data-source-registry-manager-provider-implementation-2026-06-01.md
+++ b/docs/reports/quality/backend-data-source-registry-manager-provider-implementation-2026-06-01.md
@@ -1,0 +1,139 @@
+# Backend Data Source Registry Manager Provider Implementation
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Node: `G2.291`
+- Status: review input for future PR `#444`
+- Prepared at: `2026-06-01T11:08:00+08:00`
+- Base HEAD: `e517163385e96a6c7115e14b77fb89819b4cead4`
+- Parent: G2.290 provider authorization, PR `#443` merged at `e517163385e96a6c7115e14b77fb89819b4cead4`
+
+Boundary note: this report records a path-limited backend source implementation
+for review. It does not authorize auto-merge. Future PR `#444` must stop for
+human review because it changes backend source/tests and the target has
+GitNexus MEDIUM impact with one affected process.
+
+## Scope
+
+Allowed implementation paths:
+
+- `web/backend/app/api/data_source_registry.py`
+- `web/backend/tests/test_data_source_registry_manager_provider.py`
+- `tests/unit/test_data_source_metrics_integration.py`
+
+Allowed governance paths:
+
+- `.planning/codebase/generated/data-source-registry-manager-provider-implementation-2026-06-01.json`
+- `.planning/codebase/steward-tree/current-next-gates.md`
+- `.planning/codebase/steward-tree/evidence-index.md`
+- `.planning/codebase/steward-tree/completed-ledger.md`
+- `.planning/codebase/steward-tree/branch-register.md`
+- `.planning/codebase/steward-tree/tracks/service-lifecycle-di.md`
+- `.planning/codebase/steward-tree/steward-index.json`
+- `docs/reports/quality/backend-data-source-registry-manager-provider-implementation-2026-06-01.md`
+- `governance/mainline/task-cards/pr-444.yaml`
+
+Forbidden scope:
+
+- `web/backend/app/api/data_source_config.py`
+- `src/core/data_source/**`
+- `src/core/data_source_manager_v2.py`
+- `docs/api/**`
+- `web/frontend/**`
+- `config/**`
+- `scripts/**`
+- `openspec/changes/**`
+- `openspec/specs/**`
+- PM2 or runtime state
+
+## Implementation Result
+
+G2.291 implements the G2.290-approved route-local provider shape:
+
+- Added `get_data_source_registry_manager()`.
+- Kept `get_manager()` as the backing compatibility / monkeypatch seam.
+- Preserved fresh `DataSourceManagerV2()` construction semantics through `get_manager()`.
+- Moved the seven active data-source registry handlers to dependency parameters backed by `Depends(get_data_source_registry_manager)`.
+- Added `_resolve_data_source_registry_manager()` to preserve direct unit-call compatibility when tests invoke route handlers without FastAPI injection.
+- Kept route paths, methods, response models, response metadata, OpenAPI exposure, operation IDs, `UnifiedResponse`, and error contract behavior unchanged.
+
+Target handler set:
+
+- `search_data_sources`
+- `get_category_stats`
+- `get_data_source`
+- `update_data_source`
+- `test_data_source`
+- `health_check_data_source`
+- `health_check_all_data_sources`
+
+Post-implementation counts:
+
+- Direct route-body `get_manager()` calls: `0`
+- Provider backing `get_manager()` calls: `1`
+- `Depends(get_data_source_registry_manager)` bindings: `7`
+- Runtime routes: `548`
+- OpenAPI paths: `500`
+- Duplicate operation IDs: `0`
+- Data-source runtime routes: `16`
+
+## Test Notes
+
+TDD evidence:
+
+- Red: `web/backend/tests/test_data_source_registry_manager_provider.py` failed with `3` expected failures before implementation.
+- Green: the same test file passed with `3 passed` after implementation.
+
+Focused verification:
+
+- `web/backend/tests/test_data_source_registry_manager_provider.py`
+- `tests/api/file_tests/test_data_source_registry_api.py`
+- `web/backend/tests/test_data_source_registry_error_contract.py`
+- `web/backend/tests/test_data_source_auth_hardening.py`
+- `tests/unit/test_data_source_metrics_integration.py`
+
+Result: `34 passed in 11.95s`.
+
+During focused verification, `tests/unit/test_data_source_metrics_integration.py`
+was corrected inside the authorized test scope:
+
+- use canonical `app.core.middleware.performance` imports instead of the
+  parallel `web.backend.app...` import path, avoiding duplicate Prometheus
+  metric registration in combined runs;
+- assert the canonical `UnifiedResponse.data` model shape for the manual
+  data-source test route.
+
+## GitNexus
+
+GitNexus MCP status:
+
+- `context`: `Transport closed`
+- `impact`: `Transport closed`
+
+CLI fallback:
+
+- Target: `Function:web/backend/app/api/data_source_registry.py:get_manager`
+- Risk: `MEDIUM`
+- Impacted symbols: `7`
+- Direct callers: `7`
+- Affected processes: `1`
+- Affected modules: `1`
+- Index status: stale warning
+
+This confirms the source implementation PR must stop for human review.
+
+## Verification
+
+- `ruff check web/backend/app/api/data_source_registry.py web/backend/tests/test_data_source_registry_manager_provider.py tests/unit/test_data_source_metrics_integration.py`: all checks passed.
+- Focused pytest command: `34 passed`.
+- Route/OpenAPI smoke: `548` routes, `500` OpenAPI paths, duplicate operation IDs `0`, data-source runtime routes `16`.
+- `openspec validate migrate-backend-singletons-to-lifecycle-di --strict`: valid; PostHog telemetry noise only.
+- `git diff --check`: passed.
+
+## Next Gate
+
+If future PR `#444` is accepted and merged, start G2.292 as a no-source
+provider closeout / residual refresh. G2.292 should confirm this lane is closed,
+refresh remaining candidates, and select the next target without editing source.

--- a/governance/mainline/task-cards/pr-444.yaml
+++ b/governance/mainline/task-cards/pr-444.yaml
@@ -1,0 +1,137 @@
+version: "v0.2"
+
+task:
+  id: "pr-444"
+  title: "Implement data_source_registry manager provider injection"
+  owner: "codex"
+  created_at: "2026-06-01"
+
+mainline:
+  id: "L1-data-source-registry-manager-provider-implementation"
+  objective: "move data_source_registry get_manager route-body consumers to an explicit FastAPI provider while preserving route contracts"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "G2.291 preserves route paths, methods, response models, OpenAPI exposure, operation IDs, and runtime route count; no FUNCTION_TREE catalog change is required."
+
+scope:
+  allowed_paths:
+    - "web/backend/app/api/data_source_registry.py"
+    - "web/backend/tests/test_data_source_registry_manager_provider.py"
+    - "tests/unit/test_data_source_metrics_integration.py"
+    - ".planning/codebase/generated/data-source-registry-manager-provider-implementation-2026-06-01.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-source-registry-manager-provider-implementation-2026-06-01.md"
+    - "governance/mainline/task-cards/pr-444.yaml"
+  forbidden_paths:
+    - "web/backend/app/api/data_source_config.py"
+    - "src/core/data_source/**"
+    - "src/core/data_source_manager_v2.py"
+    - "docs/api/**"
+    - "web/frontend/**"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "route path, method, response model, response metadata, operation ID, or OpenAPI exposure changes"
+  - "generated OpenAPI artifact edits"
+  - "process-level singleton introduction"
+  - "data source manager implementation changes"
+  - "data_source_config.py changes"
+  - "frontend/config/script changes"
+  - "OpenSpec proposal or spec edits"
+  - "PM2 commands or stateful runtime gates"
+  - "compatibility seam removal"
+  - "auto-merge"
+
+acceptance:
+  checks:
+    - id: "pr443-merged"
+      command: "gh pr view 443 confirms MERGED at e517163385e96a6c7115e14b77fb89819b4cead4"
+      required: true
+    - id: "gitnexus-impact-before-edit"
+      command: "GitNexus MCP context/impact returned Transport closed; CLI fallback records MEDIUM risk, 7 direct callers, 7 impacted symbols, 1 affected process"
+      required: true
+    - id: "tdd-red"
+      command: "PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov web/backend/tests/test_data_source_registry_manager_provider.py fails with 3 expected failures before implementation"
+      required: true
+    - id: "tdd-green"
+      command: "PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov web/backend/tests/test_data_source_registry_manager_provider.py passes with 3 passed after implementation"
+      required: true
+    - id: "focused-tests"
+      command: "PYTHONPATH=web/backend pytest -q -n 0 --tb=short --no-cov web/backend/tests/test_data_source_registry_manager_provider.py tests/api/file_tests/test_data_source_registry_api.py web/backend/tests/test_data_source_registry_error_contract.py web/backend/tests/test_data_source_auth_hardening.py tests/unit/test_data_source_metrics_integration.py"
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/api/data_source_registry.py web/backend/tests/test_data_source_registry_manager_provider.py tests/unit/test_data_source_metrics_integration.py"
+      required: true
+    - id: "route-openapi-smoke"
+      command: "app.main route/OpenAPI smoke records 548 routes, 500 paths, duplicate operation IDs 0, and 16 data-source runtime routes"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-444.yaml --base-sha e517163385e96a6c7115e14b77fb89819b4cead4 --head-sha HEAD --report /tmp/pr444-mainline-governance-report.json"
+      required: true
+    - id: "gitnexus-detect-changes"
+      command: "GitNexus staged verification attempted before commit; stale-index warning recorded if present"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "The target has MEDIUM GitNexus impact and one affected process, so PR #444 must stop for human review."
+    - "Existing tests monkeypatch data_source_registry.get_manager directly; implementation must preserve that seam."
+    - "FastAPI dependency parameters must not leak into OpenAPI query parameters."
+  rollback_plan: "Revert PR #444; this restores previous route-body get_manager calls and removes the focused provider regression test and steward updates."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Move data_source_registry get_manager route-body consumers to a route-local FastAPI provider."
+    modified_scope: "One backend route file, two focused test files, governance evidence, steward tree, and task card."
+    dependency_changes: "No package or infrastructure dependency changes."
+    legacy_logic_impact: "get_manager remains as public/backing compatibility seam; no route/OpenAPI contract change."
+    rollback_ready: "Revert PR #444."
+    risk_and_rollback_point: "MEDIUM GitNexus impact with one affected process; stop for review before merge."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-01T11:08:00+08:00"
+    approval_note: "Human maintainer approved continuing after PR #443 merge into G2.291 path-limited source implementation. PR #444 must stop for review because it changes backend source/tests and the target has GitNexus MEDIUM impact with one affected process."
+    secondary_approved: true

--- a/tests/unit/test_data_source_metrics_integration.py
+++ b/tests/unit/test_data_source_metrics_integration.py
@@ -63,7 +63,7 @@ def test_record_success_updates_runtime_stats_and_prometheus_metrics(monkeypatch
 
 
 def test_backend_metrics_endpoint_includes_canonical_datasource_metrics(monkeypatch):
-    from web.backend.app.core.middleware.performance import metrics_endpoint
+    from app.core.middleware.performance import metrics_endpoint
     from src.core.data_source import metrics as metrics_module
 
     metrics = DataSourceMetrics(registry=CollectorRegistry())
@@ -78,7 +78,7 @@ def test_backend_metrics_endpoint_includes_canonical_datasource_metrics(monkeypa
 
 
 def test_backend_metrics_endpoint_merges_canonical_metrics_even_with_runtime_datasource_prefix(monkeypatch):
-    from web.backend.app.core.middleware import performance
+    from app.core.middleware import performance
     from src.core.data_source import metrics as metrics_module
 
     metrics = DataSourceMetrics(registry=CollectorRegistry())
@@ -144,10 +144,10 @@ async def test_manual_datasource_test_route_records_canonical_metrics(monkeypatc
         authorization="Bearer local-test",
     )
 
-    assert response["success"] is True
-    assert response["row_count"] >= 1
-    assert response["error"] is None
-    assert response["quality_checks"]["has_data"] is True
+    assert response.data.success is True
+    assert response.data.row_count >= 1
+    assert response.data.error is None
+    assert response.data.quality_checks["has_data"] is True
     assert (
         metrics.api_calls_total.labels(
             endpoint="demo.daily_kline",
@@ -235,7 +235,7 @@ def test_backend_metrics_endpoint_includes_cache_hit_and_miss_samples(monkeypatc
     from src.core.data_source import metrics as metrics_module
     from src.core.data_source.handler import _call_endpoint
     from src.core.data_source.smart_cache import SmartCache
-    from web.backend.app.core.middleware.performance import metrics_endpoint
+    from app.core.middleware.performance import metrics_endpoint
 
     class CountingHandler:
         def __init__(self):

--- a/web/backend/app/api/data_source_registry.py
+++ b/web/backend/app/api/data_source_registry.py
@@ -1,11 +1,13 @@
-"""数据源注册表管理 API 路由。"""
+"""数据源注册表管理 API 路由."""
+
+# ruff: noqa: PT028
 
 import logging
 import os
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Body, Header, Path, Query
+from fastapi import APIRouter, Body, Depends, Header, Path, Query
 
 from app.core.config import settings
 from app.core.exceptions import BusinessException
@@ -65,6 +67,18 @@ def get_manager():
     return DataSourceManagerV2()
 
 
+def get_data_source_registry_manager():
+    """FastAPI dependency provider for the data source registry manager."""
+    return get_manager()
+
+
+def _resolve_data_source_registry_manager(manager: Any) -> Any:
+    """Keep direct unit-call compatibility while FastAPI injects the manager."""
+    if getattr(manager, "dependency", None) is get_data_source_registry_manager:
+        return get_data_source_registry_manager()
+    return manager
+
+
 def _require_write_auth(authorization: Optional[str]) -> None:
     """写操作鉴权：测试环境放行，非测试环境要求有效Bearer Token。"""
     if settings.testing:
@@ -101,10 +115,11 @@ async def search_data_sources(
     only_healthy: Optional[bool] = Query(False, description="仅返回健康的数据源"),
     keyword: Optional[str] = Query(None, description="模糊搜索关键词"),
     status: str = Query("active", description="数据源状态（active/maintenance/deprecated）"),
+    manager: Any = Depends(get_data_source_registry_manager),
 ) -> UnifiedResponse[DataSourceSearchResponse]:
     """按分类、类型、健康状态和关键词搜索数据源接口。"""
     try:
-        manager = get_manager()
+        manager = _resolve_data_source_registry_manager(manager)
 
         # 使用V2管理器的查询功能
         endpoints = manager.find_endpoints(
@@ -144,10 +159,12 @@ async def search_data_sources(
     description="汇总所有五层数据分类的接口规模、健康状态、平均质量评分和平均响应时间。",
     responses=DATA_SOURCE_CATEGORY_STATS_RESPONSES,
 )
-async def get_category_stats() -> UnifiedResponse[List[CategoryStatsResponse]]:
+async def get_category_stats(
+    manager: Any = Depends(get_data_source_registry_manager),
+) -> UnifiedResponse[List[CategoryStatsResponse]]:
     """获取所有 5 层数据分类的统计信息。"""
     try:
-        manager = get_manager()
+        manager = _resolve_data_source_registry_manager(manager)
 
         # 按分类分组统计
         categories = {}
@@ -221,10 +238,11 @@ async def get_category_stats() -> UnifiedResponse[List[CategoryStatsResponse]]:
 )
 async def get_data_source(
     endpoint_name: str = Path(..., description="需要查询详情的数据源接口名称。"),
+    manager: Any = Depends(get_data_source_registry_manager),
 ) -> UnifiedResponse[Dict[str, Any]]:
     """获取单个数据源的详细信息。"""
     try:
-        manager = get_manager()
+        manager = _resolve_data_source_registry_manager(manager)
 
         if endpoint_name not in manager.registry:
             raise BusinessException(status_code=404, detail=f"接口不存在: {endpoint_name}")
@@ -254,16 +272,17 @@ async def get_data_source(
 async def update_data_source(
     endpoint_name: str = Path(..., description="需要更新配置的数据源接口名称。"),
     update: DataSourceUpdate = Body(..., openapi_examples=DATA_SOURCE_UPDATE_EXAMPLES),
-    authorization: Optional[str] = Header(
+    authorization: Optional[str] = Header(  # noqa: PT028
         default=None,
         alias="Authorization",
         description="Bearer Token。非测试环境下写操作必须提供有效认证凭据。",
     ),
+    manager: Any = Depends(get_data_source_registry_manager),
 ) -> UnifiedResponse[Dict[str, Any]]:
     """更新数据源配置。"""
     try:
         _require_write_auth(authorization)
-        manager = get_manager()
+        manager = _resolve_data_source_registry_manager(manager)
 
         if endpoint_name not in manager.registry:
             raise BusinessException(status_code=404, detail=f"接口不存在: {endpoint_name}")
@@ -328,11 +347,12 @@ async def test_data_source(
         alias="Authorization",
         description="Bearer Token。非测试环境下手动测试操作必须提供有效认证凭据。",
     ),
+    manager: Any = Depends(get_data_source_registry_manager),
 ) -> UnifiedResponse[TestResponse]:
     """手动测试数据源。"""
     try:
         _require_write_auth(authorization)
-        manager = get_manager()
+        manager = _resolve_data_source_registry_manager(manager)
 
         if endpoint_name not in manager.registry:
             raise BusinessException(status_code=404, detail=f"接口不存在: {endpoint_name}")
@@ -407,11 +427,12 @@ async def health_check_data_source(
         alias="Authorization",
         description="Bearer Token。非测试环境下健康检查操作必须提供有效认证凭据。",
     ),
+    manager: Any = Depends(get_data_source_registry_manager),
 ) -> UnifiedResponse[Dict[str, Any]]:
     """健康检查单个数据源。"""
     try:
         _require_write_auth(authorization)
-        manager = get_manager()
+        manager = _resolve_data_source_registry_manager(manager)
 
         if endpoint_name not in manager.registry:
             raise BusinessException(status_code=404, detail=f"接口不存在: {endpoint_name}")
@@ -452,11 +473,12 @@ async def health_check_all_data_sources(
         alias="Authorization",
         description="Bearer Token。非测试环境下批量健康检查必须提供有效认证凭据。",
     ),
+    manager: Any = Depends(get_data_source_registry_manager),
 ) -> UnifiedResponse[Dict[str, Any]]:
     """健康检查所有数据源。"""
     try:
         _require_write_auth(authorization)
-        manager = get_manager()
+        manager = _resolve_data_source_registry_manager(manager)
 
         health_result = manager.health_check()
 

--- a/web/backend/tests/test_data_source_registry_manager_provider.py
+++ b/web/backend/tests/test_data_source_registry_manager_provider.py
@@ -1,0 +1,52 @@
+"""Regression tests for the data source registry manager provider seam."""
+
+import ast
+import inspect
+
+from fastapi.params import Depends as DependsParam
+
+from app.api import data_source_registry
+
+
+HANDLER_NAMES = (
+    "search_data_sources",
+    "get_category_stats",
+    "get_data_source",
+    "update_data_source",
+    "test_data_source",
+    "health_check_data_source",
+    "health_check_all_data_sources",
+)
+
+
+def test_data_source_registry_manager_provider_delegates_to_existing_get_manager(monkeypatch):
+    sentinel = object()
+
+    monkeypatch.setattr(data_source_registry, "get_manager", lambda: sentinel)
+
+    assert data_source_registry.get_data_source_registry_manager() is sentinel
+
+
+def test_data_source_registry_handlers_receive_manager_from_fastapi_dependency():
+    for handler_name in HANDLER_NAMES:
+        handler = getattr(data_source_registry, handler_name)
+        manager_parameter = inspect.signature(handler).parameters.get("manager")
+
+        assert manager_parameter is not None, f"{handler_name} must declare manager dependency"
+        assert isinstance(manager_parameter.default, DependsParam)
+        assert manager_parameter.default.dependency is data_source_registry.get_data_source_registry_manager
+
+
+def test_data_source_registry_handlers_do_not_call_get_manager_inside_route_body():
+    for handler_name in HANDLER_NAMES:
+        source = inspect.getsource(getattr(data_source_registry, handler_name))
+        tree = ast.parse(source)
+        direct_calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "get_manager"
+        ]
+
+        assert direct_calls == [], f"{handler_name} still calls get_manager() in the route body"


### PR DESCRIPTION
Line Scope: path-limited backend source implementation
Workline Lane: G2 service lifecycle / provider governance
Current Source of Truth: docs/reports/quality/backend-data-source-registry-manager-provider-implementation-2026-06-01.md plus steward tree

Summary:
- Merges G2.290 authorization state from PR #443.
- Adds route-local get_data_source_registry_manager() provider in web/backend/app/api/data_source_registry.py.
- Keeps get_manager() as the backing compatibility / monkeypatch seam and preserves fresh DataSourceManagerV2() construction semantics.
- Moves seven active data-source registry handlers to Depends(get_data_source_registry_manager).
- Keeps route paths, methods, response models, OpenAPI exposure, operation IDs, UnifiedResponse, and error contract behavior unchanged.
- Corrects authorized focused metrics tests to use canonical app.core import path and UnifiedResponse.data model shape.

Validation:
- GitNexus MCP context/impact: Transport closed; CLI fallback impact before edit records MEDIUM risk, 7 direct callers, 7 impacted symbols, 1 affected process.
- TDD red: provider regression failed with 3 expected failures before implementation.
- TDD green: provider regression passed with 3 passed after implementation.
- Focused pytest: 34 passed.
- Ruff changed files: all checks passed.
- Route/OpenAPI smoke: 548 routes, 500 paths, duplicate operation IDs 0, data-source runtime routes 16.
- OpenSpec strict validate migrate-backend-singletons-to-lifecycle-di: valid; PostHog telemetry noise only.
- Mainline governance scope gate: pass.
- git diff --check / cached diff check: pass.
- GitNexus verify-staged fallback: MEDIUM risk, 16 changed symbols, 1 affected execution flow.

Review boundary:
This PR changes backend source/tests and the target has GitNexus MEDIUM impact with one affected process. It must stop for human review and must not be auto-merged under the limited-autopilot rule.

Next gate after acceptance:
G2.292 no-source data_source_registry provider closeout / residual refresh.