### PR TITLE
docs(governance): authorize indicator registry factory provider

### DIFF
--- a/.planning/codebase/generated/indicator-registry-factory-provider-authorization-2026-06-02.json
+++ b/.planning/codebase/generated/indicator-registry-factory-provider-authorization-2026-06-02.json
@@ -1,0 +1,159 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-02T01:46:33+08:00",
+  "node": "G2.314",
+  "title": "indicator_registry get_factory provider authorization package",
+  "repo": "mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "75f6c63023bec35453892f63aaeaf193023e4881",
+  "parent_gate": {
+    "node": "G2.313",
+    "github_pr": {
+      "number": 466,
+      "url": "https://github.com/chengjon/mystocks/pull/466",
+      "state": "MERGED",
+      "merge_commit": "75f6c63023bec35453892f63aaeaf193023e4881",
+      "merged_at": "2026-06-01T17:41:49Z",
+      "head_ref": "g2-313-indicator-registry-factory-ownership-decision"
+    },
+    "decision": "indicator_registry.get_factory ownership decision accepted the target as an active route-local singleton factory helper"
+  },
+  "source_edit_authority": false,
+  "authorization_type": "future-source-lane-authorization-only",
+  "authorized_future_node": "G2.315",
+  "target": {
+    "file": "web/backend/app/api/indicator_registry.py",
+    "symbol": "get_factory",
+    "line": 99,
+    "global_state": "_factory",
+    "factory_class": "IndicatorFactory",
+    "direct_route_body_call_lines": [
+      159,
+      186,
+      201
+    ]
+  },
+  "route_truth": {
+    "total_routes": 548,
+    "openapi_paths": 500,
+    "duplicate_operation_id_warnings": 0,
+    "registered_routes": [
+      {
+        "method": "GET",
+        "path": "/api/indicator-registry/indicators",
+        "endpoint": "list_indicators",
+        "direct_call_line": 159
+      },
+      {
+        "method": "GET",
+        "path": "/api/indicator-registry/indicators/{indicator_id}",
+        "endpoint": "get_indicator_details",
+        "direct_call_line": 186
+      },
+      {
+        "method": "POST",
+        "path": "/api/indicator-registry/calculate",
+        "endpoint": "calculate_indicator",
+        "direct_call_line": 201
+      }
+    ]
+  },
+  "gitnexus": {
+    "mcp_impact": {
+      "status": "failed",
+      "tool": "mcp__gitnexus.impact",
+      "error": "Transport closed"
+    },
+    "cli_fallback": {
+      "command": "npx gitnexus impact get_factory -r mystocks --direction upstream --summary-only",
+      "target": "Function:web/backend/app/api/indicator_registry.py:get_factory",
+      "risk": "LOW",
+      "direct_callers": 3,
+      "affected_processes": 0,
+      "affected_modules": [
+        "Api"
+      ],
+      "stale_index": true,
+      "commits_behind": 0
+    }
+  },
+  "future_source_scope": {
+    "authorized": true,
+    "requires_human_review_before_merge": true,
+    "allowed_paths": [
+      "web/backend/app/api/indicator_registry.py",
+      "tests/api/file_tests/test_indicator_registry_api.py"
+    ],
+    "forbidden_paths": [
+      "non-indicator-registry backend source",
+      "generated OpenAPI artifacts",
+      "docs/api artifacts",
+      "frontend",
+      "config",
+      "scripts",
+      "OpenSpec proposals/specs",
+      "PM2/runtime state"
+    ],
+    "required_shape": [
+      "Add a route-local provider dependency for IndicatorFactory without changing public route paths, methods, response models, or OpenAPI path count.",
+      "Move list_indicators, get_indicator_details, and calculate_indicator away from route-body get_factory() calls.",
+      "Retain get_factory() as backing compatibility / singleton construction seam unless a later explicit retirement decision exists.",
+      "Add or update focused file-level tests proving provider wiring and preserving route/model contracts.",
+      "Run route/OpenAPI smoke and focused tests before PR."
+    ],
+    "future_stop_rule": "G2.315 source implementation PR must stop for human review before merge; limited autopilot must not merge it automatically."
+  },
+  "verification_plan": {
+    "focused_tests": [
+      "pytest -o addopts= tests/api/file_tests/test_indicator_registry_api.py --no-cov -q",
+      "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov"
+    ],
+    "static_checks": [
+      "ruff check web/backend/app/api/indicator_registry.py tests/api/file_tests/test_indicator_registry_api.py",
+      "route/OpenAPI smoke: 548 routes, 500 paths, duplicate_operation_id_warnings=0"
+    ],
+    "gitnexus": [
+      "Run GitNexus impact before source edit.",
+      "Run gitnexus verify-staged or detect_changes before commit."
+    ]
+  },
+  "decision": {
+    "classification": "bounded-active-route-local-factory-provider-authorization",
+    "source_lane_recommendation": "authorize-future-g2-315-path-limited-source-pr-only-after-human-review",
+    "provider_implementation_authorized_by_this_no_source_package": true,
+    "autopilot_continue_allowed": false,
+    "autopilot_stop_reason": "The next node is a source implementation lane and must stop for human review before merge."
+  },
+  "allowed_scope": [
+    ".planning/codebase/generated/indicator-registry-factory-provider-authorization-2026-06-02.json",
+    ".planning/codebase/steward-tree/current-next-gates.md",
+    ".planning/codebase/steward-tree/steward-index.json",
+    ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+    ".planning/codebase/steward-tree/branch-register.md",
+    ".planning/codebase/steward-tree/evidence-index.md",
+    ".planning/codebase/steward-tree/completed-ledger.md",
+    "docs/reports/quality/backend-indicator-registry-factory-provider-authorization-2026-06-02.md",
+    "governance/mainline/task-cards/pr-467.yaml"
+  ],
+  "forbidden_scope": [
+    "web/backend/**",
+    "web/frontend/**",
+    "src/**",
+    "tests/**",
+    "docs/api/**",
+    "docs/FUNCTION_TREE.md",
+    "governance/function-tree/catalog.yaml",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**"
+  ],
+  "freshness": {
+    "current_head_checked": "75f6c63023bec35453892f63aaeaf193023e4881",
+    "stale_if_head_or_pr_state_changes": true,
+    "stale_if_route_or_openapi_counts_change": true,
+    "stale_if_get_factory_call_surface_changes": true,
+    "stale_if_gitnexus_index_refresh_changes_risk": true
+  },
+  "next_gate": "Review future PR #467. If accepted and merged, G2.315 may be created as a source implementation PR but must stop for human review before merge."
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-06-02T01:35:43+08:00`
-- Base HEAD checked: `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`
+- Prepared at: `2026-06-02T01:46:33+08:00`
+- Base HEAD checked: `75f6c63023bec35453892f63aaeaf193023e4881`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -290,3 +290,5 @@ G2.311 is the no-source indicator config router ownership / registration-retirem
 G2.312 is the no-source service lifecycle residual candidate refresh after PR `#464` merged G2.311 at `0f5382cea875d2983ada5d9c63548b0530861002`. It excludes dormant `create_indicator_config.py` / `get_mysql_session`, records `371` Python files scanned, `663` getter-like names, and `53` active interesting candidates, and selects only G2.313 no-source `indicator_registry.get_factory` ownership / route-provider decision for `web/backend/app/api/indicator_registry.py`.
 
 G2.313 is the no-source `indicator_registry.get_factory` ownership / route-provider decision after PR `#465` merged G2.312 at `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`. It records `web/backend/app/api/indicator_registry.py` as an active registered route module with three `get_factory()` route-body calls at lines `159`, `186`, and `201`, route/OpenAPI `548/500/0`, and GitNexus CLI `LOW` risk with `3` direct callers and `0` affected processes. It does not authorize source implementation and selects only G2.314 no-source `indicator_registry.get_factory` provider authorization after future PR `#466` acceptance.
+
+G2.314 is the no-source `indicator_registry.get_factory` provider authorization after PR `#466` merged G2.313 at `75f6c63023bec35453892f63aaeaf193023e4881`. It authorizes only a future G2.315 path-limited implementation lane for `web/backend/app/api/indicator_registry.py` plus `tests/api/file_tests/test_indicator_registry_api.py`, requires route/OpenAPI `548/500/0` preservation, and requires G2.315 to stop for human review before merge. It does not edit source in PR `#467`.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-06-02T01:35:43+08:00`
-- Base HEAD checked: `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`
+- Prepared at: `2026-06-02T01:46:33+08:00`
+- Base HEAD checked: `75f6c63023bec35453892f63aaeaf193023e4881`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -19,7 +19,7 @@ exact verification output.
 | Route/OpenAPI and control-plane governance | Established route table, OpenAPI exposure, health/probe taxonomy, and consumer-contract evidence as first-class governance facts | Continue through route/OpenAPI track, not ad hoc route edits |
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
-| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.312 accepted/merged by PR `#465` at `ac6b9faa`; continue with G2.313 no-source indicator_registry get_factory ownership decision; no source work is authorized |
+| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.313 accepted/merged by PR `#466` at `75f6c630`; continue with G2.314 no-source indicator_registry get_factory provider authorization; source implementation remains human-review gated |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
 | Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.301 have progressed through PR `#337`-`#454`; current review target is G2.302 admin optimization provider authorization in future PR `#455` |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
@@ -28,6 +28,7 @@ exact verification output.
 
 | Item | Accepted evidence | Follow-up |
 |---|---|---|
+| G2.313 indicator_registry `get_factory` ownership / route-provider decision | PR `#466` merged at `75f6c63023bec35453892f63aaeaf193023e4881`; generated decision evidence records active route-local singleton factory calls at lines `159`, `186`, and `201`, route/OpenAPI `548/500/0`, and GitNexus CLI `LOW` / direct `3` / affected processes `0` | G2.314 may authorize only a future path-limited source/test implementation lane and must keep source merge human-review gated |
 | G2.312 service lifecycle residual refresh after dormant indicator-config exclusion | PR `#465` merged at `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`; generated refresh evidence records `371` Python files scanned, `663` getter-like names, `53` active interesting candidates, and selects `indicator_registry.get_factory` as the next no-source decision | G2.313 decides active route-local singleton factory ownership and can select only a no-source authorization package |
 | G2.311 indicator config router ownership / registration-retirement decision | PR `#464` merged at `0f5382cea875d2983ada5d9c63548b0530861002`; generated decision evidence records `create_indicator_config.py` as retained dormant route code with route/OpenAPI `548/500/0`, `13` indicator-related active routes, and `0` registered handlers from that module | G2.312 refreshes residual candidates after excluding dormant indicator-config provider calls |
 | G2.310 `get_mysql_session` ownership / route-provider decision | PR `#463` merged at `67083d40808fea9963137e3e128c0c6cb0683e57`; generated decision evidence records five `get_mysql_session()` calls in unregistered `create_indicator_config.py`, route/OpenAPI `548/500/0`, GitNexus CLI `MEDIUM`, and provider implementation not authorized | G2.311 decides route ownership / registration-retirement handling for the dormant module |

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-06-02T01:35:43+08:00`
-- Base HEAD checked: `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`
+- Prepared at: `2026-06-02T01:46:33+08:00`
+- Base HEAD checked: `75f6c63023bec35453892f63aaeaf193023e4881`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.313 `indicator_registry.get_factory` ownership / route-provider decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#465` merged at `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`; G2.313 classifies active route-local singleton factory calls at lines `159`, `186`, and `201`, route/OpenAPI `548/500/0`, and GitNexus CLI `LOW` / direct `3` / affected processes `0` | Review future PR `#466`; if accepted, start G2.314 no-source `indicator_registry.get_factory` provider authorization package |
+| P0 | Review G2.314 `indicator_registry.get_factory` provider authorization package | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#466` merged at `75f6c63023bec35453892f63aaeaf193023e4881`; G2.314 authorizes only a future G2.315 path-limited implementation for `indicator_registry.py` plus `tests/api/file_tests/test_indicator_registry_api.py`; no source edits in PR `#467` | Review future PR `#467`; if accepted, G2.315 source implementation may be created but must stop for human review before merge |
+| P0 | Preserve G2.313 `indicator_registry.get_factory` ownership / route-provider decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#466` merged at `75f6c63023bec35453892f63aaeaf193023e4881`; G2.313 classifies active route-local singleton factory calls at lines `159`, `186`, and `201`, route/OpenAPI `548/500/0`, and GitNexus CLI `LOW` / direct `3` / affected processes `0` | Do not use G2.313 as source implementation authority; use G2.314 only as no-source provider authorization package |
 | P0 | Preserve G2.312 service lifecycle residual candidate refresh after dormant indicator-config exclusion | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#465` merged at `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`; G2.312 excludes dormant `create_indicator_config.py` / `get_mysql_session`, records `371` Python files scanned, `663` getter names, and `53` active interesting candidates | Do not use G2.312 as source implementation authority; use G2.313 only as no-source `indicator_registry.get_factory` ownership / route-provider decision |
 | P0 | Preserve G2.311 indicator config router ownership / registration-retirement decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#464` merged at `0f5382cea875d2983ada5d9c63548b0530861002`; G2.311 classifies `create_indicator_config.py` as retained dormant route code, records `548/500/0`, `13` indicator-related routes, and `0` registered handlers from that module | Do not use G2.311 as source implementation authority; use G2.312 only as no-source residual candidate refresh |
 | P0 | Preserve G2.310 `get_mysql_session` ownership / route-provider decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#463` merged at `67083d40808fea9963137e3e128c0c6cb0683e57`; G2.310 classifies the five `get_mysql_session()` calls in `create_indicator_config.py` as an unregistered indicator-config router surface; route/OpenAPI remains `548/500/0`; GitNexus CLI risk is `MEDIUM` with direct `5` and affected processes `0` | Do not use G2.310 as provider implementation authority; use G2.311 only as no-source route ownership decision |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-06-02T01:35:43+08:00`
-- Base HEAD checked: `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`
+- Prepared at: `2026-06-02T01:46:33+08:00`
+- Base HEAD checked: `75f6c63023bec35453892f63aaeaf193023e4881`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -16,9 +16,12 @@ state transition.
 
 | Evidence | Role | Freshness policy |
 |---|---|---|
-| `.planning/codebase/generated/indicator-registry-factory-ownership-decision-2026-06-02.json` | G2.313 `indicator_registry.get_factory` ownership / route-provider decision evidence | Review input for future PR `#466`; no-source decision package; route/OpenAPI `548/500/0`, GitNexus CLI `LOW`, and selects G2.314 authorization only |
-| `docs/reports/quality/backend-indicator-registry-factory-ownership-decision-2026-06-02.md` | G2.313 human-readable ownership decision report | Review input for future PR `#466`; records PR `#465` accepted/merged, active indicator-registry route surface, GitNexus fallback impact, and next gate |
-| `governance/mainline/task-cards/pr-466.yaml` | Governance task card for G2.313 no-source decision | Review input; allows only steward tree, generated evidence, report, and task card updates |
+| `.planning/codebase/generated/indicator-registry-factory-provider-authorization-2026-06-02.json` | G2.314 `indicator_registry.get_factory` provider authorization evidence | Review input for future PR `#467`; no-source authorization package; authorizes only future G2.315 path-limited source/test lane and human-review stop |
+| `docs/reports/quality/backend-indicator-registry-factory-provider-authorization-2026-06-02.md` | G2.314 human-readable authorization report | Review input for future PR `#467`; records PR `#466` accepted/merged, implementation boundary, required tests, and source stop rule |
+| `governance/mainline/task-cards/pr-467.yaml` | Governance task card for G2.314 no-source authorization | Review input; allows only steward tree, generated evidence, report, and task card updates |
+| `.planning/codebase/generated/indicator-registry-factory-ownership-decision-2026-06-02.json` | G2.313 `indicator_registry.get_factory` ownership / route-provider decision evidence | Accepted by PR `#466`, merged at `75f6c63023bec35453892f63aaeaf193023e4881`; no-source decision package; superseded for authorization by G2.314 |
+| `docs/reports/quality/backend-indicator-registry-factory-ownership-decision-2026-06-02.md` | G2.313 human-readable ownership decision report | Accepted by PR `#466`; records PR `#465` accepted/merged, active indicator-registry route surface, GitNexus fallback impact, and next gate |
+| `governance/mainline/task-cards/pr-466.yaml` | Governance task card for G2.313 no-source decision | Accepted by PR `#466`; allowed only steward tree, generated evidence, report, and task card updates |
 | `.planning/codebase/generated/service-lifecycle-residual-refresh-after-indicator-config-2026-06-02.json` | G2.312 service lifecycle residual refresh evidence | Accepted by PR `#465`, merged at `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`; no-source candidate refresh; superseded for ownership decision by G2.313 |
 | `docs/reports/quality/backend-service-lifecycle-residual-refresh-after-indicator-config-2026-06-02.md` | G2.312 human-readable residual refresh report | Accepted by PR `#465`; records PR `#464` accepted/merged, refreshed scanner counts, and next gate |
 | `governance/mainline/task-cards/pr-465.yaml` | Governance task card for G2.312 no-source refresh | Accepted by PR `#465`; allowed only steward tree, generated evidence, report, and task card updates |

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,9 +1,9 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-06-02T01:35:43+08:00",
+  "generated_at": "2026-06-02T01:46:33+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18",
+  "base_head": "75f6c63023bec35453892f63aaeaf193023e4881",
   "split_branch": "g2-312-service-lifecycle-residual-refresh-after-indicator-config",
   "scope": "service_lifecycle_residual_refresh_after_indicator_config",
   "source_edit_authority": false,
@@ -11894,16 +11894,18 @@
     {
       "id": "g2-313-indicator-registry-factory-ownership-decision",
       "type": "ownership_decision",
-      "state": "for_review",
+      "state": "accepted_merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.312 service lifecycle residual refresh after dormant indicator-config exclusion",
       "source_edit_authority": false,
-      "autopilot_status": "review_gate",
-      "autopilot_stop_reason": "G2.313 is a no-source ownership decision in planned PR #466; it selects only a future no-source authorization package and does not authorize source implementation.",
+      "autopilot_status": "merged",
+      "autopilot_stop_reason": "G2.313 was a no-source ownership decision and PR #466 merged after checks passed; it selected only a future no-source authorization package.",
       "github_pr": {
         "number": 466,
         "url": "https://github.com/chengjon/mystocks/pull/466",
-        "state": "PLANNED_FOR_REVIEW",
+        "state": "MERGED",
+        "merge_commit": "75f6c63023bec35453892f63aaeaf193023e4881",
+        "merged_at": "2026-06-01T17:41:49Z",
         "head_ref": "g2-313-indicator-registry-factory-ownership-decision"
       },
       "closed_parent": {
@@ -12039,7 +12041,143 @@
         "stale_if_get_factory_call_surface_changes": true,
         "stale_if_gitnexus_index_refresh_changes_risk": true
       },
-      "next_gate": "Review future PR #466. If accepted and merged, start G2.314 no-source indicator_registry get_factory provider authorization package."
+      "next_gate": "Superseded by G2.314 no-source indicator_registry get_factory provider authorization package."
+    },
+    {
+      "id": "g2-314-indicator-registry-factory-provider-authorization",
+      "type": "provider_authorization",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.313 indicator_registry get_factory ownership / route-provider decision",
+      "source_edit_authority": false,
+      "autopilot_status": "review_gate",
+      "autopilot_stop_reason": "G2.314 is no-source, but its selected next node G2.315 is source implementation and must stop for human review before merge.",
+      "github_pr": {
+        "number": 467,
+        "url": "https://github.com/chengjon/mystocks/pull/467",
+        "state": "PLANNED_FOR_REVIEW",
+        "head_ref": "g2-314-indicator-registry-factory-provider-authorization"
+      },
+      "closed_parent": {
+        "pr": 466,
+        "state": "MERGED",
+        "merge_commit": "75f6c63023bec35453892f63aaeaf193023e4881",
+        "merged_at": "2026-06-01T17:41:49Z"
+      },
+      "evidence": [
+        ".planning/codebase/generated/indicator-registry-factory-provider-authorization-2026-06-02.json",
+        "docs/reports/quality/backend-indicator-registry-factory-provider-authorization-2026-06-02.md",
+        "governance/mainline/task-cards/pr-467.yaml"
+      ],
+      "allowed_scope": [
+        ".planning/codebase/generated/indicator-registry-factory-provider-authorization-2026-06-02.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-indicator-registry-factory-provider-authorization-2026-06-02.md",
+        "governance/mainline/task-cards/pr-467.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "tests/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "future_source_scope": {
+        "authorized": true,
+        "requires_human_review_before_merge": true,
+        "allowed_paths": [
+          "web/backend/app/api/indicator_registry.py",
+          "tests/api/file_tests/test_indicator_registry_api.py"
+        ],
+        "forbidden_paths": [
+          "non-indicator-registry backend source",
+          "generated OpenAPI artifacts",
+          "docs/api artifacts",
+          "frontend",
+          "config",
+          "scripts",
+          "OpenSpec proposals/specs",
+          "PM2/runtime state"
+        ],
+        "required_shape": [
+          "Add a route-local provider dependency for IndicatorFactory without changing public route paths, methods, response models, or OpenAPI path count.",
+          "Move list_indicators, get_indicator_details, and calculate_indicator away from route-body get_factory() calls.",
+          "Retain get_factory() as backing compatibility / singleton construction seam unless a later explicit retirement decision exists.",
+          "Add or update focused file-level tests proving provider wiring and preserving route/model contracts.",
+          "Run route/OpenAPI smoke and focused tests before PR."
+        ],
+        "future_stop_rule": "G2.315 source implementation PR must stop for human review before merge; limited autopilot must not merge it automatically."
+      },
+      "route_truth": {
+        "total_routes": 548,
+        "openapi_paths": 500,
+        "duplicate_operation_id_warnings": 0,
+        "registered_routes": [
+          {
+            "method": "GET",
+            "path": "/api/indicator-registry/indicators",
+            "endpoint": "list_indicators",
+            "direct_call_line": 159
+          },
+          {
+            "method": "GET",
+            "path": "/api/indicator-registry/indicators/{indicator_id}",
+            "endpoint": "get_indicator_details",
+            "direct_call_line": 186
+          },
+          {
+            "method": "POST",
+            "path": "/api/indicator-registry/calculate",
+            "endpoint": "calculate_indicator",
+            "direct_call_line": 201
+          }
+        ]
+      },
+      "gitnexus": {
+        "mcp_impact": {
+          "status": "failed",
+          "tool": "mcp__gitnexus.impact",
+          "error": "Transport closed"
+        },
+        "cli_fallback": {
+          "command": "npx gitnexus impact get_factory -r mystocks --direction upstream --summary-only",
+          "target": "Function:web/backend/app/api/indicator_registry.py:get_factory",
+          "risk": "LOW",
+          "direct_callers": 3,
+          "affected_processes": 0,
+          "affected_modules": [
+            "Api"
+          ],
+          "stale_index": true,
+          "commits_behind": 0
+        }
+      },
+      "decision": {
+        "classification": "bounded-active-route-local-factory-provider-authorization",
+        "source_lane_recommendation": "authorize-future-g2-315-path-limited-source-pr-only-after-human-review",
+        "provider_implementation_authorized_by_this_no_source_package": true,
+        "autopilot_continue_allowed": false,
+        "autopilot_stop_reason": "The next node is a source implementation lane and must stop for human review before merge."
+      },
+      "freshness": {
+        "current_head_checked": "75f6c63023bec35453892f63aaeaf193023e4881",
+        "stale_if_head_or_pr_state_changes": true,
+        "stale_if_route_or_openapi_counts_change": true,
+        "stale_if_get_factory_call_surface_changes": true,
+        "stale_if_gitnexus_index_refresh_changes_risk": true
+      },
+      "next_gate": "Review future PR #467. If accepted and merged, G2.315 may be created as a source implementation PR but must stop for human review before merge."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-06-02T01:35:43+08:00`
-- Base HEAD checked: `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`
+- Prepared at: `2026-06-02T01:46:33+08:00`
+- Base HEAD checked: `75f6c63023bec35453892f63aaeaf193023e4881`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -29,6 +29,7 @@ It proved a repeatable conveyor:
 
 | Node | State | Notes |
 |---|---|---|
+| G2.314 indicator_registry `get_factory` provider authorization | Future PR `#467` review target | Authorizes only future G2.315 path-limited source/test lane and requires human review before source merge; no source edits in G2.314 |
 | G2.313 indicator_registry `get_factory` ownership / route-provider decision | Future PR `#466` review target | Classifies active route-local singleton factory helper with 3 route-body calls, route/OpenAPI `548/500/0`, GitNexus CLI `LOW`, and selects only G2.314 no-source provider authorization |
 | G2.312 residual refresh after dormant indicator-config exclusion | Merged by PR `#465` | Excludes dormant `create_indicator_config.py` / `get_mysql_session`, records `371` Python files scanned, `663` getter names, `53` active interesting candidates, and selects G2.313 |
 | Steward split | Merged by PR `#332` | Root task tree is now a short entrypoint; active state belongs in this split track and `steward-index.json` |
@@ -3455,7 +3456,7 @@ Status: accepted / merged by PR `#465`.
 
 ## G2.313 Indicator Registry `get_factory` Ownership / Route-Provider Decision
 
-Status: for review in future PR `#466`.
+Status: accepted / merged by PR `#466`.
 
 - Parent PR `#465` merged at `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`.
 - G2.313 is a no-source ownership decision. It does not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
@@ -3464,3 +3465,13 @@ Status: for review in future PR `#466`.
 - GitNexus MCP impact failed with `Transport closed`; CLI fallback records `LOW` risk, `3` direct callers, `0` affected processes, and stale index with `commits_behind=0`.
 - G2.313 selects only G2.314 no-source `indicator_registry.get_factory` provider authorization package. If G2.314 is accepted, any future source implementation lane must stop at human review before merge.
 - Stop rule: G2.313 must not be used as source implementation authority or as authorization to edit `indicator_registry.py`, route contracts, OpenAPI artifacts, tests, docs/api, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+
+## G2.314 Indicator Registry `get_factory` Provider Authorization
+
+Status: for review in future PR `#467`.
+
+- Parent PR `#466` merged at `75f6c63023bec35453892f63aaeaf193023e4881`.
+- G2.314 is a no-source authorization package. It does not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+- G2.314 authorizes only a future G2.315 source implementation lane limited to `web/backend/app/api/indicator_registry.py` and `tests/api/file_tests/test_indicator_registry_api.py`.
+- Required future shape: route-local provider dependency for `IndicatorFactory`, no route/OpenAPI contract drift, three handlers moved away from route-body `get_factory()`, and `get_factory()` retained as backing compatibility seam unless separately retired.
+- Stop rule: G2.315 must stop at human review before merge and must not be auto-merged under the no-source autopilot rule.

--- a/docs/reports/quality/backend-indicator-registry-factory-provider-authorization-2026-06-02.md
+++ b/docs/reports/quality/backend-indicator-registry-factory-provider-authorization-2026-06-02.md
@@ -1,0 +1,64 @@
+# Backend Indicator Registry Factory Provider Authorization - G2.314
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: for review
+- Prepared at: `2026-06-02T01:46:33+08:00`
+- Base HEAD checked: `75f6c63023bec35453892f63aaeaf193023e4881`
+- Parent gate: G2.313 accepted / merged by PR `#466`
+- Target: `web/backend/app/api/indicator_registry.py:get_factory`
+- Source edit authority in this PR: none
+
+Boundary note: this G2.314 package is no-source governance only. It authorizes only a future path-limited source PR after acceptance; it does not itself edit backend source, tests, route registration, route/OpenAPI contracts, docs/api, frontend/config/scripts, OpenSpec specs, PM2, or runtime state.
+
+## Authorization Decision
+
+G2.314 authorizes a future G2.315 path-limited implementation lane for `indicator_registry.get_factory` provider injection, but only after PR `#467` is accepted / merged. G2.315 must stop for human review before merge because it will modify backend source and tests.
+
+## Future G2.315 Allowed Scope
+
+| Category | Paths |
+|---|---|
+| Backend source | `web/backend/app/api/indicator_registry.py` |
+| Focused tests | `tests/api/file_tests/test_indicator_registry_api.py` |
+
+No other backend source, generated OpenAPI artifact, docs/api artifact, frontend, config, script, OpenSpec proposal/spec, PM2, or runtime-state change is authorized by this package.
+
+## Required Implementation Shape
+
+A future G2.315 implementation must:
+
+1. Add a route-local provider dependency for `IndicatorFactory` without changing route paths, methods, response models, or OpenAPI path count.
+2. Move `list_indicators`, `get_indicator_details`, and `calculate_indicator` away from route-body `get_factory()` calls.
+3. Retain `get_factory()` as backing compatibility / singleton construction seam unless a later explicit retirement decision exists.
+4. Add or update focused file-level tests proving provider wiring and preserving route/model contracts.
+5. Run route/OpenAPI smoke and focused tests before PR.
+
+## Current Evidence
+
+| Item | Value |
+|---|---|
+| Direct route-body calls | 3 |
+| Call lines | 159, 186, 201 |
+| Registered indicator-registry routes | 3 |
+| FastAPI route count | 548 |
+| OpenAPI path count | 500 |
+| Duplicate operation ID warnings | 0 |
+| GitNexus CLI risk | LOW |
+| GitNexus direct callers | 3 |
+| GitNexus affected processes | 0 |
+
+## Required Verification For Future Source PR
+
+- `pytest -o addopts= tests/api/file_tests/test_indicator_registry_api.py --no-cov -q`
+- `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov`
+- `ruff check web/backend/app/api/indicator_registry.py tests/api/file_tests/test_indicator_registry_api.py`
+- route/OpenAPI smoke confirming `548` routes, `500` paths, and `duplicate_operation_id_warnings=0`
+- GitNexus impact before source edit
+- GitNexus staged verification before commit
+
+## Stop Rules
+
+G2.314 itself remains no-source. If accepted, the next G2.315 implementation branch must stop at PR review and must not be automatically merged under the no-source autopilot rule.

--- a/governance/mainline/task-cards/pr-467.yaml
+++ b/governance/mainline/task-cards/pr-467.yaml
@@ -1,0 +1,133 @@
+version: "v0.2"
+
+task:
+  id: "pr-467"
+  title: "Authorize indicator_registry get_factory provider implementation lane"
+  owner: "codex"
+  created_at: "2026-06-02"
+
+mainline:
+  id: "L1-indicator-registry-factory-provider-authorization"
+  objective: "authorize a future path-limited provider implementation lane for indicator_registry.get_factory without editing source in this PR"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "api"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "G2.314 is a no-source authorization package. It changes no runtime route, handler, contract, source file, or test file."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/indicator-registry-factory-provider-authorization-2026-06-02.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-indicator-registry-factory-provider-authorization-2026-06-02.md"
+    - "governance/mainline/task-cards/pr-467.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits in this PR"
+  - "test edits in this PR"
+  - "route registration changes in this PR"
+  - "route path, method, response model, or generated OpenAPI artifact changes"
+  - "docs/api artifact edits"
+  - "frontend/config/script changes"
+  - "OpenSpec proposal or spec edits"
+  - "PM2 commands or stateful runtime gates"
+  - "source retirement"
+  - "editing indicator_registry.py or get_factory in this PR"
+  - "automatically merging the future source implementation PR"
+
+acceptance:
+  checks:
+    - id: "pr466-merged"
+      command: "gh pr view 466 confirms MERGED at 75f6c63023bec35453892f63aaeaf193023e4881"
+      required: true
+    - id: "authorization-boundary"
+      command: "generated evidence authorizes only future G2.315 edits to indicator_registry.py and tests/api/file_tests/test_indicator_registry_api.py"
+      required: true
+    - id: "source-stop-rule"
+      command: "report states G2.315 must stop for human review before merge"
+      required: true
+    - id: "route-openapi-baseline"
+      command: "route/OpenAPI smoke baseline remains 548 routes, 500 paths, 0 duplicate operation ID warnings"
+      required: true
+    - id: "gitnexus-fallback-impact"
+      command: "GitNexus CLI fallback records LOW risk, 3 direct callers, 0 affected processes"
+      required: true
+    - id: "no-source-boundary"
+      command: "PR #467 edits no backend source, tests, route contracts, docs/api, frontend, config, scripts, OpenSpec, PM2, or runtime state"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-indicator-registry-factory-provider-authorization-2026-06-02.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-467.yaml --base-sha 75f6c63023bec35453892f63aaeaf193023e4881 --head-sha HEAD --report /tmp/pr467-mainline-governance-report.json"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "No runtime risk from this PR because it is no-source governance only."
+    - "Future G2.315 becomes stale if indicator-registry route registration, get_factory calls, or GitNexus impact changes."
+  rollback_plan: "Revert PR #467; this removes only G2.314 authorization evidence and restores the prior G2.313 next gate."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Authorize a future bounded indicator_registry.get_factory provider implementation lane."
+    modified_scope: "Governance evidence, steward tree indexes, report, and task card only."
+    dependency_changes: "No package dependency changes."
+    legacy_logic_impact: "No runtime behavior, route contract, OpenAPI, or source changes in this PR."
+    rollback_ready: "Revert PR #467."
+    risk_and_rollback_point: "No-source authorization; rollback is single-PR revert."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer-autopilot"
+    approved_at: "2026-06-02T01:46:33+08:00"
+    approval_note: "Human maintainer previously authorized automatic no-source governance continuation; G2.314 remains no-source but any future source implementation PR must stop for human review."
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- Records G2.314 no-source authorization package for the future `indicator_registry.get_factory` provider implementation lane.
- Authorizes only a future G2.315 source PR limited to `web/backend/app/api/indicator_registry.py` and `tests/api/file_tests/test_indicator_registry_api.py`.
- Explicitly requires G2.315 to stop for human review before merge; this PR itself changes no source or tests.

## Line Scope

G2 service lifecycle / provider governance.

## Workline Lane

No-source governance / authorization package.

## Current Source of Truth

- `architecture/STANDARDS.md`
- `openspec/changes/migrate-backend-singletons-to-lifecycle-di`
- `.planning/codebase/steward-tree/steward-index.json`
- `docs/reports/quality/backend-indicator-registry-factory-provider-authorization-2026-06-02.md`

## Validation

- JSON parse gate: passed
- Markdown governance gate: 6 checked files, 0 errors
- `openspec validate migrate-backend-singletons-to-lifecycle-di --strict`: valid
- `git diff --check`: passed in G2.314 worktree
- `git diff --cached --check`: passed
- `npx gitnexus verify-staged -r mystocks`: low risk, 9 files, 0 symbols, 0 affected processes
- Mainline scope gate for `governance/mainline/task-cards/pr-467.yaml`: pass
- Route/OpenAPI baseline: 548 routes, 500 OpenAPI paths, 0 duplicate operation ID warnings
- GitNexus CLI impact fallback: LOW, 3 direct callers, 0 affected processes

## Boundary

This PR edits only governance artifacts. It does not modify backend source, tests, route contracts, OpenAPI artifacts, docs/api, frontend, config, scripts, OpenSpec specs/proposals, PM2, or runtime state.

The next G2.315 implementation PR, if created, must stop for human review before merge.
