### PR TITLE
G2.294: authorize admin audit session provider

### DIFF
--- a/.planning/codebase/generated/admin-audit-postgresql-session-provider-authorization-2026-06-01.json
+++ b/.planning/codebase/generated/admin-audit-postgresql-session-provider-authorization-2026-06-01.json
@@ -1,0 +1,152 @@
+{
+  "schema_version": "2026-05-27.steward-evidence.v1",
+  "generated_at": "2026-06-01T13:02:37+08:00",
+  "git_head": "a62d5e3fa4e9efbbe388e4bd317ae0cfae371319",
+  "base_branch": "wip/root-dirty-20260403",
+  "node": {
+    "id": "g2-294-admin-audit-postgresql-session-provider-authorization",
+    "label": "G2.294 admin audit database_factory get_postgresql_session provider authorization",
+    "type": "authorization_package",
+    "state": "for_review",
+    "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+    "parent": "G2.293 get_postgresql_session ownership / route-provider decision",
+    "source_edit_authority": false,
+    "autopilot_status": "stop_at_pr_review_gate",
+    "autopilot_stop_reason": "G2.294 is no-source, but it authorizes a future backend source implementation lane and the selected helper participates in one affected execution process."
+  },
+  "closed_parent": {
+    "pr": 446,
+    "state": "MERGED",
+    "url": "https://github.com/chengjon/mystocks/pull/446",
+    "merge_commit": "a62d5e3fa4e9efbbe388e4bd317ae0cfae371319",
+    "merged_at": "2026-06-01T04:43:16Z"
+  },
+  "target_surface": {
+    "file": "web/backend/app/api/v1/admin/audit.py",
+    "helper_origin": "app.core.database_factory.get_postgresql_session",
+    "direct_helper_occurrences": 2,
+    "helper_occurrences": [
+      {
+        "line": 225,
+        "function": "_load_audit_logs",
+        "route_handler": false,
+        "cleanup_semantics": "session.close() in finally"
+      },
+      {
+        "line": 365,
+        "function": "get_audit_statistics",
+        "route_handler": true,
+        "cleanup_semantics": "session.close() in finally"
+      }
+    ],
+    "route_surface": [
+      {
+        "path": "/api/v1/audit/logs",
+        "methods": [
+          "GET"
+        ],
+        "endpoint": "list_audit_logs",
+        "include_in_schema": true
+      },
+      {
+        "path": "/api/v1/audit/logs/{log_id}",
+        "methods": [
+          "GET"
+        ],
+        "endpoint": "get_audit_log",
+        "include_in_schema": true
+      },
+      {
+        "path": "/api/v1/audit/statistics",
+        "methods": [
+          "GET"
+        ],
+        "endpoint": "get_audit_statistics",
+        "include_in_schema": true
+      }
+    ],
+    "effective_endpoint_surface": 3
+  },
+  "route_openapi_smoke": {
+    "routes": 548,
+    "paths": 500,
+    "duplicate_operation_ids": 0,
+    "audit_routes": 3,
+    "captured_at": "2026-06-01T12:46:10+08:00",
+    "freshness_policy": "Stale if HEAD, route registration, include_in_schema policy, or audit route module changes."
+  },
+  "gitnexus_evidence": {
+    "mcp_impact": "tool call failed: Transport closed",
+    "cli_impact_database_factory_get_postgresql_session": {
+      "command": "npx gitnexus impact -r mystocks -d upstream --depth 2 --include-tests --summary-only Function:web/backend/app/core/database_factory.py:get_postgresql_session",
+      "risk": "LOW",
+      "impacted_count": 4,
+      "direct": 2,
+      "processes_affected": 1,
+      "modules_affected": 1,
+      "affected_processes": [
+        {
+          "name": "get_audit_statistics",
+          "type": "Function",
+          "filePath": "web/backend/app/api/v1/admin/audit.py",
+          "earliest_broken_step": 1
+        }
+      ],
+      "affected_modules": [
+        {
+          "name": "Admin",
+          "hits": 4,
+          "impact": "direct"
+        }
+      ],
+      "index_status": "stale warning, commits_behind=0"
+    },
+    "cli_query": {
+      "command": "npx gitnexus query -r mystocks -l 5 \"admin audit get_postgresql_session database_factory\"",
+      "matched_primary_process": "proc_22_get_audit_statistics",
+      "matched_symbols": [
+        "Function:web/backend/app/api/v1/admin/audit.py:_load_audit_logs",
+        "Function:web/backend/app/api/v1/admin/audit.py:get_audit_statistics"
+      ],
+      "index_status": "stale warning, commits_behind=0"
+    }
+  },
+  "authorization_decision": {
+    "classification": "bounded-admin-audit-database-factory-session-provider-candidate",
+    "approved_future_lane_if_reviewed": "G2.295 path-limited admin audit database_factory get_postgresql_session provider implementation",
+    "future_source_authority": "Requires human acceptance of PR #447 / G2.294 before any source lane starts.",
+    "allowed_future_source_paths": [
+      "web/backend/app/api/v1/admin/audit.py"
+    ],
+    "allowed_future_test_paths": [
+      "web/backend/tests/test_v1_audit_regressions.py",
+      "web/backend/tests/test_v1_admin_exports.py"
+    ],
+    "required_future_shape": [
+      "Add or use a route-local provider dependency for the admin audit database_factory PostgreSQL session.",
+      "Move only the admin audit helper uses behind dependency/provider wiring.",
+      "Preserve existing session.close() cleanup semantics for both _load_audit_logs and get_audit_statistics paths.",
+      "Keep route paths, methods, response models, OpenAPI exposure, and response contracts unchanged.",
+      "Run focused audit regression/export tests and route/OpenAPI smoke before any implementation PR is reviewed."
+    ],
+    "forbidden_future_scope": [
+      "app.core.database.py",
+      "app.core.database_factory.py helper definitions",
+      "web/backend/app/api/auth.py",
+      "web/backend/app/api/v1/admin/optimization.py",
+      "web/backend/app/api/market/market_data_request.py",
+      "route registration changes",
+      "generated OpenAPI artifacts",
+      "frontend/config/scripts/OpenSpec/PM2/runtime state"
+    ]
+  },
+  "freshness": {
+    "current_head_checked": "a62d5e3fa4e9efbbe388e4bd317ae0cfae371319",
+    "stale_if_head_or_pr_state_changes": true,
+    "stale_if_route_or_openapi_counts_change": true,
+    "stale_if_admin_audit_call_sites_change": true,
+    "stale_if_gitnexus_risk_changes": true,
+    "stale_if_test_inventory_changes": true
+  },
+  "next_gate": "Stop for human review in PR #447. If accepted, start G2.295 path-limited admin audit database_factory get_postgresql_session provider implementation."
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-06-01T12:19:25+08:00`
-- Base HEAD checked: `05cdf04f646d844c11e90e7c453ed4f985c8d382`
+- Prepared at: `2026-06-01T13:02:37+08:00`
+- Base HEAD checked: `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -123,7 +123,8 @@ PRs, change issue labels, or authorize source implementation.
 | `#443` | `g2-290-data-source-registry-manager-provider-authorization` | `wip/root-dirty-20260403` | `MERGED` at `e517163385e96a6c7115e14b77fb89819b4cead4` | No-source provider authorization for future G2.291 data_source_registry implementation |
 | `#444` | `g2-291-data-source-registry-manager-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `3d161e90547720f4ce95111ea511d3f8dc3174dc` | Path-limited data_source_registry manager provider implementation; now closed by G2.292 closeout |
 | `#445` | `g2-292-data-source-registry-provider-closeout-refresh` | `wip/root-dirty-20260403` | `MERGED` at `05cdf04f646d844c11e90e7c453ed4f985c8d382` | No-source data_source_registry provider closeout selecting G2.293 `get_postgresql_session` ownership decision |
-| `#446` | `g2-293-postgresql-session-ownership-decision` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | No-source `get_postgresql_session` ownership decision; auto-merge paused because the family includes CRITICAL GitNexus impact |
+| `#446` | `g2-293-postgresql-session-ownership-decision` | `wip/root-dirty-20260403` | `MERGED` at `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319` | No-source `get_postgresql_session` ownership decision selecting G2.294 admin audit provider authorization |
+| `#447` | `g2-294-admin-audit-postgresql-session-provider-authorization` | `wip/root-dirty-20260403` | `PLANNED_FOR_REVIEW` | No-source admin audit `database_factory.get_postgresql_session` provider authorization; auto-merge paused because it authorizes future backend source work |
 
 ## Steward Governance Branch
 
@@ -161,6 +162,9 @@ PRs, change issue labels, or authorize source implementation.
 | `g2-289-data-source-registry-manager-ownership` | `origin/wip/root-dirty-20260403` at `75ce550ceaf9f77b7659193b9cbd3c9ab2181c37` | Decide data_source_registry `get_manager` ownership / route-provider disposition; stop auto-merge due GitNexus MEDIUM risk and one affected process | No |
 | `g2-290-data-source-registry-manager-provider-authorization` | `origin/wip/root-dirty-20260403` at `1f0a909355f5db9002cfc2d0fcbba21e366dc0bf` | Authorize a future path-limited data_source_registry `get_manager` route-provider implementation | No |
 | `g2-291-data-source-registry-manager-provider-implementation` | `origin/wip/root-dirty-20260403` at `e517163385e96a6c7115e14b77fb89819b4cead4` | Implement path-limited data_source_registry manager provider injection and focused tests | Yes |
+| `g2-292-data-source-registry-provider-closeout-refresh` | `origin/wip/root-dirty-20260403` at `3d161e90547720f4ce95111ea511d3f8dc3174dc` | Close out data_source_registry provider implementation and select G2.293 `get_postgresql_session` ownership decision | No |
+| `g2-293-postgresql-session-ownership-decision` | `origin/wip/root-dirty-20260403` at `05cdf04f646d844c11e90e7c453ed4f985c8d382` | Decide split `get_postgresql_session` ownership and select bounded admin audit provider authorization | No |
+| `g2-294-admin-audit-postgresql-session-provider-authorization` | `origin/wip/root-dirty-20260403` at `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319` | Authorize a future path-limited admin audit database_factory `get_postgresql_session` provider implementation; stop auto-merge because it authorizes future source work | No |
 
 ## OpenSpec Relationship
 
@@ -238,4 +242,6 @@ G2.291 is the path-limited `data_source_registry.get_manager` provider implement
 
 G2.292 is the no-source `data_source_registry.get_manager` provider closeout / residual refresh after PR `#444` merged G2.291 at `3d161e90547720f4ce95111ea511d3f8dc3174dc`. It records the data-source registry provider lane as closed, confirms direct route-body `get_manager()` calls are `0`, provider backing calls are `1`, dependency bindings are `7`, and route/OpenAPI remains `548/500/0`. It selects `G2.293 no-source get_postgresql_session ownership / route-provider decision` as the next gate. PR `#445` must stop for human review because the selected next target includes a CRITICAL-impact core database helper.
 
-G2.293 is the no-source `get_postgresql_session` ownership / route-provider decision after PR `#445` merged G2.292 at `05cdf04f646d844c11e90e7c453ed4f985c8d382`. It classifies `get_postgresql_session` as a cross-domain helper family with `9` direct helper occurrences across auth, admin audit, admin optimization, and market routes. It splits ownership by helper origin and route domain, marks `app.core.database.get_postgresql_session` as CRITICAL impact, and selects only `G2.294 no-source admin audit database_factory get_postgresql_session provider authorization` as the next candidate. PR `#446` must stop for human review and must not auto-merge.
+G2.293 is the no-source `get_postgresql_session` ownership / route-provider decision after PR `#445` merged G2.292 at `05cdf04f646d844c11e90e7c453ed4f985c8d382`. It merged by PR `#446` at `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`. It classifies `get_postgresql_session` as a cross-domain helper family with `9` direct helper occurrences across auth, admin audit, admin optimization, and market routes. It splits ownership by helper origin and route domain, marks `app.core.database.get_postgresql_session` as CRITICAL impact, and selects only `G2.294 no-source admin audit database_factory get_postgresql_session provider authorization` as the next candidate. It must not be used as source implementation authority.
+
+G2.294 is the no-source admin audit `database_factory.get_postgresql_session` provider authorization after PR `#446` merged G2.293 at `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`. It authorizes only a future G2.295 path-limited implementation lane for `web/backend/app/api/v1/admin/audit.py` after PR `#447` human acceptance. It records two active helper call sites, three audit routes, cleanup semantics, runtime/OpenAPI `548/500/0`, and GitNexus LOW risk with one affected execution process. PR `#447` must stop for human review and must not auto-merge.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-06-01T12:19:25+08:00`
-- Base HEAD checked: `05cdf04f646d844c11e90e7c453ed4f985c8d382`
+- Prepared at: `2026-06-01T13:02:37+08:00`
+- Base HEAD checked: `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -19,15 +19,16 @@ exact verification output.
 | Route/OpenAPI and control-plane governance | Established route table, OpenAPI exposure, health/probe taxonomy, and consumer-contract evidence as first-class governance facts | Continue through route/OpenAPI track, not ad hoc route edits |
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
-| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.292 accepted/merged by PR `#445` at `05cdf04` | Continue with G2.293 `get_postgresql_session` ownership / route-provider decision review; do not auto-merge because the family includes a CRITICAL shared database helper |
+| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.293 accepted/merged by PR `#446` at `a62d5e3` | Continue with G2.294 admin audit `database_factory.get_postgresql_session` provider authorization review; do not auto-merge because the package authorizes future backend source work |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
-| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.292 have progressed through PR `#337`-`#445`; current review target is G2.293 `get_postgresql_session` ownership / route-provider decision in future PR `#446` |
+| Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.293 have progressed through PR `#337`-`#446`; current review target is G2.294 admin audit provider authorization in future PR `#447` |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
 
 ## Recent Closeouts
 
 | Item | Accepted evidence | Follow-up |
 |---|---|---|
+| G2.293 `get_postgresql_session` ownership / route-provider decision | PR `#446` merged at `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`; helper family split across auth, admin audit, admin optimization, and market route modules; shared `app.core.database.get_postgresql_session` marked CRITICAL impact | G2.294 authorizes only the bounded admin audit `database_factory` subgroup and must stop at PR `#447` review |
 | G2.292 data_source_registry get_manager provider closeout | PR `#445` merged at `05cdf04f646d844c11e90e7c453ed4f985c8d382`; direct route-body `get_manager()` calls `0`, provider backing `1`, provider bindings `7`, runtime/OpenAPI `548/500/0` | G2.293 classifies `get_postgresql_session` ownership and splits future provider work by route domain/helper origin |
 | G2.291 data_source_registry get_manager provider implementation | PR `#444` merged at `3d161e90547720f4ce95111ea511d3f8dc3174dc`; direct route-body `get_manager()` calls `0`, provider bindings `7`, focused regression `3/3`, runtime/OpenAPI `548/500/0` | G2.292 closes the provider lane and selects only a no-source `get_postgresql_session` ownership decision |
 | G2.290 data_source_registry get_manager provider authorization | PR `#443` merged at `e517163385e96a6c7115e14b77fb89819b4cead4`; authorized only a path-limited G2.291 implementation lane | Superseded by the accepted/merged G2.291 provider implementation and G2.292 closeout review |

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-06-01T12:19:25+08:00`
-- Base HEAD checked: `05cdf04f646d844c11e90e7c453ed4f985c8d382`
+- Prepared at: `2026-06-01T13:02:37+08:00`
+- Base HEAD checked: `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.293 `get_postgresql_session` ownership / route-provider decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#445` merged at `05cdf04f646d844c11e90e7c453ed4f985c8d382`; G2.293 classifies `get_postgresql_session` as a cross-domain helper family with `9` direct helper occurrences across auth, admin audit, admin optimization, and market routes; `app.core.database.get_postgresql_session` has CRITICAL GitNexus impact | Review future PR `#446`; do not auto-merge because the family includes a CRITICAL shared core helper and only the bounded admin audit subgroup is selected for a future no-source authorization package |
+| P0 | Review G2.294 admin audit `database_factory.get_postgresql_session` provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#446` merged at `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`; G2.294 authorizes only a future path-limited admin audit provider implementation after human acceptance; no source is edited in this package | Review future PR `#447`; do not auto-merge because this package authorizes future backend source work and the selected helper participates in one affected execution process |
+| P0 | Preserve G2.293 `get_postgresql_session` ownership / route-provider decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#446` merged at `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`; G2.293 classified `get_postgresql_session` as a cross-domain helper family with `9` direct helper occurrences across auth, admin audit, admin optimization, and market routes; `app.core.database.get_postgresql_session` has CRITICAL GitNexus impact | Do not use G2.293 as source implementation authorization; use only the bounded G2.294 admin audit authorization package after review |
 | P0 | Preserve G2.292 `data_source_registry.get_manager` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#445` merged at `05cdf04f646d844c11e90e7c453ed4f985c8d382`; G2.292 closed the data-source registry provider lane with direct route-body `get_manager()` calls `0`, provider backing calls `1`, provider bindings `7`, focused regression `3 passed`, and runtime/OpenAPI `548/500/0` | Do not use G2.292 as source implementation authorization; use G2.293 only for no-source `get_postgresql_session` ownership / route-provider decision |
 | P0 | Preserve G2.291 `data_source_registry.get_manager` provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#444` merged at `3d161e90547720f4ce95111ea511d3f8dc3174dc`; G2.291 added route-local `get_data_source_registry_manager`, moved 7 target handlers to `Depends(...)`, kept `get_manager()` as compatibility/backing seam, and preserved runtime/OpenAPI `548/500/0` | Do not use G2.291 as authority for non-data-source-registry source edits, route/OpenAPI changes, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state |
 | P0 | Preserve G2.290 `data_source_registry.get_manager` provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#443` merged at `e517163385e96a6c7115e14b77fb89819b4cead4`; G2.290 authorized only the path-limited G2.291 source lane now represented by this worktree | Do not use G2.290 to expand scope beyond `web/backend/app/api/data_source_registry.py` plus focused data-source registry tests |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-06-01T12:19:25+08:00`
-- Base HEAD checked: `05cdf04f646d844c11e90e7c453ed4f985c8d382`
+- Prepared at: `2026-06-01T13:02:37+08:00`
+- Base HEAD checked: `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -16,9 +16,12 @@ state transition.
 
 | Evidence | Role | Freshness policy |
 |---|---|---|
-| `.planning/codebase/generated/postgresql-session-ownership-decision-2026-06-01.json` | G2.293 `get_postgresql_session` ownership / route-provider decision evidence | Review input for future PR `#446`; no-source package; must stop because the family includes CRITICAL GitNexus impact on `app.core.database.get_postgresql_session` |
-| `docs/reports/quality/backend-postgresql-session-ownership-decision-2026-06-01.md` | G2.293 human-readable ownership / route-provider decision report | Review input for future PR `#446`; records PR `#445` accepted/merged, call-site groups, route/OpenAPI smoke, GitNexus fallback, split decision, and stop rule |
-| `governance/mainline/task-cards/pr-446.yaml` | Governance task card for G2.293 no-source decision | Review input; allows only steward tree, generated evidence, report, and task card updates; no auto-merge because the target family includes CRITICAL impact |
+| `.planning/codebase/generated/admin-audit-postgresql-session-provider-authorization-2026-06-01.json` | G2.294 admin audit `database_factory.get_postgresql_session` provider authorization evidence | Review input for future PR `#447`; no-source authorization package; must stop because it authorizes future backend source work and the selected helper participates in one affected execution process |
+| `docs/reports/quality/backend-admin-audit-postgresql-session-provider-authorization-2026-06-01.md` | G2.294 human-readable provider authorization report | Review input for future PR `#447`; records PR `#446` accepted/merged, admin audit call sites, cleanup semantics, route/OpenAPI smoke, GitNexus fallback, and G2.295 source-lane envelope |
+| `governance/mainline/task-cards/pr-447.yaml` | Governance task card for G2.294 no-source authorization | Review input; allows only steward tree, generated evidence, report, and task card updates; no auto-merge because the package authorizes future backend source work |
+| `.planning/codebase/generated/postgresql-session-ownership-decision-2026-06-01.json` | G2.293 `get_postgresql_session` ownership / route-provider decision evidence | Accepted by PR `#446`, merged at `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`; no-source package; superseded for bounded admin audit authorization by G2.294 |
+| `docs/reports/quality/backend-postgresql-session-ownership-decision-2026-06-01.md` | G2.293 human-readable ownership / route-provider decision report | Accepted by PR `#446`; records PR `#445` accepted/merged, call-site groups, route/OpenAPI smoke, GitNexus fallback, split decision, and stop rule |
+| `governance/mainline/task-cards/pr-446.yaml` | Governance task card for G2.293 no-source decision | Accepted by PR `#446`; allowed only steward tree, generated evidence, report, and task card updates; no source implementation authority |
 | `.planning/codebase/generated/data-source-registry-provider-closeout-refresh-2026-06-01.json` | G2.292 `data_source_registry.get_manager` provider closeout / residual refresh evidence | Accepted by PR `#445`, merged at `05cdf04f646d844c11e90e7c453ed4f985c8d382`; no-source closeout package; superseded for next-gate decision by G2.293 |
 | `docs/reports/quality/backend-data-source-registry-provider-closeout-refresh-2026-06-01.md` | G2.292 human-readable provider closeout / residual refresh report | Accepted by PR `#445`; records PR `#444` accepted/merged, provider closeout, route/OpenAPI smoke, residual scan, and stop rule |
 | `governance/mainline/task-cards/pr-445.yaml` | Governance task card for G2.292 no-source closeout / residual refresh | Accepted by PR `#445`; allowed only steward tree, generated evidence, report, and task card updates |

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-06-01T12:19:25+08:00",
+  "generated_at": "2026-06-01T13:02:37+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "05cdf04f646d844c11e90e7c453ed4f985c8d382",
-  "split_branch": "g2-293-postgresql-session-ownership-decision",
-  "scope": "postgresql_session_ownership_decision",
+  "base_head": "a62d5e3fa4e9efbbe388e4bd317ae0cfae371319",
+  "split_branch": "g2-294-admin-audit-postgresql-session-provider-authorization",
+  "scope": "admin_audit_postgresql_session_provider_authorization",
   "source_edit_authority": false,
   "root_entrypoint": ".planning/codebase/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.md",
   "archived_full_snapshot": ".planning/codebase/steward-tree/archive/CODEBASE-MAP-OPENSPEC-TASK-TREE-2026-05-20.full-2026-05-27.md",
@@ -9596,7 +9596,7 @@
     {
       "id": "g2-293-postgresql-session-ownership-decision",
       "type": "ownership_decision",
-      "state": "for_review",
+      "state": "accepted_merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.292 data_source_registry get_manager provider closeout / residual refresh",
       "source_edit_authority": false,
@@ -9605,8 +9605,10 @@
       "github_pr": {
         "number": 446,
         "url": "https://github.com/chengjon/mystocks/pull/446",
-        "state": "PLANNED_FOR_REVIEW",
-        "head_ref": "g2-293-postgresql-session-ownership-decision"
+        "state": "MERGED",
+        "merged_at": "2026-06-01T04:43:16Z",
+        "head_ref": "g2-293-postgresql-session-ownership-decision",
+        "merge_commit": "a62d5e3fa4e9efbbe388e4bd317ae0cfae371319"
       },
       "evidence": [
         ".planning/codebase/generated/postgresql-session-ownership-decision-2026-06-01.json",
@@ -9693,7 +9695,7 @@
         "reason": "The full get_postgresql_session family includes CRITICAL shared core database impact. The admin audit subgroup is the only currently bounded LOW-impact helper-origin subgroup and should be authorized separately before any source lane."
       },
       "freshness": {
-        "current_head_checked": "05cdf04f646d844c11e90e7c453ed4f985c8d382",
+        "current_head_checked": "a62d5e3fa4e9efbbe388e4bd317ae0cfae371319",
         "stale_if_head_or_pr_state_changes": true,
         "stale_if_route_or_openapi_counts_change": true,
         "stale_if_auth_session_call_sites_change": true,
@@ -9702,7 +9704,125 @@
         "stale_if_market_request_call_sites_change": true,
         "stale_if_gitnexus_risk_changes": true
       },
-      "next_gate": "Stop for human review in PR #446. If accepted, start G2.294 no-source admin audit database_factory get_postgresql_session provider authorization."
+      "next_gate": "Superseded by G2.294 no-source admin audit database_factory get_postgresql_session provider authorization."
+    },
+    {
+      "id": "g2-294-admin-audit-postgresql-session-provider-authorization",
+      "type": "authorization_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.293 get_postgresql_session ownership / route-provider decision",
+      "source_edit_authority": false,
+      "autopilot_status": "stop_at_pr_review_gate",
+      "autopilot_stop_reason": "G2.294 authorizes future backend source work and the selected helper participates in one affected execution process",
+      "github_pr": {
+        "number": 447,
+        "url": "https://github.com/chengjon/mystocks/pull/447",
+        "state": "PLANNED_FOR_REVIEW",
+        "head_ref": "g2-294-admin-audit-postgresql-session-provider-authorization"
+      },
+      "evidence": [
+        ".planning/codebase/generated/admin-audit-postgresql-session-provider-authorization-2026-06-01.json",
+        "docs/reports/quality/backend-admin-audit-postgresql-session-provider-authorization-2026-06-01.md",
+        "governance/mainline/task-cards/pr-447.yaml"
+      ],
+      "closed_parent": {
+        "pr": 446,
+        "state": "MERGED",
+        "merge_commit": "a62d5e3fa4e9efbbe388e4bd317ae0cfae371319",
+        "merged_at": "2026-06-01T04:43:16Z"
+      },
+      "allowed_scope": [
+        ".planning/codebase/generated/admin-audit-postgresql-session-provider-authorization-2026-06-01.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-admin-audit-postgresql-session-provider-authorization-2026-06-01.md",
+        "governance/mainline/task-cards/pr-447.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "tests/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "surface": {
+        "target_file": "web/backend/app/api/v1/admin/audit.py",
+        "helper_origin": "app.core.database_factory.get_postgresql_session",
+        "direct_helper_occurrences": 2,
+        "effective_route_surface": 3,
+        "call_sites": [
+          {
+            "function": "_load_audit_logs",
+            "line": 225,
+            "cleanup_semantics": "session.close() in finally"
+          },
+          {
+            "function": "get_audit_statistics",
+            "line": 365,
+            "cleanup_semantics": "session.close() in finally"
+          }
+        ],
+        "route_openapi_smoke": {
+          "routes": 548,
+          "paths": 500,
+          "duplicate_operation_ids": 0,
+          "audit_routes": 3
+        }
+      },
+      "gitnexus_evidence": {
+        "mcp_impact": "tool call failed: Transport closed",
+        "cli_impact_database_factory": {
+          "risk": "LOW",
+          "impacted_count": 4,
+          "direct": 2,
+          "processes_affected": 1,
+          "modules_affected": 1,
+          "index_status": "stale warning"
+        },
+        "affected_process": "get_audit_statistics"
+      },
+      "decision": {
+        "classification": "bounded-admin-audit-database-factory-session-provider-authorization",
+        "source_lane_recommendation": "G2.295 path-limited admin audit database_factory get_postgresql_session provider implementation after PR #447 human acceptance",
+        "autopilot_continue_allowed": false,
+        "allowed_future_source_paths": [
+          "web/backend/app/api/v1/admin/audit.py"
+        ],
+        "allowed_future_test_paths": [
+          "web/backend/tests/test_v1_audit_regressions.py",
+          "web/backend/tests/test_v1_admin_exports.py"
+        ],
+        "forbidden_future_scope": [
+          "app.core.database.py",
+          "app.core.database_factory.py helper definitions",
+          "auth.py",
+          "admin/optimization.py",
+          "market/market_data_request.py",
+          "route registration changes",
+          "generated OpenAPI artifacts",
+          "frontend/config/scripts/OpenSpec/PM2/runtime state"
+        ]
+      },
+      "freshness": {
+        "current_head_checked": "a62d5e3fa4e9efbbe388e4bd317ae0cfae371319",
+        "stale_if_head_or_pr_state_changes": true,
+        "stale_if_route_or_openapi_counts_change": true,
+        "stale_if_admin_audit_call_sites_change": true,
+        "stale_if_gitnexus_risk_changes": true,
+        "stale_if_test_inventory_changes": true
+      },
+      "next_gate": "Stop for human review in PR #447. If accepted, start G2.295 path-limited admin audit database_factory get_postgresql_session provider implementation."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-06-01T11:08:00+08:00`
-- Base HEAD checked: `e517163385e96a6c7115e14b77fb89819b4cead4`
+- Prepared at: `2026-06-01T13:02:37+08:00`
+- Base HEAD checked: `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -3169,9 +3169,10 @@ Status: accepted/merged by PR `#445` at `05cdf04f646d844c11e90e7c453ed4f985c8d38
 
 ## G2.293 get_postgresql_session Ownership / Route-Provider Decision
 
-Status: for review in future PR `#446`.
+Status: accepted/merged by PR `#446`.
 
 - Parent PR `#445` merged at `05cdf04f646d844c11e90e7c453ed4f985c8d382`.
+- G2.293 PR `#446` merged at `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`.
 - G2.293 is a no-source ownership / route-provider decision package. It does not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
 - It classifies `get_postgresql_session` as a cross-domain helper family, not a single implementation target.
 - Current scan records `9` direct helper occurrences across `auth.py`, `v1/admin/audit.py`, `v1/admin/optimization.py`, and `market/market_data_request.py`; effective OpenAPI endpoint surface is `12`.
@@ -3180,4 +3181,18 @@ Status: for review in future PR `#446`.
 - Route/OpenAPI smoke remains `548` routes, `500` paths, duplicate operation IDs `0`.
 - Decision: do not modify shared helper definitions; split future route-provider work by route domain/helper origin.
 - Recommended next gate after human acceptance and merge: G2.294 no-source admin audit database_factory `get_postgresql_session` provider authorization.
-- Stop rule: PR `#446` must stop for human review because the target family includes CRITICAL GitNexus impact.
+- Stop rule satisfied by PR `#446` human review and merge; G2.293 must not be used as source implementation authorization.
+
+## G2.294 Admin Audit PostgreSQL Session Provider Authorization
+
+Status: for review in future PR `#447`.
+
+- Parent PR `#446` merged at `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`.
+- G2.294 is a no-source authorization package. It does not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+- Target scope is only `web/backend/app/api/v1/admin/audit.py`, helper origin `app.core.database_factory.get_postgresql_session`.
+- Current scan records `2` direct helper occurrences: `_load_audit_logs` and `get_audit_statistics`.
+- Current cleanup semantics use `session.close()` in `finally` for both helper paths; any future implementation must preserve equivalent cleanup lifecycle.
+- Route/OpenAPI smoke remains `548` routes, `500` paths, duplicate operation IDs `0`, with `3` admin audit routes in schema.
+- GitNexus MCP returned `Transport closed`; CLI fallback reports LOW risk, `4` impacted symbols, `2` direct callers, `1` affected process, and `1` affected module for `Function:web/backend/app/core/database_factory.py:get_postgresql_session`.
+- Decision: authorize only a future G2.295 path-limited admin audit provider implementation after PR `#447` human acceptance.
+- Stop rule: PR `#447` must stop for human review because it authorizes future backend source work and the selected helper participates in one affected execution process.

--- a/docs/reports/quality/backend-admin-audit-postgresql-session-provider-authorization-2026-06-01.md
+++ b/docs/reports/quality/backend-admin-audit-postgresql-session-provider-authorization-2026-06-01.md
@@ -1,0 +1,162 @@
+# Backend Admin Audit PostgreSQL Session Provider Authorization
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: for review in future PR `#447`
+- Prepared at: `2026-06-01T13:02:37+08:00`
+- Base branch: `wip/root-dirty-20260403`
+- Current HEAD checked: `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`
+- Parent: G2.293 `get_postgresql_session` ownership / route-provider decision
+- Parent PR: `#446`, merged at `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`
+
+This is a no-source authorization package. It does not edit backend source,
+tests, route contracts, docs/api artifacts, frontend, config, scripts,
+OpenSpec, PM2, or runtime state.
+
+Because it authorizes a future backend source implementation lane and the
+selected helper participates in one affected execution process, PR `#447` must
+stop for human review. It must not auto-merge.
+
+## Target
+
+G2.293 split the broader `get_postgresql_session` family by route domain and
+helper origin. G2.294 selects only the bounded admin audit subgroup that imports
+`get_postgresql_session` from `app.core.database_factory`.
+
+| Item | Value |
+|---|---|
+| Target file | `web/backend/app/api/v1/admin/audit.py` |
+| Helper origin | `app.core.database_factory.get_postgresql_session` |
+| Direct helper occurrences | `2` |
+| Effective exposed route surface | `3` |
+| Candidate future lane | G2.295 path-limited admin audit provider implementation |
+
+## Current Call Sites
+
+| Function | Line | Route handler | Current cleanup semantics | Future handling |
+|---|---:|---|---|---|
+| `_load_audit_logs` | `225` | No, helper used by `list_audit_logs` and `get_audit_log` | `session.close()` in `finally` | Future provider lane must preserve equivalent cleanup lifecycle |
+| `get_audit_statistics` | `365` | Yes | `session.close()` in `finally` | Future provider lane must preserve equivalent cleanup lifecycle |
+
+The current source shape means the future implementation cannot be a blind
+parameter rewrite. It must preserve the helper-function path used by
+`list_audit_logs` and `get_audit_log`, not only the direct route handler
+`get_audit_statistics`.
+
+## Route / OpenAPI Smoke
+
+Current smoke evidence:
+
+```json
+{
+  "routes": 548,
+  "paths": 500,
+  "duplicate_operation_ids": 0,
+  "audit_routes": [
+    {
+      "path": "/api/v1/audit/logs",
+      "methods": ["GET"],
+      "endpoint": "list_audit_logs",
+      "include_in_schema": true
+    },
+    {
+      "path": "/api/v1/audit/logs/{log_id}",
+      "methods": ["GET"],
+      "endpoint": "get_audit_log",
+      "include_in_schema": true
+    },
+    {
+      "path": "/api/v1/audit/statistics",
+      "methods": ["GET"],
+      "endpoint": "get_audit_statistics",
+      "include_in_schema": true
+    }
+  ]
+}
+```
+
+Any future implementation must keep these route paths, methods,
+`include_in_schema` values, response models, and response contracts stable.
+
+## GitNexus Evidence
+
+GitNexus MCP impact failed with the known `Transport closed` tool issue. CLI
+fallback was used.
+
+| Target | Risk | Impacted | Direct | Processes affected | Modules affected | Index status |
+|---|---|---:|---:|---:|---:|---|
+| `Function:web/backend/app/core/database_factory.py:get_postgresql_session` | LOW | `4` | `2` | `1` | `1` | stale warning, `commits_behind=0` |
+
+Affected process:
+
+| Process | File | Earliest affected step |
+|---|---|---:|
+| `get_audit_statistics` | `web/backend/app/api/v1/admin/audit.py` | `1` |
+
+Query fallback also matched the primary admin audit process
+`proc_22_get_audit_statistics` and the symbols
+`_load_audit_logs` / `get_audit_statistics` in
+`web/backend/app/api/v1/admin/audit.py`.
+
+## Authorization Decision
+
+Decision: authorize only a future G2.295 path-limited source lane after human
+acceptance of this no-source G2.294 package.
+
+Allowed future source scope:
+
+- `web/backend/app/api/v1/admin/audit.py`
+
+Allowed future focused test scope:
+
+- `web/backend/tests/test_v1_audit_regressions.py`
+- `web/backend/tests/test_v1_admin_exports.py`
+
+Required future implementation shape:
+
+- Add or use a route-local provider dependency for the admin audit
+  `database_factory` PostgreSQL session.
+- Move only the admin audit helper uses behind dependency/provider wiring.
+- Preserve existing `session.close()` cleanup semantics for both
+  `_load_audit_logs` and `get_audit_statistics`.
+- Keep route paths, methods, response models, OpenAPI exposure, and response
+  contracts unchanged.
+- Run focused audit regression/export tests and route/OpenAPI smoke before any
+  implementation PR is reviewed.
+
+Forbidden future scope:
+
+- `web/backend/app/core/database.py`
+- `web/backend/app/core/database_factory.py` helper definitions
+- `web/backend/app/api/auth.py`
+- `web/backend/app/api/v1/admin/optimization.py`
+- `web/backend/app/api/market/market_data_request.py`
+- route registration changes
+- generated OpenAPI artifacts
+- docs/api artifacts
+- frontend/config/scripts/OpenSpec/PM2/runtime state
+
+## Stop Rule
+
+PR `#447` must stop for human review before merge.
+
+Reason: G2.294 is no-source, but it authorizes future backend source work and
+the selected helper participates in one affected execution process. The next
+step must be an explicit human decision: either accept the G2.295
+path-limited implementation lane or keep the subgroup deferred.
+
+## Evidence
+
+- `.planning/codebase/generated/admin-audit-postgresql-session-provider-authorization-2026-06-01.json`
+- `.planning/codebase/steward-tree/steward-index.json`
+- `.planning/codebase/steward-tree/current-next-gates.md`
+- `.planning/codebase/steward-tree/tracks/service-lifecycle-di.md`
+- `.planning/codebase/steward-tree/branch-register.md`
+- `.planning/codebase/steward-tree/evidence-index.md`
+- `.planning/codebase/steward-tree/completed-ledger.md`
+- `governance/mainline/task-cards/pr-447.yaml`
+
+Freshness policy: stale if HEAD, PR state, route/OpenAPI counts, admin audit
+call sites, focused test inventory, or GitNexus risk changes.

--- a/governance/mainline/task-cards/pr-447.yaml
+++ b/governance/mainline/task-cards/pr-447.yaml
@@ -1,0 +1,137 @@
+version: "v0.2"
+
+task:
+  id: "pr-447"
+  title: "Authorize admin audit PostgreSQL session provider lane"
+  owner: "codex"
+  created_at: "2026-06-01"
+
+mainline:
+  id: "L1-admin-audit-postgresql-session-provider-authorization"
+  objective: "authorize a future path-limited admin audit database_factory get_postgresql_session provider implementation without editing source"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "G2.294 is a no-source authorization package. It changes no runtime entrypoint, route path, route registration, generated OpenAPI artifact, frontend route, or FUNCTION_TREE catalog entry."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/admin-audit-postgresql-session-provider-authorization-2026-06-01.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-admin-audit-postgresql-session-provider-authorization-2026-06-01.md"
+    - "governance/mainline/task-cards/pr-447.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits"
+  - "test edits"
+  - "route registration changes"
+  - "route path, method, response model, or generated OpenAPI artifact changes"
+  - "docs/api artifact edits"
+  - "frontend/config/script changes"
+  - "OpenSpec proposal or spec edits"
+  - "PM2 commands or stateful runtime gates"
+  - "source retirement"
+  - "immediate implementation of admin audit provider injection"
+  - "modification of app.core.database.py or app.core.database_factory.py helper definitions"
+  - "migration of auth, admin optimization, or market request get_postgresql_session call sites"
+
+acceptance:
+  checks:
+    - id: "pr446-merged"
+      command: "gh pr view 446 confirms MERGED at a62d5e3fa4e9efbbe388e4bd317ae0cfae371319"
+      required: true
+    - id: "admin-audit-call-site-inventory"
+      command: "current scan records 2 direct app.core.database_factory get_postgresql_session occurrences in web/backend/app/api/v1/admin/audit.py at _load_audit_logs and get_audit_statistics"
+      required: true
+    - id: "cleanup-semantics"
+      command: "current scan records both admin audit helper paths close sessions through session.close() in finally blocks; future implementation must preserve equivalent cleanup lifecycle"
+      required: true
+    - id: "route-openapi-smoke"
+      command: "app.main route/OpenAPI smoke records 548 routes, 500 paths, duplicate operation IDs 0, and 3 admin audit runtime/OpenAPI routes"
+      required: true
+    - id: "gitnexus-impact"
+      command: "GitNexus MCP returned Transport closed; CLI impact records LOW risk, 4 impacted symbols, 2 direct callers, 1 affected process, and 1 affected module for Function:web/backend/app/core/database_factory.py:get_postgresql_session"
+      required: true
+    - id: "authorization-boundary"
+      command: "G2.294 authorizes only a future G2.295 path-limited source lane after human acceptance; PR #447 itself edits no source"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-admin-audit-postgresql-session-provider-authorization-2026-06-01.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-447.yaml --base-sha a62d5e3fa4e9efbbe388e4bd317ae0cfae371319 --head-sha HEAD --report /tmp/pr447-mainline-governance-report.json"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "gitnexus-detect-changes"
+      command: "GitNexus staged verification attempted before commit; stale-index warning recorded if present"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "A future worker may treat this authorization as immediate source authority; this package requires human acceptance before G2.295 can start."
+    - "The selected helper has LOW GitNexus risk but participates in one affected execution process, so PR #447 must stop for review."
+    - "The current admin audit code closes sessions manually in finally blocks; any future provider implementation must preserve cleanup semantics."
+    - "GitNexus index is stale; current route/helper scan is the source for active admin audit call-site counts."
+  rollback_plan: "Revert PR #447; this removes only governance evidence and restores the previous steward tree state."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Authorize a future path-limited admin audit database_factory get_postgresql_session provider lane."
+    modified_scope: "Governance evidence, steward tree indexes, human-readable report, and task card only."
+    dependency_changes: "No dependency changes."
+    legacy_logic_impact: "No runtime, route, OpenAPI, frontend, config, script, or OpenSpec changes."
+    rollback_ready: "Revert PR #447."
+    risk_and_rollback_point: "No-source authorization, but future source work must preserve session cleanup and stop for human review."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-01T13:02:37+08:00"
+    approval_note: "Human maintainer approved continuing after PR #446 merge into G2.294 no-source admin audit database_factory get_postgresql_session provider authorization. PR #447 must stop for review because it authorizes future backend source implementation and the selected helper participates in one affected execution process."
+    secondary_approved: false


### PR DESCRIPTION
# Backend Admin Audit PostgreSQL Session Provider Authorization

> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。

## Status

- Status: for review in future PR `#447`
- Prepared at: `2026-06-01T13:02:37+08:00`
- Base branch: `wip/root-dirty-20260403`
- Current HEAD checked: `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`
- Parent: G2.293 `get_postgresql_session` ownership / route-provider decision
- Parent PR: `#446`, merged at `a62d5e3fa4e9efbbe388e4bd317ae0cfae371319`

This is a no-source authorization package. It does not edit backend source,
tests, route contracts, docs/api artifacts, frontend, config, scripts,
OpenSpec, PM2, or runtime state.

Because it authorizes a future backend source implementation lane and the
selected helper participates in one affected execution process, PR `#447` must
stop for human review. It must not auto-merge.

## Target

G2.293 split the broader `get_postgresql_session` family by route domain and
helper origin. G2.294 selects only the bounded admin audit subgroup that imports
`get_postgresql_session` from `app.core.database_factory`.

| Item | Value |
|---|---|
| Target file | `web/backend/app/api/v1/admin/audit.py` |
| Helper origin | `app.core.database_factory.get_postgresql_session` |
| Direct helper occurrences | `2` |
| Effective exposed route surface | `3` |
| Candidate future lane | G2.295 path-limited admin audit provider implementation |

## Current Call Sites

| Function | Line | Route handler | Current cleanup semantics | Future handling |
|---|---:|---|---|---|
| `_load_audit_logs` | `225` | No, helper used by `list_audit_logs` and `get_audit_log` | `session.close()` in `finally` | Future provider lane must preserve equivalent cleanup lifecycle |
| `get_audit_statistics` | `365` | Yes | `session.close()` in `finally` | Future provider lane must preserve equivalent cleanup lifecycle |

The current source shape means the future implementation cannot be a blind
parameter rewrite. It must preserve the helper-function path used by
`list_audit_logs` and `get_audit_log`, not only the direct route handler
`get_audit_statistics`.

## Route / OpenAPI Smoke

Current smoke evidence:

```json
{
  "routes": 548,
  "paths": 500,
  "duplicate_operation_ids": 0,
  "audit_routes": [
    {
      "path": "/api/v1/audit/logs",
      "methods": ["GET"],
      "endpoint": "list_audit_logs",
      "include_in_schema": true
    },
    {
      "path": "/api/v1/audit/logs/{log_id}",
      "methods": ["GET"],
      "endpoint": "get_audit_log",
      "include_in_schema": true
    },
    {
      "path": "/api/v1/audit/statistics",
      "methods": ["GET"],
      "endpoint": "get_audit_statistics",
      "include_in_schema": true
    }
  ]
}
```

Any future implementation must keep these route paths, methods,
`include_in_schema` values, response models, and response contracts stable.

## GitNexus Evidence

GitNexus MCP impact failed with the known `Transport closed` tool issue. CLI
fallback was used.

| Target | Risk | Impacted | Direct | Processes affected | Modules affected | Index status |
|---|---|---:|---:|---:|---:|---|
| `Function:web/backend/app/core/database_factory.py:get_postgresql_session` | LOW | `4` | `2` | `1` | `1` | stale warning, `commits_behind=0` |

Affected process:

| Process | File | Earliest affected step |
|---|---|---:|
| `get_audit_statistics` | `web/backend/app/api/v1/admin/audit.py` | `1` |

Query fallback also matched the primary admin audit process
`proc_22_get_audit_statistics` and the symbols
`_load_audit_logs` / `get_audit_statistics` in
`web/backend/app/api/v1/admin/audit.py`.

## Authorization Decision

Decision: authorize only a future G2.295 path-limited source lane after human
acceptance of this no-source G2.294 package.

Allowed future source scope:

- `web/backend/app/api/v1/admin/audit.py`

Allowed future focused test scope:

- `web/backend/tests/test_v1_audit_regressions.py`
- `web/backend/tests/test_v1_admin_exports.py`

Required future implementation shape:

- Add or use a route-local provider dependency for the admin audit
  `database_factory` PostgreSQL session.
- Move only the admin audit helper uses behind dependency/provider wiring.
- Preserve existing `session.close()` cleanup semantics for both
  `_load_audit_logs` and `get_audit_statistics`.
- Keep route paths, methods, response models, OpenAPI exposure, and response
  contracts unchanged.
- Run focused audit regression/export tests and route/OpenAPI smoke before any
  implementation PR is reviewed.

Forbidden future scope:

- `web/backend/app/core/database.py`
- `web/backend/app/core/database_factory.py` helper definitions
- `web/backend/app/api/auth.py`
- `web/backend/app/api/v1/admin/optimization.py`
- `web/backend/app/api/market/market_data_request.py`
- route registration changes
- generated OpenAPI artifacts
- docs/api artifacts
- frontend/config/scripts/OpenSpec/PM2/runtime state

## Stop Rule

PR `#447` must stop for human review before merge.

Reason: G2.294 is no-source, but it authorizes future backend source work and
the selected helper participates in one affected execution process. The next
step must be an explicit human decision: either accept the G2.295
path-limited implementation lane or keep the subgroup deferred.

## Evidence

- `.planning/codebase/generated/admin-audit-postgresql-session-provider-authorization-2026-06-01.json`
- `.planning/codebase/steward-tree/steward-index.json`
- `.planning/codebase/steward-tree/current-next-gates.md`
- `.planning/codebase/steward-tree/tracks/service-lifecycle-di.md`
- `.planning/codebase/steward-tree/branch-register.md`
- `.planning/codebase/steward-tree/evidence-index.md`
- `.planning/codebase/steward-tree/completed-ledger.md`
- `governance/mainline/task-cards/pr-447.yaml`

Freshness policy: stale if HEAD, PR state, route/OpenAPI counts, admin audit
call sites, focused test inventory, or GitNexus risk changes.
