### PR TITLE
docs(governance): close out indicator registry factory provider

### DIFF
--- a/.planning/codebase/generated/indicator-registry-factory-provider-closeout-2026-06-02.json
+++ b/.planning/codebase/generated/indicator-registry-factory-provider-closeout-2026-06-02.json
@@ -1,0 +1,115 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-06-02T08:24:18+08:00",
+  "node": "G2.316",
+  "title": "indicator_registry get_factory provider closeout / residual refresh",
+  "repo": "mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "base_head": "8b09c714784ce90a1a8b1fe938e5904a81110094",
+  "parent_gate": {
+    "node": "G2.315",
+    "github_pr": {
+      "number": 468,
+      "url": "https://github.com/chengjon/mystocks/pull/468",
+      "state": "MERGED",
+      "merge_commit": "8b09c714784ce90a1a8b1fe938e5904a81110094",
+      "merged_at": "2026-06-02T00:17:40Z",
+      "head_ref": "g2-315-indicator-registry-factory-provider-implementation"
+    }
+  },
+  "source_edit_authority": false,
+  "closeout": {
+    "target": "web/backend/app/api/indicator_registry.py:get_factory",
+    "route_body_direct_get_factory_calls": 0,
+    "provider_backing_get_factory_calls": 1,
+    "depends_bindings": 3,
+    "provider_dependency": "get_indicator_factory",
+    "focused_test": "tests/api/file_tests/test_indicator_registry_api.py: 11 passed, 1 warning",
+    "ruff": "All checks passed",
+    "route_openapi": {
+      "total_routes": 548,
+      "openapi_paths": 500,
+      "duplicate_operation_id_warnings": 0,
+      "indicator_registry_dependency_calls": [
+        "get_indicator_factory",
+        "get_indicator_factory",
+        "get_indicator_factory"
+      ]
+    }
+  },
+  "residual_refresh": {
+    "scan_roots": [
+      "web/backend/app/api",
+      "web/backend/app/services"
+    ],
+    "python_files_scanned": 364,
+    "getter_names_seen": 658,
+    "broad_residual_groups": 827,
+    "selected_next_candidate": {
+      "node": "G2.317",
+      "name": "get_config_manager",
+      "files": [
+        "web/backend/app/api/data_source_config.py",
+        "web/backend/app/api/_data_source_config_responses.py"
+      ],
+      "surface": "data_source_config route provider backing seam",
+      "route_count": 9,
+      "current_route_dependency": "get_config_manager_dependency",
+      "sample_backing_line": "web/backend/app/api/data_source_config.py:103 return get_config_manager()"
+    },
+    "gitnexus_for_selected_candidate": {
+      "mcp_impact": {
+        "status": "failed",
+        "error": "Transport closed"
+      },
+      "cli_fallback": {
+        "target": "Function:web/backend/app/api/_data_source_config_responses.py:get_config_manager",
+        "risk": "HIGH",
+        "direct_callers": 9,
+        "affected_processes": 3,
+        "modules_affected": 1,
+        "stale_index": true,
+        "commits_behind": 0
+      }
+    }
+  },
+  "decision": {
+    "classification": "indicator-registry-provider-closed-no-source-lane",
+    "source_lane_recommendation": "do-not-start-source-implementation-from-g2-316",
+    "recommended_next_work_item": "G2.317 no-source data_source_config get_config_manager ownership / provider seam decision",
+    "autopilot_continue_allowed": true,
+    "next_source_authority": false
+  },
+  "allowed_scope": [
+    ".planning/codebase/generated/indicator-registry-factory-provider-closeout-2026-06-02.json",
+    ".planning/codebase/steward-tree/current-next-gates.md",
+    ".planning/codebase/steward-tree/steward-index.json",
+    ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+    ".planning/codebase/steward-tree/branch-register.md",
+    ".planning/codebase/steward-tree/evidence-index.md",
+    ".planning/codebase/steward-tree/completed-ledger.md",
+    "docs/reports/quality/backend-indicator-registry-factory-provider-closeout-2026-06-02.md",
+    "governance/mainline/task-cards/pr-469.yaml"
+  ],
+  "forbidden_scope": [
+    "web/backend/**",
+    "web/frontend/**",
+    "src/**",
+    "tests/**",
+    "docs/api/**",
+    "docs/FUNCTION_TREE.md",
+    "governance/function-tree/catalog.yaml",
+    "config/**",
+    "scripts/**",
+    "openspec/changes/**",
+    "openspec/specs/**"
+  ],
+  "freshness": {
+    "current_head_checked": "8b09c714784ce90a1a8b1fe938e5904a81110094",
+    "stale_if_head_or_pr_state_changes": true,
+    "stale_if_route_or_openapi_counts_change": true,
+    "stale_if_residual_scan_changes": true,
+    "stale_if_gitnexus_index_refresh_changes_risk": true
+  },
+  "next_gate": "Review future PR #469. If accepted and merged, start G2.317 no-source data_source_config get_config_manager ownership / provider seam decision."
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active branch / PR register
-- Prepared at: `2026-06-02T01:58:00+08:00`
-- Base HEAD checked: `8d52fa0548fd200f0c9b606e5880e71286c07d10`
+- Prepared at: `2026-06-02T08:24:18+08:00`
+- Base HEAD checked: `8b09c714784ce90a1a8b1fe938e5904a81110094`
 
 Boundary note: this register records relationship state only. It does not merge
 PRs, change issue labels, or authorize source implementation.
@@ -294,3 +294,5 @@ G2.313 is the no-source `indicator_registry.get_factory` ownership / route-provi
 G2.314 is the no-source `indicator_registry.get_factory` provider authorization after PR `#466` merged G2.313 at `75f6c63023bec35453892f63aaeaf193023e4881`. It authorizes only a future G2.315 path-limited implementation lane for `web/backend/app/api/indicator_registry.py` plus `tests/api/file_tests/test_indicator_registry_api.py`, requires route/OpenAPI `548/500/0` preservation, and requires G2.315 to stop for human review before merge. It does not edit source in PR `#467`.
 
 G2.315 is the path-limited `indicator_registry.get_factory` provider implementation after PR `#467` merged G2.314 at `8d52fa0548fd200f0c9b606e5880e71286c07d10`. It changes `web/backend/app/api/indicator_registry.py` and `tests/api/file_tests/test_indicator_registry_api.py`, moves the three active indicator-registry routes to `Depends(get_indicator_factory)`, preserves route/OpenAPI `548/500/0`, records focused test `11 passed`, and must stop at PR `#468` human review before merge.
+
+G2.316 is the no-source indicator registry factory provider closeout / residual refresh after PR `#468` merged G2.315 at `8b09c714784ce90a1a8b1fe938e5904a81110094`. It records route-body direct `get_factory()` calls `0`, provider backing calls `1`, `Depends(get_indicator_factory)` bindings `3`, focused test `11 passed`, route/OpenAPI `548/500/0`, and selects only G2.317 no-source `data_source_config.get_config_manager` ownership / provider seam decision. The selected next candidate is GitNexus CLI `HIGH`, with `9` direct callers and `3` affected processes, so G2.317 must not start source implementation.

--- a/.planning/codebase/steward-tree/completed-ledger.md
+++ b/.planning/codebase/steward-tree/completed-ledger.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: summarized completed ledger
-- Prepared at: `2026-06-02T01:58:00+08:00`
-- Base HEAD checked: `8d52fa0548fd200f0c9b606e5880e71286c07d10`
+- Prepared at: `2026-06-02T08:24:18+08:00`
+- Base HEAD checked: `8b09c714784ce90a1a8b1fe938e5904a81110094`
 
 Boundary note: this ledger summarizes accepted or reviewed work. Use the
 archived full tree for exhaustive older G2 rows and the relevant PR/report for
@@ -19,7 +19,7 @@ exact verification output.
 | Route/OpenAPI and control-plane governance | Established route table, OpenAPI exposure, health/probe taxonomy, and consumer-contract evidence as first-class governance facts | Continue through route/OpenAPI track, not ad hoc route edits |
 | Core split / wrapper governance | Completed early low-risk wrapper migration and held Batch 2 behind explicit reconciliation gates | Keep Batch 2 blocked until the shared evidence and Task 3.2 gates are explicit |
 | Error contract migration | Canonical API error path became the active route error contract after P3-C5 completion evidence | Treat as closed unless current HEAD contradicts completion evidence |
-| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.314 accepted/merged by PR `#467` at `8d52fa05`; G2.315 source implementation is now at human-review gate and must not auto-merge |
+| Service lifecycle DI conveyor | Proven candidate classification, authorization, implementation, closeout, and residual refresh pattern across multiple services; G2.315 accepted/merged by PR `#468` at `8b09c714`; continue with G2.316 no-source closeout / residual refresh |
 | Strategy route/provider residuals | Route provider, backtest resolver, adapter wrapper, and canonical adapter provider decisions narrowed residual `get_strategy_service` surfaces | G2.178 merged by PR `#331`; G2.180 merged by PR `#333`; G2.181 merged by PR `#334`; G2.182 merged by PR `#335`; G2.183 merged by PR `#336` and closes the current Strategy getter residual track with retained residuals |
 | Non-Strategy provider governance queue | Next-candidate selection moved remaining provider-shaped residuals out of direct implementation candidacy | G2.184-G2.301 have progressed through PR `#337`-`#454`; current review target is G2.302 admin optimization provider authorization in future PR `#455` |
 | Steward-tree practice learning | Retrospective and practice guide captured the need for machine-readable state and split documents | This branch implements the split and JSON index |
@@ -28,6 +28,7 @@ exact verification output.
 
 | Item | Accepted evidence | Follow-up |
 |---|---|---|
+| G2.315 indicator_registry `get_factory` provider implementation | PR `#468` merged at `8b09c714784ce90a1a8b1fe938e5904a81110094`; generated implementation evidence records route-body direct `get_factory()` calls `0`, provider backing calls `1`, dependency bindings `3`, focused test `11 passed`, route/OpenAPI `548/500/0`, and GitNexus staged low risk / `0` affected processes | G2.316 no-source closeout / residual refresh records closure and selects the next no-source decision target |
 | G2.314 indicator_registry `get_factory` provider authorization | PR `#467` merged at `8d52fa0548fd200f0c9b606e5880e71286c07d10`; generated authorization evidence limits G2.315 to `indicator_registry.py` plus `tests/api/file_tests/test_indicator_registry_api.py` and requires human review before source merge | G2.315 source implementation PR must be reviewed manually before merge; if accepted, start G2.316 no-source closeout / residual refresh |
 | G2.313 indicator_registry `get_factory` ownership / route-provider decision | PR `#466` merged at `75f6c63023bec35453892f63aaeaf193023e4881`; generated decision evidence records active route-local singleton factory calls at lines `159`, `186`, and `201`, route/OpenAPI `548/500/0`, and GitNexus CLI `LOW` / direct `3` / affected processes `0` | G2.314 may authorize only a future path-limited source/test implementation lane and must keep source merge human-review gated |
 | G2.312 service lifecycle residual refresh after dormant indicator-config exclusion | PR `#465` merged at `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`; generated refresh evidence records `371` Python files scanned, `663` getter-like names, `53` active interesting candidates, and selects `indicator_registry.get_factory` as the next no-source decision | G2.313 decides active route-local singleton factory ownership and can select only a no-source authorization package |

--- a/.planning/codebase/steward-tree/current-next-gates.md
+++ b/.planning/codebase/steward-tree/current-next-gates.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active gate register
-- Prepared at: `2026-06-02T01:58:00+08:00`
-- Base HEAD checked: `8d52fa0548fd200f0c9b606e5880e71286c07d10`
+- Prepared at: `2026-06-02T08:24:18+08:00`
+- Base HEAD checked: `8b09c714784ce90a1a8b1fe938e5904a81110094`
 
 Boundary note: this file records gates. It does not authorize code changes,
 issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
@@ -15,7 +15,8 @@ issue label changes, OpenSpec proposal creation, PM2 commands, or PR merges.
 
 | Priority | Gate | Owner lane | Status | Next action |
 |---|---|---|---|---|
-| P0 | Review G2.315 `indicator_registry.get_factory` provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | Source PR `#468` review target; moves 3 indicator-registry handlers to `Depends(get_indicator_factory)`, preserves route/OpenAPI `548/500/0`, focused test `11 passed`, and provider scan `0/1/3` | Human review required; do not auto-merge PR `#468`; if accepted, start G2.316 no-source closeout / residual refresh |
+| P0 | Review G2.316 indicator registry factory provider closeout / residual refresh | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#468` merged at `8b09c714784ce90a1a8b1fe938e5904a81110094`; G2.316 records `get_factory` route-body direct calls `0`, provider backing `1`, dependency bindings `3`, route/OpenAPI `548/500/0`, and next candidate `data_source_config.get_config_manager` with GitNexus CLI `HIGH` | Review future PR `#469`; if accepted, start G2.317 no-source `data_source_config.get_config_manager` ownership / provider seam decision |
+| P0 | Preserve G2.315 `indicator_registry.get_factory` provider implementation | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#468` merged at `8b09c714784ce90a1a8b1fe938e5904a81110094`; G2.315 moved 3 indicator-registry handlers to `Depends(get_indicator_factory)`, preserved route/OpenAPI `548/500/0`, focused test `11 passed`, and provider scan `0/1/3` | Do not use G2.315 as authority for broader source edits; use G2.316 only as no-source closeout / residual refresh |
 | P0 | Preserve G2.314 `indicator_registry.get_factory` provider authorization package | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#467` merged at `8d52fa0548fd200f0c9b606e5880e71286c07d10`; G2.314 authorized only future G2.315 path-limited implementation for `indicator_registry.py` plus `tests/api/file_tests/test_indicator_registry_api.py` | G2.315 source implementation must stop for human review before merge |
 | P0 | Preserve G2.313 `indicator_registry.get_factory` ownership / route-provider decision | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#466` merged at `75f6c63023bec35453892f63aaeaf193023e4881`; G2.313 classifies active route-local singleton factory calls at lines `159`, `186`, and `201`, route/OpenAPI `548/500/0`, and GitNexus CLI `LOW` / direct `3` / affected processes `0` | Do not use G2.313 as source implementation authority; use G2.314 only as no-source provider authorization package |
 | P0 | Preserve G2.312 service lifecycle residual candidate refresh after dormant indicator-config exclusion | G/#79 service lifecycle DI + Route/OpenAPI governance | PR `#465` merged at `ac6b9faaf9cf7d2e04b29da08a2c28bce7d4fb18`; G2.312 excludes dormant `create_indicator_config.py` / `get_mysql_session`, records `371` Python files scanned, `663` getter names, and `53` active interesting candidates | Do not use G2.312 as source implementation authority; use G2.313 only as no-source `indicator_registry.get_factory` ownership / route-provider decision |

--- a/.planning/codebase/steward-tree/evidence-index.md
+++ b/.planning/codebase/steward-tree/evidence-index.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active evidence index
-- Prepared at: `2026-06-02T01:58:00+08:00`
-- Base HEAD checked: `8d52fa0548fd200f0c9b606e5880e71286c07d10`
+- Prepared at: `2026-06-02T08:24:18+08:00`
+- Base HEAD checked: `8b09c714784ce90a1a8b1fe938e5904a81110094`
 
 Boundary note: this index points to evidence artifacts. It does not promote
 review input into accepted truth without a matching review, PR, or OpenSpec
@@ -16,9 +16,12 @@ state transition.
 
 | Evidence | Role | Freshness policy |
 |---|---|---|
-| `.planning/codebase/generated/indicator-registry-factory-provider-implementation-2026-06-02.json` | G2.315 `indicator_registry.get_factory` provider implementation evidence | Review input for future PR `#468`; source implementation package; human review required before merge |
-| `docs/reports/quality/backend-indicator-registry-factory-provider-implementation-2026-06-02.md` | G2.315 human-readable implementation report | Review input for future PR `#468`; records TDD, provider scan, route/OpenAPI, focused tests, ruff, and GitNexus fallback |
-| `governance/mainline/task-cards/pr-468.yaml` | Governance task card for G2.315 source implementation | Review input; allows only path-limited source/test plus steward tree, generated evidence, report, and task card updates |
+| `.planning/codebase/generated/indicator-registry-factory-provider-closeout-2026-06-02.json` | G2.316 indicator registry factory provider closeout / residual refresh evidence | Review input for future PR `#469`; no-source closeout package; selects only G2.317 no-source `data_source_config.get_config_manager` decision |
+| `docs/reports/quality/backend-indicator-registry-factory-provider-closeout-2026-06-02.md` | G2.316 human-readable closeout / residual refresh report | Review input for future PR `#469`; records PR `#468` accepted/merged, closeout counts, route/OpenAPI baseline, residual scan, and next gate |
+| `governance/mainline/task-cards/pr-469.yaml` | Governance task card for G2.316 no-source closeout | Review input; allows only steward tree, generated evidence, report, and task card updates |
+| `.planning/codebase/generated/indicator-registry-factory-provider-implementation-2026-06-02.json` | G2.315 `indicator_registry.get_factory` provider implementation evidence | Accepted by PR `#468`, merged at `8b09c714784ce90a1a8b1fe938e5904a81110094`; source implementation package; superseded for closeout by G2.316 |
+| `docs/reports/quality/backend-indicator-registry-factory-provider-implementation-2026-06-02.md` | G2.315 human-readable implementation report | Accepted by PR `#468`; records TDD, provider scan, route/OpenAPI, focused tests, ruff, and GitNexus fallback |
+| `governance/mainline/task-cards/pr-468.yaml` | Governance task card for G2.315 source implementation | Accepted by PR `#468`; allowed only path-limited source/test plus steward tree, generated evidence, report, and task card updates |
 | `.planning/codebase/generated/indicator-registry-factory-provider-authorization-2026-06-02.json` | G2.314 `indicator_registry.get_factory` provider authorization evidence | Accepted by PR `#467`, merged at `8d52fa0548fd200f0c9b606e5880e71286c07d10`; no-source authorization package; superseded for implementation by G2.315 |
 | `docs/reports/quality/backend-indicator-registry-factory-provider-authorization-2026-06-02.md` | G2.314 human-readable authorization report | Accepted by PR `#467`; records PR `#466` accepted/merged, implementation boundary, required tests, and source stop rule |
 | `governance/mainline/task-cards/pr-467.yaml` | Governance task card for G2.314 no-source authorization | Accepted by PR `#467`; allowed only steward tree, generated evidence, report, and task card updates |

--- a/.planning/codebase/steward-tree/steward-index.json
+++ b/.planning/codebase/steward-tree/steward-index.json
@@ -1,9 +1,9 @@
 {
   "schema_version": "2026-05-27.steward-index.v1",
-  "generated_at": "2026-06-02T01:58:00+08:00",
+  "generated_at": "2026-06-02T08:24:18+08:00",
   "repo": "chengjon/mystocks",
   "base_branch": "wip/root-dirty-20260403",
-  "base_head": "8d52fa0548fd200f0c9b606e5880e71286c07d10",
+  "base_head": "8b09c714784ce90a1a8b1fe938e5904a81110094",
   "split_branch": "g2-312-service-lifecycle-residual-refresh-after-indicator-config",
   "scope": "service_lifecycle_residual_refresh_after_indicator_config",
   "source_edit_authority": false,
@@ -12184,16 +12184,18 @@
     {
       "id": "g2-315-indicator-registry-factory-provider-implementation",
       "type": "source_implementation",
-      "state": "for_human_review",
+      "state": "accepted_merged",
       "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
       "parent": "G2.314 indicator_registry get_factory provider authorization",
       "source_edit_authority": true,
-      "autopilot_status": "stopped_for_source_review",
-      "autopilot_stop_reason": "G2.315 edits backend source/tests and must not be auto-merged.",
+      "autopilot_status": "merged_after_human_approval",
+      "autopilot_stop_reason": "G2.315 edited backend source/tests and was merged only after human approval.",
       "github_pr": {
         "number": 468,
         "url": "https://github.com/chengjon/mystocks/pull/468",
-        "state": "PLANNED_FOR_REVIEW",
+        "state": "MERGED",
+        "merge_commit": "8b09c714784ce90a1a8b1fe938e5904a81110094",
+        "merged_at": "2026-06-02T00:17:40Z",
         "head_ref": "g2-315-indicator-registry-factory-provider-implementation"
       },
       "closed_parent": {
@@ -12284,7 +12286,89 @@
           "commits_behind": 0
         }
       },
-      "next_gate": "Human review PR #468. If accepted and merged, start G2.316 no-source indicator_registry factory provider closeout / residual refresh."
+      "next_gate": "Superseded by G2.316 no-source indicator_registry factory provider closeout / residual refresh."
+    },
+    {
+      "id": "g2-316-indicator-registry-factory-provider-closeout",
+      "type": "closeout_refresh",
+      "state": "for_review",
+      "owner_lane": "G/#79 service lifecycle DI + Route/OpenAPI governance",
+      "parent": "G2.315 indicator_registry get_factory provider implementation",
+      "source_edit_authority": false,
+      "autopilot_status": "review_gate",
+      "autopilot_stop_reason": "G2.316 is no-source closeout / residual refresh and selects only a future no-source ownership decision gate.",
+      "github_pr": {
+        "number": 469,
+        "url": "https://github.com/chengjon/mystocks/pull/469",
+        "state": "PLANNED_FOR_REVIEW",
+        "head_ref": "g2-316-indicator-registry-factory-provider-closeout"
+      },
+      "closed_parent": {
+        "pr": 468,
+        "state": "MERGED",
+        "merge_commit": "8b09c714784ce90a1a8b1fe938e5904a81110094",
+        "merged_at": "2026-06-02T00:17:40Z"
+      },
+      "evidence": [
+        ".planning/codebase/generated/indicator-registry-factory-provider-closeout-2026-06-02.json",
+        "docs/reports/quality/backend-indicator-registry-factory-provider-closeout-2026-06-02.md",
+        "governance/mainline/task-cards/pr-469.yaml"
+      ],
+      "allowed_scope": [
+        ".planning/codebase/generated/indicator-registry-factory-provider-closeout-2026-06-02.json",
+        ".planning/codebase/steward-tree/current-next-gates.md",
+        ".planning/codebase/steward-tree/steward-index.json",
+        ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+        ".planning/codebase/steward-tree/branch-register.md",
+        ".planning/codebase/steward-tree/evidence-index.md",
+        ".planning/codebase/steward-tree/completed-ledger.md",
+        "docs/reports/quality/backend-indicator-registry-factory-provider-closeout-2026-06-02.md",
+        "governance/mainline/task-cards/pr-469.yaml"
+      ],
+      "forbidden_scope": [
+        "web/backend/**",
+        "web/frontend/**",
+        "src/**",
+        "tests/**",
+        "docs/api/**",
+        "docs/FUNCTION_TREE.md",
+        "governance/function-tree/catalog.yaml",
+        "config/**",
+        "scripts/**",
+        "openspec/changes/**",
+        "openspec/specs/**"
+      ],
+      "closeout": {
+        "target": "web/backend/app/api/indicator_registry.py:get_factory",
+        "route_body_direct_get_factory_calls": 0,
+        "provider_backing_get_factory_calls": 1,
+        "depends_bindings": 3,
+        "focused_test": "11 passed, 1 warning",
+        "route_openapi": "548/500/0"
+      },
+      "residual_refresh": {
+        "python_files_scanned": 364,
+        "getter_names_seen": 658,
+        "broad_residual_groups": 827,
+        "selected_next_candidate": "data_source_config.get_config_manager",
+        "selected_next_candidate_risk": "HIGH",
+        "selected_next_candidate_direct_callers": 9,
+        "selected_next_candidate_affected_processes": 3
+      },
+      "decision": {
+        "classification": "indicator-registry-provider-closed-no-source-lane",
+        "source_lane_recommendation": "do-not-start-source-implementation-from-g2-316",
+        "recommended_next_work_item": "G2.317 no-source data_source_config get_config_manager ownership / provider seam decision",
+        "autopilot_continue_allowed": true
+      },
+      "freshness": {
+        "current_head_checked": "8b09c714784ce90a1a8b1fe938e5904a81110094",
+        "stale_if_head_or_pr_state_changes": true,
+        "stale_if_route_or_openapi_counts_change": true,
+        "stale_if_residual_scan_changes": true,
+        "stale_if_gitnexus_index_refresh_changes_risk": true
+      },
+      "next_gate": "Review future PR #469. If accepted and merged, start G2.317 no-source data_source_config get_config_manager ownership / provider seam decision."
     }
   ]
 }

--- a/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
+++ b/.planning/codebase/steward-tree/tracks/service-lifecycle-di.md
@@ -5,8 +5,8 @@
 ## Status
 
 - Status: active track summary
-- Prepared at: `2026-06-02T01:58:00+08:00`
-- Base HEAD checked: `8d52fa0548fd200f0c9b606e5880e71286c07d10`
+- Prepared at: `2026-06-02T08:24:18+08:00`
+- Base HEAD checked: `8b09c714784ce90a1a8b1fe938e5904a81110094`
 
 Boundary note: this track summary does not authorize source changes. Each
 implementation still needs a path-limited authorization package, GitNexus impact
@@ -29,9 +29,10 @@ It proved a repeatable conveyor:
 
 | Node | State | Notes |
 |---|---|---|
-| G2.315 indicator_registry `get_factory` provider implementation | Future PR `#468` source review target | Moves 3 route handlers to `Depends(get_indicator_factory)`, keeps route/OpenAPI `548/500/0`, focused test `11 passed`, and must stop for human review before merge |
-| G2.314 indicator_registry `get_factory` provider authorization | Future PR `#467` review target | Authorizes only future G2.315 path-limited source/test lane and requires human review before source merge; no source edits in G2.314 |
-| G2.313 indicator_registry `get_factory` ownership / route-provider decision | Future PR `#466` review target | Classifies active route-local singleton factory helper with 3 route-body calls, route/OpenAPI `548/500/0`, GitNexus CLI `LOW`, and selects only G2.314 no-source provider authorization |
+| G2.316 indicator registry factory provider closeout / residual refresh | Future PR `#469` review target | Closes G2.315 with route-body direct calls `0`, provider backing `1`, dependency bindings `3`, route/OpenAPI `548/500/0`, and selects only G2.317 no-source `data_source_config.get_config_manager` decision |
+| G2.315 indicator_registry `get_factory` provider implementation | Merged by PR `#468` | Moves 3 route handlers to `Depends(get_indicator_factory)`, keeps route/OpenAPI `548/500/0`, focused test `11 passed`, and is closed by G2.316 |
+| G2.314 indicator_registry `get_factory` provider authorization | Merged by PR `#467` | Authorized only G2.315 path-limited source/test lane and required human review before source merge |
+| G2.313 indicator_registry `get_factory` ownership / route-provider decision | Merged by PR `#466` | Classifies active route-local singleton factory helper with 3 route-body calls, route/OpenAPI `548/500/0`, GitNexus CLI `LOW`, and selects only G2.314 no-source provider authorization |
 | G2.312 residual refresh after dormant indicator-config exclusion | Merged by PR `#465` | Excludes dormant `create_indicator_config.py` / `get_mysql_session`, records `371` Python files scanned, `663` getter names, `53` active interesting candidates, and selects G2.313 |
 | Steward split | Merged by PR `#332` | Root task tree is now a short entrypoint; active state belongs in this split track and `steward-index.json` |
 | G2.177 Strategy canonical adapter provider authorization | Accepted and merged by PR `#330` | Authorized only a constructor-level Strategy service provider seam in canonical `strategy_adapter.py` and focused tests |
@@ -3479,7 +3480,7 @@ Status: accepted / merged by PR `#467`.
 
 ## G2.315 Indicator Registry `get_factory` Provider Implementation
 
-Status: source implementation PR review required in future PR `#468`.
+Status: accepted / merged by PR `#468`.
 
 - Parent PR `#467` merged at `8d52fa0548fd200f0c9b606e5880e71286c07d10`.
 - G2.315 edits only `web/backend/app/api/indicator_registry.py`, `tests/api/file_tests/test_indicator_registry_api.py`, and governance artifacts.
@@ -3487,3 +3488,14 @@ Status: source implementation PR review required in future PR `#468`.
 - TDD evidence: RED `2 failed, 9 passed`; GREEN `11 passed, 1 warning`.
 - Verification: health collect-only 121 tests collected, ruff focused pass, provider scan route-body direct calls `0`, backing calls `1`, dependency bindings `3`.
 - Stop rule: PR `#468` must be manually reviewed and must not be auto-merged.
+
+## G2.316 Indicator Registry Factory Provider Closeout / Residual Refresh
+
+Status: for review in future PR `#469`.
+
+- Parent PR `#468` merged at `8b09c714784ce90a1a8b1fe938e5904a81110094`.
+- G2.316 is a no-source closeout / residual refresh. It does not edit backend source, tests, route contracts, docs/api artifacts, frontend, config, scripts, OpenSpec, PM2, or runtime state.
+- Closeout result: `indicator_registry.get_factory` route-body direct calls are `0`, provider backing calls are `1`, `Depends(get_indicator_factory)` bindings are `3`, focused test remains `11 passed`, and route/OpenAPI remains `548/500/0`.
+- Residual refresh selected G2.317 no-source `data_source_config.get_config_manager` ownership / provider seam decision.
+- The selected next candidate is high-risk: GitNexus MCP impact failed with `Transport closed`, and CLI fallback resolved `web/backend/app/api/_data_source_config_responses.py:get_config_manager` as `HIGH`, with `9` direct callers and `3` affected processes.
+- Stop rule: G2.316 must not be used as source implementation authority or as authorization to edit `data_source_config.py`, `_data_source_config_responses.py`, route contracts, OpenAPI artifacts, tests, docs/api, frontend, config, scripts, OpenSpec, PM2, or runtime state.

--- a/docs/reports/quality/backend-indicator-registry-factory-provider-closeout-2026-06-02.md
+++ b/docs/reports/quality/backend-indicator-registry-factory-provider-closeout-2026-06-02.md
@@ -1,0 +1,52 @@
+# Backend Indicator Registry Factory Provider Closeout - G2.316
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: for review
+- Prepared at: `2026-06-02T08:24:18+08:00`
+- Base HEAD checked: `8b09c714784ce90a1a8b1fe938e5904a81110094`
+- Parent gate: G2.315 accepted / merged by PR `#468`
+- Source edit authority: none
+
+Boundary note: this G2.316 package is no-source closeout / residual refresh only. It does not authorize backend source edits, tests, route registration changes, route/OpenAPI contract edits, docs/api artifacts, frontend/config/script changes, PM2 commands, OpenSpec spec edits, or source retirement.
+
+## Closeout Result
+
+The `indicator_registry.get_factory` provider lane is closed.
+
+| Check | Result |
+|---|---|
+| Route-body direct `get_factory()` calls | `0` |
+| Provider backing `get_factory()` calls | `1` |
+| `Depends(get_indicator_factory)` bindings | `3` |
+| Focused test | `tests/api/file_tests/test_indicator_registry_api.py`: `11 passed, 1 warning` |
+| Ruff | target source/test files pass |
+| Route/OpenAPI | `548` FastAPI routes, `500` OpenAPI paths, duplicate operation IDs `0` |
+
+All three indicator-registry routes now expose `get_indicator_factory` as their route dependency, while `get_factory()` remains as the backing singleton compatibility seam.
+
+## Residual Refresh
+
+The broad residual scan covered `364` active API/service Python files after excluding old/backup/archive-style paths. It saw `658` getter-like names and `827` broad residual groups. This broad count is a triage index only, not a direct replacement for earlier curated candidate counts.
+
+The next selected candidate is:
+
+| Field | Value |
+|---|---|
+| Next node | G2.317 |
+| Candidate | `get_config_manager` |
+| Main route file | `web/backend/app/api/data_source_config.py` |
+| Backing implementation file | `web/backend/app/api/_data_source_config_responses.py` |
+| Current route dependency | `get_config_manager_dependency` |
+| Registered route count | `9` |
+| Sample backing line | `data_source_config.py:103 return get_config_manager()` |
+
+GitNexus MCP impact failed with `Transport closed`; CLI fallback resolved the backing symbol as `Function:web/backend/app/api/_data_source_config_responses.py:get_config_manager` and reported `HIGH` risk, `9` direct callers, and `3` affected processes. Because of that, G2.317 must be ownership / provider seam decision only. It must not authorize source implementation directly.
+
+## Next Gate
+
+Start G2.317 as a no-source `data_source_config.get_config_manager` ownership / provider seam decision after PR `#469` is accepted / merged.
+
+G2.317 should decide whether the current provider/backing split is already acceptable, needs closeout documentation only, or needs a later high-risk authorization package. It must not edit source.

--- a/governance/mainline/task-cards/pr-469.yaml
+++ b/governance/mainline/task-cards/pr-469.yaml
@@ -1,0 +1,130 @@
+version: "v0.2"
+
+task:
+  id: "pr-469"
+  title: "Close out indicator registry factory provider and refresh residual candidates"
+  owner: "codex"
+  created_at: "2026-06-02"
+
+mainline:
+  id: "L1-indicator-registry-factory-provider-closeout"
+  objective: "record G2.315 provider closure and select the next service lifecycle ownership decision target"
+  milestone_id: "L2-architecture-governance-continuation"
+  slice_id: "L3-g2-service-lifecycle-routing"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "migrate-backend-singletons-to-lifecycle-di"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+    - "api"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "meta-governance"
+  exemption_reason: "G2.316 is a no-source closeout and residual refresh. It changes no runtime route, handler, contract, source file, or test file."
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/indicator-registry-factory-provider-closeout-2026-06-02.json"
+    - ".planning/codebase/steward-tree/current-next-gates.md"
+    - ".planning/codebase/steward-tree/steward-index.json"
+    - ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - ".planning/codebase/steward-tree/evidence-index.md"
+    - ".planning/codebase/steward-tree/completed-ledger.md"
+    - "docs/reports/quality/backend-indicator-registry-factory-provider-closeout-2026-06-02.md"
+    - "governance/mainline/task-cards/pr-469.yaml"
+  forbidden_paths:
+    - "web/backend/**"
+    - "web/frontend/**"
+    - "src/**"
+    - "tests/**"
+    - "docs/api/**"
+    - "docs/FUNCTION_TREE.md"
+    - "governance/function-tree/catalog.yaml"
+    - "config/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openspec/specs/**"
+
+non_goals:
+  - "backend source edits in this PR"
+  - "test edits in this PR"
+  - "route registration changes"
+  - "route path, method, response model, or generated OpenAPI artifact changes"
+  - "docs/api artifact edits"
+  - "frontend/config/script changes"
+  - "OpenSpec proposal or spec edits"
+  - "PM2 commands or stateful runtime gates"
+  - "source retirement"
+  - "editing data_source_config.py or _data_source_config_responses.py"
+  - "authorizing source implementation directly from G2.316"
+
+acceptance:
+  checks:
+    - id: "pr468-merged"
+      command: "gh pr view 468 confirms MERGED at 8b09c714784ce90a1a8b1fe938e5904a81110094"
+      required: true
+    - id: "indicator-registry-closeout"
+      command: "generated evidence records route-body direct get_factory calls 0, provider backing calls 1, Depends bindings 3"
+      required: true
+    - id: "route-openapi-baseline"
+      command: "route/OpenAPI smoke remains 548 routes, 500 paths, 0 duplicate operation ID warnings"
+      required: true
+    - id: "next-gate-selection"
+      command: "report selects only G2.317 no-source data_source_config get_config_manager ownership / provider seam decision"
+      required: true
+    - id: "no-source-boundary"
+      command: "PR #469 edits no backend source, tests, route contracts, docs/api, frontend, config, scripts, OpenSpec, PM2, or runtime state"
+      required: true
+    - id: "markdown-governance"
+      command: "python scripts/compliance/markdown_governance_gate.py --root-dir . --format json docs/reports/quality/backend-indicator-registry-factory-provider-closeout-2026-06-02.md .planning/codebase/steward-tree/current-next-gates.md .planning/codebase/steward-tree/branch-register.md .planning/codebase/steward-tree/evidence-index.md .planning/codebase/steward-tree/completed-ledger.md .planning/codebase/steward-tree/tracks/service-lifecycle-di.md"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/pr-469.yaml --base-sha 8b09c714784ce90a1a8b1fe938e5904a81110094 --head-sha HEAD --report /tmp/pr469-mainline-governance-report.json"
+      required: true
+    - id: "openspec-validate"
+      command: "openspec validate migrate-backend-singletons-to-lifecycle-di --strict"
+      required: true
+    - id: "git-diff-check"
+      command: "git diff --cached --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "No runtime risk from this PR because it is no-source governance only."
+    - "Residual scan selection can become stale if route/provider surfaces change."
+  rollback_plan: "Revert PR #469; this removes only G2.316 closeout / residual refresh evidence and restores the prior G2.315 review gate."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Close out indicator_registry provider implementation and select the next ownership decision target."
+    modified_scope: "Governance evidence, steward tree indexes, report, and task card only."
+    dependency_changes: "No package dependency changes."
+    legacy_logic_impact: "No runtime behavior, route contract, OpenAPI, or source changes."
+    rollback_ready: "Revert PR #469."
+    risk_and_rollback_point: "No-source closeout / residual refresh; rollback is single-PR revert."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer-autopilot"
+    approved_at: "2026-06-02T08:24:18+08:00"
+    approval_note: "Human maintainer previously authorized automatic no-source governance continuation; G2.316 remains no-source and selects only a future no-source decision gate."
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- Records G2.316 no-source closeout for the indicator-registry factory provider lane.
- Confirms `indicator_registry.get_factory` route-body direct calls are closed: direct `0`, provider backing `1`, dependency bindings `3`.
- Records route/OpenAPI baseline `548/500/0` and focused test/ruff evidence from the merged G2.315 source lane.
- Selects only G2.317 no-source `data_source_config.get_config_manager` ownership / provider seam decision. The selected candidate is HIGH risk by GitNexus CLI and must not enter source implementation directly.

## Line Scope

G2 service lifecycle / provider governance.

## Workline Lane

No-source governance / closeout and residual refresh.

## Current Source of Truth

- `architecture/STANDARDS.md`
- `openspec/changes/migrate-backend-singletons-to-lifecycle-di`
- `.planning/codebase/steward-tree/steward-index.json`
- `docs/reports/quality/backend-indicator-registry-factory-provider-closeout-2026-06-02.md`

## Validation

- JSON parse gate: passed
- Markdown governance gate: 6 checked files, 0 errors
- `openspec validate migrate-backend-singletons-to-lifecycle-di --strict`: valid
- `git diff --check`: passed
- `git diff --cached --check`: passed
- `npx gitnexus verify-staged -r mystocks`: low risk, 9 files, 0 symbols, 0 affected processes
- Mainline scope gate for `governance/mainline/task-cards/pr-469.yaml`: pass
- Closeout evidence: route-body direct `get_factory()` calls 0, provider backing calls 1, `Depends(get_indicator_factory)` bindings 3
- Route/OpenAPI baseline: 548 routes, 500 paths, duplicate operation ID warnings 0
- Next candidate evidence: `data_source_config.get_config_manager`, GitNexus CLI HIGH, 9 direct callers, 3 affected processes

## Boundary

This PR edits only governance artifacts. It does not modify backend source, tests, route contracts, OpenAPI artifacts, docs/api, frontend, config, scripts, OpenSpec specs/proposals, PM2, or runtime state.

If accepted and merged, the next node should be G2.317 no-source `data_source_config.get_config_manager` ownership / provider seam decision.
