### PR TITLE
docs(governance): authorize auth session provider lane

### DIFF
--- a/.planning/codebase/generated/auth-postgresql-session-provider-authorization-2026-06-01.json
+++ b/.planning/codebase/generated/auth-postgresql-session-provider-authorization-2026-06-01.json
@@ -1,0 +1,183 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-01T21:10:00+08:00",
+  "g_node": "G2.306",
+  "title": "Auth.py get_postgresql_session provider authorization",
+  "branch": "g2-306-auth-postgresql-session-provider-authorization",
+  "parent_pr": {
+    "number": 458,
+    "url": "https://github.com/chengjon/mystocks/pull/458",
+    "state": "MERGED",
+    "merged_at": "2026-06-01T12:58:10Z",
+    "merge_commit": "8a6cfa615f472f23643a13ab18ab02dd0853ad96",
+    "head_ref": "g2-305-auth-postgresql-session-ownership-decision"
+  },
+  "base_head": "8a6cfa615f472f23643a13ab18ab02dd0853ad96",
+  "source_edit_authority": false,
+  "authorizes_future_source_lane": true,
+  "future_source_lane": {
+    "g_node": "G2.307",
+    "kind": "path-limited source implementation",
+    "human_review_required_before_merge": true,
+    "allowed_source_paths": [
+      "web/backend/app/api/auth.py"
+    ],
+    "allowed_test_paths": [
+      "web/backend/tests/test_auth.py",
+      "web/backend/tests/test_auth_login_contract.py"
+    ],
+    "required_source_shape": [
+      "add a route-local auth PostgreSQL session factory provider",
+      "inject the provider into get_users",
+      "inject the provider into register_user",
+      "inject the provider into request_password_reset",
+      "inject the provider into confirm_password_reset",
+      "replace direct route-body get_postgresql_session() calls with the injected factory",
+      "preserve session.close() in finally for all four affected handlers",
+      "preserve confirm_password_reset commit/rollback semantics"
+    ],
+    "forbidden_source_scope": [
+      "app.core.database.get_postgresql_session definition edits",
+      "login/logout/me/refresh/csrf handler changes",
+      "route path or method changes",
+      "response model changes",
+      "OpenAPI include_in_schema changes",
+      "docs/api artifact edits",
+      "frontend/config/script edits",
+      "PM2 or stateful runtime commands"
+    ]
+  },
+  "allowed_scope": [
+    ".planning/codebase/generated/auth-postgresql-session-provider-authorization-2026-06-01.json",
+    ".planning/codebase/steward-tree/current-next-gates.md",
+    ".planning/codebase/steward-tree/steward-index.json",
+    ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+    ".planning/codebase/steward-tree/branch-register.md",
+    ".planning/codebase/steward-tree/evidence-index.md",
+    ".planning/codebase/steward-tree/completed-ledger.md",
+    "docs/reports/quality/backend-auth-postgresql-session-provider-authorization-2026-06-01.md",
+    "governance/mainline/task-cards/pr-459.yaml"
+  ],
+  "forbidden_scope_this_pr": [
+    "web/backend/**",
+    "web/frontend/**",
+    "src/**",
+    "tests/**",
+    "docs/api/**",
+    "docs/FUNCTION_TREE.md",
+    "governance/function-tree/catalog.yaml",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**",
+    "PM2/runtime state"
+  ],
+  "current_surface": {
+    "file": "web/backend/app/api/auth.py",
+    "helper_origin": "app.core.database.get_postgresql_session",
+    "direct_calls": 4,
+    "import_lines": 4,
+    "affected_handlers": [
+      {
+        "function": "get_users",
+        "import_line": 195,
+        "call_line": 199,
+        "cleanup": "session.close() in finally"
+      },
+      {
+        "function": "register_user",
+        "import_line": 377,
+        "call_line": 387,
+        "cleanup": "session.close() in finally"
+      },
+      {
+        "function": "request_password_reset",
+        "import_line": 503,
+        "call_line": 509,
+        "cleanup": "session.close() in finally"
+      },
+      {
+        "function": "confirm_password_reset",
+        "import_line": 607,
+        "call_line": 649,
+        "cleanup": "session.close() in finally plus commit/rollback semantics"
+      }
+    ]
+  },
+  "verification": {
+    "focused_auth_tests": "web/backend/tests/test_auth.py web/backend/tests/test_auth_login_contract.py: 10 passed, 18 skipped in 12.48s",
+    "route_openapi": {
+      "runtime_routes": 548,
+      "openapi_paths": 500,
+      "duplicate_operation_ids": 0,
+      "warning_count": 119,
+      "note": "Smoke used non-secret test-only environment values and did not start PM2."
+    },
+    "ruff_no_fix": {
+      "status": "existing_findings_retained",
+      "count": 6,
+      "findings": [
+        "F401 app.core.security.verify_token imported but unused",
+        "F401 app.api._auth_responses._success_response_spec imported but unused",
+        "F401 app.api._auth_responses._error_response_spec imported but unused",
+        "F401 app.api._auth_helpers.security imported but unused",
+        "F401 app.api._auth_helpers.get_current_active_user imported but unused",
+        "F811 redefinition of unused verify_token from line 26"
+      ],
+      "note": "Not fixed in G2.306 because this package is no-source."
+    }
+  },
+  "gitnexus_evidence": {
+    "mcp_impact": "Transport closed",
+    "cli_impact_samples": {
+      "Function:web/backend/app/core/database.py:get_postgresql_session": {
+        "risk": "CRITICAL",
+        "direct": 15,
+        "processes_affected": 54,
+        "modules_affected": 8,
+        "index_status": "stale warning"
+      },
+      "get_users": {
+        "risk": "UNKNOWN",
+        "index_status": "stale warning"
+      },
+      "register_user": {
+        "risk": "LOW",
+        "direct": 0,
+        "processes_affected": 0,
+        "modules_affected": 0,
+        "index_status": "stale warning"
+      },
+      "request_password_reset": {
+        "risk": "LOW",
+        "direct": 0,
+        "processes_affected": 0,
+        "modules_affected": 0,
+        "index_status": "stale warning"
+      },
+      "confirm_password_reset": {
+        "risk": "LOW",
+        "direct": 0,
+        "processes_affected": 0,
+        "modules_affected": 0,
+        "index_status": "stale warning"
+      }
+    }
+  },
+  "decision": {
+    "classification": "auth-route-domain-provider-authorization-inside-critical-shared-helper-family",
+    "source_lane_authorized_by_this_pr": false,
+    "future_source_lane_authorized_after_acceptance": "G2.307 path-limited auth provider implementation",
+    "autopilot_continue_allowed_for_this_pr": true,
+    "autopilot_stop_after_merge": "Stop before G2.307 source PR merge; human review required for implementation.",
+    "recommended_next_work_item": "G2.307 path-limited auth.py PostgreSQL session provider implementation after PR #459 acceptance"
+  },
+  "freshness": {
+    "current_head_checked": "8a6cfa615f472f23643a13ab18ab02dd0853ad96",
+    "stale_if_head_or_pr_state_changes": true,
+    "stale_if_auth_session_call_sites_change": true,
+    "stale_if_route_or_openapi_counts_change": true,
+    "stale_if_auth_tests_change": true,
+    "stale_if_gitnexus_risk_changes": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-06-01T18:20:26+08:00`
-- Base HEAD checked: `3d89c7e64a93c7f2ca074dc502762ad203f15bdc`
+- Prepared at: `2026-06-01T21:10:00+08:00`
+- Base HEAD checked: `8a6cfa615f472f23643a13ab18ab02dd0853ad96`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -274,3 +274,5 @@ G2.303 is the path-limited admin optimization PostgreSQL session provider implem
 G2.304 is the no-source admin optimization PostgreSQL session provider closeout / residual refresh after PR `#456` merged G2.303 at `1cc89b285cd265bce96991b8dc4c7e8bd71d85d0`. It records admin optimization helper-body direct `get_postgresql_session()` calls `0`, provider backing calls `1`, `Depends` bindings `4`, focused optimization regression `7/7`, ruff clean, runtime/OpenAPI `548/500/0`, and remaining active direct residuals concentrated in `web/backend/app/api/auth.py` with `4` calls. It selects only `G2.305 no-source auth.py get_postgresql_session ownership / provider-shape decision`; it must not edit auth source or shared helper definitions.
 
 G2.305 is the no-source auth.py `get_postgresql_session` ownership / provider-shape decision after PR `#457` merged G2.304 at `d8e52a3b0000426a9ce278c5dbc1c4bbd8c6b4f9`. It records four active auth residual calls across `get_users`, `register_user`, `request_password_reset`, and `confirm_password_reset`, focused auth tests `10 passed / 18 skipped`, route/OpenAPI `548/500/0`, and existing ruff no-fix findings `6`. It selects only G2.306 no-source auth provider authorization and must not authorize auth source edits.
+
+G2.306 is the no-source auth.py `get_postgresql_session` provider authorization after PR `#458` merged G2.305 at `8a6cfa615f472f23643a13ab18ab02dd0853ad96`. It authorizes only a future G2.307 path-limited source lane for `web/backend/app/api/auth.py` plus focused auth tests, requiring a route-local auth PostgreSQL session factory provider, injection into the four affected handlers, preservation of close/finally cleanup, and preservation of `confirm_password_reset` commit/rollback semantics. It records focused auth tests `10 passed / 18 skipped`, route/OpenAPI `548/500/0`, ruff no-fix findings `6`, and shared helper GitNexus CLI impact `CRITICAL` with `15` direct dependants and `54` affected processes. It must not edit source in PR `#459`, and G2.307 must stop at human review before merge.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-06-01T19:28:21+08:00`
-- Base HEAD checked: `13a81aec15fc8e98e7e4e927abe6d27e3e16f93d`
+- Prepared at: `2026-06-01T21:10:00+08:00`
+- Base HEAD checked: `8a6cfa615f472f23643a13ab18ab02dd0853ad96`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -19,7 +19,7 @@ exact verification output.
 | Route/OpenAPI and control-plane governance | Established route table, OpenAPI exposure, health/probe taxonomy, and consumer-contract evidence as first-class governance facts | Continue through route/OpenAPI track, not ad hoc route edits |
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
-| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.301 accepted/merged by PR `#454` at `13a81aec` | Continue with G2.302 admin optimization provider authorization; do not auto-merge because it authorizes future source/test edits under the CRITICAL shared-helper-family target |
+| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.305 accepted/merged by PR `#458` at `8a6cfa61` | Continue with G2.306 auth provider authorization; future G2.307 source implementation must stop at human review |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
 | Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.301 have progressed through PR `#337`-`#454`; current review target is G2.302 admin optimization provider authorization in future PR `#455` |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
@@ -28,6 +28,7 @@ exact verification output.
 
 | Item | Accepted evidence | Follow-up |
 |---|---|---|
+| G2.305 auth.py PostgreSQL session ownership / provider-shape decision | PR `#458` merged at `8a6cfa615f472f23643a13ab18ab02dd0853ad96`; generated decision evidence records auth direct calls `4`, focused auth tests `10 passed / 18 skipped`, route/OpenAPI `548/500/0`, and existing ruff no-fix findings `6` | G2.306 no-source authorization may authorize only a bounded future G2.307 auth provider implementation |
 | G2.304 admin optimization provider closeout / residual refresh | PR `#457` merged at `d8e52a3b0000426a9ce278c5dbc1c4bbd8c6b4f9`; generated closeout evidence records admin optimization helper direct calls `0`, provider backing `1`, dependency bindings `4`, focused test `7/7`, route/OpenAPI `548/500/0`, and remaining auth direct calls `4` | G2.305 no-source auth ownership / provider-shape decision records auth surface and selects only no-source authorization |
 | G2.303 admin optimization PostgreSQL session provider implementation | PR `#456` merged at `1cc89b285cd265bce96991b8dc4c7e8bd71d85d0`; generated implementation evidence records provider `get_admin_optimization_postgresql_session_factory`, four dependency bindings, helper direct calls `0`, provider backing `1`, focused test `7/7`, and route/OpenAPI `548/500/0` | G2.304 no-source closeout / residual refresh records admin optimization closure and selects the next no-source auth ownership decision |
 | G2.302 admin optimization PostgreSQL session provider authorization | Generated authorization evidence records PR `#454` merged at `13a81aec15fc8e98e7e4e927abe6d27e3e16f93d`, future G2.303 scope limited to `optimization.py` and focused optimization tests, route/OpenAPI `548/500/0`, focused test `5/5`, and CRITICAL shared helper-family risk | G2.303 may only start as path-limited source implementation after PR `#455` human acceptance |

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-06-01T19:28:21+08:00`
-- Base HEAD checked: `13a81aec15fc8e98e7e4e927abe6d27e3e16f93d`
+- Prepared at: `2026-06-01T21:10:00+08:00`
+- Base HEAD checked: `8a6cfa615f472f23643a13ab18ab02dd0853ad96`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.305 auth.py `get_postgresql_session` ownership / provider-shape decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#457` merged at `d8e52a3b0000426a9ce278c5dbc1c4bbd8c6b4f9`; G2.305 classifies four active auth direct calls across `get_users`, `register_user`, `request_password_reset`, and `confirm_password_reset`, focused auth tests `10 passed / 18 skipped`, route/OpenAPI `548/500/0` | Review future PR `#458`; no source work is authorized, next gate is only G2.306 no-source auth provider authorization |
+| P0 | Review G2.306 auth.py `get_postgresql_session` provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#458` merged at `8a6cfa615f472f23643a13ab18ab02dd0853ad96`; G2.306 authorizes only a future path-limited G2.307 auth provider implementation after PR `#459` acceptance; current auth residuals remain `4`, focused auth tests `10 passed / 18 skipped`, route/OpenAPI `548/500/0` | Review future PR `#459`; if accepted, open G2.307 source implementation PR and stop it at human review before merge |
+| P0 | Preserve G2.305 auth.py `get_postgresql_session` ownership / provider-shape decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#458` merged at `8a6cfa615f472f23643a13ab18ab02dd0853ad96`; G2.305 classified four active auth direct calls across `get_users`, `register_user`, `request_password_reset`, and `confirm_password_reset`, focused auth tests `10 passed / 18 skipped`, route/OpenAPI `548/500/0` | Do not use G2.305 as source implementation authority; use G2.306 only as no-source authorization package |
 | P0 | Preserve G2.304 admin optimization provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#457` merged at `d8e52a3b0000426a9ce278c5dbc1c4bbd8c6b4f9`; G2.304 closed admin optimization with helper direct calls `0`, provider backing `1`, `Depends` bindings `4`, focused tests `7 passed`, route/OpenAPI `548/500/0`, and remaining active direct residuals concentrated in `auth.py` `4` | Do not use G2.304 as source implementation authority; use G2.305 only as no-source auth ownership decision |
 | P0 | Preserve G2.303 admin optimization PostgreSQL session provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#456` merged at `1cc89b285cd265bce96991b8dc4c7e8bd71d85d0`; G2.303 moved four admin optimization handlers to `Depends(get_admin_optimization_postgresql_session_factory)`, preserved cleanup, recorded focused tests `7 passed`, ruff clean, provider scan `4/1/0`, and route/OpenAPI `548/500/0` | Do not use G2.303 as authority for shared helper definitions, auth, market, admin audit, route contracts, docs/api, frontend, config, scripts, OpenSpec, PM2, or runtime state |
 | P0 | Preserve G2.302 admin optimization PostgreSQL session provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#455` merged at `4af141da7411d30b31b972ace51d104ae28606ed`; G2.302 authorized only the path-limited G2.303 implementation lane for `optimization.py` and focused optimization tests | Do not use G2.302 to expand into shared helper definitions, auth, market, admin audit, route contracts, docs/api, frontend, config, scripts, OpenSpec, PM2, or runtime state |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-06-01T19:28:21+08:00`
-- Base HEAD checked: `13a81aec15fc8e98e7e4e927abe6d27e3e16f93d`
+- Prepared at: `2026-06-01T21:10:00+08:00`
+- Base HEAD checked: `8a6cfa615f472f23643a13ab18ab02dd0853ad96`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -16,6 +16,9 @@ state transition.
 
 | Evidence | Role | Freshness policy |
 |---|---|---|
+| `.planning/codebase/generated/auth-postgresql-session-provider-authorization-2026-06-01.json` | G2.306 auth.py PostgreSQL session provider authorization evidence | Review input for future PR `#459`; no-source authorization package; authorizes only future G2.307 path-limited source implementation and requires human review before source PR merge |
+| `docs/reports/quality/backend-auth-postgresql-session-provider-authorization-2026-06-01.md` | G2.306 human-readable authorization report | Review input for future PR `#459`; records PR `#458` accepted/merged, auth call surface, focused tests, route/OpenAPI smoke, ruff no-fix findings, GitNexus fallback impact, and next gate |
+| `governance/mainline/task-cards/pr-459.yaml` | Governance task card for G2.306 no-source authorization | Review input; allows only steward tree, generated evidence, report, and task card updates |
 | `.planning/codebase/generated/auth-postgresql-session-ownership-decision-2026-06-01.json` | G2.305 auth.py PostgreSQL session ownership / provider-shape decision evidence | Review input for future PR `#458`; no-source decision package; selects only G2.306 no-source auth provider authorization |
 | `docs/reports/quality/backend-auth-postgresql-session-ownership-decision-2026-06-01.md` | G2.305 human-readable ownership / provider-shape report | Review input for future PR `#458`; records PR `#457` accepted/merged, auth call surface, focused tests, route/OpenAPI smoke, ruff no-fix findings, and next gate |
 | `governance/mainline/task-cards/pr-458.yaml` | Governance task card for G2.305 no-source decision | Review input; allows only steward tree, generated evidence, report, and task card updates |

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,9 +1,9 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-06-01T20:08:00+08:00",
+  "generated_at": "2026-06-01T21:10:00+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "13a81aec15fc8e98e7e4e927abe6d27e3e16f93d",
+  "base_head": "8a6cfa615f472f23643a13ab18ab02dd0853ad96",
   "split_branch": "g2-302-admin-optimization-postgresql-session-provider-authorization",
   "scope": "admin_optimization_postgresql_session_provider_authorization",
   "source_edit_authority": false,
@@ -11143,17 +11143,19 @@
     {
       "id": "g2-305-auth-postgresql-session-ownership-decision",
       "type": "decision_package",
-      "state": "for_review",
+      "state": "accepted_merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.304 admin optimization provider closeout / residual refresh",
       "source_edit_authority": false,
-      "autopilot_status": "review_gate",
-      "autopilot_stop_reason": "Auth is security-sensitive and remains under the CRITICAL shared app.core.database.get_postgresql_session helper family; G2.305 selects only a future no-source authorization package.",
+      "autopilot_status": "no_source_automerge_completed",
+      "autopilot_stop_reason": "PR #458 was no-source, checks passed, and it was merged under the limited no-source governance autopilot. G2.305 selects only a future no-source authorization package.",
       "github_pr": {
         "number": 458,
         "url": "https://github.com/chengjon/mystocks/pull/458",
-        "state": "PLANNED_FOR_REVIEW",
-        "head_ref": "g2-305-auth-postgresql-session-ownership-decision"
+        "state": "MERGED",
+        "merged_at": "2026-06-01T12:58:10Z",
+        "head_ref": "g2-305-auth-postgresql-session-ownership-decision",
+        "merge_commit": "8a6cfa615f472f23643a13ab18ab02dd0853ad96"
       },
       "evidence": [
         ".planning/codebase/generated/auth-postgresql-session-ownership-decision-2026-06-01.json",
@@ -11227,7 +11229,103 @@
         "stale_if_auth_tests_change": true,
         "stale_if_gitnexus_risk_changes": true
       },
-      "next_gate": "Review PR #458. If accepted and merged, start G2.306 no-source auth.py get_postgresql_session provider authorization."
+      "next_gate": "Superseded by G2.306 no-source auth.py get_postgresql_session provider authorization."
+    },
+    {
+      "id": "g2-306-auth-postgresql-session-provider-authorization",
+      "type": "authorization_package",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.305 auth.py get_postgresql_session ownership / provider-shape decision",
+      "source_edit_authority": false,
+      "authorizes_future_source_lane": true,
+      "autopilot_status": "review_gate",
+      "autopilot_stop_reason": "G2.306 is no-source and may be auto-merged if checks pass; it authorizes only future G2.307 source work, which must stop at human review before merge.",
+      "github_pr": {
+        "number": 459,
+        "url": "https://github.com/chengjon/mystocks/pull/459",
+        "state": "PLANNED_FOR_REVIEW",
+        "head_ref": "g2-306-auth-postgresql-session-provider-authorization"
+      },
+      "evidence": [
+        ".planning/codebase/generated/auth-postgresql-session-provider-authorization-2026-06-01.json",
+        "docs/reports/quality/backend-auth-postgresql-session-provider-authorization-2026-06-01.md",
+        "governance/mainline/task-cards/pr-459.yaml"
+      ],
+      "closed_parent": {
+        "pr": 458,
+        "state": "MERGED",
+        "merge_commit": "8a6cfa615f472f23643a13ab18ab02dd0853ad96",
+        "merged_at": "2026-06-01T12:58:10Z"
+      },
+      "allowed_scope": [
+        ".planning/codebase/generated/auth-postgresql-session-provider-authorization-2026-06-01.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-auth-postgresql-session-provider-authorization-2026-06-01.md",
+        "governance/mainline/task-cards/pr-459.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "tests/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "current_surface": {
+        "file": "web/backend/app/api/auth.py",
+        "direct_calls": 4,
+        "affected_handlers": [
+          "get_users",
+          "register_user",
+          "request_password_reset",
+          "confirm_password_reset"
+        ],
+        "focused_auth_tests": "10 passed, 18 skipped",
+        "route_openapi": "548/500/0",
+        "ruff_no_fix": "6 existing F401/F811 findings retained due no-source boundary"
+      },
+      "authorization": {
+        "future_source_lane": "G2.307 path-limited auth.py PostgreSQL session provider implementation",
+        "future_allowed_source_paths": [
+          "web/backend/app/api/auth.py"
+        ],
+        "future_allowed_test_paths": [
+          "web/backend/tests/test_auth.py",
+          "web/backend/tests/test_auth_login_contract.py"
+        ],
+        "required_shape": "route-local auth PostgreSQL session factory provider injected into the four affected handlers while preserving close/finally and confirm_password_reset transaction semantics",
+        "human_review_required_before_future_source_merge": true
+      },
+      "gitnexus_evidence": {
+        "mcp_impact": "Transport closed",
+        "cli_shared_helper_impact": {
+          "risk": "CRITICAL",
+          "direct": 15,
+          "processes_affected": 54,
+          "modules_affected": 8,
+          "index_status": "stale warning"
+        }
+      },
+      "freshness": {
+        "current_head_checked": "8a6cfa615f472f23643a13ab18ab02dd0853ad96",
+        "stale_if_head_or_pr_state_changes": true,
+        "stale_if_auth_session_call_sites_change": true,
+        "stale_if_route_or_openapi_counts_change": true,
+        "stale_if_auth_tests_change": true,
+        "stale_if_gitnexus_risk_changes": true
+      },
+      "next_gate": "Review PR #459. If accepted and merged, start G2.307 path-limited auth.py PostgreSQL session provider implementation and stop the source PR at human review before merge."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -3347,7 +3347,7 @@ Status: accepted/merged by PR `#457` at `d8e52a3b0000426a9ce278c5dbc1c4bbd8c6b4f
 
 ## G2.305 Auth.py PostgreSQL Session Ownership / Provider-Shape Decision
 
-Status: for review in future PR `#458`.
+Status: accepted/merged by PR `#458` at `8a6cfa615f472f23643a13ab18ab02dd0853ad96`.
 
 - Parent PR `#457` merged at `d8e52a3b0000426a9ce278c5dbc1c4bbd8c6b4f9`.
 - G2.305 is a no-source ownership / provider-shape decision package. It does not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
@@ -3358,3 +3358,17 @@ Status: for review in future PR `#458`.
 - Decision: classify auth as a security-sensitive route-domain surface inside the CRITICAL shared `app.core.database.get_postgresql_session` helper family.
 - Recommended next gate after PR `#458` acceptance: G2.306 no-source auth.py `get_postgresql_session` provider authorization.
 - Stop rule: G2.305 must not be used as auth source implementation authority.
+
+## G2.306 Auth.py PostgreSQL Session Provider Authorization
+
+Status: for review in future PR `#459`.
+
+- Parent PR `#458` merged at `8a6cfa615f472f23643a13ab18ab02dd0853ad96`.
+- G2.306 is a no-source authorization package. It does not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+- Current auth surface remains `4` direct `get_postgresql_session()` calls across `get_users`, `register_user`, `request_password_reset`, and `confirm_password_reset`.
+- Future G2.307 may only add a route-local auth PostgreSQL session factory provider, inject it into the four affected handlers, and preserve close/finally plus `confirm_password_reset` commit/rollback semantics.
+- Focused auth tests record `10 passed, 18 skipped`; route/OpenAPI smoke remains `548` routes, `500` paths, duplicate operation IDs `0`.
+- `ruff check --no-fix` records `6` existing F401/F811 issues in `auth.py`; they were not fixed because G2.306 is no-source.
+- GitNexus MCP impact returned `Transport closed`; CLI fallback keeps the shared `Function:web/backend/app/core/database.py:get_postgresql_session` family at `CRITICAL` with `15` direct dependants and `54` affected processes.
+- Recommended next gate after PR `#459` acceptance: G2.307 path-limited auth PostgreSQL session provider implementation.
+- Stop rule: G2.307 is a source implementation PR and must stop at human review before merge.

--- a/docs/reports/quality/backend-auth-postgresql-session-provider-authorization-2026-06-01.md
+++ b/docs/reports/quality/backend-auth-postgresql-session-provider-authorization-2026-06-01.md
@@ -1,0 +1,81 @@
+# Backend Auth PostgreSQL Session Provider Authorization
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: this report is a no-source authorization package. It does not
+edit backend source, tests, route contracts, docs/api artifacts, frontend,
+config, scripts, OpenSpec changes/specs, PM2, or runtime state.
+
+Status: for review in future PR `#459`.
+
+## Summary
+
+G2.306 converts the accepted G2.305 auth ownership decision into a bounded
+future implementation authorization. PR `#458` was merged at
+`8a6cfa615f472f23643a13ab18ab02dd0853ad96`.
+
+This package authorizes only a future G2.307 source lane after PR `#459`
+acceptance. The future implementation PR must still stop for human review
+before merge because it will modify `web/backend/app/api/auth.py`.
+
+## Current Surface
+
+| Function | Import line | Call line | Required lifecycle preservation |
+|---|---:|---:|---|
+| `get_users` | `195` | `199` | `session.close()` in `finally` |
+| `register_user` | `377` | `387` | `session.close()` in `finally` |
+| `request_password_reset` | `503` | `509` | `session.close()` in `finally` |
+| `confirm_password_reset` | `607` | `649` | `session.close()` in `finally`; preserve commit/rollback semantics |
+
+Current auth residual count remains `4` direct route-body calls to
+`get_postgresql_session()`.
+
+## Authorized Future Source Lane
+
+G2.307 may only make a path-limited auth provider implementation with this
+scope:
+
+- `web/backend/app/api/auth.py`
+- `web/backend/tests/test_auth.py`
+- `web/backend/tests/test_auth_login_contract.py`
+
+Required implementation shape:
+
+- Add a route-local auth PostgreSQL session factory provider.
+- Inject that provider into `get_users`, `register_user`,
+  `request_password_reset`, and `confirm_password_reset`.
+- Replace direct route-body `get_postgresql_session()` calls with the injected
+  factory.
+- Preserve all current `session.close()` in `finally` cleanup behavior.
+- Preserve `confirm_password_reset` commit/rollback behavior.
+
+Forbidden scope:
+
+- Editing the `app.core.database.get_postgresql_session` definition.
+- Changing login/logout/me/refresh/csrf handlers.
+- Changing route path, method, response model, or OpenAPI exposure.
+- Editing docs/api artifacts, frontend, config, scripts, OpenSpec specs/changes,
+  PM2 state, or runtime deployment state.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Parent gate | PR `#458` is `MERGED` at `8a6cfa615f472f23643a13ab18ab02dd0853ad96` |
+| Auth residual scan | `4` direct calls, `4` import lines |
+| Focused auth tests | `10 passed, 18 skipped in 12.48s` |
+| Route/OpenAPI smoke | `548` routes, `500` paths, duplicate operation IDs `0` |
+| Ruff no-fix scan | `6` existing F401/F811 findings in `auth.py`; retained because G2.306 is no-source |
+| GitNexus MCP | `Transport closed`; CLI impact fallback used |
+| Shared helper impact | `Function:web/backend/app/core/database.py:get_postgresql_session` remains `CRITICAL`, `15` direct dependants, `54` affected processes |
+
+The route/OpenAPI smoke used smoke-only non-secret environment values and did
+not start PM2.
+
+## Decision
+
+Approve only a future path-limited G2.307 source implementation for the auth
+PostgreSQL session provider. G2.306 itself remains no-source.
+
+The future G2.307 implementation PR must stop at human review before merge,
+even if all checks pass, because it will modify backend source and tests.

--- a/governance/mainline/task-cards/pr-459.yaml
+++ b/governance/mainline/task-cards/pr-459.yaml
@@ -1,0 +1,133 @@
+version: "v0.2"
+
+task:
+  id: "pr-459"
+  title: "Authorize auth PostgreSQL session provider lane"
+  owner: "codex"
+  created_at: "2026-06-01"
+
+mainline:
+  id: "L1-auth-postgresql-session-provider-authorization"
+  objective: "authorize a future path-limited auth.py get_postgresql_session provider implementation lane"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "api"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "G2.306 is a no-source authorization package. It changes no runtime route, handler, contract, source file, or test file."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/auth-postgresql-session-provider-authorization-2026-06-01.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-auth-postgresql-session-provider-authorization-2026-06-01.md"
+    - "governance/mainline/task-cards/pr-459.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits in this PR"
+  - "test edits in this PR"
+  - "route registration changes"
+  - "route path, method, response model, or generated OpenAPI artifact changes"
+  - "docs/api artifact edits"
+  - "frontend/config/script changes"
+  - "OpenSpec proposal or spec edits"
+  - "PM2 commands or stateful runtime gates"
+  - "source retirement"
+  - "editing app.core.database.get_postgresql_session"
+  - "editing auth.py"
+
+acceptance:
+  checks:
+    - id: "pr458-merged"
+      command: "gh pr view 458 confirms MERGED at 8a6cfa615f472f23643a13ab18ab02dd0853ad96"
+      required: true
+    - id: "auth-surface"
+      command: "current scan records 4 auth.py get_postgresql_session calls across get_users, register_user, request_password_reset, and confirm_password_reset"
+      required: true
+    - id: "focused-auth-tests"
+      command: "pytest -q web/backend/tests/test_auth.py web/backend/tests/test_auth_login_contract.py --tb=short --no-cov -n 0 records 10 passed, 18 skipped"
+      required: true
+    - id: "route-openapi-smoke"
+      command: "app.main route/OpenAPI smoke records 548 routes, 500 paths, duplicate operation IDs 0"
+      required: true
+    - id: "ruff-no-fix"
+      command: "ruff check --no-fix records 6 existing auth.py F401/F811 findings and this PR does not fix them"
+      required: true
+    - id: "future-source-boundary"
+      command: "report authorizes only future G2.307 path-limited auth.py provider implementation and requires human review before source PR merge"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-auth-postgresql-session-provider-authorization-2026-06-01.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-459.yaml --base-sha 8a6cfa615f472f23643a13ab18ab02dd0853ad96 --head-sha HEAD --report /tmp/pr459-mainline-governance-report.json"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "No runtime risk from this PR because it is no-source governance only."
+    - "The future G2.307 source PR is auth/security-sensitive and must stop for human review before merge."
+  rollback_plan: "Revert PR #459; this removes only G2.306 authorization evidence and restores the prior G2.305 gate text."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Authorize a future path-limited auth PostgreSQL session provider implementation lane."
+    modified_scope: "Governance evidence, steward tree indexes, report, and task card only."
+    dependency_changes: "No package dependency changes."
+    legacy_logic_impact: "No runtime behavior, route contract, OpenAPI, or source changes."
+    rollback_ready: "Revert PR #459."
+    risk_and_rollback_point: "No-source authorization; rollback is single-PR revert. Future source PR requires human review."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-01T21:00:00+08:00"
+    approval_note: "Human maintainer approved continuing after PR #458 merge into G2.306 no-source auth provider authorization."
+    secondary_approved: false


### PR DESCRIPTION
# Backend Auth PostgreSQL Session Provider Authorization

> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。

Boundary note: this report is a no-source authorization package. It does not
edit backend source, tests, route contracts, docs/api artifacts, frontend,
config, scripts, OpenSpec changes/specs, PM2, or runtime state.

Status: for review in future PR `#459`.

## Summary

G2.306 converts the accepted G2.305 auth ownership decision into a bounded
future implementation authorization. PR `#458` was merged at
`8a6cfa615f472f23643a13ab18ab02dd0853ad96`.

This package authorizes only a future G2.307 source lane after PR `#459`
acceptance. The future implementation PR must still stop for human review
before merge because it will modify `web/backend/app/api/auth.py`.

## Current Surface

| Function | Import line | Call line | Required lifecycle preservation |
|---|---:|---:|---|
| `get_users` | `195` | `199` | `session.close()` in `finally` |
| `register_user` | `377` | `387` | `session.close()` in `finally` |
| `request_password_reset` | `503` | `509` | `session.close()` in `finally` |
| `confirm_password_reset` | `607` | `649` | `session.close()` in `finally`; preserve commit/rollback semantics |

Current auth residual count remains `4` direct route-body calls to
`get_postgresql_session()`.

## Authorized Future Source Lane

G2.307 may only make a path-limited auth provider implementation with this
scope:

- `web/backend/app/api/auth.py`
- `web/backend/tests/test_auth.py`
- `web/backend/tests/test_auth_login_contract.py`

Required implementation shape:

- Add a route-local auth PostgreSQL session factory provider.
- Inject that provider into `get_users`, `register_user`,
  `request_password_reset`, and `confirm_password_reset`.
- Replace direct route-body `get_postgresql_session()` calls with the injected
  factory.
- Preserve all current `session.close()` in `finally` cleanup behavior.
- Preserve `confirm_password_reset` commit/rollback behavior.

Forbidden scope:

- Editing the `app.core.database.get_postgresql_session` definition.
- Changing login/logout/me/refresh/csrf handlers.
- Changing route path, method, response model, or OpenAPI exposure.
- Editing docs/api artifacts, frontend, config, scripts, OpenSpec specs/changes,
  PM2 state, or runtime deployment state.

## Verification

| Check | Result |
|---|---|
| Parent gate | PR `#458` is `MERGED` at `8a6cfa615f472f23643a13ab18ab02dd0853ad96` |
| Auth residual scan | `4` direct calls, `4` import lines |
| Focused auth tests | `10 passed, 18 skipped in 12.48s` |
| Route/OpenAPI smoke | `548` routes, `500` paths, duplicate operation IDs `0` |
| Ruff no-fix scan | `6` existing F401/F811 findings in `auth.py`; retained because G2.306 is no-source |
| GitNexus MCP | `Transport closed`; CLI impact fallback used |
| Shared helper impact | `Function:web/backend/app/core/database.py:get_postgresql_session` remains `CRITICAL`, `15` direct dependants, `54` affected processes |

The route/OpenAPI smoke used smoke-only non-secret environment values and did
not start PM2.

## Decision

Approve only a future path-limited G2.307 source implementation for the auth
PostgreSQL session provider. G2.306 itself remains no-source.

The future G2.307 implementation PR must stop at human review before merge,
even if all checks pass, because it will modify backend source and tests.
