### PR TITLE
refactor(api): inject indicator registry factory provider

### DIFF
--- a/.planning/codebase/generated/indicator-registry-factory-provider-implementation-2026-06-02.json
+++ b/.planning/codebase/generated/indicator-registry-factory-provider-implementation-2026-06-02.json
@@ -1,0 +1,118 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-02T01:58:00+08:00",
+  "node": "G2.315",
+  "title": "indicator_registry get_factory provider implementation",
+  "repo": "mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "8d52fa0548fd200f0c9b606e5880e71286c07d10",
+  "parent_gate": {
+    "node": "G2.314",
+    "github_pr": {
+      "number": 467,
+      "url": "https://github.com/chengjon/mystocks/pull/467",
+      "state": "MERGED",
+      "merge_commit": "8d52fa0548fd200f0c9b606e5880e71286c07d10",
+      "merged_at": "2026-06-01T17:49:41Z",
+      "head_ref": "g2-314-indicator-registry-factory-provider-authorization"
+    },
+    "decision": "provider authorization accepted for a path-limited source/test implementation lane"
+  },
+  "source_edit_authority": true,
+  "automerge_authority": false,
+  "human_review_required_before_merge": true,
+  "target": {
+    "file": "web/backend/app/api/indicator_registry.py",
+    "provider": "get_indicator_factory",
+    "backing": "get_factory",
+    "factory_class": "IndicatorFactory"
+  },
+  "implementation": {
+    "source_files": [
+      "web/backend/app/api/indicator_registry.py"
+    ],
+    "test_files": [
+      "tests/api/file_tests/test_indicator_registry_api.py"
+    ],
+    "changes": [
+      "Added Depends import and route-local get_indicator_factory provider.",
+      "Moved list_indicators, get_indicator_details, and calculate_indicator to Depends(get_indicator_factory).",
+      "Retained get_factory as backing singleton compatibility seam.",
+      "Updated file-level response_model assertions to current UnifiedResponse contract.",
+      "Added provider wiring test for all three indicator-registry routes."
+    ]
+  },
+  "tdd": {
+    "red": "pytest -o addopts= tests/api/file_tests/test_indicator_registry_api.py --no-cov -q produced expected provider AttributeError plus stale response_model assertion: 2 failed, 9 passed.",
+    "green": "pytest -o addopts= tests/api/file_tests/test_indicator_registry_api.py --no-cov -q passed: 11 passed, 1 warning."
+  },
+  "verification": {
+    "health_collect_only": "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov collected 121 tests without collection failure.",
+    "ruff": "ruff check web/backend/app/api/indicator_registry.py tests/api/file_tests/test_indicator_registry_api.py passed: All checks passed.",
+    "route_openapi": {
+      "total_routes": 548,
+      "openapi_paths": 500,
+      "duplicate_operation_id_warnings": 0,
+      "indicator_registry_dependency_calls": [
+        "get_indicator_factory",
+        "get_indicator_factory",
+        "get_indicator_factory"
+      ]
+    },
+    "provider_scan": {
+      "route_body_direct_get_factory_calls": 0,
+      "provider_backing_get_factory_calls": 1,
+      "depends_bindings": 3
+    }
+  },
+  "gitnexus": {
+    "pre_edit_mcp_impact": {
+      "status": "failed",
+      "error": "Transport closed"
+    },
+    "pre_edit_cli_impact": {
+      "risk": "LOW",
+      "direct_callers": 3,
+      "affected_processes": 0,
+      "affected_modules": [
+        "Api"
+      ],
+      "stale_index": true,
+      "commits_behind": 0
+    }
+  },
+  "allowed_scope": [
+    "web/backend/app/api/indicator_registry.py",
+    "tests/api/file_tests/test_indicator_registry_api.py",
+    ".planning/codebase/generated/indicator-registry-factory-provider-implementation-2026-06-02.json",
+    ".planning/codebase/steward-tree/current-next-gates.md",
+    ".planning/codebase/steward-tree/steward-index.json",
+    ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+    ".planning/codebase/steward-tree/branch-register.md",
+    ".planning/codebase/steward-tree/evidence-index.md",
+    ".planning/codebase/steward-tree/completed-ledger.md",
+    "docs/reports/quality/backend-indicator-registry-factory-provider-implementation-2026-06-02.md",
+    "governance/mainline/task-cards/pr-468.yaml"
+  ],
+  "forbidden_scope": [
+    "web/backend/app/core/database.py",
+    "web/backend/app/router_registry.py",
+    "web/backend/app/api/data_lineage.py",
+    "web/frontend/**",
+    "src/**",
+    "docs/api/**",
+    "docs/FUNCTION_TREE.md",
+    "governance/function-tree/catalog.yaml",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**"
+  ],
+  "freshness": {
+    "current_head_checked": "8d52fa0548fd200f0c9b606e5880e71286c07d10",
+    "stale_if_head_or_pr_state_changes": true,
+    "stale_if_route_or_openapi_counts_change": true,
+    "stale_if_get_factory_call_surface_changes": true
+  },
+  "next_gate": "Human review PR #468. If accepted and merged, start G2.316 no-source indicator_registry factory provider closeout / residual refresh."
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-06-02T01:46:33+08:00`
-- Base HEAD checked: `75f6c63023bec35453892f63aaeaf193023e4881`
+- Prepared at: `2026-06-02T01:58:00+08:00`
+- Base HEAD checked: `8d52fa0548fd200f0c9b606e5880e71286c07d10`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -292,3 +292,5 @@ G2.312 is the no-source service lifecycle residual candidate refresh after PR `#
 G2.313 is the no-source `indicator_registry.get_factory` ownership / route-provider decision after PR `#465` merged G2.312 at `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`. It records `web/backend/app/api/indicator_registry.py` as an active registered route module with three `get_factory()` route-body calls at lines `159`, `186`, and `201`, route/OpenAPI `548/500/0`, and GitNexus CLI `LOW` risk with `3` direct callers and `0` affected processes. It does not authorize source implementation and selects only G2.314 no-source `indicator_registry.get_factory` provider authorization after future PR `#466` acceptance.
 
 G2.314 is the no-source `indicator_registry.get_factory` provider authorization after PR `#466` merged G2.313 at `75f6c63023bec35453892f63aaeaf193023e4881`. It authorizes only a future G2.315 path-limited implementation lane for `web/backend/app/api/indicator_registry.py` plus `tests/api/file_tests/test_indicator_registry_api.py`, requires route/OpenAPI `548/500/0` preservation, and requires G2.315 to stop for human review before merge. It does not edit source in PR `#467`.
+
+G2.315 is the path-limited `indicator_registry.get_factory` provider implementation after PR `#467` merged G2.314 at `8d52fa0548fd200f0c9b606e5880e71286c07d10`. It changes `web/backend/app/api/indicator_registry.py` and `tests/api/file_tests/test_indicator_registry_api.py`, moves the three active indicator-registry routes to `Depends(get_indicator_factory)`, preserves route/OpenAPI `548/500/0`, records focused test `11 passed`, and must stop at PR `#468` human review before merge.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-06-02T01:46:33+08:00`
-- Base HEAD checked: `75f6c63023bec35453892f63aaeaf193023e4881`
+- Prepared at: `2026-06-02T01:58:00+08:00`
+- Base HEAD checked: `8d52fa0548fd200f0c9b606e5880e71286c07d10`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -19,7 +19,7 @@ exact verification output.
 | Route/OpenAPI and control-plane governance | Established route table, OpenAPI exposure, health/probe taxonomy, and consumer-contract evidence as first-class governance facts | Continue through route/OpenAPI track, not ad hoc route edits |
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
-| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.313 accepted/merged by PR `#466` at `75f6c630`; continue with G2.314 no-source indicator_registry get_factory provider authorization; source implementation remains human-review gated |
+| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.314 accepted/merged by PR `#467` at `8d52fa05`; G2.315 source implementation is now at human-review gate and must not auto-merge |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
 | Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.301 have progressed through PR `#337`-`#454`; current review target is G2.302 admin optimization provider authorization in future PR `#455` |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
@@ -28,6 +28,7 @@ exact verification output.
 
 | Item | Accepted evidence | Follow-up |
 |---|---|---|
+| G2.314 indicator_registry `get_factory` provider authorization | PR `#467` merged at `8d52fa0548fd200f0c9b606e5880e71286c07d10`; generated authorization evidence limits G2.315 to `indicator_registry.py` plus `tests/api/file_tests/test_indicator_registry_api.py` and requires human review before source merge | G2.315 source implementation PR must be reviewed manually before merge; if accepted, start G2.316 no-source closeout / residual refresh |
 | G2.313 indicator_registry `get_factory` ownership / route-provider decision | PR `#466` merged at `75f6c63023bec35453892f63aaeaf193023e4881`; generated decision evidence records active route-local singleton factory calls at lines `159`, `186`, and `201`, route/OpenAPI `548/500/0`, and GitNexus CLI `LOW` / direct `3` / affected processes `0` | G2.314 may authorize only a future path-limited source/test implementation lane and must keep source merge human-review gated |
 | G2.312 service lifecycle residual refresh after dormant indicator-config exclusion | PR `#465` merged at `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`; generated refresh evidence records `371` Python files scanned, `663` getter-like names, `53` active interesting candidates, and selects `indicator_registry.get_factory` as the next no-source decision | G2.313 decides active route-local singleton factory ownership and can select only a no-source authorization package |
 | G2.311 indicator config router ownership / registration-retirement decision | PR `#464` merged at `0f5382cea875d2983ada5d9c63548b0530861002`; generated decision evidence records `create_indicator_config.py` as retained dormant route code with route/OpenAPI `548/500/0`, `13` indicator-related active routes, and `0` registered handlers from that module | G2.312 refreshes residual candidates after excluding dormant indicator-config provider calls |

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-06-02T01:46:33+08:00`
-- Base HEAD checked: `75f6c63023bec35453892f63aaeaf193023e4881`
+- Prepared at: `2026-06-02T01:58:00+08:00`
+- Base HEAD checked: `8d52fa0548fd200f0c9b606e5880e71286c07d10`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.314 `indicator_registry.get_factory` provider authorization package | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#466` merged at `75f6c63023bec35453892f63aaeaf193023e4881`; G2.314 authorizes only a future G2.315 path-limited implementation for `indicator_registry.py` plus `tests/api/file_tests/test_indicator_registry_api.py`; no source edits in PR `#467` | Review future PR `#467`; if accepted, G2.315 source implementation may be created but must stop for human review before merge |
+| P0 | Review G2.315 `indicator_registry.get_factory` provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | Source PR `#468` review target; moves 3 indicator-registry handlers to `Depends(get_indicator_factory)`, preserves route/OpenAPI `548/500/0`, focused test `11 passed`, and provider scan `0/1/3` | Human review required; do not auto-merge PR `#468`; if accepted, start G2.316 no-source closeout / residual refresh |
+| P0 | Preserve G2.314 `indicator_registry.get_factory` provider authorization package | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#467` merged at `8d52fa0548fd200f0c9b606e5880e71286c07d10`; G2.314 authorized only future G2.315 path-limited implementation for `indicator_registry.py` plus `tests/api/file_tests/test_indicator_registry_api.py` | G2.315 source implementation must stop for human review before merge |
 | P0 | Preserve G2.313 `indicator_registry.get_factory` ownership / route-provider decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#466` merged at `75f6c63023bec35453892f63aaeaf193023e4881`; G2.313 classifies active route-local singleton factory calls at lines `159`, `186`, and `201`, route/OpenAPI `548/500/0`, and GitNexus CLI `LOW` / direct `3` / affected processes `0` | Do not use G2.313 as source implementation authority; use G2.314 only as no-source provider authorization package |
 | P0 | Preserve G2.312 service lifecycle residual candidate refresh after dormant indicator-config exclusion | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#465` merged at `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`; G2.312 excludes dormant `create_indicator_config.py` / `get_mysql_session`, records `371` Python files scanned, `663` getter names, and `53` active interesting candidates | Do not use G2.312 as source implementation authority; use G2.313 only as no-source `indicator_registry.get_factory` ownership / route-provider decision |
 | P0 | Preserve G2.311 indicator config router ownership / registration-retirement decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#464` merged at `0f5382cea875d2983ada5d9c63548b0530861002`; G2.311 classifies `create_indicator_config.py` as retained dormant route code, records `548/500/0`, `13` indicator-related routes, and `0` registered handlers from that module | Do not use G2.311 as source implementation authority; use G2.312 only as no-source residual candidate refresh |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-06-02T01:46:33+08:00`
-- Base HEAD checked: `75f6c63023bec35453892f63aaeaf193023e4881`
+- Prepared at: `2026-06-02T01:58:00+08:00`
+- Base HEAD checked: `8d52fa0548fd200f0c9b606e5880e71286c07d10`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -16,9 +16,12 @@ state transition.
 
 | Evidence | Role | Freshness policy |
 |---|---|---|
-| `.planning/codebase/generated/indicator-registry-factory-provider-authorization-2026-06-02.json` | G2.314 `indicator_registry.get_factory` provider authorization evidence | Review input for future PR `#467`; no-source authorization package; authorizes only future G2.315 path-limited source/test lane and human-review stop |
-| `docs/reports/quality/backend-indicator-registry-factory-provider-authorization-2026-06-02.md` | G2.314 human-readable authorization report | Review input for future PR `#467`; records PR `#466` accepted/merged, implementation boundary, required tests, and source stop rule |
-| `governance/mainline/task-cards/pr-467.yaml` | Governance task card for G2.314 no-source authorization | Review input; allows only steward tree, generated evidence, report, and task card updates |
+| `.planning/codebase/generated/indicator-registry-factory-provider-implementation-2026-06-02.json` | G2.315 `indicator_registry.get_factory` provider implementation evidence | Review input for future PR `#468`; source implementation package; human review required before merge |
+| `docs/reports/quality/backend-indicator-registry-factory-provider-implementation-2026-06-02.md` | G2.315 human-readable implementation report | Review input for future PR `#468`; records TDD, provider scan, route/OpenAPI, focused tests, ruff, and GitNexus fallback |
+| `governance/mainline/task-cards/pr-468.yaml` | Governance task card for G2.315 source implementation | Review input; allows only path-limited source/test plus steward tree, generated evidence, report, and task card updates |
+| `.planning/codebase/generated/indicator-registry-factory-provider-authorization-2026-06-02.json` | G2.314 `indicator_registry.get_factory` provider authorization evidence | Accepted by PR `#467`, merged at `8d52fa0548fd200f0c9b606e5880e71286c07d10`; no-source authorization package; superseded for implementation by G2.315 |
+| `docs/reports/quality/backend-indicator-registry-factory-provider-authorization-2026-06-02.md` | G2.314 human-readable authorization report | Accepted by PR `#467`; records PR `#466` accepted/merged, implementation boundary, required tests, and source stop rule |
+| `governance/mainline/task-cards/pr-467.yaml` | Governance task card for G2.314 no-source authorization | Accepted by PR `#467`; allowed only steward tree, generated evidence, report, and task card updates |
 | `.planning/codebase/generated/indicator-registry-factory-ownership-decision-2026-06-02.json` | G2.313 `indicator_registry.get_factory` ownership / route-provider decision evidence | Accepted by PR `#466`, merged at `75f6c63023bec35453892f63aaeaf193023e4881`; no-source decision package; superseded for authorization by G2.314 |
 | `docs/reports/quality/backend-indicator-registry-factory-ownership-decision-2026-06-02.md` | G2.313 human-readable ownership decision report | Accepted by PR `#466`; records PR `#465` accepted/merged, active indicator-registry route surface, GitNexus fallback impact, and next gate |
 | `governance/mainline/task-cards/pr-466.yaml` | Governance task card for G2.313 no-source decision | Accepted by PR `#466`; allowed only steward tree, generated evidence, report, and task card updates |

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,9 +1,9 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-06-02T01:46:33+08:00",
+  "generated_at": "2026-06-02T01:58:00+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "75f6c63023bec35453892f63aaeaf193023e4881",
+  "base_head": "8d52fa0548fd200f0c9b606e5880e71286c07d10",
   "split_branch": "g2-312-service-lifecycle-residual-refresh-after-indicator-config",
   "scope": "service_lifecycle_residual_refresh_after_indicator_config",
   "source_edit_authority": false,
@@ -12046,16 +12046,18 @@
     {
       "id": "g2-314-indicator-registry-factory-provider-authorization",
       "type": "provider_authorization",
-      "state": "for_review",
+      "state": "accepted_merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.313 indicator_registry get_factory ownership / route-provider decision",
       "source_edit_authority": false,
-      "autopilot_status": "review_gate",
+      "autopilot_status": "merged",
       "autopilot_stop_reason": "G2.314 is no-source, but its selected next node G2.315 is source implementation and must stop for human review before merge.",
       "github_pr": {
         "number": 467,
         "url": "https://github.com/chengjon/mystocks/pull/467",
-        "state": "PLANNED_FOR_REVIEW",
+        "state": "MERGED",
+        "merge_commit": "8d52fa0548fd200f0c9b606e5880e71286c07d10",
+        "merged_at": "2026-06-01T17:49:41Z",
         "head_ref": "g2-314-indicator-registry-factory-provider-authorization"
       },
       "closed_parent": {
@@ -12177,7 +12179,112 @@
         "stale_if_get_factory_call_surface_changes": true,
         "stale_if_gitnexus_index_refresh_changes_risk": true
       },
-      "next_gate": "Review future PR #467. If accepted and merged, G2.315 may be created as a source implementation PR but must stop for human review before merge."
+      "next_gate": "Superseded by G2.315 source implementation PR review gate."
+    },
+    {
+      "id": "g2-315-indicator-registry-factory-provider-implementation",
+      "type": "source_implementation",
+      "state": "for_human_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.314 indicator_registry get_factory provider authorization",
+      "source_edit_authority": true,
+      "autopilot_status": "stopped_for_source_review",
+      "autopilot_stop_reason": "G2.315 edits backend source/tests and must not be auto-merged.",
+      "github_pr": {
+        "number": 468,
+        "url": "https://github.com/chengjon/mystocks/pull/468",
+        "state": "PLANNED_FOR_REVIEW",
+        "head_ref": "g2-315-indicator-registry-factory-provider-implementation"
+      },
+      "closed_parent": {
+        "pr": 467,
+        "state": "MERGED",
+        "merge_commit": "8d52fa0548fd200f0c9b606e5880e71286c07d10",
+        "merged_at": "2026-06-01T17:49:41Z"
+      },
+      "evidence": [
+        ".planning/codebase/generated/indicator-registry-factory-provider-implementation-2026-06-02.json",
+        "docs/reports/quality/backend-indicator-registry-factory-provider-implementation-2026-06-02.md",
+        "governance/mainline/task-cards/pr-468.yaml"
+      ],
+      "allowed_scope": [
+        "web/backend/app/api/indicator_registry.py",
+        "tests/api/file_tests/test_indicator_registry_api.py",
+        ".planning/codebase/generated/indicator-registry-factory-provider-implementation-2026-06-02.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-indicator-registry-factory-provider-implementation-2026-06-02.md",
+        "governance/mainline/task-cards/pr-468.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/app/core/database.py",
+        "web/backend/app/router_registry.py",
+        "web/backend/app/api/data_lineage.py",
+        "web/frontend/**",
+        "src/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "implementation": {
+        "source_files": [
+          "web/backend/app/api/indicator_registry.py"
+        ],
+        "test_files": [
+          "tests/api/file_tests/test_indicator_registry_api.py"
+        ],
+        "changes": [
+          "Added Depends import and route-local get_indicator_factory provider.",
+          "Moved list_indicators, get_indicator_details, and calculate_indicator to Depends(get_indicator_factory).",
+          "Retained get_factory as backing singleton compatibility seam.",
+          "Updated file-level response_model assertions to current UnifiedResponse contract.",
+          "Added provider wiring test for all three indicator-registry routes."
+        ]
+      },
+      "verification": {
+        "health_collect_only": "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov collected 121 tests without collection failure.",
+        "ruff": "ruff check web/backend/app/api/indicator_registry.py tests/api/file_tests/test_indicator_registry_api.py passed: All checks passed.",
+        "route_openapi": {
+          "total_routes": 548,
+          "openapi_paths": 500,
+          "duplicate_operation_id_warnings": 0,
+          "indicator_registry_dependency_calls": [
+            "get_indicator_factory",
+            "get_indicator_factory",
+            "get_indicator_factory"
+          ]
+        },
+        "provider_scan": {
+          "route_body_direct_get_factory_calls": 0,
+          "provider_backing_get_factory_calls": 1,
+          "depends_bindings": 3
+        }
+      },
+      "gitnexus": {
+        "pre_edit_mcp_impact": {
+          "status": "failed",
+          "error": "Transport closed"
+        },
+        "pre_edit_cli_impact": {
+          "risk": "LOW",
+          "direct_callers": 3,
+          "affected_processes": 0,
+          "affected_modules": [
+            "Api"
+          ],
+          "stale_index": true,
+          "commits_behind": 0
+        }
+      },
+      "next_gate": "Human review PR #468. If accepted and merged, start G2.316 no-source indicator_registry factory provider closeout / residual refresh."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-06-02T01:46:33+08:00`
-- Base HEAD checked: `75f6c63023bec35453892f63aaeaf193023e4881`
+- Prepared at: `2026-06-02T01:58:00+08:00`
+- Base HEAD checked: `8d52fa0548fd200f0c9b606e5880e71286c07d10`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -29,6 +29,7 @@ It proved a repeatable conveyor:
 
 | Node | State | Notes |
 |---|---|---|
+| G2.315 indicator_registry `get_factory` provider implementation | Future PR `#468` source review target | Moves 3 route handlers to `Depends(get_indicator_factory)`, keeps route/OpenAPI `548/500/0`, focused test `11 passed`, and must stop for human review before merge |
 | G2.314 indicator_registry `get_factory` provider authorization | Future PR `#467` review target | Authorizes only future G2.315 path-limited source/test lane and requires human review before source merge; no source edits in G2.314 |
 | G2.313 indicator_registry `get_factory` ownership / route-provider decision | Future PR `#466` review target | Classifies active route-local singleton factory helper with 3 route-body calls, route/OpenAPI `548/500/0`, GitNexus CLI `LOW`, and selects only G2.314 no-source provider authorization |
 | G2.312 residual refresh after dormant indicator-config exclusion | Merged by PR `#465` | Excludes dormant `create_indicator_config.py` / `get_mysql_session`, records `371` Python files scanned, `663` getter names, `53` active interesting candidates, and selects G2.313 |
@@ -3468,10 +3469,21 @@ Status: accepted / merged by PR `#466`.
 
 ## G2.314 Indicator Registry `get_factory` Provider Authorization
 
-Status: for review in future PR `#467`.
+Status: accepted / merged by PR `#467`.
 
 - Parent PR `#466` merged at `75f6c63023bec35453892f63aaeaf193023e4881`.
 - G2.314 is a no-source authorization package. It does not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
 - G2.314 authorizes only a future G2.315 source implementation lane limited to `web/backend/app/api/indicator_registry.py` and `tests/api/file_tests/test_indicator_registry_api.py`.
 - Required future shape: route-local provider dependency for `IndicatorFactory`, no route/OpenAPI contract drift, three handlers moved away from route-body `get_factory()`, and `get_factory()` retained as backing compatibility seam unless separately retired.
 - Stop rule: G2.315 must stop at human review before merge and must not be auto-merged under the no-source autopilot rule.
+
+## G2.315 Indicator Registry `get_factory` Provider Implementation
+
+Status: source implementation PR review required in future PR `#468`.
+
+- Parent PR `#467` merged at `8d52fa0548fd200f0c9b606e5880e71286c07d10`.
+- G2.315 edits only `web/backend/app/api/indicator_registry.py`, `tests/api/file_tests/test_indicator_registry_api.py`, and governance artifacts.
+- Implementation moves all three indicator-registry routes to `Depends(get_indicator_factory)`, retains `get_factory()` as the backing compatibility seam, and preserves route/OpenAPI `548/500/0`.
+- TDD evidence: RED `2 failed, 9 passed`; GREEN `11 passed, 1 warning`.
+- Verification: health collect-only 121 tests collected, ruff focused pass, provider scan route-body direct calls `0`, backing calls `1`, dependency bindings `3`.
+- Stop rule: PR `#468` must be manually reviewed and must not be auto-merged.

--- a/docs/reports/quality/backend-indicator-registry-factory-provider-implementation-2026-06-02.md
+++ b/docs/reports/quality/backend-indicator-registry-factory-provider-implementation-2026-06-02.md
@@ -1,0 +1,55 @@
+# Backend Indicator Registry Factory Provider Implementation - G2.315
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: source implementation PR review required
+- Prepared at: `2026-06-02T01:58:00+08:00`
+- Base HEAD checked: `8d52fa0548fd200f0c9b606e5880e71286c07d10`
+- Parent gate: G2.314 accepted / merged by PR `#467`
+- Target: `web/backend/app/api/indicator_registry.py:get_factory`
+- Automerge authority: none
+
+Boundary note: this G2.315 package changes backend source and a focused test file. It must stop at PR review and must not be automatically merged under the no-source autopilot rule.
+
+## Scope
+
+| Category | Paths |
+|---|---|
+| Backend source | `web/backend/app/api/indicator_registry.py` |
+| Focused tests | `tests/api/file_tests/test_indicator_registry_api.py` |
+| Governance evidence | steward tree, generated evidence, quality report, task card |
+
+No route registration, generated OpenAPI artifact, docs/api, frontend, config, script, OpenSpec proposal/spec, PM2, or runtime-state change is included.
+
+## Implementation Summary
+
+- Added `Depends` and route-local `get_indicator_factory()` provider.
+- Moved `list_indicators`, `get_indicator_details`, and `calculate_indicator` to `Depends(get_indicator_factory)`.
+- Retained `get_factory()` as the backing singleton compatibility seam.
+- Added a file-level provider wiring test for all three indicator-registry routes.
+- Updated the same file-level contract test to assert the current `UnifiedResponse[...]` response model contract.
+
+## TDD Evidence
+
+| Phase | Result |
+|---|---|
+| RED | `pytest -o addopts= tests/api/file_tests/test_indicator_registry_api.py --no-cov -q` produced the expected provider AttributeError; the same run also exposed an existing stale response_model assertion. Result: 2 failed, 9 passed. |
+| GREEN | Same focused test command passed: 11 passed, 1 warning. |
+
+## Verification
+
+| Gate | Result |
+|---|---|
+| Focused test | `11 passed, 1 warning` |
+| Health route collect-only | 121 tests collected without collection failure |
+| Ruff | `All checks passed` for target source/test files |
+| Route/OpenAPI smoke | 548 routes, 500 OpenAPI paths, duplicate operation ID warnings 0 |
+| Indicator-registry dependencies | all 3 routes expose `get_indicator_factory` dependency |
+| Provider scan | route-body direct `get_factory()` calls 0; provider backing calls 1; `Depends` bindings 3 |
+| GitNexus pre-edit impact | MCP failed with `Transport closed`; CLI fallback LOW, 3 direct callers, affected processes 0 |
+
+## Review Stop
+
+PR `#468` must be manually reviewed. If accepted and merged, the next node should be G2.316 no-source indicator-registry factory provider closeout / residual refresh.

--- a/governance/mainline/task-cards/pr-468.yaml
+++ b/governance/mainline/task-cards/pr-468.yaml
@@ -1,0 +1,138 @@
+version: "v0.2"
+
+task:
+  id: "pr-468"
+  title: "Implement indicator_registry get_factory provider injection"
+  owner: "codex"
+  created_at: "2026-06-02"
+
+mainline:
+  id: "L1-indicator-registry-factory-provider-implementation"
+  objective: "move indicator_registry route handlers from direct get_factory calls to an explicit route-local provider dependency"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "api"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "G2.315 keeps the same route paths, methods, response models, and OpenAPI path count while changing route-local dependency wiring."
+
+scope:
+  allowed_paths:
+    - "web/backend/app/api/indicator_registry.py"
+    - "tests/api/file_tests/test_indicator_registry_api.py"
+    - ".planning/codebase/generated/indicator-registry-factory-provider-implementation-2026-06-02.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-indicator-registry-factory-provider-implementation-2026-06-02.md"
+    - "governance/mainline/task-cards/pr-468.yaml"
+  forbidden_paths:
+    - "web/backend/app/core/database.py"
+    - "web/backend/app/router_registry.py"
+    - "web/backend/app/api/data_lineage.py"
+    - "web/frontend/**"
+    - "src/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "route registration changes"
+  - "route path, method, response model, or generated OpenAPI artifact changes"
+  - "docs/api artifact edits"
+  - "frontend/config/script changes"
+  - "OpenSpec proposal or spec edits"
+  - "PM2 commands or stateful runtime gates"
+  - "source retirement"
+  - "editing non-indicator-registry backend source"
+  - "automatic PR merge"
+
+acceptance:
+  checks:
+    - id: "pr467-merged"
+      command: "gh pr view 467 confirms MERGED at 8d52fa0548fd200f0c9b606e5880e71286c07d10"
+      required: true
+    - id: "pre-edit-gitnexus-impact"
+      command: "GitNexus MCP impact failed with Transport closed; CLI fallback records LOW risk, 3 direct callers, 0 affected processes"
+      required: true
+    - id: "tdd-red"
+      command: "pytest -o addopts= tests/api/file_tests/test_indicator_registry_api.py --no-cov -q failed before implementation with provider AttributeError"
+      required: true
+    - id: "focused-test-green"
+      command: "pytest -o addopts= tests/api/file_tests/test_indicator_registry_api.py --no-cov -q records 11 passed, 1 warning"
+      required: true
+    - id: "health-collect-only"
+      command: "pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov collects 121 tests without collection failure"
+      required: true
+    - id: "ruff"
+      command: "ruff check web/backend/app/api/indicator_registry.py tests/api/file_tests/test_indicator_registry_api.py passes"
+      required: true
+    - id: "route-openapi-smoke"
+      command: "app.main route/OpenAPI smoke records 548 routes, 500 paths, duplicate operation IDs 0, and get_indicator_factory dependency on all 3 indicator-registry routes"
+      required: true
+    - id: "provider-scan"
+      command: "source scan records route-body direct get_factory calls 0, provider backing calls 1, dependency bindings 3"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-indicator-registry-factory-provider-implementation-2026-06-02.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-468.yaml --base-sha 8d52fa0548fd200f0c9b606e5880e71286c07d10 --head-sha HEAD --report /tmp/pr468-mainline-governance-report.json"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Route handler dependency wiring changes can affect tests that introspect route signatures."
+    - "Existing response model contract tests were stale and are updated to current UnifiedResponse contracts."
+  rollback_plan: "Revert PR #468; this restores direct route-body get_factory calls and previous file-level test assertions."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Move indicator_registry route handlers to explicit factory provider dependency."
+    modified_scope: "indicator_registry.py, focused file-level route test, governance evidence, report, and task card."
+    dependency_changes: "No package dependency changes."
+    legacy_logic_impact: "Route paths, methods, response models, OpenAPI path count, and singleton backing seam are preserved."
+    rollback_ready: "Revert PR #468."
+    risk_and_rollback_point: "Source PR requires human review before merge."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-02T01:58:00+08:00"
+    approval_note: "PR #467 accepted/merged the G2.314 no-source authorization; G2.315 may implement only the bounded indicator_registry provider lane and must stop at PR review."
+    secondary_approved: true

--- a/tests/api/file_tests/test_indicator_registry_api.py
+++ b/tests/api/file_tests/test_indicator_registry_api.py
@@ -54,11 +54,13 @@ class TestIndicatorRegistryAPIFile:
     def test_response_models_remain_stable(self, indicator_registry_module):
         response_models = {(route.path, tuple(sorted(route.methods or []))): route.response_model for route in indicator_registry_module.router.routes}
 
-        assert response_models[("/api/indicator-registry/indicators", ("GET",))] == indicator_registry_module.List[
-            indicator_registry_module.IndicatorInfo
+        assert response_models[("/api/indicator-registry/indicators", ("GET",))] == indicator_registry_module.UnifiedResponse[
+            indicator_registry_module.List[indicator_registry_module.IndicatorInfo]
         ]
-        assert response_models[("/api/indicator-registry/indicators/{indicator_id}", ("GET",))] is None
-        assert response_models[("/api/indicator-registry/calculate", ("POST",))] is indicator_registry_module.CalculationResponse
+        assert response_models[("/api/indicator-registry/indicators/{indicator_id}", ("GET",))] is indicator_registry_module.UnifiedResponse
+        assert response_models[("/api/indicator-registry/calculate", ("POST",))] == indicator_registry_module.UnifiedResponse[
+            indicator_registry_module.CalculationResponse
+        ]
 
     @pytest.mark.file_test
     def test_route_names_remain_stable(self, indicator_registry_module):
@@ -67,6 +69,22 @@ class TestIndicatorRegistryAPIFile:
         assert route_names[("/api/indicator-registry/indicators", ("GET",))] == "list_indicators"
         assert route_names[("/api/indicator-registry/indicators/{indicator_id}", ("GET",))] == "get_indicator_details"
         assert route_names[("/api/indicator-registry/calculate", ("POST",))] == "calculate_indicator"
+
+    @pytest.mark.file_test
+    def test_routes_use_indicator_factory_dependency(self, indicator_registry_module):
+        expected_routes = {
+            "list_indicators",
+            "get_indicator_details",
+            "calculate_indicator",
+        }
+        provider = indicator_registry_module.get_indicator_factory
+
+        for route in indicator_registry_module.router.routes:
+            if route.name not in expected_routes:
+                continue
+
+            dependency_calls = {dependency.call for dependency in route.dependant.dependencies}
+            assert provider in dependency_calls
 
     @pytest.mark.file_test
     def test_get_factory_behaves_as_singleton(self, indicator_registry_module, monkeypatch):

--- a/web/backend/app/api/indicator_registry.py
+++ b/web/backend/app/api/indicator_registry.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
-from fastapi import APIRouter, Body, Path
+from fastapi import APIRouter, Body, Depends, Path
 
 from app.core.exceptions import BusinessException
 from app.core.responses import UnifiedResponse, create_unified_success_response
@@ -96,11 +96,15 @@ INDICATOR_CALCULATE_RESPONSES = {
 }
 
 
-def get_factory():
+def get_factory() -> IndicatorFactory:
     global _factory
     if _factory is None:
         _factory = IndicatorFactory()
     return _factory
+
+
+def get_indicator_factory() -> IndicatorFactory:
+    return get_factory()
 
 
 # Models
@@ -154,9 +158,8 @@ class CalculationResponse(BaseModel):
     description="返回指标注册表中的全部指标摘要，供前端配置面板、功能发现和下拉选择器读取。",
     responses=INDICATOR_LIST_RESPONSES,
 )
-async def list_indicators():
+async def list_indicators(factory: IndicatorFactory = Depends(get_indicator_factory)):
     """List all registered indicators."""
-    factory = get_factory()
     results = []
     for i_id, config in factory.registry.items():
         results.append(
@@ -180,10 +183,10 @@ async def list_indicators():
     responses=INDICATOR_DETAIL_RESPONSES,
 )
 async def get_indicator_details(
-    indicator_id: str = Path(..., description="指标唯一标识，用于查询单个指标的详细注册配置。")
+    indicator_id: str = Path(..., description="指标唯一标识，用于查询单个指标的详细注册配置。"),
+    factory: IndicatorFactory = Depends(get_indicator_factory),
 ):
     """Get detailed configuration for a specific indicator."""
-    factory = get_factory()
     if indicator_id not in factory.registry:
         raise BusinessException(status_code=404, detail="Indicator not found")
     return create_unified_success_response(data=factory.registry[indicator_id])
@@ -196,9 +199,11 @@ async def get_indicator_details(
     description="接收一组 OHLCV 数据和可选参数，执行指定技术指标的批量计算并返回对齐后的结果序列。",
     responses=INDICATOR_CALCULATE_RESPONSES,
 )
-async def calculate_indicator(req: CalculationRequest = Body(..., openapi_examples=CALCULATION_REQUEST_EXAMPLES)):
+async def calculate_indicator(
+    req: CalculationRequest = Body(..., openapi_examples=CALCULATION_REQUEST_EXAMPLES),
+    factory: IndicatorFactory = Depends(get_indicator_factory),
+):
     """Run a batch calculation."""
-    factory = get_factory()
 
     # Convert input JSON to DataFrame
     try:


### PR DESCRIPTION
## Summary

- Implements G2.315 path-limited provider injection for `app.api.indicator_registry.get_factory`.
- Adds route-local `get_indicator_factory` and moves all three indicator-registry handlers to `Depends(get_indicator_factory)`.
- Retains `get_factory()` as the backing singleton compatibility seam and preserves route/OpenAPI shape.
- Updates focused file-level tests, including current `UnifiedResponse[...]` response model assertions and provider wiring coverage.

## Line Scope

G2 service lifecycle / provider governance.

## Workline Lane

Source implementation PR. Human review required before merge.

## Current Source of Truth

- `architecture/STANDARDS.md`
- `openspec/changes/migrate-backend-singletons-to-lifecycle-di`
- `.planning/codebase/steward-tree/steward-index.json`
- `docs/reports/quality/backend-indicator-registry-factory-provider-implementation-2026-06-02.md`

## Validation

- Pre-edit GitNexus MCP impact: failed with `Transport closed`; CLI fallback LOW, 3 direct callers, 0 affected processes
- TDD RED: focused test failed before implementation with provider AttributeError; run also exposed stale response_model assertion
- Focused test GREEN: `pytest -o addopts= tests/api/file_tests/test_indicator_registry_api.py --no-cov -q` -> 11 passed, 1 warning
- Health collect-only: `pytest -o addopts= web/backend/tests/test_health_route_conflicts.py --collect-only -q --no-cov` -> 121 tests collected
- Ruff: `ruff check web/backend/app/api/indicator_registry.py tests/api/file_tests/test_indicator_registry_api.py` -> All checks passed
- Route/OpenAPI smoke: 548 routes, 500 OpenAPI paths, duplicate operation ID warnings 0; all 3 indicator-registry routes expose `get_indicator_factory` dependency
- Provider scan: route-body direct `get_factory()` calls 0, provider backing calls 1, dependency bindings 3
- JSON parse gate: passed
- Markdown governance gate: 6 checked files, 0 errors
- `openspec validate migrate-backend-singletons-to-lifecycle-di --strict`: valid
- `git diff --check` and `git diff --cached --check`: passed
- `npx gitnexus verify-staged -r mystocks`: low risk, 11 files, 16 symbols, 0 affected processes
- Mainline scope gate for `governance/mainline/task-cards/pr-468.yaml`: pass

## Boundary

This is a source PR and must not be auto-merged. It changes only `web/backend/app/api/indicator_registry.py`, `tests/api/file_tests/test_indicator_registry_api.py`, and governance artifacts. It does not change route registration, generated OpenAPI artifacts, docs/api, frontend, config, scripts, OpenSpec specs/proposals, PM2, or runtime state.

If accepted and merged, the next node should be G2.316 no-source closeout / residual refresh.
