### PR TITLE
G2.292: close data_source_registry provider lane

### DIFF
--- a/.planning/codebase/generated/data-source-registry-provider-closeout-refresh-2026-06-01.json
+++ b/.planning/codebase/generated/data-source-registry-provider-closeout-refresh-2026-06-01.json
@@ -1,0 +1,196 @@
+{
+  "gate": "G2.292",
+  "prepared_at": "2026-06-01T11:52:20+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "3d161e90547720f4ce95111ea511d3f8dc3174dc",
+  "parent": {
+    "gate": "G2.291",
+    "pr": 444,
+    "state": "MERGED",
+    "merged_at": "2026-06-01T03:40:06Z",
+    "merge_commit": "3d161e90547720f4ce95111ea511d3f8dc3174dc",
+    "summary": "Path-limited data_source_registry get_manager provider implementation accepted and merged."
+  },
+  "scope": {
+    "source_edit_authority": false,
+    "allowed_change_type": "no-source closeout and residual candidate refresh",
+    "forbidden": [
+      "backend source edits",
+      "test edits",
+      "route registration changes",
+      "route path/method/response model changes",
+      "generated OpenAPI artifact edits",
+      "docs/api edits",
+      "frontend/config/script changes",
+      "OpenSpec proposal/spec edits",
+      "PM2 commands or runtime state changes",
+      "source retirement",
+      "implementation authorization for the next candidate"
+    ]
+  },
+  "closeout": {
+    "module": "web/backend/app/api/data_source_registry.py",
+    "helper": "get_manager",
+    "provider": "get_data_source_registry_manager",
+    "route_handlers": {
+      "search_data_sources": {
+        "direct_get_manager_calls": 0,
+        "depends_get_data_source_registry_manager": 1
+      },
+      "get_category_stats": {
+        "direct_get_manager_calls": 0,
+        "depends_get_data_source_registry_manager": 1
+      },
+      "get_data_source": {
+        "direct_get_manager_calls": 0,
+        "depends_get_data_source_registry_manager": 1
+      },
+      "update_data_source": {
+        "direct_get_manager_calls": 0,
+        "depends_get_data_source_registry_manager": 1
+      },
+      "test_data_source": {
+        "direct_get_manager_calls": 0,
+        "depends_get_data_source_registry_manager": 1
+      },
+      "health_check_data_source": {
+        "direct_get_manager_calls": 0,
+        "depends_get_data_source_registry_manager": 1
+      },
+      "health_check_all_data_sources": {
+        "direct_get_manager_calls": 0,
+        "depends_get_data_source_registry_manager": 1
+      }
+    },
+    "direct_route_body_get_manager_calls_after": 0,
+    "provider_backing_get_manager_calls_after": 1,
+    "depends_provider_bindings_after": 7,
+    "data_source_runtime_routes": 16,
+    "runtime_routes": 548,
+    "openapi_paths": 500,
+    "duplicate_operation_ids": 0
+  },
+  "verification": {
+    "parent_pr": "gh pr view 444 records MERGED at 2026-06-01T03:40:06Z with merge commit 3d161e90547720f4ce95111ea511d3f8dc3174dc",
+    "focused_regression": "PYTHONPATH=web/backend pytest -q web/backend/tests/test_data_source_registry_manager_provider.py --tb=short --no-cov: 3 passed in 6.74s",
+    "route_openapi_smoke": "app.main smoke records 548 routes, 500 OpenAPI paths, duplicate operation IDs 0, data-source runtime routes 16",
+    "route_openapi_smoke_notes": "Smoke emitted expected import-time service logs and historical GPU NumPy fallback warning; counts were produced successfully."
+  },
+  "residual_scan": {
+    "scan_roots": [
+      "web/backend/app/api",
+      "web/backend/app/services"
+    ],
+    "exclusions": [
+      "known closed G2 service lifecycle provider surfaces",
+      "data_source_config.old.py historical compatibility file",
+      "data_source_registry.get_manager just-closed provider surface",
+      "data_source_config.get_config_manager active provider backing surface"
+    ],
+    "active_interesting_candidates": 58,
+    "top_candidates": [
+      {
+        "name": "get_postgresql_session",
+        "api_bare_calls": 9,
+        "service_bare_calls": 0,
+        "files": [
+          "web/backend/app/api/auth.py",
+          "web/backend/app/api/market/market_data_request.py",
+          "web/backend/app/api/v1/admin/audit.py",
+          "web/backend/app/api/v1/admin/optimization.py"
+        ],
+        "classification": "cross-domain PostgreSQL session route helper family requiring ownership decision before implementation"
+      },
+      {
+        "name": "get_cache_manager",
+        "api_bare_calls": 7,
+        "service_bare_calls": 0,
+        "files": [
+          "web/backend/app/api/_cache_basic_routes.py",
+          "web/backend/app/api/cache.py",
+          "web/backend/app/api/dashboard.py"
+        ],
+        "classification": "ambiguous dashboard/cache helper; defer until cache ownership is disambiguated"
+      },
+      {
+        "name": "get_postgresql_engine",
+        "api_bare_calls": 6,
+        "service_bare_calls": 0,
+        "files": [
+          "web/backend/app/api/industry_concept_analysis.py",
+          "web/backend/app/api/v1/pool_monitoring.py"
+        ],
+        "classification": "mixed business/control-plane PostgreSQL engine helper; defer behind ownership split"
+      },
+      {
+        "name": "get_risk_management_core",
+        "api_bare_calls": 6,
+        "service_bare_calls": 0,
+        "files": [
+          "web/backend/app/api/risk/_alerts_responses.py",
+          "web/backend/app/api/risk/stop_loss.py",
+          "web/backend/app/api/risk/v31.py"
+        ],
+        "classification": "risk-domain core helper; separate risk ownership decision required"
+      },
+      {
+        "name": "get_mtm_engine",
+        "api_bare_calls": 5,
+        "service_bare_calls": 0,
+        "files": [
+          "web/backend/app/api/realtime_market.py"
+        ],
+        "classification": "realtime MTM helper; defer to realtime/streaming lane"
+      },
+      {
+        "name": "get_mysql_session",
+        "api_bare_calls": 5,
+        "service_bare_calls": 0,
+        "files": [
+          "web/backend/app/api/indicators/create_indicator_config.py"
+        ],
+        "classification": "indicator config database session helper; separate ownership decision required"
+      }
+    ]
+  },
+  "gitnexus_evidence": {
+    "mcp_context": "tool call failed: Transport closed",
+    "mcp_impact": "tool call failed: Transport closed",
+    "cli_query": "npx gitnexus query -r mystocks -l 5 get_postgresql_session found core/database.py and core/database_factory.py definitions plus affected auth/admin flows; index status stale warning",
+    "cli_impact_core_database": {
+      "uid": "Function:web/backend/app/core/database.py:get_postgresql_session",
+      "risk": "CRITICAL",
+      "impacted_count": 67,
+      "direct": 15,
+      "processes_affected": 54,
+      "modules_affected": 12,
+      "index_status": "stale warning"
+    },
+    "cli_impact_database_factory": {
+      "uid": "Function:web/backend/app/core/database_factory.py:get_postgresql_session",
+      "risk": "LOW",
+      "impacted_count": 4,
+      "direct": 2,
+      "processes_affected": 1,
+      "modules_affected": 1,
+      "index_status": "stale warning"
+    }
+  },
+  "decision": {
+    "classification": "closeout-refresh-complete-no-source-lane",
+    "data_source_registry_provider_status": "closed",
+    "source_lane_recommendation": "do-not-start-source-implementation-from-g2-292",
+    "autopilot_continue_allowed": false,
+    "selected_next_governance_target": "postgresql-session-route-helper-ownership-decision",
+    "recommended_next_work_item": "G2.293 no-source get_postgresql_session ownership / route-provider decision after PR #445 human review",
+    "reason": "G2.291 is merged and the data_source_registry provider lane is closed. The highest remaining active non-closed route/helper surface is get_postgresql_session across auth, admin, and market modules. It resolves to two underlying database helper definitions, including a CRITICAL-impact core/database.py target, so only a no-source ownership decision is selected and PR #445 must stop for human review."
+  },
+  "freshness": {
+    "current_head_checked": "3d161e90547720f4ce95111ea511d3f8dc3174dc",
+    "stale_if_head_or_pr_state_changes": true,
+    "stale_if_route_or_openapi_counts_change": true,
+    "stale_if_data_source_registry_call_sites_change": true,
+    "stale_if_candidate_scan_changes": true,
+    "stale_if_gitnexus_risk_changes": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-06-01T11:08:00+08:00`
-- Base HEAD checked: `e517163385e96a6c7115e14b77fb89819b4cead4`
+- Prepared at: `2026-06-01T11:52:20+08:00`
+- Base HEAD checked: `3d161e90547720f4ce95111ea511d3f8dc3174dc`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -121,7 +121,8 @@ PRs, change issue labels, or authorize source implementation.
 | `#441` | `g2-288-governance-dashboard-postgres-provider-closeout` | `wip/root-dirty-20260403` | `MERGED` at `75ce550ceaf9f77b7659193b9cbd3c9ab2181c37` | No-source governance dashboard provider closeout selecting G2.289 data_source_registry ownership decision |
 | `#442` | `g2-289-data-source-registry-manager-ownership` | `wip/root-dirty-20260403` | `MERGED` at `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf` | No-source data_source_registry `get_manager` ownership decision selecting G2.290 provider authorization |
 | `#443` | `g2-290-data-source-registry-manager-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `e517163385e96a6c7115e14b77fb89819b4cead4` | No-source provider authorization for future G2.291 data_source_registry implementation |
-| `#444` | `g2-291-data-source-registry-manager-provider-implementation` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | Path-limited data_source_registry manager provider implementation; auto-merge paused because it changes backend source/tests and target risk is MEDIUM |
+| `#444` | `g2-291-data-source-registry-manager-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `3d161e90547720f4ce95111ea511d3f8dc3174dc` | Path-limited data_source_registry manager provider implementation; now closed by G2.292 closeout |
+| `#445` | `g2-292-data-source-registry-provider-closeout-refresh` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | No-source data_source_registry provider closeout; auto-merge paused because the next selected target is `get_postgresql_session` and the underlying database helper impact is CRITICAL |
 
 ## Steward Governance Branch
 
@@ -233,3 +234,5 @@ G2.289 is the no-source `data_source_registry.get_manager` ownership / route-pro
 G2.290 is the no-source `data_source_registry.get_manager` provider authorization after PR `#442` merged G2.289 at `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf`. It merged by PR `#443` at `e517163385e96a6c7115e14b77fb89819b4cead4`. It authorized only the G2.291 path-limited source lane for `web/backend/app/api/data_source_registry.py` plus focused data-source registry tests. It must not be used to expand scope beyond that implementation envelope.
 
 G2.291 is the path-limited `data_source_registry.get_manager` provider implementation after PR `#443` merged G2.290 at `e517163385e96a6c7115e14b77fb89819b4cead4`. It adds `get_data_source_registry_manager`, keeps `get_manager()` as backing compatibility / monkeypatch seam, moves seven target handlers to `Depends(get_data_source_registry_manager)`, preserves runtime/OpenAPI `548/500/0`, and records focused tests `34/34`. It edits backend source/tests and must stop at future PR `#444` review; if accepted, the next gate is G2.292 no-source provider closeout / residual refresh.
+
+G2.292 is the no-source `data_source_registry.get_manager` provider closeout / residual refresh after PR `#444` merged G2.291 at `3d161e90547720f4ce95111ea511d3f8dc3174dc`. It records the data-source registry provider lane as closed, confirms direct route-body `get_manager()` calls are `0`, provider backing calls are `1`, dependency bindings are `7`, and route/OpenAPI remains `548/500/0`. It selects `G2.293 no-source get_postgresql_session ownership / route-provider decision` as the next gate. PR `#445` must stop for human review because the selected next target includes a CRITICAL-impact core database helper.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-06-01T11:08:00+08:00`
-- Base HEAD checked: `e517163385e96a6c7115e14b77fb89819b4cead4`
+- Prepared at: `2026-06-01T11:52:20+08:00`
+- Base HEAD checked: `3d161e90547720f4ce95111ea511d3f8dc3174dc`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -19,16 +19,17 @@ exact verification output.
 | Route/OpenAPI and control-plane governance | Established route table, OpenAPI exposure, health/probe taxonomy, and consumer-contract evidence as first-class governance facts | Continue through route/OpenAPI track, not ad hoc route edits |
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
-| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.290 accepted/merged by PR `#443` at `e5171633` | Continue with G2.291 `data_source_registry.get_manager` provider implementation review; do not auto-merge because it changes backend source/tests and the target impact is MEDIUM |
+| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.291 accepted/merged by PR `#444` at `3d161e9` | Continue with G2.292 `data_source_registry.get_manager` provider closeout / residual refresh review; do not auto-merge because it selects a next CRITICAL-impact database-session candidate |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.290 have progressed through PR `#337`-`#443`; current review target is G2.291 provider implementation in future PR `#444` |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.291 have progressed through PR `#337`-`#444`; current review target is G2.292 provider closeout / residual refresh in future PR `#445` |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Recent Closeouts
 
 | Item | Accepted evidence | Follow-up |
 |---|---|---|
-| G2.290 data_source_registry get_manager provider authorization | PR `#443` merged at `e517163385e96a6c7115e14b77fb89819b4cead4`; authorized only a path-limited G2.291 implementation lane | G2.291 implements the provider injection and must stop at future PR `#444` review |
+| G2.291 data_source_registry get_manager provider implementation | PR `#444` merged at `3d161e90547720f4ce95111ea511d3f8dc3174dc`; direct route-body `get_manager()` calls `0`, provider bindings `7`, focused regression `3/3`, runtime/OpenAPI `548/500/0` | G2.292 closes the provider lane and selects only a no-source `get_postgresql_session` ownership decision |
+| G2.290 data_source_registry get_manager provider authorization | PR `#443` merged at `e517163385e96a6c7115e14b77fb89819b4cead4`; authorized only a path-limited G2.291 implementation lane | Superseded by the accepted/merged G2.291 provider implementation and G2.292 closeout review |
 | G2.265 signal statistics stale contract cleanup | PR `#418` merged at `2b53352d6869f66147ce3892b1b0a7174ba064b4`; targeted tests `2/2`; runtime OpenAPI target paths `0` | G2.266 records closeout and selects `G2.267 no-source monitoring/signal residual provider classification refresh` |
 | G2.266 signal statistics dormant contract closeout | PR `#419` merged at `eec68bb47a4ee98508480ef0ac2cdd3716e04b05`; stale contract branch closed | G2.267 classifies monitoring/signal residuals and selects G2.268 no-source authorization |
 | G2.267 monitoring/signal residual classification | PR `#420` merged at `772e4a3ac8e05edaa243d660d67c7e5df18158f9`; active portfolio optimizer route-body candidate selected | G2.268 authorizes a future path-limited portfolio optimizer provider implementation lane |

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-06-01T11:08:00+08:00`
-- Base HEAD checked: `e517163385e96a6c7115e14b77fb89819b4cead4`
+- Prepared at: `2026-06-01T11:52:20+08:00`
+- Base HEAD checked: `3d161e90547720f4ce95111ea511d3f8dc3174dc`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.291 `data_source_registry.get_manager` provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#443` merged at `e517163385e96a6c7115e14b77fb89819b4cead4`; G2.291 adds route-local `get_data_source_registry_manager`, moves 7 target handlers to `Depends(...)`, keeps `get_manager()` as compatibility/backing seam, and preserves runtime/OpenAPI `548/500/0` | Review future PR `#444`; do not auto-merge because it changes backend source/tests and the target has GitNexus MEDIUM impact with one affected process |
+| P0 | Review G2.292 `data_source_registry.get_manager` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#444` merged at `3d161e90547720f4ce95111ea511d3f8dc3174dc`; G2.292 closes the data-source registry provider lane with direct route-body `get_manager()` calls `0`, provider backing calls `1`, provider bindings `7`, focused regression `3 passed`, and runtime/OpenAPI `548/500/0` | Review future PR `#445`; do not auto-merge because it selects `get_postgresql_session` only for no-source ownership decision and the underlying `app.core.database.get_postgresql_session` impact is CRITICAL |
+| P0 | Preserve G2.291 `data_source_registry.get_manager` provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#444` merged at `3d161e90547720f4ce95111ea511d3f8dc3174dc`; G2.291 added route-local `get_data_source_registry_manager`, moved 7 target handlers to `Depends(...)`, kept `get_manager()` as compatibility/backing seam, and preserved runtime/OpenAPI `548/500/0` | Do not use G2.291 as authority for non-data-source-registry source edits, route/OpenAPI changes, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state |
 | P0 | Preserve G2.290 `data_source_registry.get_manager` provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#443` merged at `e517163385e96a6c7115e14b77fb89819b4cead4`; G2.290 authorized only the path-limited G2.291 source lane now represented by this worktree | Do not use G2.290 to expand scope beyond `web/backend/app/api/data_source_registry.py` plus focused data-source registry tests |
 | P0 | Preserve G2.289 `data_source_registry.get_manager` ownership / route-provider decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#442` merged at `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf`; G2.289 classified `get_manager` as a bounded active data-source registry route helper with `7` direct route-body callers, runtime/OpenAPI `548/500/0`, and GitNexus MEDIUM impact with one affected process | Do not use G2.289 as source implementation authorization; use G2.290 only as no-source provider authorization after review |
 | P0 | Preserve G2.288 `governance_dashboard.get_postgres_connection` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#441` merged at `75ce550ceaf9f77b7659193b9cbd3c9ab2181c37`; G2.288 closed the governance dashboard provider lane, confirmed direct route-body calls `0`, manual close calls `0`, provider bindings `5`, and selected `data_source_registry.get_manager` only for no-source ownership / route-provider decision | Do not use G2.288 as source implementation authorization; use G2.289 only for no-source ownership / route-provider decision |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-06-01T11:08:00+08:00`
-- Base HEAD checked: `e517163385e96a6c7115e14b77fb89819b4cead4`
+- Prepared at: `2026-06-01T11:52:20+08:00`
+- Base HEAD checked: `3d161e90547720f4ce95111ea511d3f8dc3174dc`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -16,9 +16,12 @@ state transition.
 
 | Evidence | Role | Freshness policy |
 |---|---|---|
-| `.planning/codebase/generated/data-source-registry-manager-provider-implementation-2026-06-01.json` | G2.291 `data_source_registry.get_manager` provider implementation evidence | Review input for future PR `#444`; path-limited source implementation package; must stop because it changes backend source/tests and the target has GitNexus MEDIUM impact with one affected process |
-| `docs/reports/quality/backend-data-source-registry-manager-provider-implementation-2026-06-01.md` | G2.291 human-readable provider implementation report | Review input for future PR `#444`; records PR `#443` accepted/merged, implementation envelope, tests, and stop rule |
-| `governance/mainline/task-cards/pr-444.yaml` | Governance task card for G2.291 source implementation | Review input; allows only steward tree, generated evidence, report, source file, and focused test updates; no auto-merge because it changes backend source work |
+| `.planning/codebase/generated/data-source-registry-provider-closeout-refresh-2026-06-01.json` | G2.292 `data_source_registry.get_manager` provider closeout / residual refresh evidence | Review input for future PR `#445`; no-source package; must stop because it selects next `get_postgresql_session` decision target with CRITICAL GitNexus impact on `app.core.database.get_postgresql_session` |
+| `docs/reports/quality/backend-data-source-registry-provider-closeout-refresh-2026-06-01.md` | G2.292 human-readable provider closeout / residual refresh report | Review input for future PR `#445`; records PR `#444` accepted/merged, provider closeout, route/OpenAPI smoke, residual scan, and stop rule |
+| `governance/mainline/task-cards/pr-445.yaml` | Governance task card for G2.292 no-source closeout / residual refresh | Review input; allows only steward tree, generated evidence, report, and task card updates; no auto-merge because the selected next target has CRITICAL impact |
+| `.planning/codebase/generated/data-source-registry-manager-provider-implementation-2026-06-01.json` | G2.291 `data_source_registry.get_manager` provider implementation evidence | Accepted by PR `#444`, merged at `3d161e90547720f4ce95111ea511d3f8dc3174dc`; superseded for next-gate decision by G2.292 |
+| `docs/reports/quality/backend-data-source-registry-manager-provider-implementation-2026-06-01.md` | G2.291 human-readable provider implementation report | Accepted by PR `#444`; records PR `#443` accepted/merged, implementation envelope, tests, and stop rule |
+| `governance/mainline/task-cards/pr-444.yaml` | Governance task card for G2.291 source implementation | Accepted by PR `#444`; allowed only steward tree, generated evidence, report, source file, and focused test updates |
 | `.planning/codebase/generated/data-source-registry-manager-provider-authorization-2026-06-01.json` | G2.290 `data_source_registry.get_manager` provider authorization evidence | Accepted by PR `#443`; historical no-source authorization package that led to the current source implementation lane |
 | `docs/reports/quality/backend-data-source-registry-manager-provider-authorization-2026-06-01.md` | G2.290 human-readable provider authorization report | Accepted by PR `#443`; records PR `#442` accepted/merged and the future path-limited implementation envelope |
 | `governance/mainline/task-cards/pr-443.yaml` | Governance task card for G2.290 | Accepted by PR `#443`; historical no-source authorization record |

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,12 +1,12 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-06-01T11:08:00+08:00",
+  "generated_at": "2026-06-01T11:52:20+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "e517163385e96a6c7115e14b77fb89819b4cead4",
-  "split_branch": "g2-291-data-source-registry-manager-provider-implementation",
-  "scope": "data_source_registry_manager_provider_implementation",
-  "source_edit_authority": true,
+  "base_head": "3d161e90547720f4ce95111ea511d3f8dc3174dc",
+  "split_branch": "g2-292-data-source-registry-provider-closeout-refresh",
+  "scope": "data_source_registry_provider_closeout_refresh",
+  "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
   "split_files": [
@@ -9359,7 +9359,7 @@
     {
       "id": "g2-291-data-source-registry-manager-provider-implementation",
       "type": "implementation_package",
-      "state": "for_review",
+      "state": "accepted_merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.290 data_source_registry get_manager provider authorization",
       "source_edit_authority": true,
@@ -9368,8 +9368,10 @@
       "github_pr": {
         "number": 444,
         "url": "https://github.com/chengjon/mystocks/pull/444",
-        "state": "PLANNED_FOR_REVIEW",
-        "head_ref": "g2-291-data-source-registry-manager-provider-implementation"
+        "state": "MERGED",
+        "merged_at": "2026-06-01T03:40:06Z",
+        "head_ref": "g2-291-data-source-registry-manager-provider-implementation",
+        "merge_commit": "3d161e90547720f4ce95111ea511d3f8dc3174dc"
       },
       "evidence": [
         ".planning/codebase/generated/data-source-registry-manager-provider-implementation-2026-06-01.json",
@@ -9459,7 +9461,7 @@
         "recommended_next_work_item": "G2.292 no-source data_source_registry.get_manager provider closeout / residual refresh after PR #444 human acceptance"
       },
       "freshness": {
-        "current_head_checked": "e517163385e96a6c7115e14b77fb89819b4cead4",
+        "current_head_checked": "3d161e90547720f4ce95111ea511d3f8dc3174dc",
         "stale_if_head_or_pr_state_changes": true,
         "stale_if_route_or_openapi_counts_change": true,
         "stale_if_data_source_registry_call_sites_change": true,
@@ -9467,7 +9469,127 @@
         "stale_if_gitnexus_risk_changes": true,
         "stale_if_test_inventory_changes": true
       },
-      "next_gate": "Stop for human review in PR #444. If accepted, start G2.292 no-source provider closeout / residual refresh."
+      "next_gate": "Superseded by G2.292 no-source data_source_registry provider closeout / residual refresh."
+    },
+    {
+      "id": "g2-292-data-source-registry-provider-closeout-refresh",
+      "type": "closeout_refresh",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.291 data_source_registry get_manager provider implementation",
+      "source_edit_authority": false,
+      "autopilot_status": "stop_at_pr_review_gate",
+      "autopilot_stop_reason": "G2.292 selects a next target with CRITICAL GitNexus impact on app.core.database.get_postgresql_session",
+      "github_pr": {
+        "number": 445,
+        "url": "https://github.com/chengjon/mystocks/pull/445",
+        "state": "PLANNED_FOR_REVIEW",
+        "head_ref": "g2-292-data-source-registry-provider-closeout-refresh"
+      },
+      "evidence": [
+        ".planning/codebase/generated/data-source-registry-provider-closeout-refresh-2026-06-01.json",
+        "docs/reports/quality/backend-data-source-registry-provider-closeout-refresh-2026-06-01.md",
+        "governance/mainline/task-cards/pr-445.yaml"
+      ],
+      "closed_parent": {
+        "pr": 444,
+        "state": "MERGED",
+        "merge_commit": "3d161e90547720f4ce95111ea511d3f8dc3174dc",
+        "merged_at": "2026-06-01T03:40:06Z"
+      },
+      "allowed_scope": [
+        ".planning/codebase/generated/data-source-registry-provider-closeout-refresh-2026-06-01.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-data-source-registry-provider-closeout-refresh-2026-06-01.md",
+        "governance/mainline/task-cards/pr-445.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "tests/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "closeout": {
+        "module": "web/backend/app/api/data_source_registry.py",
+        "helper": "get_manager",
+        "provider": "get_data_source_registry_manager",
+        "direct_route_body_calls_after": 0,
+        "provider_backing_calls_after": 1,
+        "depends_provider_bindings_after": 7,
+        "focused_regression": "3 passed in 6.74s",
+        "runtime_routes": 548,
+        "openapi_paths": 500,
+        "duplicate_operation_ids": 0,
+        "data_source_runtime_routes": 16
+      },
+      "selected_next_target": {
+        "gate": "G2.293",
+        "symbol_family": "get_postgresql_session",
+        "files": [
+          "web/backend/app/api/auth.py",
+          "web/backend/app/api/market/market_data_request.py",
+          "web/backend/app/api/v1/admin/audit.py",
+          "web/backend/app/api/v1/admin/optimization.py"
+        ],
+        "active_route_body_calls": 9,
+        "classification": "cross-domain PostgreSQL session route helper family requiring no-source ownership decision before implementation",
+        "gitnexus_core_database_risk": "CRITICAL",
+        "gitnexus_core_database_impacted_symbols": 67,
+        "gitnexus_core_database_direct_callers": 15,
+        "gitnexus_core_database_affected_processes": 54,
+        "gitnexus_database_factory_risk": "LOW",
+        "gitnexus_database_factory_affected_processes": 1
+      },
+      "gitnexus_evidence": {
+        "mcp_context": "tool call failed: Transport closed",
+        "mcp_impact": "tool call failed: Transport closed",
+        "cli_query": "get_postgresql_session found both core/database.py and core/database_factory.py definitions",
+        "cli_impact_core_database": {
+          "risk": "CRITICAL",
+          "impacted_count": 67,
+          "direct": 15,
+          "processes_affected": 54,
+          "modules_affected": 12,
+          "index_status": "stale warning"
+        },
+        "cli_impact_database_factory": {
+          "risk": "LOW",
+          "impacted_count": 4,
+          "direct": 2,
+          "processes_affected": 1,
+          "modules_affected": 1,
+          "index_status": "stale warning"
+        }
+      },
+      "decision": {
+        "classification": "closeout-refresh-complete-no-source-lane",
+        "data_source_registry_provider_status": "closed",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-292",
+        "autopilot_continue_allowed": false,
+        "selected_next_governance_target": "postgresql-session-route-helper-ownership-decision",
+        "recommended_next_work_item": "G2.293 no-source get_postgresql_session ownership / route-provider decision after PR #445 human acceptance"
+      },
+      "freshness": {
+        "current_head_checked": "3d161e90547720f4ce95111ea511d3f8dc3174dc",
+        "stale_if_head_or_pr_state_changes": true,
+        "stale_if_route_or_openapi_counts_change": true,
+        "stale_if_data_source_registry_call_sites_change": true,
+        "stale_if_candidate_scan_changes": true,
+        "stale_if_gitnexus_risk_changes": true
+      },
+      "next_gate": "Stop for human review in PR #445. If accepted, start G2.293 no-source get_postgresql_session ownership / route-provider decision."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -3142,7 +3142,7 @@ Status: for review in future PR `#443`.
 
 ## G2.291 data_source_registry get_manager Provider Implementation
 
-- PR state: planned future PR `#444` for review.
+- PR state: accepted/merged by PR `#444` at `3d161e90547720f4ce95111ea511d3f8dc3174dc`.
 - Parent state: PR `#443` merged G2.290 at `e517163385e96a6c7115e14b77fb89819b4cead4`.
 - G2.291 is a path-limited source implementation package. It edits only `web/backend/app/api/data_source_registry.py`, focused data-source registry tests, steward evidence, this track, and the PR task card.
 - Implementation shape: add route-local provider `get_data_source_registry_manager` delegating to existing `get_manager()`, keep `get_manager()` as backing compatibility / monkeypatch seam, and move the seven active data-source registry handlers to `Depends(get_data_source_registry_manager)`.
@@ -3153,3 +3153,16 @@ Status: for review in future PR `#443`.
 - GitNexus: MCP `context` and `impact` returned `Transport closed`; CLI fallback reports MEDIUM risk, `7` direct callers, `7` impacted symbols, `1` affected process, and stale-index warning for `Function:web/backend/app/api/data_source_registry.py:get_manager`.
 - Stop rule: PR `#444` must stop for human review because it changes backend source/tests and the target has GitNexus MEDIUM impact with one affected process.
 - Recommended next gate after human acceptance and merge: G2.292 no-source `data_source_registry.get_manager` provider closeout / residual refresh.
+
+## G2.292 data_source_registry get_manager Provider Closeout / Residual Refresh
+
+Status: for review in future PR `#445`.
+
+- Parent PR `#444` merged at `3d161e90547720f4ce95111ea511d3f8dc3174dc`.
+- G2.292 is a no-source closeout / residual refresh package. It does not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+- It records the `data_source_registry.get_manager` provider lane as closed: direct route-body `get_manager()` calls are `0`, provider backing `get_manager()` calls are `1`, and `Depends(get_data_source_registry_manager)` bindings are `7`.
+- Route/OpenAPI smoke remains `548` routes, `500` paths, duplicate operation IDs `0`, and `16` data-source runtime routes.
+- Residual scan keeps `get_postgresql_session` as the next no-source ownership decision candidate because it spans auth, admin, and market route modules and resolves to a CRITICAL-impact core database helper.
+- GitNexus MCP returned `Transport closed`; CLI fallback reports CRITICAL risk for `Function:web/backend/app/core/database.py:get_postgresql_session`.
+- Stop rule: PR `#445` must stop for human review because the next selected target includes CRITICAL GitNexus impact.
+- Recommended next gate after human acceptance and merge: G2.293 no-source `get_postgresql_session` ownership / route-provider decision.

--- a/docs/reports/quality/backend-data-source-registry-provider-closeout-refresh-2026-06-01.md
+++ b/docs/reports/quality/backend-data-source-registry-provider-closeout-refresh-2026-06-01.md
@@ -1,0 +1,161 @@
+# Backend Data Source Registry Provider Closeout / Residual Refresh
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Gate: G2.292
+- Status: for review in future PR `#445`
+- Prepared at: `2026-06-01T11:52:20+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD: `3d161e90547720f4ce95111ea511d3f8dc3174dc`
+- Parent gate: G2.291 provider implementation, PR `#444`, merged at `3d161e90547720f4ce95111ea511d3f8dc3174dc`
+- OpenSpec change: `migrate-backend-singletons-to-lifecycle-di`
+
+Boundary note: G2.292 is a no-source closeout / residual refresh package. It
+does not authorize backend source edits, test edits, route/OpenAPI contract
+changes, docs/api artifact edits, frontend/config/script changes, OpenSpec
+proposal/spec edits, PM2 commands, runtime state changes, source retirement, or
+implementation authorization for the next candidate.
+
+## Closeout Result
+
+G2.291 is accepted/merged and the `data_source_registry.get_manager` provider
+lane is closed.
+
+Current scan of `web/backend/app/api/data_source_registry.py` records:
+
+- route-local provider `get_data_source_registry_manager` exists
+- direct route-body `get_manager()` calls: `0`
+- provider backing `get_manager()` calls: `1`
+- `Depends(get_data_source_registry_manager)` bindings: `7`
+- data-source registry runtime routes: `16`
+
+Closed target handlers:
+
+| Handler | Direct route-body calls | Provider binding |
+|---|---:|---:|
+| `search_data_sources` | 0 | 1 |
+| `get_category_stats` | 0 | 1 |
+| `get_data_source` | 0 | 1 |
+| `update_data_source` | 0 | 1 |
+| `test_data_source` | 0 | 1 |
+| `health_check_data_source` | 0 | 1 |
+| `health_check_all_data_sources` | 0 | 1 |
+
+## Verification
+
+Parent PR state:
+
+- PR `#444`: `MERGED`
+- merged at: `2026-06-01T03:40:06Z`
+- merge commit: `3d161e90547720f4ce95111ea511d3f8dc3174dc`
+
+Focused regression:
+
+```text
+PYTHONPATH=web/backend pytest -q web/backend/tests/test_data_source_registry_manager_provider.py --tb=short --no-cov
+3 passed in 6.74s
+```
+
+Route/OpenAPI smoke with placeholder import-time environment values records:
+
+- FastAPI routes: `548`
+- OpenAPI paths: `500`
+- duplicate operation IDs: `0`
+- data-source registry runtime routes: `16`
+
+The smoke emitted expected import-time service logs and the historical GPU
+NumPy fallback warning; these did not affect route/OpenAPI counts.
+
+## Residual Refresh
+
+The post-closeout route/helper residual scan covered:
+
+- `web/backend/app/api`
+- `web/backend/app/services`
+
+The scan excluded known closed G2 provider surfaces, the historical
+`data_source_config.old.py` compatibility file, the just-closed
+`data_source_registry.get_manager` surface, and the already closed
+`data_source_config.get_config_manager` provider backing surface.
+
+The filtered scan found `58` active interesting residual names. The highest
+remaining non-closed candidate is:
+
+- gate: G2.293
+- target family: `get_postgresql_session`
+- files:
+  - `web/backend/app/api/auth.py`
+  - `web/backend/app/api/market/market_data_request.py`
+  - `web/backend/app/api/v1/admin/audit.py`
+  - `web/backend/app/api/v1/admin/optimization.py`
+- active route-body calls: `9`
+- classification: cross-domain PostgreSQL session route helper family requiring
+  ownership decision before implementation
+
+The next candidate is not selected for implementation. It spans auth, admin,
+and market route modules and resolves to two underlying database helper
+definitions:
+
+- `Function:web/backend/app/core/database.py:get_postgresql_session`
+- `Function:web/backend/app/core/database_factory.py:get_postgresql_session`
+
+GitNexus evidence for the selected next target:
+
+- MCP `context`: `Transport closed`
+- MCP `impact`: `Transport closed`
+- CLI query found both core/database and core/database_factory definitions
+- CLI impact on `Function:web/backend/app/core/database.py:get_postgresql_session`:
+  - risk: `CRITICAL`
+  - impacted symbols: `67`
+  - direct callers: `15`
+  - affected processes: `54`
+  - affected modules: `12`
+  - index status: stale warning
+- CLI impact on `Function:web/backend/app/core/database_factory.py:get_postgresql_session`:
+  - risk: `LOW`
+  - impacted symbols: `4`
+  - direct callers: `2`
+  - affected processes: `1`
+  - affected modules: `1`
+  - index status: stale warning
+
+Because the selected next target includes a CRITICAL-impact database helper and
+cross-domain route consumers, G2.292 must stop for human review and must not
+auto-merge under the limited autopilot rule.
+
+## Deferred / Excluded Residuals
+
+`web/backend/app/api/data_source_config.old.py:get_config_manager` appears in
+raw scans but is historical compatibility surface and is not selected from the
+active route/helper residual queue.
+
+`web/backend/app/api/data_source_config.py:get_config_manager` currently appears
+only as active provider backing after the prior data-source config manager lane
+closed. It is not reopened by G2.292.
+
+`get_cache_manager` remains an ambiguous dashboard/cache helper and should stay
+deferred until cache ownership is disambiguated.
+
+`get_postgresql_engine` spans industry/concept business routes and pool
+monitoring control-plane routes. It should not be batched with
+`get_postgresql_session`.
+
+## Decision
+
+G2.292 closes the `data_source_registry.get_manager` provider lane and selects
+only the next no-source decision target:
+
+G2.293 no-source `get_postgresql_session` ownership / route-provider decision.
+
+G2.292 does not authorize G2.293 implementation. G2.293 must classify route
+ownership, database helper ownership, security/auth boundaries, test scope,
+OpenAPI behavior, and GitNexus blast radius before any future authorization
+package.
+
+## Evidence
+
+- `.planning/codebase/generated/data-source-registry-provider-closeout-refresh-2026-06-01.json`
+- `docs/reports/quality/backend-data-source-registry-provider-closeout-refresh-2026-06-01.md`
+- `governance/mainline/task-cards/pr-445.yaml`

--- a/governance/mainline/task-cards/pr-445.yaml
+++ b/governance/mainline/task-cards/pr-445.yaml
@@ -1,0 +1,134 @@
+version: "v0.2"
+
+task:
+  id: "pr-445"
+  title: "Close out data_source_registry manager provider lane"
+  owner: "codex"
+  created_at: "2026-06-01"
+
+mainline:
+  id: "L1-data-source-registry-provider-closeout"
+  objective: "close out the accepted data_source_registry get_manager provider lane and refresh the next residual candidate without editing source"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "G2.292 is a no-source closeout / residual refresh package. It changes no runtime entrypoint, route path, route registration, generated OpenAPI artifact, frontend route, or FUNCTION_TREE catalog entry."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/data-source-registry-provider-closeout-refresh-2026-06-01.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-data-source-registry-provider-closeout-refresh-2026-06-01.md"
+    - "governance/mainline/task-cards/pr-445.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits"
+  - "test edits"
+  - "route registration changes"
+  - "route path, method, response model, or generated OpenAPI artifact changes"
+  - "docs/api artifact edits"
+  - "frontend/config/script changes"
+  - "OpenSpec proposal or spec edits"
+  - "PM2 commands or stateful runtime gates"
+  - "source retirement"
+  - "implementation authorization for get_postgresql_session"
+
+acceptance:
+  checks:
+    - id: "pr444-merged"
+      command: "gh pr view 444 confirms MERGED at 3d161e90547720f4ce95111ea511d3f8dc3174dc"
+      required: true
+    - id: "data-source-registry-closeout"
+      command: "current HEAD records direct route-body get_manager calls 0, provider backing calls 1, and Depends(get_data_source_registry_manager) bindings 7"
+      required: true
+    - id: "focused-regression"
+      command: "PYTHONPATH=web/backend pytest -q web/backend/tests/test_data_source_registry_manager_provider.py --tb=short --no-cov records 3 passed"
+      required: true
+    - id: "route-openapi-smoke"
+      command: "app.main route/OpenAPI smoke records 548 routes, 500 paths, duplicate operation IDs 0, and 16 data-source runtime routes"
+      required: true
+    - id: "residual-refresh"
+      command: "filtered route/helper residual scan records get_postgresql_session as the next selected no-source decision target with 9 active route-body calls"
+      required: true
+    - id: "gitnexus-next-target-impact"
+      command: "GitNexus MCP returned Transport closed; CLI impact records CRITICAL risk, 67 impacted symbols, 15 direct callers, 54 affected processes for Function:web/backend/app/core/database.py:get_postgresql_session"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-data-source-registry-provider-closeout-refresh-2026-06-01.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-445.yaml --base-sha 3d161e90547720f4ce95111ea511d3f8dc3174dc --head-sha HEAD --report /tmp/pr445-mainline-governance-report.json"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "gitnexus-detect-changes"
+      command: "GitNexus staged verification attempted before commit; stale-index warning recorded if present"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "A future worker may treat get_postgresql_session as implementation-authorized; this package only selects a no-source ownership decision."
+    - "The selected next target includes a CRITICAL-impact core database helper, so PR #445 must stop for review."
+    - "GitNexus index is stale; current route/helper scan is the source for active route-body counts."
+  rollback_plan: "Revert PR #445; this removes only governance evidence and restores the previous steward tree state."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Close out the accepted data_source_registry provider lane and select the next no-source ownership decision target."
+    modified_scope: "Governance evidence, steward tree indexes, human-readable report, and task card only."
+    dependency_changes: "No dependency changes."
+    legacy_logic_impact: "No runtime, route, OpenAPI, frontend, config, script, or OpenSpec changes."
+    rollback_ready: "Revert PR #445."
+    risk_and_rollback_point: "No-source closeout, but next selected target includes CRITICAL GitNexus impact; rollback is single-PR revert."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-01T11:52:20+08:00"
+    approval_note: "Human maintainer approved continuing after PR #444 merge into G2.292 no-source closeout / residual refresh. PR #445 must stop for review because the next selected target includes CRITICAL GitNexus impact."
+    secondary_approved: false


### PR DESCRIPTION
# Backend Data Source Registry Provider Closeout / Residual Refresh

> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。

## Status

- Gate: G2.292
- Status: for review in future PR `#445`
- Prepared at: `2026-06-01T11:52:20+08:00`
- Base branch: `wip/root-dirty-20260403`
- Base HEAD: `3d161e90547720f4ce95111ea511d3f8dc3174dc`
- Parent gate: G2.291 provider implementation, PR `#444`, merged at `3d161e90547720f4ce95111ea511d3f8dc3174dc`
- OpenSpec change: `migrate-backend-singletons-to-lifecycle-di`

Boundary note: G2.292 is a no-source closeout / residual refresh package. It
does not authorize backend source edits, test edits, route/OpenAPI contract
changes, docs/api artifact edits, frontend/config/script changes, OpenSpec
proposal/spec edits, PM2 commands, runtime state changes, source retirement, or
implementation authorization for the next candidate.

## Closeout Result

G2.291 is accepted/merged and the `data_source_registry.get_manager` provider
lane is closed.

Current scan of `web/backend/app/api/data_source_registry.py` records:

- route-local provider `get_data_source_registry_manager` exists
- direct route-body `get_manager()` calls: `0`
- provider backing `get_manager()` calls: `1`
- `Depends(get_data_source_registry_manager)` bindings: `7`
- data-source registry runtime routes: `16`

Closed target handlers:

| Handler | Direct route-body calls | Provider binding |
|---|---:|---:|
| `search_data_sources` | 0 | 1 |
| `get_category_stats` | 0 | 1 |
| `get_data_source` | 0 | 1 |
| `update_data_source` | 0 | 1 |
| `test_data_source` | 0 | 1 |
| `health_check_data_source` | 0 | 1 |
| `health_check_all_data_sources` | 0 | 1 |

## Verification

Parent PR state:

- PR `#444`: `MERGED`
- merged at: `2026-06-01T03:40:06Z`
- merge commit: `3d161e90547720f4ce95111ea511d3f8dc3174dc`

Focused regression:

```text
PYTHONPATH=web/backend pytest -q web/backend/tests/test_data_source_registry_manager_provider.py --tb=short --no-cov
3 passed in 6.74s
```

Route/OpenAPI smoke with placeholder import-time environment values records:

- FastAPI routes: `548`
- OpenAPI paths: `500`
- duplicate operation IDs: `0`
- data-source registry runtime routes: `16`

The smoke emitted expected import-time service logs and the historical GPU
NumPy fallback warning; these did not affect route/OpenAPI counts.

## Residual Refresh

The post-closeout route/helper residual scan covered:

- `web/backend/app/api`
- `web/backend/app/services`

The scan excluded known closed G2 provider surfaces, the historical
`data_source_config.old.py` compatibility file, the just-closed
`data_source_registry.get_manager` surface, and the already closed
`data_source_config.get_config_manager` provider backing surface.

The filtered scan found `58` active interesting residual names. The highest
remaining non-closed candidate is:

- gate: G2.293
- target family: `get_postgresql_session`
- files:
  - `web/backend/app/api/auth.py`
  - `web/backend/app/api/market/market_data_request.py`
  - `web/backend/app/api/v1/admin/audit.py`
  - `web/backend/app/api/v1/admin/optimization.py`
- active route-body calls: `9`
- classification: cross-domain PostgreSQL session route helper family requiring
  ownership decision before implementation

The next candidate is not selected for implementation. It spans auth, admin,
and market route modules and resolves to two underlying database helper
definitions:

- `Function:web/backend/app/core/database.py:get_postgresql_session`
- `Function:web/backend/app/core/database_factory.py:get_postgresql_session`

GitNexus evidence for the selected next target:

- MCP `context`: `Transport closed`
- MCP `impact`: `Transport closed`
- CLI query found both core/database and core/database_factory definitions
- CLI impact on `Function:web/backend/app/core/database.py:get_postgresql_session`:
  - risk: `CRITICAL`
  - impacted symbols: `67`
  - direct callers: `15`
  - affected processes: `54`
  - affected modules: `12`
  - index status: stale warning
- CLI impact on `Function:web/backend/app/core/database_factory.py:get_postgresql_session`:
  - risk: `LOW`
  - impacted symbols: `4`
  - direct callers: `2`
  - affected processes: `1`
  - affected modules: `1`
  - index status: stale warning

Because the selected next target includes a CRITICAL-impact database helper and
cross-domain route consumers, G2.292 must stop for human review and must not
auto-merge under the limited autopilot rule.

## Deferred / Excluded Residuals

`web/backend/app/api/data_source_config.old.py:get_config_manager` appears in
raw scans but is historical compatibility surface and is not selected from the
active route/helper residual queue.

`web/backend/app/api/data_source_config.py:get_config_manager` currently appears
only as active provider backing after the prior data-source config manager lane
closed. It is not reopened by G2.292.

`get_cache_manager` remains an ambiguous dashboard/cache helper and should stay
deferred until cache ownership is disambiguated.

`get_postgresql_engine` spans industry/concept business routes and pool
monitoring control-plane routes. It should not be batched with
`get_postgresql_session`.

## Decision

G2.292 closes the `data_source_registry.get_manager` provider lane and selects
only the next no-source decision target:

G2.293 no-source `get_postgresql_session` ownership / route-provider decision.

G2.292 does not authorize G2.293 implementation. G2.293 must classify route
ownership, database helper ownership, security/auth boundaries, test scope,
OpenAPI behavior, and GitNexus blast radius before any future authorization
package.

## Evidence

- `.planning/codebase/generated/data-source-registry-provider-closeout-refresh-2026-06-01.json`
- `docs/reports/quality/backend-data-source-registry-provider-closeout-refresh-2026-06-01.md`
- `governance/mainline/task-cards/pr-445.yaml`
