### PR TITLE
refactor(auth): inject postgres session provider

### DIFF
--- a/.planning/codebase/generated/auth-postgresql-session-provider-implementation-2026-06-01.json
+++ b/.planning/codebase/generated/auth-postgresql-session-provider-implementation-2026-06-01.json
@@ -1,0 +1,158 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-01T21:38:00+08:00",
+  "g_node": "G2.307",
+  "title": "Auth.py get_postgresql_session provider implementation",
+  "branch": "g2-307-auth-postgresql-session-provider-implementation",
+  "parent_pr": {
+    "number": 459,
+    "url": "https://github.com/chengjon/mystocks/pull/459",
+    "state": "MERGED",
+    "merged_at": "2026-06-01T13:21:45Z",
+    "merge_commit": "702816e7aa23378b2acd5dbc27de449fc74a3af5",
+    "head_ref": "g2-306-auth-postgresql-session-provider-authorization"
+  },
+  "base_head": "702816e7aa23378b2acd5dbc27de449fc74a3af5",
+  "source_edit_authority": true,
+  "automerge_allowed": false,
+  "allowed_scope": [
+    "web/backend/app/api/auth.py",
+    "web/backend/tests/test_auth_login_contract.py",
+    ".planning/codebase/generated/auth-postgresql-session-provider-implementation-2026-06-01.json",
+    ".planning/codebase/steward-tree/current-next-gates.md",
+    ".planning/codebase/steward-tree/steward-index.json",
+    ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+    ".planning/codebase/steward-tree/branch-register.md",
+    ".planning/codebase/steward-tree/evidence-index.md",
+    ".planning/codebase/steward-tree/completed-ledger.md",
+    "docs/reports/quality/backend-auth-postgresql-session-provider-implementation-2026-06-01.md",
+    "governance/mainline/task-cards/pr-460.yaml"
+  ],
+  "forbidden_scope": [
+    "app.core.database.get_postgresql_session definition edits",
+    "login/logout/me/refresh/csrf handler changes",
+    "route path, method, response model, or OpenAPI exposure changes",
+    "docs/api/**",
+    "web/frontend/**",
+    "src/**",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**",
+    "PM2/runtime state"
+  ],
+  "implementation": {
+    "provider": "get_auth_postgresql_session_factory",
+    "provider_line": 41,
+    "provider_backing_get_postgresql_session_calls": 1,
+    "route_body_direct_get_postgresql_session_calls": 0,
+    "dependency_bindings": 4,
+    "affected_handlers": {
+      "get_users": {
+        "dependency_line": 197,
+        "call_line": 210
+      },
+      "register_user": {
+        "dependency_line": 338,
+        "call_line": 398
+      },
+      "request_password_reset": {
+        "dependency_line": 481,
+        "call_line": 520
+      },
+      "confirm_password_reset": {
+        "dependency_line": 582,
+        "call_line": 658,
+        "transaction_semantics": "commit/rollback preserved"
+      }
+    },
+    "compatibility_exports_retained": [
+      "verify_token",
+      "get_current_active_user"
+    ]
+  },
+  "tdd": {
+    "red": "test_auth_db_handlers_use_route_local_session_factory_dependency failed with AttributeError because get_auth_postgresql_session_factory did not exist",
+    "red_result": "1 failed in 0.95s",
+    "green_target": "test_auth_db_handlers_use_route_local_session_factory_dependency passed",
+    "green_result": "1 passed in 0.93s",
+    "focused_regression": "web/backend/tests/test_auth.py web/backend/tests/test_auth_login_contract.py: 11 passed, 18 skipped in 12.24s"
+  },
+  "verification": {
+    "ruff": "ruff check --no-fix web/backend/app/api/auth.py web/backend/tests/test_auth.py web/backend/tests/test_auth_login_contract.py: all checks passed",
+    "provider_scan": "provider present, direct_calls_source=1, all four target handlers use Depends(get_auth_postgresql_session_factory)",
+    "route_openapi": {
+      "runtime_routes": 548,
+      "openapi_paths": 500,
+      "duplicate_operation_ids": 0,
+      "warning_count": 119,
+      "note": "Smoke used non-secret test-only environment values and did not start PM2."
+    }
+  },
+  "gitnexus_evidence": {
+    "mcp_impact": "Transport closed",
+    "cli_pre_edit_impact": {
+      "Function:web/backend/app/core/database.py:get_postgresql_session": {
+        "risk": "CRITICAL",
+        "direct": 15,
+        "processes_affected": 54,
+        "modules_affected": 8,
+        "index_status": "stale warning"
+      },
+      "get_users": {
+        "risk": "UNKNOWN",
+        "index_status": "stale warning"
+      },
+      "register_user": {
+        "risk": "LOW",
+        "direct": 0,
+        "processes_affected": 0,
+        "modules_affected": 0,
+        "index_status": "stale warning"
+      },
+      "request_password_reset": {
+        "risk": "LOW",
+        "direct": 0,
+        "processes_affected": 0,
+        "modules_affected": 0,
+        "index_status": "stale warning"
+      },
+      "confirm_password_reset": {
+        "risk": "LOW",
+        "direct": 0,
+        "processes_affected": 0,
+        "modules_affected": 0,
+        "index_status": "stale warning"
+      }
+    },
+    "cli_staged_verification": {
+      "risk": "medium",
+      "files": 11,
+      "symbols": 6,
+      "affected_processes": 5,
+      "changed_symbols": [
+        "repository",
+        "users_list",
+        "get_users",
+        "register_user",
+        "request_password_reset",
+        "confirm_password_reset"
+      ],
+      "index_status": "stale warning",
+      "note": "Medium risk confirms PR #460 must stop at human review before merge."
+    }
+  },
+  "next_gate": {
+    "human_review_required": true,
+    "recommended_after_acceptance": "G2.308 no-source auth provider closeout / residual refresh",
+    "autopilot_stop_reason": "This PR changes backend source and tests under an auth/security-sensitive surface."
+  },
+  "freshness": {
+    "current_head_checked": "702816e7aa23378b2acd5dbc27de449fc74a3af5",
+    "stale_if_head_or_pr_state_changes": true,
+    "stale_if_auth_session_call_sites_change": true,
+    "stale_if_route_or_openapi_counts_change": true,
+    "stale_if_auth_tests_change": true,
+    "stale_if_gitnexus_risk_changes": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-06-01T21:10:00+08:00`
-- Base HEAD checked: `8a6cfa615f472f23643a13ab18ab02dd0853ad96`
+- Prepared at: `2026-06-01T21:38:00+08:00`
+- Base HEAD checked: `702816e7aa23378b2acd5dbc27de449fc74a3af5`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -276,3 +276,5 @@ G2.304 is the no-source admin optimization PostgreSQL session provider closeout 
 G2.305 is the no-source auth.py `get_postgresql_session` ownership / provider-shape decision after PR `#457` merged G2.304 at `d8e52a3b0000426a9ce278c5dbc1c4bbd8c6b4f9`. It records four active auth residual calls across `get_users`, `register_user`, `request_password_reset`, and `confirm_password_reset`, focused auth tests `10 passed / 18 skipped`, route/OpenAPI `548/500/0`, and existing ruff no-fix findings `6`. It selects only G2.306 no-source auth provider authorization and must not authorize auth source edits.
 
 G2.306 is the no-source auth.py `get_postgresql_session` provider authorization after PR `#458` merged G2.305 at `8a6cfa615f472f23643a13ab18ab02dd0853ad96`. It authorizes only a future G2.307 path-limited source lane for `web/backend/app/api/auth.py` plus focused auth tests, requiring a route-local auth PostgreSQL session factory provider, injection into the four affected handlers, preservation of close/finally cleanup, and preservation of `confirm_password_reset` commit/rollback semantics. It records focused auth tests `10 passed / 18 skipped`, route/OpenAPI `548/500/0`, ruff no-fix findings `6`, and shared helper GitNexus CLI impact `CRITICAL` with `15` direct dependants and `54` affected processes. It must not edit source in PR `#459`, and G2.307 must stop at human review before merge.
+
+G2.307 is the path-limited auth.py `get_postgresql_session` provider implementation after PR `#459` merged G2.306 at `702816e7aa23378b2acd5dbc27de449fc74a3af5`. It adds `get_auth_postgresql_session_factory`, injects it into `get_users`, `register_user`, `request_password_reset`, and `confirm_password_reset`, preserves close/finally cleanup and password reset commit/rollback semantics, and keeps route/OpenAPI at `548/500/0`. It records TDD RED `1 failed`, GREEN target `1 passed`, focused auth regression `11 passed / 18 skipped`, ruff clean, provider backing calls `1`, and route-body direct calls `0`. It changes backend source/tests and must stop at future PR `#460` review; if accepted, the next gate is G2.308 no-source auth provider closeout / residual refresh.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-06-01T21:10:00+08:00`
-- Base HEAD checked: `8a6cfa615f472f23643a13ab18ab02dd0853ad96`
+- Prepared at: `2026-06-01T21:38:00+08:00`
+- Base HEAD checked: `702816e7aa23378b2acd5dbc27de449fc74a3af5`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -19,7 +19,7 @@ exact verification output.
 | Route/OpenAPI and control-plane governance | Established route table, OpenAPI exposure, health/probe taxonomy, and consumer-contract evidence as first-class governance facts | Continue through route/OpenAPI track, not ad hoc route edits |
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
-| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.305 accepted/merged by PR `#458` at `8a6cfa61` | Continue with G2.306 auth provider authorization; future G2.307 source implementation must stop at human review |
+| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.306 accepted/merged by PR `#459` at `702816e7` | Continue with G2.307 auth provider implementation; source PR must stop at human review |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
 | Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.301 have progressed through PR `#337`-`#454`; current review target is G2.302 admin optimization provider authorization in future PR `#455` |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
@@ -28,6 +28,7 @@ exact verification output.
 
 | Item | Accepted evidence | Follow-up |
 |---|---|---|
+| G2.306 auth.py PostgreSQL session provider authorization | PR `#459` merged at `702816e7aa23378b2acd5dbc27de449fc74a3af5`; generated authorization evidence records future G2.307 scope limited to `auth.py` plus focused auth tests, route/OpenAPI `548/500/0`, focused auth tests `10 passed / 18 skipped`, and CRITICAL shared helper-family risk | G2.307 may only implement the bounded auth provider lane and must stop at PR `#460` review |
 | G2.305 auth.py PostgreSQL session ownership / provider-shape decision | PR `#458` merged at `8a6cfa615f472f23643a13ab18ab02dd0853ad96`; generated decision evidence records auth direct calls `4`, focused auth tests `10 passed / 18 skipped`, route/OpenAPI `548/500/0`, and existing ruff no-fix findings `6` | G2.306 no-source authorization may authorize only a bounded future G2.307 auth provider implementation |
 | G2.304 admin optimization provider closeout / residual refresh | PR `#457` merged at `d8e52a3b0000426a9ce278c5dbc1c4bbd8c6b4f9`; generated closeout evidence records admin optimization helper direct calls `0`, provider backing `1`, dependency bindings `4`, focused test `7/7`, route/OpenAPI `548/500/0`, and remaining auth direct calls `4` | G2.305 no-source auth ownership / provider-shape decision records auth surface and selects only no-source authorization |
 | G2.303 admin optimization PostgreSQL session provider implementation | PR `#456` merged at `1cc89b285cd265bce96991b8dc4c7e8bd71d85d0`; generated implementation evidence records provider `get_admin_optimization_postgresql_session_factory`, four dependency bindings, helper direct calls `0`, provider backing `1`, focused test `7/7`, and route/OpenAPI `548/500/0` | G2.304 no-source closeout / residual refresh records admin optimization closure and selects the next no-source auth ownership decision |

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-06-01T21:10:00+08:00`
-- Base HEAD checked: `8a6cfa615f472f23643a13ab18ab02dd0853ad96`
+- Prepared at: `2026-06-01T21:38:00+08:00`
+- Base HEAD checked: `702816e7aa23378b2acd5dbc27de449fc74a3af5`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.306 auth.py `get_postgresql_session` provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#458` merged at `8a6cfa615f472f23643a13ab18ab02dd0853ad96`; G2.306 authorizes only a future path-limited G2.307 auth provider implementation after PR `#459` acceptance; current auth residuals remain `4`, focused auth tests `10 passed / 18 skipped`, route/OpenAPI `548/500/0` | Review future PR `#459`; if accepted, open G2.307 source implementation PR and stop it at human review before merge |
+| P0 | Review G2.307 auth.py `get_postgresql_session` provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#459` merged at `702816e7aa23378b2acd5dbc27de449fc74a3af5`; G2.307 adds `get_auth_postgresql_session_factory`, moves four auth handlers to provider injection, leaves provider backing calls `1` and route-body direct calls `0`, focused auth tests `11 passed / 18 skipped`, route/OpenAPI `548/500/0` | Review future PR `#460`; source PR must not auto-merge. If accepted, start G2.308 no-source auth provider closeout / residual refresh |
+| P0 | Preserve G2.306 auth.py `get_postgresql_session` provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#459` merged at `702816e7aa23378b2acd5dbc27de449fc74a3af5`; G2.306 authorized only the bounded G2.307 auth implementation lane | Do not use G2.306 to expand beyond `auth.py` and focused auth contract tests |
 | P0 | Preserve G2.305 auth.py `get_postgresql_session` ownership / provider-shape decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#458` merged at `8a6cfa615f472f23643a13ab18ab02dd0853ad96`; G2.305 classified four active auth direct calls across `get_users`, `register_user`, `request_password_reset`, and `confirm_password_reset`, focused auth tests `10 passed / 18 skipped`, route/OpenAPI `548/500/0` | Do not use G2.305 as source implementation authority; use G2.306 only as no-source authorization package |
 | P0 | Preserve G2.304 admin optimization provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#457` merged at `d8e52a3b0000426a9ce278c5dbc1c4bbd8c6b4f9`; G2.304 closed admin optimization with helper direct calls `0`, provider backing `1`, `Depends` bindings `4`, focused tests `7 passed`, route/OpenAPI `548/500/0`, and remaining active direct residuals concentrated in `auth.py` `4` | Do not use G2.304 as source implementation authority; use G2.305 only as no-source auth ownership decision |
 | P0 | Preserve G2.303 admin optimization PostgreSQL session provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#456` merged at `1cc89b285cd265bce96991b8dc4c7e8bd71d85d0`; G2.303 moved four admin optimization handlers to `Depends(get_admin_optimization_postgresql_session_factory)`, preserved cleanup, recorded focused tests `7 passed`, ruff clean, provider scan `4/1/0`, and route/OpenAPI `548/500/0` | Do not use G2.303 as authority for shared helper definitions, auth, market, admin audit, route contracts, docs/api, frontend, config, scripts, OpenSpec, PM2, or runtime state |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-06-01T21:10:00+08:00`
-- Base HEAD checked: `8a6cfa615f472f23643a13ab18ab02dd0853ad96`
+- Prepared at: `2026-06-01T21:38:00+08:00`
+- Base HEAD checked: `702816e7aa23378b2acd5dbc27de449fc74a3af5`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -16,6 +16,9 @@ state transition.
 
 | Evidence | Role | Freshness policy |
 |---|---|---|
+| `.planning/codebase/generated/auth-postgresql-session-provider-implementation-2026-06-01.json` | G2.307 auth.py PostgreSQL session provider implementation evidence | Review input for future PR `#460`; source implementation package; must stop at human review before merge |
+| `docs/reports/quality/backend-auth-postgresql-session-provider-implementation-2026-06-01.md` | G2.307 human-readable implementation report | Review input for future PR `#460`; records TDD RED/GREEN, provider scan, focused tests, route/OpenAPI smoke, ruff, and GitNexus fallback |
+| `governance/mainline/task-cards/pr-460.yaml` | Governance task card for G2.307 source implementation | Review input; allows only path-limited auth source/test plus steward tree, generated evidence, report, and task card updates |
 | `.planning/codebase/generated/auth-postgresql-session-provider-authorization-2026-06-01.json` | G2.306 auth.py PostgreSQL session provider authorization evidence | Review input for future PR `#459`; no-source authorization package; authorizes only future G2.307 path-limited source implementation and requires human review before source PR merge |
 | `docs/reports/quality/backend-auth-postgresql-session-provider-authorization-2026-06-01.md` | G2.306 human-readable authorization report | Review input for future PR `#459`; records PR `#458` accepted/merged, auth call surface, focused tests, route/OpenAPI smoke, ruff no-fix findings, GitNexus fallback impact, and next gate |
 | `governance/mainline/task-cards/pr-459.yaml` | Governance task card for G2.306 no-source authorization | Review input; allows only steward tree, generated evidence, report, and task card updates |

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,9 +1,9 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-06-01T21:10:00+08:00",
+  "generated_at": "2026-06-01T21:38:00+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "8a6cfa615f472f23643a13ab18ab02dd0853ad96",
+  "base_head": "702816e7aa23378b2acd5dbc27de449fc74a3af5",
   "split_branch": "g2-302-admin-optimization-postgresql-session-provider-authorization",
   "scope": "admin_optimization_postgresql_session_provider_authorization",
   "source_edit_authority": false,
@@ -11234,18 +11234,20 @@
     {
       "id": "g2-306-auth-postgresql-session-provider-authorization",
       "type": "authorization_package",
-      "state": "for_review",
+      "state": "accepted_merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.305 auth.py get_postgresql_session ownership / provider-shape decision",
       "source_edit_authority": false,
       "authorizes_future_source_lane": true,
-      "autopilot_status": "review_gate",
-      "autopilot_stop_reason": "G2.306 is no-source and may be auto-merged if checks pass; it authorizes only future G2.307 source work, which must stop at human review before merge.",
+      "autopilot_status": "no_source_automerge_completed",
+      "autopilot_stop_reason": "PR #459 was no-source, checks passed, and it was merged under the limited no-source governance autopilot. It authorizes only future G2.307 source work, which must stop at human review before merge.",
       "github_pr": {
         "number": 459,
         "url": "https://github.com/chengjon/mystocks/pull/459",
-        "state": "PLANNED_FOR_REVIEW",
-        "head_ref": "g2-306-auth-postgresql-session-provider-authorization"
+        "state": "MERGED",
+        "merged_at": "2026-06-01T13:21:45Z",
+        "head_ref": "g2-306-auth-postgresql-session-provider-authorization",
+        "merge_commit": "702816e7aa23378b2acd5dbc27de449fc74a3af5"
       },
       "evidence": [
         ".planning/codebase/generated/auth-postgresql-session-provider-authorization-2026-06-01.json",
@@ -11315,6 +11317,13 @@
           "processes_affected": 54,
           "modules_affected": 8,
           "index_status": "stale warning"
+        },
+        "cli_staged_verification": {
+          "risk": "medium",
+          "files": 11,
+          "symbols": 6,
+          "affected_processes": 5,
+          "index_status": "stale warning"
         }
       },
       "freshness": {
@@ -11325,7 +11334,102 @@
         "stale_if_auth_tests_change": true,
         "stale_if_gitnexus_risk_changes": true
       },
-      "next_gate": "Review PR #459. If accepted and merged, start G2.307 path-limited auth.py PostgreSQL session provider implementation and stop the source PR at human review before merge."
+      "next_gate": "Superseded by G2.307 path-limited auth.py PostgreSQL session provider implementation."
+    },
+    {
+      "id": "g2-307-auth-postgresql-session-provider-implementation",
+      "type": "implementation",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.306 auth.py get_postgresql_session provider authorization",
+      "source_edit_authority": true,
+      "autopilot_status": "stop_at_source_pr_review",
+      "autopilot_stop_reason": "G2.307 changes backend source/tests under an auth/security-sensitive surface and must not auto-merge.",
+      "github_pr": {
+        "number": 460,
+        "url": "https://github.com/chengjon/mystocks/pull/460",
+        "state": "PLANNED_FOR_REVIEW",
+        "head_ref": "g2-307-auth-postgresql-session-provider-implementation"
+      },
+      "evidence": [
+        ".planning/codebase/generated/auth-postgresql-session-provider-implementation-2026-06-01.json",
+        "docs/reports/quality/backend-auth-postgresql-session-provider-implementation-2026-06-01.md",
+        "governance/mainline/task-cards/pr-460.yaml"
+      ],
+      "closed_parent": {
+        "pr": 459,
+        "state": "MERGED",
+        "merge_commit": "702816e7aa23378b2acd5dbc27de449fc74a3af5",
+        "merged_at": "2026-06-01T13:21:45Z"
+      },
+      "allowed_scope": [
+        "web/backend/app/api/auth.py",
+        "web/backend/tests/test_auth_login_contract.py",
+        ".planning/codebase/generated/auth-postgresql-session-provider-implementation-2026-06-01.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-auth-postgresql-session-provider-implementation-2026-06-01.md",
+        "governance/mainline/task-cards/pr-460.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/app/core/database.py",
+        "web/backend/app/router_registry.py",
+        "web/frontend/**",
+        "src/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "implementation": {
+        "provider": "get_auth_postgresql_session_factory",
+        "provider_backing_get_postgresql_session_calls": 1,
+        "route_body_direct_get_postgresql_session_calls": 0,
+        "dependency_bindings": 4,
+        "affected_handlers": [
+          "get_users",
+          "register_user",
+          "request_password_reset",
+          "confirm_password_reset"
+        ],
+        "compatibility_exports_retained": [
+          "verify_token",
+          "get_current_active_user"
+        ]
+      },
+      "verification": {
+        "tdd_red": "1 failed in 0.95s",
+        "tdd_green_target": "1 passed in 0.93s",
+        "focused_auth_tests": "11 passed, 18 skipped",
+        "ruff": "all checks passed",
+        "route_openapi": "548/500/0"
+      },
+      "gitnexus_evidence": {
+        "mcp_impact": "Transport closed",
+        "cli_shared_helper_impact": {
+          "risk": "CRITICAL",
+          "direct": 15,
+          "processes_affected": 54,
+          "modules_affected": 8,
+          "index_status": "stale warning"
+        }
+      },
+      "freshness": {
+        "current_head_checked": "702816e7aa23378b2acd5dbc27de449fc74a3af5",
+        "stale_if_head_or_pr_state_changes": true,
+        "stale_if_auth_session_call_sites_change": true,
+        "stale_if_route_or_openapi_counts_change": true,
+        "stale_if_auth_tests_change": true,
+        "stale_if_gitnexus_risk_changes": true
+      },
+      "next_gate": "Review PR #460. If human accepted and merged, start G2.308 no-source auth provider closeout / residual refresh."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -3361,7 +3361,7 @@ Status: accepted/merged by PR `#458` at `8a6cfa615f472f23643a13ab18ab02dd0853ad9
 
 ## G2.306 Auth.py PostgreSQL Session Provider Authorization
 
-Status: for review in future PR `#459`.
+Status: accepted/merged by PR `#459` at `702816e7aa23378b2acd5dbc27de449fc74a3af5`.
 
 - Parent PR `#458` merged at `8a6cfa615f472f23643a13ab18ab02dd0853ad96`.
 - G2.306 is a no-source authorization package. It does not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
@@ -3372,3 +3372,17 @@ Status: for review in future PR `#459`.
 - GitNexus MCP impact returned `Transport closed`; CLI fallback keeps the shared `Function:web/backend/app/core/database.py:get_postgresql_session` family at `CRITICAL` with `15` direct dependants and `54` affected processes.
 - Recommended next gate after PR `#459` acceptance: G2.307 path-limited auth PostgreSQL session provider implementation.
 - Stop rule: G2.307 is a source implementation PR and must stop at human review before merge.
+
+## G2.307 Auth.py PostgreSQL Session Provider Implementation
+
+Status: for review in future PR `#460`.
+
+- Parent PR `#459` merged at `702816e7aa23378b2acd5dbc27de449fc74a3af5`.
+- G2.307 is a path-limited source implementation package. It edits only `web/backend/app/api/auth.py`, `web/backend/tests/test_auth_login_contract.py`, and governance evidence records.
+- Implementation adds `get_auth_postgresql_session_factory`, injects it into `get_users`, `register_user`, `request_password_reset`, and `confirm_password_reset`, and reduces route-body direct `get_postgresql_session()` calls in those handlers to `0`.
+- Provider backing `get_postgresql_session()` calls are `1`; route/OpenAPI remains `548` routes, `500` paths, duplicate operation IDs `0`.
+- TDD RED: new provider dependency test failed with missing `get_auth_postgresql_session_factory`. GREEN: target test passed, focused auth regression records `11 passed, 18 skipped`.
+- Ruff is clean for `auth.py` and focused auth tests. Compatibility exports `verify_token` and `get_current_active_user` remain available from `app.api.auth`.
+- GitNexus MCP impact returned `Transport closed`; CLI fallback keeps shared `Function:web/backend/app/core/database.py:get_postgresql_session` at `CRITICAL`, and the shared helper definition is intentionally untouched.
+- Recommended next gate after human acceptance and merge: G2.308 no-source auth provider closeout / residual refresh.
+- Stop rule: PR `#460` changes backend source/tests and must not auto-merge.

--- a/docs/reports/quality/backend-auth-postgresql-session-provider-implementation-2026-06-01.md
+++ b/docs/reports/quality/backend-auth-postgresql-session-provider-implementation-2026-06-01.md
@@ -1,0 +1,89 @@
+# Backend Auth PostgreSQL Session Provider Implementation
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: this report documents a path-limited source implementation
+package. It does not authorize PR merge, future source expansion, route contract
+changes, OpenAPI artifact edits, docs/api edits, PM2 commands, source retirement,
+or edits outside the G2.307 scope.
+
+Status: for review in future PR `#460`.
+
+## Summary
+
+G2.307 implements the path-limited auth PostgreSQL session provider lane
+authorized by G2.306 after PR `#459` was accepted and merged at
+`702816e7aa23378b2acd5dbc27de449fc74a3af5`.
+
+This package changes only:
+
+- `web/backend/app/api/auth.py`
+- `web/backend/tests/test_auth_login_contract.py`
+- G2.307 governance evidence and steward tree records
+
+It does not edit `app.core.database.get_postgresql_session`, route registration,
+route paths, response models, generated OpenAPI artifacts, docs/api artifacts,
+frontend, config, scripts, OpenSpec, PM2, or runtime state.
+
+## Implementation
+
+| Item | Result |
+|---|---|
+| Route-local provider | `get_auth_postgresql_session_factory` |
+| Provider backing calls | `1` `get_postgresql_session()` call inside the provider factory |
+| Route-body direct calls | `0` direct `get_postgresql_session()` calls in the four target handlers |
+| Dependency bindings | `4`: `get_users`, `register_user`, `request_password_reset`, `confirm_password_reset` |
+| Cleanup lifecycle | Existing `session.close()` in `finally` remains preserved |
+| Transaction semantics | `confirm_password_reset` commit/rollback behavior remains preserved |
+| Compatibility exports | `verify_token` and `get_current_active_user` remain exported from `app.api.auth` |
+
+## TDD Evidence
+
+RED:
+
+- Added `test_auth_db_handlers_use_route_local_session_factory_dependency`.
+- It failed because `app.api.auth.get_auth_postgresql_session_factory` did not
+  exist.
+- RED result: `1 failed in 0.95s`.
+
+GREEN:
+
+- Added `get_auth_postgresql_session_factory` and injected it into the four
+  affected handlers.
+- Target result: `1 passed in 0.93s`.
+- Focused regression: `11 passed, 18 skipped in 12.24s`.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Ruff | `ruff check --no-fix web/backend/app/api/auth.py web/backend/tests/test_auth.py web/backend/tests/test_auth_login_contract.py`: all checks passed |
+| Provider scan | provider present, source direct `get_postgresql_session()` calls `1`, all four target handlers use `Depends(get_auth_postgresql_session_factory)` |
+| Route/OpenAPI smoke | `routes=548`, `openapi_paths=500`, duplicate operation IDs `0` |
+| Generated OpenAPI artifacts | Not edited |
+| PM2/runtime state | Not touched |
+
+The route/OpenAPI smoke used non-secret test-only environment values and did not
+start PM2.
+
+## GitNexus Evidence
+
+GitNexus MCP impact returned `Transport closed` in this session. CLI fallback
+was run before source edits.
+
+| Target | Risk | Direct | Affected processes | Notes |
+|---|---:|---:|---:|---|
+| `Function:web/backend/app/core/database.py:get_postgresql_session` | CRITICAL | 15 | 54 | shared helper definition intentionally untouched |
+| `get_users` | UNKNOWN | n/a | n/a | stale index warning |
+| `register_user` | LOW | 0 | 0 | stale index warning |
+| `request_password_reset` | LOW | 0 | 0 | stale index warning |
+| `confirm_password_reset` | LOW | 0 | 0 | stale index warning |
+| staged verification fallback | MEDIUM | 6 changed symbols | 5 | `npx gitnexus verify-staged -r mystocks`; index stale |
+
+## Decision
+
+G2.307 is implemented and ready for PR review. Because this package changes
+backend source and tests under an auth/security-sensitive surface, limited
+autopilot must stop at PR `#460` review. If PR `#460` is human accepted and
+merged, the recommended next gate is G2.308 no-source auth provider closeout /
+residual refresh.

--- a/governance/mainline/task-cards/pr-460.yaml
+++ b/governance/mainline/task-cards/pr-460.yaml
@@ -1,0 +1,133 @@
+version: "v0.2"
+
+task:
+  id: "pr-460"
+  title: "Implement auth PostgreSQL session provider lane"
+  owner: "codex"
+  created_at: "2026-06-01"
+
+mainline:
+  id: "L1-auth-postgresql-session-provider-implementation"
+  objective: "move four auth.py get_postgresql_session route-body calls behind a route-local provider dependency"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "G2.307 changes an existing auth route module implementation shape but does not add, remove, or rename user-visible functionality."
+
+scope:
+  allowed_paths:
+    - "web/backend/app/api/auth.py"
+    - "web/backend/tests/test_auth_login_contract.py"
+    - ".planning/codebase/generated/auth-postgresql-session-provider-implementation-2026-06-01.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-auth-postgresql-session-provider-implementation-2026-06-01.md"
+    - "governance/mainline/task-cards/pr-460.yaml"
+  forbidden_paths:
+    - "app/core/database.py"
+    - "web/backend/app/core/database.py"
+    - "web/backend/app/router_registry.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "editing app.core.database.get_postgresql_session"
+  - "login/logout/me/refresh/csrf handler behavior changes"
+  - "route registration changes"
+  - "route path, method, response model, or generated OpenAPI artifact changes"
+  - "docs/api artifact edits"
+  - "frontend/config/script changes"
+  - "OpenSpec proposal or spec edits"
+  - "PM2 commands or stateful runtime gates"
+  - "source retirement"
+  - "automatic PR merge"
+
+acceptance:
+  checks:
+    - id: "pr459-merged"
+      command: "gh pr view 459 confirms MERGED at 702816e7aa23378b2acd5dbc27de449fc74a3af5"
+      required: true
+    - id: "tdd-red"
+      command: "pytest -q web/backend/tests/test_auth_login_contract.py::test_auth_db_handlers_use_route_local_session_factory_dependency --tb=short --no-cov -n 0 failed before implementation"
+      required: true
+    - id: "focused-auth-tests"
+      command: "pytest -q web/backend/tests/test_auth.py web/backend/tests/test_auth_login_contract.py --tb=short --no-cov -n 0 records 11 passed, 18 skipped"
+      required: true
+    - id: "ruff"
+      command: "ruff check --no-fix web/backend/app/api/auth.py web/backend/tests/test_auth.py web/backend/tests/test_auth_login_contract.py"
+      required: true
+    - id: "route-openapi-smoke"
+      command: "app.main route/OpenAPI smoke records 548 routes, 500 paths, duplicate operation IDs 0"
+      required: true
+    - id: "provider-scan"
+      command: "source scan records provider backing call 1, route-body direct get_postgresql_session calls 0, dependency bindings 4"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-auth-postgresql-session-provider-implementation-2026-06-01.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-460.yaml --base-sha 702816e7aa23378b2acd5dbc27de449fc74a3af5 --head-sha HEAD --report /tmp/pr460-mainline-governance-report.json"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Auth is security-sensitive; source PR requires human review before merge."
+    - "Shared helper family remains CRITICAL, but the shared helper definition is intentionally untouched."
+  rollback_plan: "Revert PR #460; this restores direct auth route-body get_postgresql_session calls and removes only the provider implementation plus its tests/evidence."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Move four auth.py PostgreSQL session acquisitions behind a route-local provider dependency."
+    modified_scope: "auth.py, focused auth contract test, governance evidence, steward tree records, and task card."
+    dependency_changes: "No package dependency changes."
+    legacy_logic_impact: "Route paths, response models, OpenAPI exposure, cleanup semantics, and compatibility exports are preserved."
+    rollback_ready: "Revert PR #460."
+    risk_and_rollback_point: "Source implementation under auth surface; stop at human review before merge."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-01T21:22:00+08:00"
+    approval_note: "PR #459 accepted/merged the G2.306 no-source authorization; G2.307 may implement only the bounded auth provider lane and must stop at PR review."
+    secondary_approved: true

--- a/web/backend/app/api/auth.py
+++ b/web/backend/app/api/auth.py
@@ -3,6 +3,7 @@
 """
 
 import logging
+from collections.abc import Callable
 from datetime import timedelta
 from typing import Any, Dict
 
@@ -34,9 +35,18 @@ AUTH_ROUTE_RESPONSES = {
 
 router = APIRouter(responses=AUTH_ROUTE_RESPONSES)
 
+SessionFactory = Callable[[], Any]
+
+
+def get_auth_postgresql_session_factory() -> SessionFactory:
+    def _session_factory() -> Any:
+        from app.core.database import get_postgresql_session
+
+        return get_postgresql_session()
+
+    return _session_factory
+
 from app.api._auth_responses import (
-    _success_response_spec,
-    _error_response_spec,
     AUTH_LOGOUT_RESPONSES,
     AUTH_LOGIN_RESPONSES,
     AUTH_ME_RESPONSES,
@@ -48,10 +58,9 @@ from app.api._auth_responses import (
     AUTH_CSRF_RESPONSES,
 )
 from app.api._auth_helpers import (
-    security,
     check_permission,
     get_current_user,
-    get_current_active_user,
+    get_current_active_user,  # noqa: F401 - legacy import path used by indicator modules
 )
 
 @router.post(
@@ -183,7 +192,10 @@ async def refresh_token(
     description="返回系统中的活跃用户列表及总数，仅管理员可访问，用于后台账号管理和权限审查。",
     responses=AUTH_USERS_RESPONSES,
 )
-async def get_users(current_user: User = Depends(get_current_user)) -> Dict[str, Any]:
+async def get_users(
+    current_user: User = Depends(get_current_user),
+    session_factory: SessionFactory = Depends(get_auth_postgresql_session_factory),
+) -> Dict[str, Any]:
     """
     获取用户列表（仅管理员）
     从PostgreSQL数据库获取所有活跃用户
@@ -192,11 +204,10 @@ async def get_users(current_user: User = Depends(get_current_user)) -> Dict[str,
         raise ForbiddenException(detail="权限不足")
 
     try:
-        from app.core.database import get_postgresql_session
         from app.db import UserRepository
         from src.core.exceptions import DatabaseConnectionError, DatabaseOperationError
 
-        session = get_postgresql_session()
+        session = session_factory()
         try:
             repository = UserRepository(session)
             users_list = repository.get_all_users()
@@ -323,7 +334,8 @@ async def register_user(
             "password": "SecurePass123",
             "role": "user",
         },
-    )
+    ),
+    session_factory: SessionFactory = Depends(get_auth_postgresql_session_factory),
 ):
     """
     用户注册
@@ -374,7 +386,6 @@ async def register_user(
     - 409: 用户名或邮箱已存在
     - 500: 服务器错误
     """
-    from app.core.database import get_postgresql_session
     from app.db import UserRepository
     from src.core.exceptions import (
         DatabaseConnectionError,
@@ -384,7 +395,7 @@ async def register_user(
 
     session = None
     try:
-        session = get_postgresql_session()
+        session = session_factory()
         repository = UserRepository(session)
 
         # Hash the password
@@ -466,7 +477,8 @@ async def register_user(
     responses=AUTH_RESET_REQUEST_RESPONSES,
 )
 async def request_password_reset(
-    request: PasswordResetRequest = Body(..., example={"email": "user@example.com"})
+    request: PasswordResetRequest = Body(..., example={"email": "user@example.com"}),
+    session_factory: SessionFactory = Depends(get_auth_postgresql_session_factory),
 ):
     """
     请求密码重置
@@ -500,13 +512,12 @@ async def request_password_reset(
     - 200: 请求已处理
     - 500: 服务器错误
     """
-    from app.core.database import get_postgresql_session
     from app.db import UserRepository
     from src.core.exceptions import DatabaseConnectionError, DatabaseOperationError
 
     session = None
     try:
-        session = get_postgresql_session()
+        session = session_factory()
         repository = UserRepository(session)
 
         # Check if user exists (but don't reveal whether they exist)
@@ -567,7 +578,8 @@ async def confirm_password_reset(
     reset_data: PasswordResetConfirm = Body(
         ...,
         example={"token": "eyJhbGciOiJIUzI1NiIs...", "new_password": "NewSecurePass123"},
-    )
+    ),
+    session_factory: SessionFactory = Depends(get_auth_postgresql_session_factory),
 ):
     """
     确认密码重置
@@ -603,9 +615,6 @@ async def confirm_password_reset(
     - 500: 服务器错误
     """
     from sqlalchemy import text
-
-    from app.core.database import get_postgresql_session
-    from app.core.security import verify_token
 
     session = None
     try:
@@ -646,7 +655,7 @@ async def confirm_password_reset(
             raise BusinessException(detail="Invalid token payload", status_code=400, error_code="INVALID_TOKEN_PAYLOAD")
 
         # Update password in database
-        session = get_postgresql_session()
+        session = session_factory()
         hashed_password = get_password_hash(reset_data.new_password)
 
         update_query = text(

--- a/web/backend/tests/test_auth_login_contract.py
+++ b/web/backend/tests/test_auth_login_contract.py
@@ -1,3 +1,4 @@
+import inspect
 from types import SimpleNamespace
 
 import pytest
@@ -53,3 +54,18 @@ async def test_compat_login_response_includes_numeric_user_id(monkeypatch):
 
 def test_oauth2_password_flow_uses_canonical_v1_login_path():
     assert oauth2_scheme.model.flows.password.tokenUrl == "/api/v1/auth/login"
+
+
+def test_auth_db_handlers_use_route_local_session_factory_dependency():
+    expected_provider = auth_module.get_auth_postgresql_session_factory
+
+    for handler_name in (
+        "get_users",
+        "register_user",
+        "request_password_reset",
+        "confirm_password_reset",
+    ):
+        signature = inspect.signature(getattr(auth_module, handler_name))
+        session_factory = signature.parameters["session_factory"]
+
+        assert session_factory.default.dependency is expected_provider


### PR DESCRIPTION
# Backend Auth PostgreSQL Session Provider Implementation

> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。

Boundary note: this report documents a path-limited source implementation
package. It does not authorize PR merge, future source expansion, route contract
changes, OpenAPI artifact edits, docs/api edits, PM2 commands, source retirement,
or edits outside the G2.307 scope.

Status: for review in future PR `#460`.

## Summary

G2.307 implements the path-limited auth PostgreSQL session provider lane
authorized by G2.306 after PR `#459` was accepted and merged at
`702816e7aa23378b2acd5dbc27de449fc74a3af5`.

This package changes only:

- `web/backend/app/api/auth.py`
- `web/backend/tests/test_auth_login_contract.py`
- G2.307 governance evidence and steward tree records

It does not edit `app.core.database.get_postgresql_session`, route registration,
route paths, response models, generated OpenAPI artifacts, docs/api artifacts,
frontend, config, scripts, OpenSpec, PM2, or runtime state.

## Implementation

| Item | Result |
|---|---|
| Route-local provider | `get_auth_postgresql_session_factory` |
| Provider backing calls | `1` `get_postgresql_session()` call inside the provider factory |
| Route-body direct calls | `0` direct `get_postgresql_session()` calls in the four target handlers |
| Dependency bindings | `4`: `get_users`, `register_user`, `request_password_reset`, `confirm_password_reset` |
| Cleanup lifecycle | Existing `session.close()` in `finally` remains preserved |
| Transaction semantics | `confirm_password_reset` commit/rollback behavior remains preserved |
| Compatibility exports | `verify_token` and `get_current_active_user` remain exported from `app.api.auth` |

## TDD Evidence

RED:

- Added `test_auth_db_handlers_use_route_local_session_factory_dependency`.
- It failed because `app.api.auth.get_auth_postgresql_session_factory` did not
  exist.
- RED result: `1 failed in 0.95s`.

GREEN:

- Added `get_auth_postgresql_session_factory` and injected it into the four
  affected handlers.
- Target result: `1 passed in 0.93s`.
- Focused regression: `11 passed, 18 skipped in 12.24s`.

## Verification

| Check | Result |
|---|---|
| Ruff | `ruff check --no-fix web/backend/app/api/auth.py web/backend/tests/test_auth.py web/backend/tests/test_auth_login_contract.py`: all checks passed |
| Provider scan | provider present, source direct `get_postgresql_session()` calls `1`, all four target handlers use `Depends(get_auth_postgresql_session_factory)` |
| Route/OpenAPI smoke | `routes=548`, `openapi_paths=500`, duplicate operation IDs `0` |
| Generated OpenAPI artifacts | Not edited |
| PM2/runtime state | Not touched |

The route/OpenAPI smoke used non-secret test-only environment values and did not
start PM2.

## GitNexus Evidence

GitNexus MCP impact returned `Transport closed` in this session. CLI fallback
was run before source edits.

| Target | Risk | Direct | Affected processes | Notes |
|---|---:|---:|---:|---|
| `Function:web/backend/app/core/database.py:get_postgresql_session` | CRITICAL | 15 | 54 | shared helper definition intentionally untouched |
| `get_users` | UNKNOWN | n/a | n/a | stale index warning |
| `register_user` | LOW | 0 | 0 | stale index warning |
| `request_password_reset` | LOW | 0 | 0 | stale index warning |
| `confirm_password_reset` | LOW | 0 | 0 | stale index warning |
| staged verification fallback | MEDIUM | 6 changed symbols | 5 | `npx gitnexus verify-staged -r mystocks`; index stale |

## Decision

G2.307 is implemented and ready for PR review. Because this package changes
backend source and tests under an auth/security-sensitive surface, limited
autopilot must stop at PR `#460` review. If PR `#460` is human accepted and
merged, the recommended next gate is G2.308 no-source auth provider closeout /
residual refresh.
