### PR TITLE
docs(governance): close auth session provider lane

### DIFF
--- a/.planning/codebase/generated/auth-postgresql-session-provider-closeout-2026-06-02.json
+++ b/.planning/codebase/generated/auth-postgresql-session-provider-closeout-2026-06-02.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-02T00:20:00+08:00",
+  "g_node": "G2.308",
+  "title": "Auth.py get_postgresql_session provider closeout / residual refresh",
+  "branch": "g2-308-auth-postgresql-session-provider-closeout",
+  "parent_pr": {
+    "number": 460,
+    "url": "https://github.com/chengjon/mystocks/pull/460",
+    "state": "MERGED",
+    "merged_at": "2026-06-01T16:13:22Z",
+    "merge_commit": "833856a526c3083aa4c21a28d31b36ee2a82e9bd",
+    "head_ref": "g2-307-auth-postgresql-session-provider-implementation"
+  },
+  "base_head": "833856a526c3083aa4c21a28d31b36ee2a82e9bd",
+  "source_edit_authority": false,
+  "allowed_scope": [
+    ".planning/codebase/generated/auth-postgresql-session-provider-closeout-2026-06-02.json",
+    ".planning/codebase/steward-tree/current-next-gates.md",
+    ".planning/codebase/steward-tree/steward-index.json",
+    ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+    ".planning/codebase/steward-tree/branch-register.md",
+    ".planning/codebase/steward-tree/evidence-index.md",
+    ".planning/codebase/steward-tree/completed-ledger.md",
+    "docs/reports/quality/backend-auth-postgresql-session-provider-closeout-2026-06-02.md",
+    "governance/mainline/task-cards/pr-461.yaml"
+  ],
+  "forbidden_scope": [
+    "web/backend/**",
+    "web/frontend/**",
+    "src/**",
+    "tests/**",
+    "docs/api/**",
+    "docs/FUNCTION_TREE.md",
+    "governance/function-tree/catalog.yaml",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**",
+    "PM2/runtime state"
+  ],
+  "closeout": {
+    "auth_provider_status": "closed",
+    "provider": "get_auth_postgresql_session_factory",
+    "direct_route_body_get_postgresql_session_calls": 0,
+    "provider_backing_get_postgresql_session_calls": 1,
+    "dependency_bindings": 4,
+    "affected_handlers": [
+      "get_users",
+      "register_user",
+      "request_password_reset",
+      "confirm_password_reset"
+    ],
+    "cleanup_semantics": "session.close() in finally preserved",
+    "transaction_semantics": "confirm_password_reset commit/rollback preserved",
+    "compatibility_exports_retained": [
+      "verify_token",
+      "get_current_active_user"
+    ]
+  },
+  "residual_scan": {
+    "active_route_body_direct_get_postgresql_session_calls": 0,
+    "provider_backing_calls": 2,
+    "import_only_residual_files": [
+      "web/backend/app/api/market/market_data_request.py",
+      "web/backend/app/api/v1/admin/audit.py"
+    ],
+    "files": {
+      "web/backend/app/api/auth.py": {
+        "calls": 1,
+        "imports_or_mentions": 2,
+        "classification": "closed provider backing call"
+      },
+      "web/backend/app/api/v1/admin/optimization.py": {
+        "calls": 1,
+        "imports_or_mentions": 2,
+        "classification": "closed provider backing call"
+      },
+      "web/backend/app/api/market/market_data_request.py": {
+        "calls": 0,
+        "imports_or_mentions": 2,
+        "classification": "import-only residual"
+      },
+      "web/backend/app/api/v1/admin/audit.py": {
+        "calls": 0,
+        "imports_or_mentions": 3,
+        "classification": "import-only residual"
+      }
+    }
+  },
+  "verification": {
+    "focused_auth_tests": "web/backend/tests/test_auth.py web/backend/tests/test_auth_login_contract.py: 11 passed, 18 skipped in 14.54s",
+    "ruff": "ruff check --no-fix web/backend/app/api/auth.py web/backend/tests/test_auth.py web/backend/tests/test_auth_login_contract.py: all checks passed",
+    "route_openapi": {
+      "runtime_routes": 548,
+      "openapi_paths": 500,
+      "duplicate_operation_ids": 0,
+      "warning_count": 119,
+      "note": "Smoke used non-secret test-only environment values and did not start PM2."
+    }
+  },
+  "decision": {
+    "classification": "auth-postgresql-session-provider-closed-no-source-closeout",
+    "source_lane_recommendation": "do-not-start-source-implementation-from-g2-308",
+    "core_database_get_postgresql_session_route_body_status": "no active route-body direct residuals remain in the tracked auth/admin/market/admin-audit route-domain set",
+    "recommended_next_work_item": "G2.309 no-source service lifecycle residual candidate refresh after auth provider closeout",
+    "autopilot_continue_allowed": true
+  },
+  "freshness": {
+    "current_head_checked": "833856a526c3083aa4c21a28d31b36ee2a82e9bd",
+    "stale_if_head_or_pr_state_changes": true,
+    "stale_if_auth_provider_shape_changes": true,
+    "stale_if_route_or_openapi_counts_change": true,
+    "stale_if_residual_scan_changes": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-06-01T21:38:00+08:00`
-- Base HEAD checked: `702816e7aa23378b2acd5dbc27de449fc74a3af5`
+- Prepared at: `2026-06-02T00:20:00+08:00`
+- Base HEAD checked: `833856a526c3083aa4c21a28d31b36ee2a82e9bd`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -278,3 +278,5 @@ G2.305 is the no-source auth.py `get_postgresql_session` ownership / provider-sh
 G2.306 is the no-source auth.py `get_postgresql_session` provider authorization after PR `#458` merged G2.305 at `8a6cfa615f472f23643a13ab18ab02dd0853ad96`. It authorizes only a future G2.307 path-limited source lane for `web/backend/app/api/auth.py` plus focused auth tests, requiring a route-local auth PostgreSQL session factory provider, injection into the four affected handlers, preservation of close/finally cleanup, and preservation of `confirm_password_reset` commit/rollback semantics. It records focused auth tests `10 passed / 18 skipped`, route/OpenAPI `548/500/0`, ruff no-fix findings `6`, and shared helper GitNexus CLI impact `CRITICAL` with `15` direct dependants and `54` affected processes. It must not edit source in PR `#459`, and G2.307 must stop at human review before merge.
 
 G2.307 is the path-limited auth.py `get_postgresql_session` provider implementation after PR `#459` merged G2.306 at `702816e7aa23378b2acd5dbc27de449fc74a3af5`. It adds `get_auth_postgresql_session_factory`, injects it into `get_users`, `register_user`, `request_password_reset`, and `confirm_password_reset`, preserves close/finally cleanup and password reset commit/rollback semantics, and keeps route/OpenAPI at `548/500/0`. It records TDD RED `1 failed`, GREEN target `1 passed`, focused auth regression `11 passed / 18 skipped`, ruff clean, provider backing calls `1`, and route-body direct calls `0`. It changes backend source/tests and must stop at future PR `#460` review; if accepted, the next gate is G2.308 no-source auth provider closeout / residual refresh.
+
+G2.308 is the no-source auth.py `get_postgresql_session` provider closeout / residual refresh after PR `#460` merged G2.307 at `833856a526c3083aa4c21a28d31b36ee2a82e9bd`. It records auth route-body direct calls `0`, auth provider backing call `1`, dependency bindings `4`, focused auth tests `11 passed / 18 skipped`, ruff clean, route/OpenAPI `548/500/0`, and tracked route-domain active direct residuals `0`. It classifies remaining calls as provider backing or import-only residuals and selects only G2.309 no-source service lifecycle residual candidate refresh after auth closeout.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-06-01T21:38:00+08:00`
-- Base HEAD checked: `702816e7aa23378b2acd5dbc27de449fc74a3af5`
+- Prepared at: `2026-06-02T00:20:00+08:00`
+- Base HEAD checked: `833856a526c3083aa4c21a28d31b36ee2a82e9bd`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -19,7 +19,7 @@ exact verification output.
 | Route/OpenAPI and control-plane governance | Established route table, OpenAPI exposure, health/probe taxonomy, and consumer-contract evidence as first-class governance facts | Continue through route/OpenAPI track, not ad hoc route edits |
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
-| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.306 accepted/merged by PR `#459` at `702816e7` | Continue with G2.307 auth provider implementation; source PR must stop at human review |
+| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.307 accepted/merged by PR `#460` at `833856a5` | Continue with G2.308 auth provider closeout / residual refresh; no source work is authorized |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
 | Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.301 have progressed through PR `#337`-`#454`; current review target is G2.302 admin optimization provider authorization in future PR `#455` |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
@@ -28,6 +28,7 @@ exact verification output.
 
 | Item | Accepted evidence | Follow-up |
 |---|---|---|
+| G2.307 auth.py PostgreSQL session provider implementation | PR `#460` merged at `833856a526c3083aa4c21a28d31b36ee2a82e9bd`; generated implementation evidence records provider `get_auth_postgresql_session_factory`, four dependency bindings, provider backing `1`, route-body direct calls `0`, focused auth tests `11/29`, ruff clean, and route/OpenAPI `548/500/0` | G2.308 no-source closeout / residual refresh records auth closure and selects the next no-source residual candidate refresh |
 | G2.306 auth.py PostgreSQL session provider authorization | PR `#459` merged at `702816e7aa23378b2acd5dbc27de449fc74a3af5`; generated authorization evidence records future G2.307 scope limited to `auth.py` plus focused auth tests, route/OpenAPI `548/500/0`, focused auth tests `10 passed / 18 skipped`, and CRITICAL shared helper-family risk | G2.307 may only implement the bounded auth provider lane and must stop at PR `#460` review |
 | G2.305 auth.py PostgreSQL session ownership / provider-shape decision | PR `#458` merged at `8a6cfa615f472f23643a13ab18ab02dd0853ad96`; generated decision evidence records auth direct calls `4`, focused auth tests `10 passed / 18 skipped`, route/OpenAPI `548/500/0`, and existing ruff no-fix findings `6` | G2.306 no-source authorization may authorize only a bounded future G2.307 auth provider implementation |
 | G2.304 admin optimization provider closeout / residual refresh | PR `#457` merged at `d8e52a3b0000426a9ce278c5dbc1c4bbd8c6b4f9`; generated closeout evidence records admin optimization helper direct calls `0`, provider backing `1`, dependency bindings `4`, focused test `7/7`, route/OpenAPI `548/500/0`, and remaining auth direct calls `4` | G2.305 no-source auth ownership / provider-shape decision records auth surface and selects only no-source authorization |

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-06-01T21:38:00+08:00`
-- Base HEAD checked: `702816e7aa23378b2acd5dbc27de449fc74a3af5`
+- Prepared at: `2026-06-02T00:20:00+08:00`
+- Base HEAD checked: `833856a526c3083aa4c21a28d31b36ee2a82e9bd`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.307 auth.py `get_postgresql_session` provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#459` merged at `702816e7aa23378b2acd5dbc27de449fc74a3af5`; G2.307 adds `get_auth_postgresql_session_factory`, moves four auth handlers to provider injection, leaves provider backing calls `1` and route-body direct calls `0`, focused auth tests `11 passed / 18 skipped`, route/OpenAPI `548/500/0` | Review future PR `#460`; source PR must not auto-merge. If accepted, start G2.308 no-source auth provider closeout / residual refresh |
+| P0 | Review G2.308 auth.py `get_postgresql_session` provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#460` merged at `833856a526c3083aa4c21a28d31b36ee2a82e9bd`; G2.308 records auth route-body direct calls `0`, auth provider backing `1`, tracked route-domain active direct residuals `0`, focused auth tests `11 passed / 18 skipped`, route/OpenAPI `548/500/0` | Review future PR `#461`; if accepted, start G2.309 no-source service lifecycle residual candidate refresh after auth closeout |
+| P0 | Preserve G2.307 auth.py `get_postgresql_session` provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#460` merged at `833856a526c3083aa4c21a28d31b36ee2a82e9bd`; G2.307 added `get_auth_postgresql_session_factory`, moved four auth handlers to provider injection, kept provider backing calls `1`, route-body direct calls `0`, focused auth tests `11 passed / 18 skipped`, route/OpenAPI `548/500/0` | Do not use G2.307 as authority for shared helper definitions, route contracts, docs/api, frontend, config, scripts, OpenSpec, PM2, or runtime state |
 | P0 | Preserve G2.306 auth.py `get_postgresql_session` provider authorization | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#459` merged at `702816e7aa23378b2acd5dbc27de449fc74a3af5`; G2.306 authorized only the bounded G2.307 auth implementation lane | Do not use G2.306 to expand beyond `auth.py` and focused auth contract tests |
 | P0 | Preserve G2.305 auth.py `get_postgresql_session` ownership / provider-shape decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#458` merged at `8a6cfa615f472f23643a13ab18ab02dd0853ad96`; G2.305 classified four active auth direct calls across `get_users`, `register_user`, `request_password_reset`, and `confirm_password_reset`, focused auth tests `10 passed / 18 skipped`, route/OpenAPI `548/500/0` | Do not use G2.305 as source implementation authority; use G2.306 only as no-source authorization package |
 | P0 | Preserve G2.304 admin optimization provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#457` merged at `d8e52a3b0000426a9ce278c5dbc1c4bbd8c6b4f9`; G2.304 closed admin optimization with helper direct calls `0`, provider backing `1`, `Depends` bindings `4`, focused tests `7 passed`, route/OpenAPI `548/500/0`, and remaining active direct residuals concentrated in `auth.py` `4` | Do not use G2.304 as source implementation authority; use G2.305 only as no-source auth ownership decision |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-06-01T21:38:00+08:00`
-- Base HEAD checked: `702816e7aa23378b2acd5dbc27de449fc74a3af5`
+- Prepared at: `2026-06-02T00:20:00+08:00`
+- Base HEAD checked: `833856a526c3083aa4c21a28d31b36ee2a82e9bd`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -16,6 +16,9 @@ state transition.
 
 | Evidence | Role | Freshness policy |
 |---|---|---|
+| `.planning/codebase/generated/auth-postgresql-session-provider-closeout-2026-06-02.json` | G2.308 auth.py PostgreSQL session provider closeout / residual refresh evidence | Review input for future PR `#461`; no-source closeout package; closes auth provider lane and selects only G2.309 no-source residual candidate refresh |
+| `docs/reports/quality/backend-auth-postgresql-session-provider-closeout-2026-06-02.md` | G2.308 human-readable closeout / residual refresh report | Review input for future PR `#461`; records PR `#460` accepted/merged, auth closeout counts, residual refresh, focused tests, ruff, and route/OpenAPI smoke |
+| `governance/mainline/task-cards/pr-461.yaml` | Governance task card for G2.308 no-source closeout | Review input; allows only steward tree, generated evidence, report, and task card updates |
 | `.planning/codebase/generated/auth-postgresql-session-provider-implementation-2026-06-01.json` | G2.307 auth.py PostgreSQL session provider implementation evidence | Review input for future PR `#460`; source implementation package; must stop at human review before merge |
 | `docs/reports/quality/backend-auth-postgresql-session-provider-implementation-2026-06-01.md` | G2.307 human-readable implementation report | Review input for future PR `#460`; records TDD RED/GREEN, provider scan, focused tests, route/OpenAPI smoke, ruff, and GitNexus fallback |
 | `governance/mainline/task-cards/pr-460.yaml` | Governance task card for G2.307 source implementation | Review input; allows only path-limited auth source/test plus steward tree, generated evidence, report, and task card updates |

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,9 +1,9 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-06-01T21:38:00+08:00",
+  "generated_at": "2026-06-02T00:20:00+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "702816e7aa23378b2acd5dbc27de449fc74a3af5",
+  "base_head": "833856a526c3083aa4c21a28d31b36ee2a82e9bd",
   "split_branch": "g2-302-admin-optimization-postgresql-session-provider-authorization",
   "scope": "admin_optimization_postgresql_session_provider_authorization",
   "source_edit_authority": false,
@@ -11339,17 +11339,19 @@
     {
       "id": "g2-307-auth-postgresql-session-provider-implementation",
       "type": "implementation",
-      "state": "for_review",
+      "state": "accepted_merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.306 auth.py get_postgresql_session provider authorization",
       "source_edit_authority": true,
-      "autopilot_status": "stop_at_source_pr_review",
-      "autopilot_stop_reason": "G2.307 changes backend source/tests under an auth/security-sensitive surface and must not auto-merge.",
+      "autopilot_status": "source_pr_human_accepted_merged",
+      "autopilot_stop_reason": "PR #460 changed backend source/tests under an auth/security-sensitive surface and was merged only after human approval.",
       "github_pr": {
         "number": 460,
         "url": "https://github.com/chengjon/mystocks/pull/460",
-        "state": "PLANNED_FOR_REVIEW",
-        "head_ref": "g2-307-auth-postgresql-session-provider-implementation"
+        "state": "MERGED",
+        "merged_at": "2026-06-01T16:13:22Z",
+        "head_ref": "g2-307-auth-postgresql-session-provider-implementation",
+        "merge_commit": "833856a526c3083aa4c21a28d31b36ee2a82e9bd"
       },
       "evidence": [
         ".planning/codebase/generated/auth-postgresql-session-provider-implementation-2026-06-01.json",
@@ -11422,14 +11424,97 @@
         }
       },
       "freshness": {
-        "current_head_checked": "702816e7aa23378b2acd5dbc27de449fc74a3af5",
+        "current_head_checked": "833856a526c3083aa4c21a28d31b36ee2a82e9bd",
         "stale_if_head_or_pr_state_changes": true,
         "stale_if_auth_session_call_sites_change": true,
         "stale_if_route_or_openapi_counts_change": true,
         "stale_if_auth_tests_change": true,
         "stale_if_gitnexus_risk_changes": true
       },
-      "next_gate": "Review PR #460. If human accepted and merged, start G2.308 no-source auth provider closeout / residual refresh."
+      "next_gate": "Superseded by G2.308 no-source auth provider closeout / residual refresh."
+    },
+    {
+      "id": "g2-308-auth-postgresql-session-provider-closeout",
+      "type": "closeout_refresh",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.307 auth.py get_postgresql_session provider implementation",
+      "source_edit_authority": false,
+      "autopilot_status": "review_gate",
+      "autopilot_stop_reason": "G2.308 is no-source and may be auto-merged if checks pass; it selects only a future no-source residual candidate refresh.",
+      "github_pr": {
+        "number": 461,
+        "url": "https://github.com/chengjon/mystocks/pull/461",
+        "state": "PLANNED_FOR_REVIEW",
+        "head_ref": "g2-308-auth-postgresql-session-provider-closeout"
+      },
+      "evidence": [
+        ".planning/codebase/generated/auth-postgresql-session-provider-closeout-2026-06-02.json",
+        "docs/reports/quality/backend-auth-postgresql-session-provider-closeout-2026-06-02.md",
+        "governance/mainline/task-cards/pr-461.yaml"
+      ],
+      "closed_parent": {
+        "pr": 460,
+        "state": "MERGED",
+        "merge_commit": "833856a526c3083aa4c21a28d31b36ee2a82e9bd",
+        "merged_at": "2026-06-01T16:13:22Z"
+      },
+      "allowed_scope": [
+        ".planning/codebase/generated/auth-postgresql-session-provider-closeout-2026-06-02.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-auth-postgresql-session-provider-closeout-2026-06-02.md",
+        "governance/mainline/task-cards/pr-461.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "tests/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "closeout": {
+        "auth_provider_status": "closed",
+        "provider": "get_auth_postgresql_session_factory",
+        "direct_route_body_get_postgresql_session_calls": 0,
+        "provider_backing_get_postgresql_session_calls": 1,
+        "dependency_bindings": 4,
+        "focused_auth_tests": "11 passed, 18 skipped",
+        "ruff": "all checks passed",
+        "route_openapi": "548/500/0"
+      },
+      "residual_scan": {
+        "active_route_body_direct_get_postgresql_session_calls": 0,
+        "provider_backing_calls": 2,
+        "import_only_residual_files": [
+          "web/backend/app/api/market/market_data_request.py",
+          "web/backend/app/api/v1/admin/audit.py"
+        ]
+      },
+      "decision": {
+        "classification": "auth-postgresql-session-provider-closed-no-source-lane",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-308",
+        "recommended_next_work_item": "G2.309 no-source service lifecycle residual candidate refresh after auth provider closeout",
+        "autopilot_continue_allowed": true
+      },
+      "freshness": {
+        "current_head_checked": "833856a526c3083aa4c21a28d31b36ee2a82e9bd",
+        "stale_if_head_or_pr_state_changes": true,
+        "stale_if_auth_provider_shape_changes": true,
+        "stale_if_route_or_openapi_counts_change": true,
+        "stale_if_residual_scan_changes": true
+      },
+      "next_gate": "Review PR #461. If accepted and merged, start G2.309 no-source service lifecycle residual candidate refresh after auth provider closeout."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -3375,7 +3375,7 @@ Status: accepted/merged by PR `#459` at `702816e7aa23378b2acd5dbc27de449fc74a3af
 
 ## G2.307 Auth.py PostgreSQL Session Provider Implementation
 
-Status: for review in future PR `#460`.
+Status: accepted/merged by PR `#460` at `833856a526c3083aa4c21a28d31b36ee2a82e9bd`.
 
 - Parent PR `#459` merged at `702816e7aa23378b2acd5dbc27de449fc74a3af5`.
 - G2.307 is a path-limited source implementation package. It edits only `web/backend/app/api/auth.py`, `web/backend/tests/test_auth_login_contract.py`, and governance evidence records.
@@ -3386,3 +3386,16 @@ Status: for review in future PR `#460`.
 - GitNexus MCP impact returned `Transport closed`; CLI fallback keeps shared `Function:web/backend/app/core/database.py:get_postgresql_session` at `CRITICAL`, and the shared helper definition is intentionally untouched.
 - Recommended next gate after human acceptance and merge: G2.308 no-source auth provider closeout / residual refresh.
 - Stop rule: PR `#460` changes backend source/tests and must not auto-merge.
+
+## G2.308 Auth.py PostgreSQL Session Provider Closeout / Residual Refresh
+
+Status: for review in future PR `#461`.
+
+- Parent PR `#460` merged at `833856a526c3083aa4c21a28d31b36ee2a82e9bd`.
+- G2.308 is a no-source closeout / residual refresh package. It does not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+- Auth provider lane is closed: route-body direct `get_postgresql_session()` calls are `0`, provider backing call is `1`, and dependency bindings are `4`.
+- Focused auth tests record `11 passed, 18 skipped`; ruff is clean; route/OpenAPI smoke remains `548` routes, `500` paths, duplicate operation IDs `0`.
+- Tracked auth / admin optimization / market stock-list / admin audit route-domain active route-body direct `get_postgresql_session()` residuals are now `0`.
+- Provider backing calls remain by design in `auth.py` and admin optimization; import-only residuals remain in market stock-list and admin audit files.
+- Recommended next gate after PR `#461` acceptance: G2.309 no-source service lifecycle residual candidate refresh after auth provider closeout.
+- Stop rule: G2.308 must not be used as source implementation authority.

--- a/docs/reports/quality/backend-auth-postgresql-session-provider-closeout-2026-06-02.md
+++ b/docs/reports/quality/backend-auth-postgresql-session-provider-closeout-2026-06-02.md
@@ -1,0 +1,65 @@
+# Backend Auth PostgreSQL Session Provider Closeout
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+Boundary note: this report is a no-source closeout / residual refresh package.
+It does not edit backend source, tests, route contracts, docs/api artifacts,
+frontend, config, scripts, OpenSpec changes/specs, PM2, or runtime state.
+
+Status: for review in future PR `#461`.
+
+## Summary
+
+G2.308 closes out the auth PostgreSQL session provider implementation after PR
+`#460` was merged at `833856a526c3083aa4c21a28d31b36ee2a82e9bd`.
+
+This package is no-source. It records the implementation result, refreshes the
+remaining `get_postgresql_session()` residuals, and selects only the next
+no-source residual candidate refresh gate.
+
+## Closeout Result
+
+| Item | Result |
+|---|---|
+| Auth provider | `get_auth_postgresql_session_factory` |
+| Route-body direct calls | `0` across `get_users`, `register_user`, `request_password_reset`, and `confirm_password_reset` |
+| Provider backing calls | `1` |
+| Dependency bindings | `4` |
+| Cleanup lifecycle | `session.close()` in `finally` remains preserved |
+| Transaction semantics | `confirm_password_reset` commit/rollback behavior remains preserved |
+| Compatibility exports | `verify_token` and `get_current_active_user` remain available from `app.api.auth` |
+
+## Residual Refresh
+
+| File | Calls | Imports / mentions | Classification |
+|---|---:|---:|---|
+| `web/backend/app/api/auth.py` | `1` | `2` | closed provider backing call |
+| `web/backend/app/api/v1/admin/optimization.py` | `1` | `2` | closed provider backing call |
+| `web/backend/app/api/market/market_data_request.py` | `0` | `2` | import-only residual |
+| `web/backend/app/api/v1/admin/audit.py` | `0` | `3` | import-only residual |
+
+Tracked active route-body direct `get_postgresql_session()` residuals are now
+`0` in the auth / admin optimization / market stock-list / admin audit route
+domain set. Provider backing calls remain by design.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Parent PR | PR `#460` is `MERGED` at `833856a526c3083aa4c21a28d31b36ee2a82e9bd` |
+| Focused auth tests | `11 passed, 18 skipped in 14.54s` |
+| Ruff | `ruff check --no-fix web/backend/app/api/auth.py web/backend/tests/test_auth.py web/backend/tests/test_auth_login_contract.py`: all checks passed |
+| Route/OpenAPI smoke | `548` routes, `500` paths, duplicate operation IDs `0` |
+| Generated OpenAPI artifacts | Not edited |
+| PM2/runtime state | Not touched |
+
+The route/OpenAPI smoke used non-secret test-only environment values and did not
+start PM2.
+
+## Decision
+
+Close the auth PostgreSQL session provider lane. G2.308 must not be used as
+source implementation authority.
+
+Recommended next gate after PR `#461` acceptance: G2.309 no-source service
+lifecycle residual candidate refresh after auth provider closeout.

--- a/governance/mainline/task-cards/pr-461.yaml
+++ b/governance/mainline/task-cards/pr-461.yaml
@@ -1,0 +1,133 @@
+version: "v0.2"
+
+task:
+  id: "pr-461"
+  title: "Close auth PostgreSQL session provider lane"
+  owner: "codex"
+  created_at: "2026-06-02"
+
+mainline:
+  id: "L1-auth-postgresql-session-provider-closeout"
+  objective: "close out the auth.py get_postgresql_session provider implementation and refresh residuals"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "api"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "G2.308 is a no-source closeout / residual refresh. It changes no runtime route, handler, contract, source file, or test file."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/auth-postgresql-session-provider-closeout-2026-06-02.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-auth-postgresql-session-provider-closeout-2026-06-02.md"
+    - "governance/mainline/task-cards/pr-461.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits in this PR"
+  - "test edits in this PR"
+  - "route registration changes"
+  - "route path, method, response model, or generated OpenAPI artifact changes"
+  - "docs/api artifact edits"
+  - "frontend/config/script changes"
+  - "OpenSpec proposal or spec edits"
+  - "PM2 commands or stateful runtime gates"
+  - "source retirement"
+  - "editing app.core.database.get_postgresql_session"
+  - "editing auth.py"
+
+acceptance:
+  checks:
+    - id: "pr460-merged"
+      command: "gh pr view 460 confirms MERGED at 833856a526c3083aa4c21a28d31b36ee2a82e9bd"
+      required: true
+    - id: "auth-closeout"
+      command: "scan records auth route-body direct get_postgresql_session calls 0, provider backing calls 1, dependency bindings 4"
+      required: true
+    - id: "residual-refresh"
+      command: "scan records tracked route-domain active route-body direct get_postgresql_session residuals 0 and provider backing calls 2"
+      required: true
+    - id: "focused-auth-tests"
+      command: "pytest -q web/backend/tests/test_auth.py web/backend/tests/test_auth_login_contract.py --tb=short --no-cov -n 0 records 11 passed, 18 skipped"
+      required: true
+    - id: "route-openapi-smoke"
+      command: "app.main route/OpenAPI smoke records 548 routes, 500 paths, duplicate operation IDs 0"
+      required: true
+    - id: "no-source-boundary"
+      command: "PR #461 edits no backend source, tests, route contracts, docs/api, frontend, config, scripts, OpenSpec, PM2, or runtime state"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-auth-postgresql-session-provider-closeout-2026-06-02.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-461.yaml --base-sha 833856a526c3083aa4c21a28d31b36ee2a82e9bd --head-sha HEAD --report /tmp/pr461-mainline-governance-report.json"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "No runtime risk from this PR because it is no-source governance only."
+    - "Provider backing calls remain by design and must not be misread as route-body residuals."
+  rollback_plan: "Revert PR #461; this removes only G2.308 closeout evidence and restores the prior G2.307 gate text."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Close the auth PostgreSQL session provider lane and refresh residuals."
+    modified_scope: "Governance evidence, steward tree indexes, report, and task card only."
+    dependency_changes: "No package dependency changes."
+    legacy_logic_impact: "No runtime behavior, route contract, OpenAPI, or source changes."
+    rollback_ready: "Revert PR #461."
+    risk_and_rollback_point: "No-source closeout; rollback is single-PR revert."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-02T00:14:00+08:00"
+    approval_note: "Human maintainer approved PR #460 merge and continuation into G2.308 no-source auth provider closeout / residual refresh."
+    secondary_approved: false


### PR DESCRIPTION
# Backend Auth PostgreSQL Session Provider Closeout

> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。

Boundary note: this report is a no-source closeout / residual refresh package.
It does not edit backend source, tests, route contracts, docs/api artifacts,
frontend, config, scripts, OpenSpec changes/specs, PM2, or runtime state.

Status: for review in future PR `#461`.

## Summary

G2.308 closes out the auth PostgreSQL session provider implementation after PR
`#460` was merged at `833856a526c3083aa4c21a28d31b36ee2a82e9bd`.

This package is no-source. It records the implementation result, refreshes the
remaining `get_postgresql_session()` residuals, and selects only the next
no-source residual candidate refresh gate.

## Closeout Result

| Item | Result |
|---|---|
| Auth provider | `get_auth_postgresql_session_factory` |
| Route-body direct calls | `0` across `get_users`, `register_user`, `request_password_reset`, and `confirm_password_reset` |
| Provider backing calls | `1` |
| Dependency bindings | `4` |
| Cleanup lifecycle | `session.close()` in `finally` remains preserved |
| Transaction semantics | `confirm_password_reset` commit/rollback behavior remains preserved |
| Compatibility exports | `verify_token` and `get_current_active_user` remain available from `app.api.auth` |

## Residual Refresh

| File | Calls | Imports / mentions | Classification |
|---|---:|---:|---|
| `web/backend/app/api/auth.py` | `1` | `2` | closed provider backing call |
| `web/backend/app/api/v1/admin/optimization.py` | `1` | `2` | closed provider backing call |
| `web/backend/app/api/market/market_data_request.py` | `0` | `2` | import-only residual |
| `web/backend/app/api/v1/admin/audit.py` | `0` | `3` | import-only residual |

Tracked active route-body direct `get_postgresql_session()` residuals are now
`0` in the auth / admin optimization / market stock-list / admin audit route
domain set. Provider backing calls remain by design.

## Verification

| Check | Result |
|---|---|
| Parent PR | PR `#460` is `MERGED` at `833856a526c3083aa4c21a28d31b36ee2a82e9bd` |
| Focused auth tests | `11 passed, 18 skipped in 14.54s` |
| Ruff | `ruff check --no-fix web/backend/app/api/auth.py web/backend/tests/test_auth.py web/backend/tests/test_auth_login_contract.py`: all checks passed |
| Route/OpenAPI smoke | `548` routes, `500` paths, duplicate operation IDs `0` |
| Generated OpenAPI artifacts | Not edited |
| PM2/runtime state | Not touched |

The route/OpenAPI smoke used non-secret test-only environment values and did not
start PM2.

## Decision

Close the auth PostgreSQL session provider lane. G2.308 must not be used as
source implementation authority.

Recommended next gate after PR `#461` acceptance: G2.309 no-source service
lifecycle residual candidate refresh after auth provider closeout.
