### PR TITLE
G2.293: decide get_postgresql_session ownership

### DIFF
--- a/.planning/codebase/generated/postgresql-session-ownership-decision-2026-06-01.json
+++ b/.planning/codebase/generated/postgresql-session-ownership-decision-2026-06-01.json
@@ -1,0 +1,178 @@
+{
+  "gate": "G2.293",
+  "prepared_at": "2026-06-01T12:19:25+08:00",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "05cdf04f646d844c11e90e7c453ed4f985c8d382",
+  "parent": {
+    "gate": "G2.292",
+    "pr": 445,
+    "state": "MERGED",
+    "merged_at": "2026-06-01T04:11:52Z",
+    "merge_commit": "05cdf04f646d844c11e90e7c453ed4f985c8d382",
+    "summary": "No-source data_source_registry provider closeout / residual refresh accepted and merged."
+  },
+  "scope": {
+    "source_edit_authority": false,
+    "allowed_change_type": "no-source ownership / route-provider decision",
+    "forbidden": [
+      "backend source edits",
+      "test edits",
+      "route registration changes",
+      "route path/method/response model changes",
+      "generated OpenAPI artifact edits",
+      "docs/api edits",
+      "frontend/config/script changes",
+      "OpenSpec proposal/spec edits",
+      "PM2 commands or runtime state changes",
+      "source retirement",
+      "implementation authorization for get_postgresql_session"
+    ]
+  },
+  "surface": {
+    "symbol_family": "get_postgresql_session",
+    "direct_helper_occurrences": 9,
+    "openapi_endpoint_surface": 12,
+    "helper_definitions": [
+      {
+        "uid": "Function:web/backend/app/core/database.py:get_postgresql_session",
+        "owner": "core database session helper",
+        "route_occurrences": 7,
+        "route_files": [
+          "web/backend/app/api/auth.py",
+          "web/backend/app/api/v1/admin/optimization.py",
+          "web/backend/app/api/market/market_data_request.py"
+        ],
+        "classification": "CRITICAL shared core helper; must not be modified by a route-provider lane"
+      },
+      {
+        "uid": "Function:web/backend/app/core/database_factory.py:get_postgresql_session",
+        "owner": "database_factory session helper",
+        "route_occurrences": 2,
+        "route_files": [
+          "web/backend/app/api/v1/admin/audit.py"
+        ],
+        "classification": "LOW-impact admin audit helper origin; candidate for the first split authorization package"
+      }
+    ],
+    "call_site_groups": [
+      {
+        "group": "auth-core-database",
+        "file": "web/backend/app/api/auth.py",
+        "import_origin": "app.core.database",
+        "direct_occurrences": 4,
+        "route_handlers": [
+          "get_users",
+          "register_user",
+          "request_password_reset",
+          "confirm_password_reset"
+        ],
+        "paths": [
+          "/api/v1/auth/users",
+          "/api/v1/auth/register",
+          "/api/v1/auth/reset-password/request",
+          "/api/v1/auth/reset-password/confirm"
+        ],
+        "classification": "security-sensitive auth/session route group; separate auth-specific decision required"
+      },
+      {
+        "group": "admin-audit-database-factory",
+        "file": "web/backend/app/api/v1/admin/audit.py",
+        "import_origin": "app.core.database_factory",
+        "direct_occurrences": 2,
+        "route_handlers": [
+          "list_audit_logs",
+          "get_audit_log",
+          "get_audit_statistics"
+        ],
+        "paths": [
+          "/api/v1/audit/logs",
+          "/api/v1/audit/logs/{log_id}",
+          "/api/v1/audit/statistics"
+        ],
+        "classification": "bounded admin audit group; selected for next no-source authorization package"
+      },
+      {
+        "group": "admin-optimization-core-database",
+        "file": "web/backend/app/api/v1/admin/optimization.py",
+        "import_origin": "app.core.database",
+        "direct_occurrences": 2,
+        "route_handlers": [
+          "vacuum_database",
+          "analyze_database",
+          "reindex_database",
+          "get_database_status"
+        ],
+        "paths": [
+          "/api/v1/optimization/vacuum",
+          "/api/v1/optimization/analyze",
+          "/api/v1/optimization/reindex",
+          "/api/v1/optimization/status"
+        ],
+        "classification": "admin maintenance group; separate database-operation decision required"
+      },
+      {
+        "group": "market-stock-list-core-database",
+        "file": "web/backend/app/api/market/market_data_request.py",
+        "import_origin": "app.core.database",
+        "direct_occurrences": 1,
+        "route_handlers": [
+          "get_stock_list"
+        ],
+        "paths": [
+          "/api/v1/market/stocks"
+        ],
+        "classification": "market-data request group; separate business route decision required"
+      }
+    ],
+    "runtime_routes": 548,
+    "openapi_paths": 500,
+    "duplicate_operation_ids": 0
+  },
+  "gitnexus_evidence": {
+    "mcp_context": "tool call failed: Transport closed",
+    "mcp_impact": "tool call failed: Transport closed",
+    "cli_query": "npx gitnexus query -r mystocks -l 5 get_postgresql_session found both core/database.py and core/database_factory.py definitions plus auth/admin execution flows",
+    "cli_impact_core_database": {
+      "uid": "Function:web/backend/app/core/database.py:get_postgresql_session",
+      "risk": "CRITICAL",
+      "impacted_count": 67,
+      "direct": 15,
+      "processes_affected": 54,
+      "modules_affected": 12,
+      "index_status": "stale warning"
+    },
+    "cli_impact_database_factory": {
+      "uid": "Function:web/backend/app/core/database_factory.py:get_postgresql_session",
+      "risk": "LOW",
+      "impacted_count": 4,
+      "direct": 2,
+      "processes_affected": 1,
+      "modules_affected": 1,
+      "index_status": "stale warning"
+    }
+  },
+  "verification": {
+    "route_openapi_smoke": "Correct-worktree app.main smoke records 548 routes, 500 OpenAPI paths, duplicate operation IDs 0",
+    "route_openapi_notes": "Smoke emitted expected import-time service logs and historical GPU NumPy fallback warning; counts were produced successfully.",
+    "call_site_inventory": "9 get_postgresql_session direct helper occurrences across 4 route files; exposed endpoint surface 12 routes"
+  },
+  "decision": {
+    "classification": "cross-domain-postgresql-session-helper-family",
+    "ownership": "Split by route domain and helper origin; do not treat get_postgresql_session as a single implementation target.",
+    "source_lane_recommendation": "do-not-start-source-implementation-from-g2-293",
+    "autopilot_continue_allowed": false,
+    "selected_next_governance_target": "admin-audit-postgresql-session-provider-authorization",
+    "recommended_next_work_item": "G2.294 no-source admin audit database_factory get_postgresql_session provider authorization after PR #446 human acceptance",
+    "reason": "The full get_postgresql_session family includes CRITICAL shared core database impact. The admin audit subgroup is the only currently bounded LOW-impact helper-origin subgroup and should be authorized separately before any source lane."
+  },
+  "freshness": {
+    "current_head_checked": "05cdf04f646d844c11e90e7c453ed4f985c8d382",
+    "stale_if_head_or_pr_state_changes": true,
+    "stale_if_route_or_openapi_counts_change": true,
+    "stale_if_auth_session_call_sites_change": true,
+    "stale_if_admin_audit_call_sites_change": true,
+    "stale_if_admin_optimization_call_sites_change": true,
+    "stale_if_market_request_call_sites_change": true,
+    "stale_if_gitnexus_risk_changes": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-06-01T11:52:20+08:00`
-- Base HEAD checked: `3d161e90547720f4ce95111ea511d3f8dc3174dc`
+- Prepared at: `2026-06-01T12:19:25+08:00`
+- Base HEAD checked: `05cdf04f646d844c11e90e7c453ed4f985c8d382`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -122,7 +122,8 @@ PRs, change issue labels, or authorize source implementation.
 | `#442` | `g2-289-data-source-registry-manager-ownership` | `wip/root-dirty-20260403` | `MERGED` at `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf` | No-source data_source_registry `get_manager` ownership decision selecting G2.290 provider authorization |
 | `#443` | `g2-290-data-source-registry-manager-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `e517163385e96a6c7115e14b77fb89819b4cead4` | No-source provider authorization for future G2.291 data_source_registry implementation |
 | `#444` | `g2-291-data-source-registry-manager-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `3d161e90547720f4ce95111ea511d3f8dc3174dc` | Path-limited data_source_registry manager provider implementation; now closed by G2.292 closeout |
-| `#445` | `g2-292-data-source-registry-provider-closeout-refresh` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | No-source data_source_registry provider closeout; auto-merge paused because the next selected target is `get_postgresql_session` and the underlying database helper impact is CRITICAL |
+| `#445` | `g2-292-data-source-registry-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `05cdf04f646d844c11e90e7c453ed4f985c8d382` | No-source data_source_registry provider closeout selecting G2.293 `get_postgresql_session` ownership decision |
+| `#446` | `g2-293-postgresql-session-ownership-decision` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | No-source `get_postgresql_session` ownership decision; auto-merge paused because the family includes CRITICAL GitNexus impact |
 
 ## Steward Governance Branch
 
@@ -236,3 +237,5 @@ G2.290 is the no-source `data_source_registry.get_manager` provider authorizatio
 G2.291 is the path-limited `data_source_registry.get_manager` provider implementation after PR `#443` merged G2.290 at `e517163385e96a6c7115e14b77fb89819b4cead4`. It adds `get_data_source_registry_manager`, keeps `get_manager()` as backing compatibility / monkeypatch seam, moves seven target handlers to `Depends(get_data_source_registry_manager)`, preserves runtime/OpenAPI `548/500/0`, and records focused tests `34/34`. It edits backend source/tests and must stop at future PR `#444` review; if accepted, the next gate is G2.292 no-source provider closeout / residual refresh.
 
 G2.292 is the no-source `data_source_registry.get_manager` provider closeout / residual refresh after PR `#444` merged G2.291 at `3d161e90547720f4ce95111ea511d3f8dc3174dc`. It records the data-source registry provider lane as closed, confirms direct route-body `get_manager()` calls are `0`, provider backing calls are `1`, dependency bindings are `7`, and route/OpenAPI remains `548/500/0`. It selects `G2.293 no-source get_postgresql_session ownership / route-provider decision` as the next gate. PR `#445` must stop for human review because the selected next target includes a CRITICAL-impact core database helper.
+
+G2.293 is the no-source `get_postgresql_session` ownership / route-provider decision after PR `#445` merged G2.292 at `05cdf04f646d844c11e90e7c453ed4f985c8d382`. It classifies `get_postgresql_session` as a cross-domain helper family with `9` direct helper occurrences across auth, admin audit, admin optimization, and market routes. It splits ownership by helper origin and route domain, marks `app.core.database.get_postgresql_session` as CRITICAL impact, and selects only `G2.294 no-source admin audit database_factory get_postgresql_session provider authorization` as the next candidate. PR `#446` must stop for human review and must not auto-merge.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-06-01T11:52:20+08:00`
-- Base HEAD checked: `3d161e90547720f4ce95111ea511d3f8dc3174dc`
+- Prepared at: `2026-06-01T12:19:25+08:00`
+- Base HEAD checked: `05cdf04f646d844c11e90e7c453ed4f985c8d382`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -19,15 +19,16 @@ exact verification output.
 | Route/OpenAPI and control-plane governance | Established route table, OpenAPI exposure, health/probe taxonomy, and consumer-contract evidence as first-class governance facts | Continue through route/OpenAPI track, not ad hoc route edits |
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
-| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.291 accepted/merged by PR `#444` at `3d161e9` | Continue with G2.292 `data_source_registry.get_manager` provider closeout / residual refresh review; do not auto-merge because it selects a next CRITICAL-impact database-session candidate |
+| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.292 accepted/merged by PR `#445` at `05cdf04` | Continue with G2.293 `get_postgresql_session` ownership / route-provider decision review; do not auto-merge because the family includes a CRITICAL shared database helper |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.291 have progressed through PR `#337`-`#444`; current review target is G2.292 provider closeout / residual refresh in future PR `#445` |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.292 have progressed through PR `#337`-`#445`; current review target is G2.293 `get_postgresql_session` ownership / route-provider decision in future PR `#446` |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Recent Closeouts
 
 | Item | Accepted evidence | Follow-up |
 |---|---|---|
+| G2.292 data_source_registry get_manager provider closeout | PR `#445` merged at `05cdf04f646d844c11e90e7c453ed4f985c8d382`; direct route-body `get_manager()` calls `0`, provider backing `1`, provider bindings `7`, runtime/OpenAPI `548/500/0` | G2.293 classifies `get_postgresql_session` ownership and splits future provider work by route domain/helper origin |
 | G2.291 data_source_registry get_manager provider implementation | PR `#444` merged at `3d161e90547720f4ce95111ea511d3f8dc3174dc`; direct route-body `get_manager()` calls `0`, provider bindings `7`, focused regression `3/3`, runtime/OpenAPI `548/500/0` | G2.292 closes the provider lane and selects only a no-source `get_postgresql_session` ownership decision |
 | G2.290 data_source_registry get_manager provider authorization | PR `#443` merged at `e517163385e96a6c7115e14b77fb89819b4cead4`; authorized only a path-limited G2.291 implementation lane | Superseded by the accepted/merged G2.291 provider implementation and G2.292 closeout review |
 | G2.265 signal statistics stale contract cleanup | PR `#418` merged at `2b53352d6869f66147ce3892b1b0a7174ba064b4`; targeted tests `2/2`; runtime OpenAPI target paths `0` | G2.266 records closeout and selects `G2.267 no-source monitoring/signal residual provider classification refresh` |

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-06-01T11:52:20+08:00`
-- Base HEAD checked: `3d161e90547720f4ce95111ea511d3f8dc3174dc`
+- Prepared at: `2026-06-01T12:19:25+08:00`
+- Base HEAD checked: `05cdf04f646d844c11e90e7c453ed4f985c8d382`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.292 `data_source_registry.get_manager` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#444` merged at `3d161e90547720f4ce95111ea511d3f8dc3174dc`; G2.292 closes the data-source registry provider lane with direct route-body `get_manager()` calls `0`, provider backing calls `1`, provider bindings `7`, focused regression `3 passed`, and runtime/OpenAPI `548/500/0` | Review future PR `#445`; do not auto-merge because it selects `get_postgresql_session` only for no-source ownership decision and the underlying `app.core.database.get_postgresql_session` impact is CRITICAL |
+| P0 | Review G2.293 `get_postgresql_session` ownership / route-provider decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#445` merged at `05cdf04f646d844c11e90e7c453ed4f985c8d382`; G2.293 classifies `get_postgresql_session` as a cross-domain helper family with `9` direct helper occurrences across auth, admin audit, admin optimization, and market routes; `app.core.database.get_postgresql_session` has CRITICAL GitNexus impact | Review future PR `#446`; do not auto-merge because the family includes a CRITICAL shared core helper and only the bounded admin audit subgroup is selected for a future no-source authorization package |
+| P0 | Preserve G2.292 `data_source_registry.get_manager` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#445` merged at `05cdf04f646d844c11e90e7c453ed4f985c8d382`; G2.292 closed the data-source registry provider lane with direct route-body `get_manager()` calls `0`, provider backing calls `1`, provider bindings `7`, focused regression `3 passed`, and runtime/OpenAPI `548/500/0` | Do not use G2.292 as source implementation authorization; use G2.293 only for no-source `get_postgresql_session` ownership / route-provider decision |
 | P0 | Preserve G2.291 `data_source_registry.get_manager` provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#444` merged at `3d161e90547720f4ce95111ea511d3f8dc3174dc`; G2.291 added route-local `get_data_source_registry_manager`, moved 7 target handlers to `Depends(...)`, kept `get_manager()` as compatibility/backing seam, and preserved runtime/OpenAPI `548/500/0` | Do not use G2.291 as authority for non-data-source-registry source edits, route/OpenAPI changes, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state |
 | P0 | Preserve G2.290 `data_source_registry.get_manager` provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#443` merged at `e517163385e96a6c7115e14b77fb89819b4cead4`; G2.290 authorized only the path-limited G2.291 source lane now represented by this worktree | Do not use G2.290 to expand scope beyond `web/backend/app/api/data_source_registry.py` plus focused data-source registry tests |
 | P0 | Preserve G2.289 `data_source_registry.get_manager` ownership / route-provider decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#442` merged at `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf`; G2.289 classified `get_manager` as a bounded active data-source registry route helper with `7` direct route-body callers, runtime/OpenAPI `548/500/0`, and GitNexus MEDIUM impact with one affected process | Do not use G2.289 as source implementation authorization; use G2.290 only as no-source provider authorization after review |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-06-01T11:52:20+08:00`
-- Base HEAD checked: `3d161e90547720f4ce95111ea511d3f8dc3174dc`
+- Prepared at: `2026-06-01T12:19:25+08:00`
+- Base HEAD checked: `05cdf04f646d844c11e90e7c453ed4f985c8d382`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -16,9 +16,12 @@ state transition.
 
 | Evidence | Role | Freshness policy |
 |---|---|---|
-| `.planning/codebase/generated/data-source-registry-provider-closeout-refresh-2026-06-01.json` | G2.292 `data_source_registry.get_manager` provider closeout / residual refresh evidence | Review input for future PR `#445`; no-source package; must stop because it selects next `get_postgresql_session` decision target with CRITICAL GitNexus impact on `app.core.database.get_postgresql_session` |
-| `docs/reports/quality/backend-data-source-registry-provider-closeout-refresh-2026-06-01.md` | G2.292 human-readable provider closeout / residual refresh report | Review input for future PR `#445`; records PR `#444` accepted/merged, provider closeout, route/OpenAPI smoke, residual scan, and stop rule |
-| `governance/mainline/task-cards/pr-445.yaml` | Governance task card for G2.292 no-source closeout / residual refresh | Review input; allows only steward tree, generated evidence, report, and task card updates; no auto-merge because the selected next target has CRITICAL impact |
+| `.planning/codebase/generated/postgresql-session-ownership-decision-2026-06-01.json` | G2.293 `get_postgresql_session` ownership / route-provider decision evidence | Review input for future PR `#446`; no-source package; must stop because the family includes CRITICAL GitNexus impact on `app.core.database.get_postgresql_session` |
+| `docs/reports/quality/backend-postgresql-session-ownership-decision-2026-06-01.md` | G2.293 human-readable ownership / route-provider decision report | Review input for future PR `#446`; records PR `#445` accepted/merged, call-site groups, route/OpenAPI smoke, GitNexus fallback, split decision, and stop rule |
+| `governance/mainline/task-cards/pr-446.yaml` | Governance task card for G2.293 no-source decision | Review input; allows only steward tree, generated evidence, report, and task card updates; no auto-merge because the target family includes CRITICAL impact |
+| `.planning/codebase/generated/data-source-registry-provider-closeout-refresh-2026-06-01.json` | G2.292 `data_source_registry.get_manager` provider closeout / residual refresh evidence | Accepted by PR `#445`, merged at `05cdf04f646d844c11e90e7c453ed4f985c8d382`; no-source closeout package; superseded for next-gate decision by G2.293 |
+| `docs/reports/quality/backend-data-source-registry-provider-closeout-refresh-2026-06-01.md` | G2.292 human-readable provider closeout / residual refresh report | Accepted by PR `#445`; records PR `#444` accepted/merged, provider closeout, route/OpenAPI smoke, residual scan, and stop rule |
+| `governance/mainline/task-cards/pr-445.yaml` | Governance task card for G2.292 no-source closeout / residual refresh | Accepted by PR `#445`; allowed only steward tree, generated evidence, report, and task card updates |
 | `.planning/codebase/generated/data-source-registry-manager-provider-implementation-2026-06-01.json` | G2.291 `data_source_registry.get_manager` provider implementation evidence | Accepted by PR `#444`, merged at `3d161e90547720f4ce95111ea511d3f8dc3174dc`; superseded for next-gate decision by G2.292 |
 | `docs/reports/quality/backend-data-source-registry-manager-provider-implementation-2026-06-01.md` | G2.291 human-readable provider implementation report | Accepted by PR `#444`; records PR `#443` accepted/merged, implementation envelope, tests, and stop rule |
 | `governance/mainline/task-cards/pr-444.yaml` | Governance task card for G2.291 source implementation | Accepted by PR `#444`; allowed only steward tree, generated evidence, report, source file, and focused test updates |

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-06-01T11:52:20+08:00",
+  "generated_at": "2026-06-01T12:19:25+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "3d161e90547720f4ce95111ea511d3f8dc3174dc",
-  "split_branch": "g2-292-data-source-registry-provider-closeout-refresh",
-  "scope": "data_source_registry_provider_closeout_refresh",
+  "base_head": "05cdf04f646d844c11e90e7c453ed4f985c8d382",
+  "split_branch": "g2-293-postgresql-session-ownership-decision",
+  "scope": "postgresql_session_ownership_decision",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -9474,7 +9474,7 @@
     {
       "id": "g2-292-data-source-registry-provider-closeout-refresh",
       "type": "closeout_refresh",
-      "state": "for_review",
+      "state": "accepted_merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.291 data_source_registry get_manager provider implementation",
       "source_edit_authority": false,
@@ -9483,8 +9483,10 @@
       "github_pr": {
         "number": 445,
         "url": "https://github.com/chengjon/mystocks/pull/445",
-        "state": "PLANNED_FOR_REVIEW",
-        "head_ref": "g2-292-data-source-registry-provider-closeout-refresh"
+        "state": "MERGED",
+        "merged_at": "2026-06-01T04:11:52Z",
+        "head_ref": "g2-292-data-source-registry-provider-closeout-refresh",
+        "merge_commit": "05cdf04f646d844c11e90e7c453ed4f985c8d382"
       },
       "evidence": [
         ".planning/codebase/generated/data-source-registry-provider-closeout-refresh-2026-06-01.json",
@@ -9582,14 +9584,125 @@
         "recommended_next_work_item": "G2.293 no-source get_postgresql_session ownership / route-provider decision after PR #445 human acceptance"
       },
       "freshness": {
-        "current_head_checked": "3d161e90547720f4ce95111ea511d3f8dc3174dc",
+        "current_head_checked": "05cdf04f646d844c11e90e7c453ed4f985c8d382",
         "stale_if_head_or_pr_state_changes": true,
         "stale_if_route_or_openapi_counts_change": true,
         "stale_if_data_source_registry_call_sites_change": true,
         "stale_if_candidate_scan_changes": true,
         "stale_if_gitnexus_risk_changes": true
       },
-      "next_gate": "Stop for human review in PR #445. If accepted, start G2.293 no-source get_postgresql_session ownership / route-provider decision."
+      "next_gate": "Superseded by G2.293 no-source get_postgresql_session ownership / route-provider decision."
+    },
+    {
+      "id": "g2-293-postgresql-session-ownership-decision",
+      "type": "ownership_decision",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.292 data_source_registry get_manager provider closeout / residual refresh",
+      "source_edit_authority": false,
+      "autopilot_status": "stop_at_pr_review_gate",
+      "autopilot_stop_reason": "G2.293 includes a CRITICAL-impact shared core database helper",
+      "github_pr": {
+        "number": 446,
+        "url": "https://github.com/chengjon/mystocks/pull/446",
+        "state": "PLANNED_FOR_REVIEW",
+        "head_ref": "g2-293-postgresql-session-ownership-decision"
+      },
+      "evidence": [
+        ".planning/codebase/generated/postgresql-session-ownership-decision-2026-06-01.json",
+        "docs/reports/quality/backend-postgresql-session-ownership-decision-2026-06-01.md",
+        "governance/mainline/task-cards/pr-446.yaml"
+      ],
+      "closed_parent": {
+        "pr": 445,
+        "state": "MERGED",
+        "merge_commit": "05cdf04f646d844c11e90e7c453ed4f985c8d382",
+        "merged_at": "2026-06-01T04:11:52Z"
+      },
+      "allowed_scope": [
+        ".planning/codebase/generated/postgresql-session-ownership-decision-2026-06-01.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-postgresql-session-ownership-decision-2026-06-01.md",
+        "governance/mainline/task-cards/pr-446.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "tests/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "surface": {
+        "symbol_family": "get_postgresql_session",
+        "direct_helper_occurrences": 9,
+        "openapi_endpoint_surface": 12,
+        "helper_definitions": [
+          {
+            "uid": "Function:web/backend/app/core/database.py:get_postgresql_session",
+            "owner": "core database session helper",
+            "route_occurrences": 7,
+            "classification": "CRITICAL shared core helper; must not be modified by a route-provider lane"
+          },
+          {
+            "uid": "Function:web/backend/app/core/database_factory.py:get_postgresql_session",
+            "owner": "database_factory session helper",
+            "route_occurrences": 2,
+            "classification": "LOW-impact admin audit helper origin; candidate for the first split authorization package"
+          }
+        ]
+      },
+      "gitnexus_evidence": {
+        "mcp_context": "tool call failed: Transport closed",
+        "mcp_impact": "tool call failed: Transport closed",
+        "cli_query": "npx gitnexus query -r mystocks -l 5 get_postgresql_session found both core/database.py and core/database_factory.py definitions plus auth/admin execution flows",
+        "cli_impact_core_database": {
+          "risk": "CRITICAL",
+          "impacted_count": 67,
+          "direct": 15,
+          "processes_affected": 54,
+          "modules_affected": 12,
+          "index_status": "stale warning"
+        },
+        "cli_impact_database_factory": {
+          "risk": "LOW",
+          "impacted_count": 4,
+          "direct": 2,
+          "processes_affected": 1,
+          "modules_affected": 1,
+          "index_status": "stale warning"
+        }
+      },
+      "decision": {
+        "classification": "cross-domain-postgresql-session-helper-family",
+        "ownership": "Split by route domain and helper origin; do not treat get_postgresql_session as a single implementation target.",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-293",
+        "autopilot_continue_allowed": false,
+        "selected_next_governance_target": "admin-audit-postgresql-session-provider-authorization",
+        "recommended_next_work_item": "G2.294 no-source admin audit database_factory get_postgresql_session provider authorization after PR #446 human acceptance",
+        "reason": "The full get_postgresql_session family includes CRITICAL shared core database impact. The admin audit subgroup is the only currently bounded LOW-impact helper-origin subgroup and should be authorized separately before any source lane."
+      },
+      "freshness": {
+        "current_head_checked": "05cdf04f646d844c11e90e7c453ed4f985c8d382",
+        "stale_if_head_or_pr_state_changes": true,
+        "stale_if_route_or_openapi_counts_change": true,
+        "stale_if_auth_session_call_sites_change": true,
+        "stale_if_admin_audit_call_sites_change": true,
+        "stale_if_admin_optimization_call_sites_change": true,
+        "stale_if_market_request_call_sites_change": true,
+        "stale_if_gitnexus_risk_changes": true
+      },
+      "next_gate": "Stop for human review in PR #446. If accepted, start G2.294 no-source admin audit database_factory get_postgresql_session provider authorization."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -3156,7 +3156,7 @@ Status: for review in future PR `#443`.
 
 ## G2.292 data_source_registry get_manager Provider Closeout / Residual Refresh
 
-Status: for review in future PR `#445`.
+Status: accepted/merged by PR `#445` at `05cdf04f646d844c11e90e7c453ed4f985c8d382`.
 
 - Parent PR `#444` merged at `3d161e90547720f4ce95111ea511d3f8dc3174dc`.
 - G2.292 is a no-source closeout / residual refresh package. It does not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
@@ -3166,3 +3166,18 @@ Status: for review in future PR `#445`.
 - GitNexus MCP returned `Transport closed`; CLI fallback reports CRITICAL risk for `Function:web/backend/app/core/database.py:get_postgresql_session`.
 - Stop rule: PR `#445` must stop for human review because the next selected target includes CRITICAL GitNexus impact.
 - Recommended next gate after human acceptance and merge: G2.293 no-source `get_postgresql_session` ownership / route-provider decision.
+
+## G2.293 get_postgresql_session Ownership / Route-Provider Decision
+
+Status: for review in future PR `#446`.
+
+- Parent PR `#445` merged at `05cdf04f646d844c11e90e7c453ed4f985c8d382`.
+- G2.293 is a no-source ownership / route-provider decision package. It does not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+- It classifies `get_postgresql_session` as a cross-domain helper family, not a single implementation target.
+- Current scan records `9` direct helper occurrences across `auth.py`, `v1/admin/audit.py`, `v1/admin/optimization.py`, and `market/market_data_request.py`; effective OpenAPI endpoint surface is `12`.
+- Helper origins are split between `app.core.database.get_postgresql_session` and `app.core.database_factory.get_postgresql_session`.
+- GitNexus MCP returned `Transport closed`; CLI fallback reports CRITICAL risk for `Function:web/backend/app/core/database.py:get_postgresql_session` and LOW risk for `Function:web/backend/app/core/database_factory.py:get_postgresql_session`.
+- Route/OpenAPI smoke remains `548` routes, `500` paths, duplicate operation IDs `0`.
+- Decision: do not modify shared helper definitions; split future route-provider work by route domain/helper origin.
+- Recommended next gate after human acceptance and merge: G2.294 no-source admin audit database_factory `get_postgresql_session` provider authorization.
+- Stop rule: PR `#446` must stop for human review because the target family includes CRITICAL GitNexus impact.

--- a/docs/reports/quality/backend-postgresql-session-ownership-decision-2026-06-01.md
+++ b/docs/reports/quality/backend-postgresql-session-ownership-decision-2026-06-01.md
@@ -1,0 +1,131 @@
+# Backend PostgreSQL Session Ownership / Route-Provider Decision
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Gate: G2.293
+- Status: for review in future PR `#446`
+- Prepared at: `2026-06-01T12:19:25+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Base HEAD: `05cdf04f646d844c11e90e7c453ed4f985c8d382`
+- Parent gate: G2.292 provider closeout / residual refresh, PR `#445`, merged at `05cdf04f646d844c11e90e7c453ed4f985c8d382`
+- OpenSpec change: `migrate-backend-singletons-to-lifecycle-di`
+
+Boundary note: G2.293 is a no-source ownership / route-provider decision
+package. It does not authorize backend source edits, test edits,
+route/OpenAPI contract changes, docs/api artifact edits, frontend/config/script
+changes, OpenSpec proposal/spec edits, PM2 commands, runtime state changes,
+source retirement, or implementation authorization for `get_postgresql_session`.
+
+## Finding
+
+`get_postgresql_session` is not a single implementation target. It is a
+cross-domain session helper family with two helper origins and mixed route
+ownership:
+
+- `app.core.database.get_postgresql_session`
+- `app.core.database_factory.get_postgresql_session`
+
+Current scan records `9` direct helper occurrences across `4` route files. The
+effective OpenAPI route surface is `12` endpoints because some calls live inside
+route-local helpers used by multiple endpoints.
+
+## Call-Site Groups
+
+| Group | File | Helper origin | Direct occurrences | Exposed routes | Decision |
+|---|---|---|---:|---:|---|
+| Auth core database | `web/backend/app/api/auth.py` | `app.core.database` | 4 | 4 | Security-sensitive; separate auth-specific decision required |
+| Admin audit database factory | `web/backend/app/api/v1/admin/audit.py` | `app.core.database_factory` | 2 | 3 | Bounded LOW-impact subgroup; selected for next no-source authorization package |
+| Admin optimization core database | `web/backend/app/api/v1/admin/optimization.py` | `app.core.database` | 2 | 4 | Database-operation maintenance group; separate decision required |
+| Market stock list core database | `web/backend/app/api/market/market_data_request.py` | `app.core.database` | 1 | 1 | Business route group; separate decision required |
+
+Representative exposed routes:
+
+- `/api/v1/auth/users`
+- `/api/v1/auth/register`
+- `/api/v1/auth/reset-password/request`
+- `/api/v1/auth/reset-password/confirm`
+- `/api/v1/audit/logs`
+- `/api/v1/audit/logs/{log_id}`
+- `/api/v1/audit/statistics`
+- `/api/v1/optimization/vacuum`
+- `/api/v1/optimization/analyze`
+- `/api/v1/optimization/reindex`
+- `/api/v1/optimization/status`
+- `/api/v1/market/stocks`
+
+## Route / OpenAPI Smoke
+
+Correct-worktree app import and OpenAPI smoke records:
+
+- FastAPI routes: `548`
+- OpenAPI paths: `500`
+- duplicate operation IDs: `0`
+
+The smoke emitted expected import-time service logs and the historical GPU
+NumPy fallback warning; these did not affect route/OpenAPI counts.
+
+## GitNexus Evidence
+
+GitNexus MCP calls returned `Transport closed`; CLI fallback was used.
+
+`Function:web/backend/app/core/database.py:get_postgresql_session`:
+
+- risk: `CRITICAL`
+- impacted symbols: `67`
+- direct callers: `15`
+- affected processes: `54`
+- affected modules: `12`
+- index status: stale warning
+
+`Function:web/backend/app/core/database_factory.py:get_postgresql_session`:
+
+- risk: `LOW`
+- impacted symbols: `4`
+- direct callers: `2`
+- affected processes: `1`
+- affected modules: `1`
+- index status: stale warning
+
+This confirms that a route-provider migration must not modify either shared
+helper definition. Future source work, if authorized, must be route-local and
+path-limited.
+
+## Decision
+
+G2.293 classifies `get_postgresql_session` as a cross-domain PostgreSQL session
+helper family. It must be split by route domain and helper origin.
+
+G2.293 does not authorize implementation.
+
+Recommended next gate:
+
+G2.294 no-source admin audit database_factory `get_postgresql_session`
+provider authorization.
+
+The admin audit subgroup is selected first because it is bounded to
+`web/backend/app/api/v1/admin/audit.py`, has the LOW-impact
+`database_factory.get_postgresql_session` origin, and exposes three audit
+routes. It still requires a separate authorization package before any source
+lane.
+
+## Non-Goals
+
+G2.293 does not authorize:
+
+- editing `web/backend/app/core/database.py`
+- editing `web/backend/app/core/database_factory.py`
+- editing any route file
+- changing route registration or OpenAPI exposure
+- changing auth/session behavior
+- changing admin optimization behavior
+- changing market data request behavior
+- retiring either helper
+- combining auth, admin, and market migrations in one implementation PR
+
+## Evidence
+
+- `.planning/codebase/generated/postgresql-session-ownership-decision-2026-06-01.json`
+- `docs/reports/quality/backend-postgresql-session-ownership-decision-2026-06-01.md`
+- `governance/mainline/task-cards/pr-446.yaml`

--- a/governance/mainline/task-cards/pr-446.yaml
+++ b/governance/mainline/task-cards/pr-446.yaml
@@ -1,0 +1,131 @@
+version: "v0.2"
+
+task:
+  id: "pr-446"
+  title: "Decide get_postgresql_session ownership"
+  owner: "codex"
+  created_at: "2026-06-01"
+
+mainline:
+  id: "L1-postgresql-session-ownership-decision"
+  objective: "classify get_postgresql_session ownership and split future route-provider work without editing source"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "G2.293 is a no-source ownership / route-provider decision package. It changes no runtime entrypoint, route path, route registration, generated OpenAPI artifact, frontend route, or FUNCTION_TREE catalog entry."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/postgresql-session-ownership-decision-2026-06-01.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-postgresql-session-ownership-decision-2026-06-01.md"
+    - "governance/mainline/task-cards/pr-446.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits"
+  - "test edits"
+  - "route registration changes"
+  - "route path, method, response model, or generated OpenAPI artifact changes"
+  - "docs/api artifact edits"
+  - "frontend/config/script changes"
+  - "OpenSpec proposal or spec edits"
+  - "PM2 commands or stateful runtime gates"
+  - "source retirement"
+  - "implementation authorization for get_postgresql_session"
+
+acceptance:
+  checks:
+    - id: "pr445-merged"
+      command: "gh pr view 445 confirms MERGED at 05cdf04f646d844c11e90e7c453ed4f985c8d382"
+      required: true
+    - id: "call-site-inventory"
+      command: "current scan records 9 get_postgresql_session direct helper occurrences across auth.py, v1/admin/audit.py, v1/admin/optimization.py, and market/market_data_request.py"
+      required: true
+    - id: "route-openapi-smoke"
+      command: "correct-worktree app.main route/OpenAPI smoke records 548 routes, 500 paths, and duplicate operation IDs 0"
+      required: true
+    - id: "gitnexus-core-database-impact"
+      command: "GitNexus MCP returned Transport closed; CLI impact records CRITICAL risk, 67 impacted symbols, 15 direct callers, 54 affected processes for Function:web/backend/app/core/database.py:get_postgresql_session"
+      required: true
+    - id: "gitnexus-database-factory-impact"
+      command: "CLI impact records LOW risk, 4 impacted symbols, 2 direct callers, 1 affected process for Function:web/backend/app/core/database_factory.py:get_postgresql_session"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-postgresql-session-ownership-decision-2026-06-01.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-446.yaml --base-sha 05cdf04f646d844c11e90e7c453ed4f985c8d382 --head-sha HEAD --report /tmp/pr446-mainline-governance-report.json"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "gitnexus-detect-changes"
+      command: "GitNexus staged verification attempted before commit; stale-index warning recorded if present"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "A future worker may treat get_postgresql_session as a single implementation target; this package explicitly splits by route domain and helper origin."
+    - "The shared core database helper has CRITICAL GitNexus impact, so PR #446 must stop for review."
+    - "GitNexus index is stale; current route/helper scan is the source for active route-body counts."
+  rollback_plan: "Revert PR #446; this removes only governance evidence and restores the previous steward tree state."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Classify get_postgresql_session ownership and split future provider work by route domain/helper origin."
+    modified_scope: "Governance evidence, steward tree indexes, human-readable report, and task card only."
+    dependency_changes: "No dependency changes."
+    legacy_logic_impact: "No runtime, route, OpenAPI, frontend, config, script, or OpenSpec changes."
+    rollback_ready: "Revert PR #446."
+    risk_and_rollback_point: "No-source decision, but the shared core helper has CRITICAL impact; rollback is single-PR revert."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-01T12:19:25+08:00"
+    approval_note: "Human maintainer approved continuing after PR #445 merge into G2.293 no-source ownership / route-provider decision. PR #446 must stop for review because the selected family includes CRITICAL GitNexus impact."
+    secondary_approved: false


### PR DESCRIPTION
# Backend PostgreSQL Session Ownership / Route-Provider Decision

> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。

## Status

- Gate: G2.293
- Status: for review in future PR `#446`
- Prepared at: `2026-06-01T12:19:25+08:00`
- Base branch: `wip/root-dirty-20260403`
- Base HEAD: `05cdf04f646d844c11e90e7c453ed4f985c8d382`
- Parent gate: G2.292 provider closeout / residual refresh, PR `#445`, merged at `05cdf04f646d844c11e90e7c453ed4f985c8d382`
- OpenSpec change: `migrate-backend-singletons-to-lifecycle-di`

Boundary note: G2.293 is a no-source ownership / route-provider decision
package. It does not authorize backend source edits, test edits,
route/OpenAPI contract changes, docs/api artifact edits, frontend/config/script
changes, OpenSpec proposal/spec edits, PM2 commands, runtime state changes,
source retirement, or implementation authorization for `get_postgresql_session`.

## Finding

`get_postgresql_session` is not a single implementation target. It is a
cross-domain session helper family with two helper origins and mixed route
ownership:

- `app.core.database.get_postgresql_session`
- `app.core.database_factory.get_postgresql_session`

Current scan records `9` direct helper occurrences across `4` route files. The
effective OpenAPI route surface is `12` endpoints because some calls live inside
route-local helpers used by multiple endpoints.

## Call-Site Groups

| Group | File | Helper origin | Direct occurrences | Exposed routes | Decision |
|---|---|---|---:|---:|---|
| Auth core database | `web/backend/app/api/auth.py` | `app.core.database` | 4 | 4 | Security-sensitive; separate auth-specific decision required |
| Admin audit database factory | `web/backend/app/api/v1/admin/audit.py` | `app.core.database_factory` | 2 | 3 | Bounded LOW-impact subgroup; selected for next no-source authorization package |
| Admin optimization core database | `web/backend/app/api/v1/admin/optimization.py` | `app.core.database` | 2 | 4 | Database-operation maintenance group; separate decision required |
| Market stock list core database | `web/backend/app/api/market/market_data_request.py` | `app.core.database` | 1 | 1 | Business route group; separate decision required |

Representative exposed routes:

- `/api/v1/auth/users`
- `/api/v1/auth/register`
- `/api/v1/auth/reset-password/request`
- `/api/v1/auth/reset-password/confirm`
- `/api/v1/audit/logs`
- `/api/v1/audit/logs/{log_id}`
- `/api/v1/audit/statistics`
- `/api/v1/optimization/vacuum`
- `/api/v1/optimization/analyze`
- `/api/v1/optimization/reindex`
- `/api/v1/optimization/status`
- `/api/v1/market/stocks`

## Route / OpenAPI Smoke

Correct-worktree app import and OpenAPI smoke records:

- FastAPI routes: `548`
- OpenAPI paths: `500`
- duplicate operation IDs: `0`

The smoke emitted expected import-time service logs and the historical GPU
NumPy fallback warning; these did not affect route/OpenAPI counts.

## GitNexus Evidence

GitNexus MCP calls returned `Transport closed`; CLI fallback was used.

`Function:web/backend/app/core/database.py:get_postgresql_session`:

- risk: `CRITICAL`
- impacted symbols: `67`
- direct callers: `15`
- affected processes: `54`
- affected modules: `12`
- index status: stale warning

`Function:web/backend/app/core/database_factory.py:get_postgresql_session`:

- risk: `LOW`
- impacted symbols: `4`
- direct callers: `2`
- affected processes: `1`
- affected modules: `1`
- index status: stale warning

This confirms that a route-provider migration must not modify either shared
helper definition. Future source work, if authorized, must be route-local and
path-limited.

## Decision

G2.293 classifies `get_postgresql_session` as a cross-domain PostgreSQL session
helper family. It must be split by route domain and helper origin.

G2.293 does not authorize implementation.

Recommended next gate:

G2.294 no-source admin audit database_factory `get_postgresql_session`
provider authorization.

The admin audit subgroup is selected first because it is bounded to
`web/backend/app/api/v1/admin/audit.py`, has the LOW-impact
`database_factory.get_postgresql_session` origin, and exposes three audit
routes. It still requires a separate authorization package before any source
lane.

## Non-Goals

G2.293 does not authorize:

- editing `web/backend/app/core/database.py`
- editing `web/backend/app/core/database_factory.py`
- editing any route file
- changing route registration or OpenAPI exposure
- changing auth/session behavior
- changing admin optimization behavior
- changing market data request behavior
- retiring either helper
- combining auth, admin, and market migrations in one implementation PR

## Evidence

- `.planning/codebase/generated/postgresql-session-ownership-decision-2026-06-01.json`
- `docs/reports/quality/backend-postgresql-session-ownership-decision-2026-06-01.md`
- `governance/mainline/task-cards/pr-446.yaml`
