### PR TITLE
feat: add openstock runtime migration boundary

### DIFF
--- a/config/data_sources_registry.yaml
+++ b/config/data_sources_registry.yaml
@@ -1,4 +1,50 @@
 data_sources:
+  openstock_akshare_realtime_quotes:
+    call_method: remote_rest
+    classification_level: 1
+    data_category: REALTIME_QUOTES
+    data_classification: market_data
+    data_quality_score: 8.0
+    description: OpenStock远程运行时 AkShare A股实时行情/代码名称列表
+    endpoint_name: akshare.stock_zh_a_spot
+    parameters:
+      limit:
+        description: 返回记录数量上限
+        example: 50
+        required: false
+        type: integer
+      symbol:
+        description: 可选股票代码过滤
+        example: '000001'
+        required: false
+        type: string
+    priority: 1
+    quality_rules:
+      max_response_time: 15.0
+      min_record_count: 1
+      required_columns:
+      - symbol
+      - name
+    remote_runtime:
+      base_url_default: http://localhost:8031
+      base_url_env: OPENSTOCK_BASE_URL
+      fetch_path: /data/fetch
+      route_path: /routing/best
+      service: openstock
+      transport: rest
+    source_name: openstock
+    source_type: remote_runtime
+    status: active
+    table_name: realtime_quotes
+    tags:
+    - openstock
+    - akshare
+    - remote-runtime
+    - phase-3
+    target_db: postgresql
+    test_parameters:
+      limit: 1
+    update_frequency: realtime
   akshare_dragon_tiger_detail:
     call_method: function_call
     classification_level: 1

--- a/docs/reports/architecture/data-source-runtime-service-migration-feasibility-plan-2026-06-09.md
+++ b/docs/reports/architecture/data-source-runtime-service-migration-feasibility-plan-2026-06-09.md
@@ -1,0 +1,696 @@
+# 数据源运行时服务化迁移可行性方案
+
+日期：2026-06-09
+
+关联分析文档：
+
+- `docs/reports/architecture/data-source-service-extraction-analysis-2026-06-09.md`
+- `docs/reports/architecture/data-source-service-extraction-analysis-review-2026-06-09.md`
+- `/opt/claude/eltdx/docs/ELTDX_MCP_ACCESS_MODES.md`
+
+## 结论摘要
+
+本方案建议把 MyStocks 的数据源管理与项目功能底座分开，但不要采用“直接把数据源目录搬进 Docker”的方式。正确做法是先定义主后端与数据源运行时之间的稳定 seam，再用不同 adapter 支撑本地、远程、mock、诊断工具和实时流。
+
+核心设计：
+
+- 主后端继续承担产品 API、认证、权限、`UnifiedResponse`、OpenAPI、前端兼容路径、策略、风控、交易和看板业务编排。
+- 新增 `openstock` 数据源运行时，承担 provider adapter、registry、路由、健康检查、限流、缓存、熔断、调用指标和实时行情源订阅。
+- `openstock` 作为迁出后的独立方案/仓库名，目标本地目录为 `/opt/claude/openstock`，目标私库为 `http://192.168.123.104:3001/john/openstock.git`。
+- 主后端对外保留 `/api/v1/data-sources*`，先作为 facade/proxy，避免前端和第三方调用方跟随迁移。
+- REST/OpenAPI 用于控制面和 pull 型数据。
+- WebSocket 用于实时行情订阅。
+- SSE 仅用于浏览器单向状态流。
+- MCP 仅作为可选 agent/admin/diagnostics 工具面，不进入高频行情和批量 K 线热路径。
+- `DataSourceClient` 必须先形成可测试 interface contract，再进入 remote/Docker 实现。
+- 迁移关系上，本方案依赖并接续 active 的 `optimize-data-source-v2`，不替代其已沉淀的数据源治理能力。
+
+最关键的原则：
+
+> 这不是“把数据源搬进 Docker”，而是先把主后端和数据源之间的 interface 变深。只要 `DataSourceClient` 这个 seam 定得好，后面 local、remote、mock、MCP-admin、WebSocket-stream 都只是 adapter；业务功能底座不会再被 provider 细节拖着走。
+
+## 1. 怎么拆，功能如何分布
+
+### 1.1 拆分目标
+
+当前数据源能力仍然和主后端运行时耦合：
+
+- 主后端内直接存在 provider adapter 调用链。
+- 数据源 registry、priority、mode、health、cache 等配置分散在多个文件和运行路径。
+- provider 失败、凭证、限流、熔断和缓存策略容易穿透到业务后端。
+- 主后端既要服务前端业务，又要处理外部数据源不稳定性。
+
+拆分目标是：
+
+- 让主后端专注业务功能底座。
+- 让数据源运行时专注 provider 访问和数据源治理。
+- 保持前端和外部调用方已有 API 路径稳定。
+- 通过 Docker 让数据源运行时独立部署、独立监控、独立恢复。
+
+### 1.2 推荐模块分布
+
+| 模块 | 保留或承接功能 | 不应该承接 |
+|---|---|---|
+| `mystocks-backend` 主后端 | 产品 API、认证、权限、`UnifiedResponse`、OpenAPI、前端兼容路径、策略、风控、交易、看板业务编排 | 具体数据源 provider 调用、provider 凭证、provider 限流、provider 熔断 |
+| `openstock` 数据源运行时 | registry、路由选择、provider adapter、凭证、限流、缓存、熔断、健康检查、调用指标、实时行情源订阅 | 用户业务、前端页面契约、策略决策、交易执行、业务数据归属 |
+| DB、Redis、TDengine | PostgreSQL 存 registry/version/call history，Redis 存短 TTL 快照、分布式限流、stream 状态，TDengine/PostgreSQL 继续存市场和业务数据 | 不承担 provider 调用逻辑 |
+| MCP 工具面，可选 | agent/admin 诊断：列数据源、测 endpoint、解释路由、reload registry、查健康 | 高频行情、批量 K 线、策略执行热路径 |
+
+### 1.3 推荐 seam：`DataSourceClient`
+
+核心 seam 应该放在主后端中：
+
+```text
+业务代码 / FastAPI routes
+        |
+        v
+DataSourceClient interface
+        |
+        +-- LocalDataSourceClient     # 迁移前，调用现有 DataSourceManagerV2
+        |
+        +-- RemoteDataSourceClient    # 迁移后，REST/WS 调 openstock
+```
+
+这样拆的好处：
+
+- 调用方只学习一个 `DataSourceClient` interface。
+- 今天 interface 背后是本地 `DataSourceManagerV2`。
+- 明天可以换成远程 Docker 服务。
+- 业务代码不需要大面积知道 provider、registry、handler、熔断器、限流器和远程协议细节。
+
+#### 1.3.1 `DataSourceClient` interface contract
+
+审核意见里最关键的问题是：`DataSourceClient` 不能只是一张图里的名字。它必须先成为可测试、可替换、可审计的契约，否则 local 到 remote 迁移时会把 provider 细节原样搬进 HTTP。
+
+建议最小能力面：
+
+| 能力 | 语义 | 热路径要求 |
+|---|---|---|
+| `resolve_route(request)` | 返回本次请求选中的 provider/endpoint、fallback 候选和 route reason | 快，不能触发慢 provider 请求 |
+| `fetch_snapshot(request)` | 拉取单个 symbol/category 的一次性快照 | 必须有 timeout、freshness 和 typed error |
+| `fetch_batch(request)` | 批量拉取历史/财务/参考数据 | 可异步化或分页，不能阻塞主后端无限等待 |
+| `test_endpoint(endpoint_name)` | 诊断某个 endpoint 是否可用 | admin/diagnostics，不进入业务热路径 |
+| `get_source_health(filter)` | 查询 provider、endpoint、category 健康状态 | 可缓存，返回观测指标 |
+| `reload_registry(version)` | registry reload/version 切换 | 写操作必须有审计和回滚语义 |
+| `subscribe_quotes(request)` | 仅用于 stream client，建立行情订阅 | WebSocket 专用，不走 MCP |
+
+契约不变量：
+
+1. 每个成功响应必须携带 `source`、`endpoint_name`、`route_decision_id`、`request_id`、`exchange_time`、`received_at`、`staleness_ms`、`cache_state`、`quality_flags`、`latency_ms`。
+2. 陈旧数据不能静默返回。若允许降级返回 stale cache，必须标记 `cache_state=stale`，并带 `staleness_ms` 与降级原因。
+3. 错误必须 typed，至少区分 `ProviderUnavailable`、`ProviderTimeout`、`RateLimited`、`CircuitOpen`、`RegistryNotFound`、`InvalidRequest`、`DataQualityFailed`。
+4. 每次调用必须有明确 timeout budget；远程 client 不允许无限等待 provider。
+5. 缓存语义必须显式：`cache_state=fresh|stale|miss|bypass`，调用方可以声明 freshness requirement。
+6. registry/config 写操作必须通过运行时 owner 的 config API，不允许 fetch 类接口顺手改 provider 配置。
+7. `LocalDataSourceClient` 与 `RemoteDataSourceClient` 必须跑同一套 contract tests。主后端业务代码只依赖契约，不依赖具体 provider adapter。
+
+### 1.4 具体功能归属
+
+| 功能 | 推荐归属 |
+|---|---|
+| `/api/v1/data-sources` 对外路径 | 主后端保留，先做 facade/proxy |
+| `/api/v1/data-sources/config` 写操作 | 主后端保留外部契约，但内部代理给数据源运行时 |
+| registry 真相源 | 尽早定为 PostgreSQL；YAML 只做 bootstrap/seed/emergency fallback |
+| `config/data_sources.json` | 保留为主后端“业务模块 mock/real 模式”配置，不再承担 provider registry |
+| `adapter_priority_config.yaml` | 迁移后退役，优先级进入 registry/routing policy |
+| provider adapter | 数据源运行时 |
+| health/cache/circuit breaker/rate limit | 数据源运行时 |
+| strategy/risk/trade/portfolio | 主后端 |
+| realtime market channel | 数据源运行时产出，主后端可转发到现有 `/ws/events` |
+
+### 1.5 registry ownership 必须先定
+
+迁移前最重要的设计决定是 registry ownership。它不能拖到最后。
+
+建议在 Phase 0 就明确：
+
+```text
+PostgreSQL registry/version history = 唯一运行时真相源
+YAML registry = 初始化 seed + 离线恢复材料
+主后端 config API = 对外 facade
+数据源运行时 = registry 写入、reload、route、health 的实际 owner
+```
+
+这样可以避免新增 Docker 服务后又多出一个平行 registry，造成更多真相源。
+
+### 1.6 runtime state ownership matrix
+
+这里必须把“数据源运行态”和“业务数据存储”拆清楚。拆服务不是迁移数据库，也不是把市场数据仓库搬走；第一阶段只迁移 provider 访问、路由和运行治理。
+
+| 状态/数据 | 推荐 owner | 存储/生命周期 | 说明 |
+|---|---|---|---|
+| provider registry | 数据源运行时 | PostgreSQL 为运行时真相源；YAML 为 seed/fallback | 主后端只保留 facade，不再直接维护 provider registry |
+| registry version history / rollback | 数据源运行时 | PostgreSQL | config 写操作必须审计、可回滚 |
+| route decision history | 数据源运行时 | PostgreSQL 或短期日志 + metrics | 用于解释路由、回放故障、观察 fallback |
+| provider health | 数据源运行时 | 进程内状态 + metrics；多实例时可接 Redis | 由 provider probe、熔断器和请求结果共同更新 |
+| cache | 数据源运行时 | L1 memory + 可选 Redis L2 | 主后端不再自建 provider cache 主链 |
+| rate limit state | 数据源运行时 | 单实例内存；多实例时 Redis namespace | 每个 provider/endpoint 独立预算 |
+| circuit breaker state | 数据源运行时 | 单实例内存；多实例时可外置共享摘要 | 不能由 MCP 或主后端绕过 |
+| metrics | 数据源运行时 emit；主后端可聚合/代理 | Prometheus `datasource_*` | latency、cache hit、fallback、rate limit、circuit open、quality failure |
+| provider call audit/cost | 数据源运行时 | PostgreSQL/Prometheus，按实际需要取舍 | 用于成本、配额、问题追踪 |
+| tick/minute/daily/indicator/reference market data | 现有数据仓库 owner | TDengine/PostgreSQL 现有路径 | 第一阶段不迁移业务数据仓库 |
+| strategy/risk/trade/portfolio/user data | 主后端/现有业务域 | PostgreSQL/现有路径 | 不进入数据源运行时 |
+
+因此，`openstock` 的职责是“取得、治理、解释数据源访问”，不是成为新的市场数据仓库或策略执行引擎。
+
+## 2. 服务如何分层，保证速度与稳定
+
+### 2.1 数据源运行时内部层次
+
+`openstock` 内部建议按 5 层组织，不要让 REST handler 直接调用 AkShare、TDX 或 TuShare。
+
+```text
+Transport Layer
+  REST / WebSocket / optional MCP
+
+Application Layer
+  DataSourceRuntime
+  FetchSnapshot / FetchBatch / SubscribeQuotes / TestEndpoint / ReloadRegistry
+
+Routing Layer
+  RegistryReader
+  RoutePolicy
+  EndpointHealth
+  Cost/Freshness/Latency scoring
+
+Provider Adapter Layer
+  AkShareAdapter
+  TdxAdapter
+  TuShareAdapter
+  BaoStockAdapter
+  BYAPIAdapter
+  CustomerAdapter
+
+Resilience + State Layer
+  L1 memory cache
+  Redis L2 cache
+  Circuit breaker
+  Adaptive rate limiter
+  Bulkhead/concurrency limits
+  Prometheus metrics
+  Call history/version history
+```
+
+### 2.2 协议分工
+
+协议不是单选，而是按数据类型和使用场景分层。
+
+| 协议 | 推荐用途 | 不推荐用途 |
+|---|---|---|
+| REST/OpenAPI | registry、health、route selection、测试 endpoint、历史/财务/参考数据 fetch、batch fetch | 高频实时行情推送 |
+| WebSocket | realtime quote、tick-like update、watchlist 订阅、strategy universe 订阅 | 大批量历史数据下载 |
+| SSE | 浏览器单向状态流：同步进度、健康退化、dashboard 更新 | 双向订阅、高频行情主链路 |
+| MCP Streamable HTTP | agent/admin 诊断工具：列数据源、解释路由、reload、测 endpoint | 高频行情、批量 K 线、策略执行热路径 |
+
+### 2.3 借鉴 ELTDX 的 MCP 接入形态
+
+参考 `/opt/claude/eltdx/docs/ELTDX_MCP_ACCESS_MODES.md` 后，本方案需要明确一个额外原则：
+
+> MCP 的传输形态和数据服务能力不是同一个维度。MCP 可以作为工具入口，但不应成为 MyStocks 数据源运行时的能力底座。
+
+ELTDX 可借鉴的是 access mode 分层，而不是把数据服务等同于 MCP 服务：
+
+| MyStocks access mode | 推荐用途 | 强约束 |
+|---|---|---|
+| stdio MCP | 本地 agent/admin 诊断：列数据源、测 endpoint、解释路由 | 低频、本机、只返回摘要 |
+| standalone MCP over Streamable HTTP/SSE | NAS/Docker/内网远程 AI 工具入口 | 只调用 `DataSourceClient` 或远程 REST，不维护 provider 连接池、缓存、熔断、限流 |
+| mounted MCP | 挂在完整 `openstock` 内的诊断入口 | 必须复用同一个 `DataSourceRuntime`，不能绕过 runtime 直连 provider |
+
+目标结构应写成：
+
+```text
+openstock = REST/OpenAPI + WebSocket data runtime + optional MCP diagnostics
+```
+
+实现顺序也应明确：REST/pull 和 WebSocket/realtime 稳定后，再进入 MCP。MCP 工具只覆盖 `list_data_sources`、`get_data_source_health`、`test_data_source_endpoint`、`explain_route_decision`、`reload_data_source_registry` 这类诊断和管理动作，不返回大批量行情、K 线或财务数据。
+
+若保留 SSE compatibility，需要把部署约束写入 Docker / reverse proxy / OpenSpec：保持 stream 打开、关闭代理 buffering、`/sse` 与 `/messages` 路由到同一后端实例或外置 session state。若客户端支持 Streamable HTTP，应优先使用 Streamable HTTP，SSE 只作为兼容模式。
+
+### 2.4 速度保障
+
+#### 2.4.1 热路径不用 MCP
+
+MCP 只做诊断和运维工具。行情、K 线、批量数据不要走 MCP。
+
+当前官方 MCP 标准 transport 是 `stdio` 和 `Streamable HTTP`，但 MCP 仍然不适合作为量化系统高频数据热路径。ELTDX 的经验也说明：standalone HTTP MCP 是传输升级，不是数据能力升级；分时、逐笔、行情推送这类热数据应由完整 server runtime 承担。
+
+#### 2.4.2 REST 只处理 pull 型数据
+
+适合 REST 的数据：
+
+- 日线 K 线
+- 分钟 K 线
+- 财务数据
+- 参考数据
+- 资金流向
+- registry 查询
+- health 查询
+- route selection
+- endpoint test
+
+对大数据量结果，先支持：
+
+- 分页
+- 时间窗口
+- batch request
+- gzip 压缩
+- 明确 timeout budget
+
+后续如果 JSON 序列化成为瓶颈，再考虑：
+
+- NDJSON
+- Arrow
+- Parquet
+- 压缩二进制 payload
+
+不建议第一阶段直接引入复杂二进制格式。
+
+#### 2.4.3 实时行情走 WebSocket
+
+`REALTIME_QUOTES`、tick-like updates、watchlist 订阅应走 WebSocket。
+
+消息至少包含：
+
+- `symbol`
+- `source`
+- `endpoint_name`
+- `exchange_time`
+- `received_at`
+- `sequence`
+- `staleness_ms`
+- `quality_flags`
+
+#### 2.4.4 主后端不要同步等慢 provider
+
+外部 provider 慢时，主后端不应被拖死。
+
+推荐策略：
+
+- 有缓存快照时优先返回缓存快照。
+- 返回结果必须标记 freshness/staleness。
+- 必须拉取新数据时设置明确 timeout。
+- 大任务或慢任务走异步 job。
+- provider 失败返回 typed error，不返回随机 exception 文本。
+
+#### 2.4.5 两级缓存
+
+推荐缓存结构：
+
+```text
+L1 memory cache
+  进程内短 TTL
+  适合热点 quote/snapshot
+
+Redis L2 cache
+  多实例共享
+  主后端快速读取
+  服务重启后保留短期快照
+```
+
+缓存响应必须带 metadata：
+
+- 数据源
+- endpoint
+- 生成时间
+- 接收时间
+- TTL
+- 是否 stale
+- 缓存层级
+
+#### 2.4.6 provider 独立限流、熔断和并发池
+
+不同 provider 的稳定性和成本不同：
+
+- AkShare 慢不应该拖死 TDX。
+- TuShare token 问题不应该影响 BaoStock。
+- BYAPI 额度不足不应该影响本地 mock 或 TDX。
+
+因此需要 provider-level bulkhead：
+
+- 每个 provider 独立并发池。
+- 每个 provider 独立超时。
+- 每个 provider 独立失败计数。
+- 每个 provider 独立熔断状态。
+- 每个 provider 独立恢复探测。
+- 每个 provider 独立 rate limit。
+
+注意：当前 V2 文档显示 `AdaptiveRateLimiter` 尚未默认接入 `DataSourceManagerV2` 主出站链。所以限流应写成迁移目标能力，不应写成已有主链能力。
+
+### 2.5 稳定性保障
+
+#### 2.5.1 健康检查分层
+
+不要用一个 health 判断所有东西。
+
+推荐分层：
+
+```text
+/health/live
+  服务进程活着即可
+
+/health/ready
+  registry、Redis、PostgreSQL 等基础依赖可用
+
+/sources/{name}/health
+  provider 级健康
+```
+
+provider 失败不应该直接让整个服务 not ready。否则一个外部 provider 挂了，容器编排系统可能反复重启整个数据源服务，反而降低稳定性。
+
+#### 2.5.2 主后端 contract 稳定
+
+迁移期间，主后端对外 contract 必须保持稳定：
+
+- `/api/v1/data-sources*`
+- `UnifiedResponse`
+- OpenAPI
+- auth 行为
+- error code
+- status code
+- request body
+- response envelope
+- version history
+- rollback
+- reload
+
+这意味着主后端可以代理到远程数据源服务，但不能让前端和第三方调用方感知内部迁移。
+
+#### 2.5.3 数据源 runtime contract 稳定
+
+数据源运行时对主后端的 interface 必须稳定：
+
+- fetch 返回 normalized records + metadata。
+- route decision 始终可解释。
+- stale data 必须标记，不能静默当作 fresh。
+- provider failure 返回 typed error。
+- config writes 必须 versioned。
+- rollback 必须可验证。
+- health 必须按 provider 分层。
+
+#### 2.5.4 实时流必须定义失败和重连语义
+
+WebSocket 不只是能连上就行。实时流需要明确：
+
+- 每个 symbol/source 内消息有序。
+- 每个 update 带 source timestamp 和 receive timestamp。
+- reconnect 后返回 latest snapshot 或从已知 sequence 恢复。
+- slow consumer 被降级或断开。
+- stale quote 被标记。
+- duplicate/out-of-order message 可处理。
+- market close/open 状态明确。
+
+## 3. 迁移路径
+
+推荐迁移路径是：先 seam，后 Docker；先 REST/pull，后 WebSocket/realtime；先一个 provider/category，后全量数据源。
+
+### Phase 0：OpenSpec 与关键决策
+
+先创建 OpenSpec change，例如：
+
+```text
+extract-data-source-runtime-service
+```
+
+建议 affected specs：
+
+- 新增 `data-source-runtime-service`
+- 修改 `containerized-runtime-deployment`
+- 修改 `data-sources`
+- 如 pilot 改变市场数据行为，再修改 `market-data`
+
+不要把 `03-adapter-pattern` 作为 provider runtime 的主规格，除非 delta 明确是前端 ViewModel adapter。当前 `03-adapter-pattern` 更偏前端 API-to-UI 数据转换，不适合承载后端 provider runtime。
+
+Phase 0 必须先定：
+
+1. registry 真相源：建议 PostgreSQL，YAML 只做 seed/fallback。
+2. 主后端 facade：`/api/v1/data-sources*` 外部契约不变。
+3. 数据源运行时职责：provider 调用、路由、健康、限流、缓存、熔断、metrics。
+4. 首个 pilot：建议选 AkShare REST/pull 类 category，不要第一步就做 realtime。
+5. MCP access modes：MCP 是诊断/工具入口，不是数据服务底座；区分 stdio MCP、standalone remote MCP、mounted MCP。
+6. active OpenSpec 对齐：明确 `extract-data-source-runtime-service` 与未完成的 `optimize-data-source-v2` 是依赖、接续还是替代关系。
+
+#### Phase 0.1：与 `optimize-data-source-v2` 的关系
+
+推荐关系是“依赖并接续”，不是替代。
+
+截至本方案日期，`openspec/changes/optimize-data-source-v2/tasks.md` 仍处于 active 状态，任务进度为 `235/253`，尚未 archive。它已经沉淀了 SmartRouter、CircuitBreaker、metrics、batch processing、fetcher bridge、runtime config 等数据源治理能力；本迁移方案应把这些能力作为本地运行时事实基础，再抽 `DataSourceClient` 和远程服务边界。
+
+进入 `extract-data-source-runtime-service` proposal 前，应先完成一次 V2 对齐清单：
+
+| 对齐项 | 处理口径 |
+|---|---|
+| SmartRouter / route decision | 作为 `DataSourceClient.resolve_route()` 的本地实现来源；补 route decision metadata contract |
+| CircuitBreaker / RateLimit / Metrics | 作为数据源运行时内部能力；远程服务不得重新发明第二套不兼容状态 |
+| BatchProcessor / fetcher bridge | 作为 `fetch_batch()` 和 provider bridge 的候选实现；确认是否适合跨进程调用 |
+| registry/config runtime | 作为 Phase 0 ownership 决策的事实输入；不能继续产生 YAML/PostgreSQL 双真相源 |
+| grey/production validation 尾项 | 按“阻塞迁移”与“可并行验证”分类，不得在未 archive 前宣称 V2 已生产验收完成 |
+
+若 V2 中某项能力已经实现但缺少生产证据，本方案不回退设计；只把它列为 Phase 1/2 的 verification prerequisite。
+
+#### Phase 0.2：`STANDARDS.md` 治理对齐
+
+本方案属于架构拆分和服务边界变更，必须走 proposal-first，而不是直接改实现。执行口径：
+
+1. 先写 OpenSpec change 和验收矩阵，再改代码。
+2. 兼容层只能薄封装，不能长期形成 local/remote 两套主实现。
+3. registry、runtime state、business storage 必须各有唯一 owner。
+4. 旧路径退役必须有单独收口证据；不得用“搜不到引用”直接删除配置、shim、legacy wrapper。
+5. 每个阶段必须有 rollback path、exit criteria 和可执行验证命令。
+6. 若涉及删除/退役、兼容层收敛或批量迁移，另按 `architecture/STANDARDS.md` 与治理指南执行审批。
+
+### Phase 1：进程内先抽 `DataSourceClient`
+
+目标：不加 Docker，也能把调用方从 manager 细节里解耦出来。
+
+新增 seam：
+
+```text
+DataSourceClient interface
+LocalDataSourceClient -> DataSourceManagerV2
+```
+
+主后端和相关业务代码改为依赖 `DataSourceClient`，而不是直接依赖：
+
+- `DataSourceManagerV2`
+- `get_best_endpoint()`
+- `handler.py:_call_endpoint()`
+- 具体 provider adapter
+- provider-specific config
+
+验收：
+
+- 现有 `/api/v1/data-sources*` 行为不变。
+- config create/update/delete/version/rollback/reload 行为不变。
+- Local client contract tests 通过。
+- GitNexus impact 只落在预期文件。
+
+### Phase 2：新增 `openstock` 容器，但前端路径不变
+
+目标：数据源运行时服务化，主后端仍是对外 facade。
+
+新增服务：
+
+```text
+openstock
+```
+
+建议 REST endpoints：
+
+```text
+GET  /health/live
+GET  /health/ready
+GET  /sources
+GET  /sources/{endpoint_name}
+POST /sources/{endpoint_name}/test
+POST /registry/reload
+GET  /routing/best
+POST /data/fetch
+POST /data/batch
+```
+
+主后端新增 adapter：
+
+```text
+RemoteDataSourceClient -> HTTP call openstock
+```
+
+通过配置切换：
+
+```text
+DATA_SOURCE_CLIENT_MODE=local | remote
+```
+
+验收：
+
+- local/remote contract parity tests。
+- `/api/v1/data-sources/config` 写操作兼容测试。
+- Docker smoke 包含 data-source ready。
+- 失败时可切回 local mode。
+- 数据源服务失败不会导致主后端整体不可用。
+
+### Phase 3：迁移首个真实数据源 category
+
+推荐 first pilot：
+
+```text
+AkShare + 一个 REST/pull category
+```
+
+理由：
+
+- 当前 registry 主要是 AkShare `api_library`。
+- 这条链最接近现有 `DataSourceManagerV2`。
+- 可以先验证服务拆分，不同时引入 WebSocket 生命周期问题。
+- AkShare category 比全量数据源更容易控制回归范围。
+
+不建议第一批迁移：
+
+- 所有 AkShare 52 个 endpoint。
+- 所有 7 类 provider。
+- TDX realtime。
+- WebSocket market stream。
+
+验收：
+
+- route decision 可解释。
+- provider 失败触发熔断。
+- cache hit/miss 有指标。
+- 返回数据带 source、endpoint、latency、freshness metadata。
+- 主后端 API 响应仍符合 `UnifiedResponse`。
+- provider 慢时主后端不会无限等待。
+
+### Phase 4：实时行情 WebSocket pilot
+
+在 REST/pull 稳定后，再做 realtime。
+
+数据源服务提供：
+
+```text
+openstock /ws/market
+```
+
+消息类型：
+
+```text
+subscribe
+unsubscribe
+snapshot
+quote.update
+heartbeat
+error
+```
+
+主后端可以先作为转发者，把数据源服务的 market stream 转到现有 `/ws/events` 的 `events:market` channel。这样前端不用马上重写。
+
+验收至少包括：
+
+- subscribe/unsubscribe。
+- 首次 snapshot。
+- update sequence。
+- stale quote 标记。
+- reconnect 行为。
+- slow consumer 处理。
+- duplicate/out-of-order 处理。
+- market close/open 状态。
+
+### Phase 5：增加 MCP 工具入口
+
+在 REST/pull 和 WebSocket realtime 都稳定后，再增加 MCP 工具入口。
+
+推荐分两类：
+
+```text
+standalone MCP
+  只注册少量高价值、低风险工具
+  list_data_sources
+  get_data_source_health
+  test_data_source_endpoint
+  explain_route_decision
+  reload_data_source_registry
+
+mounted MCP
+  挂在 openstock /mcp
+  复用 DataSourceRuntime
+  可暴露更完整诊断工具
+```
+
+standalone MCP 的定位是轻量远程 AI 工具，不是完整数据源服务。它可以通过 `RemoteDataSourceClient` 调用 `openstock`，但不应自己维护完整 provider 连接池、缓存、熔断和限流。
+
+mounted MCP 的定位是完整数据源运行时的 AI 工具入口。它必须复用 `DataSourceRuntime`，不能绕过 runtime 直接调用 provider adapter。
+
+验收至少包括：
+
+- stdio MCP 可本地列数据源和测 endpoint。
+- standalone MCP 可远程查 health、解释 route decision。
+- mounted MCP 复用同一份 registry、metrics、cache 和 circuit breaker。
+- MCP 工具返回摘要和诊断结果，不返回大批量行情或财务数据。
+- SSE compatibility 如启用，代理层满足 session 粘性和 buffering 约束。
+
+### Phase 6：收敛旧路径
+
+remote 模式稳定后，再退役旧路径。
+
+建议收口：
+
+- `adapter_priority_config.yaml` 迁入 registry/routing policy。
+- YAML registry 从运行时真相源降级为 seed/fallback。
+- 旧 `DataSourceManager` 只保留兼容 wrapper，最终退役。
+- `DataAdapter`/split adapters 中重复 provider 调用路径逐步收口。
+- OpenSpec archive 已完成 change。
+
+退役前必须满足：
+
+- remote mode 稳定通过 contract tests。
+- rollback/version/reload 已覆盖。
+- provider health 和 metrics 已进入运行门禁。
+- Docker smoke 通过。
+- 主后端 public API parity 通过。
+- 没有新增平行 registry 真相源。
+
+## 4. 建议验收矩阵
+
+以下命令是 proposal/implementation 的验收目标；标注为“新增”的测试文件需要在对应阶段创建。此表不表示当前仓库已经存在这些新增测试。
+
+| 阶段 | 必跑命令 | 新增或重点测试 | 验收口径 |
+|---|---|---|---|
+| Phase 0 | `openspec validate extract-data-source-runtime-service --strict`；`openspec list` | OpenSpec proposal/spec delta | proposal 通过 strict validate；明确 V2 关系、registry owner、first pilot、rollback path |
+| Phase 1 | `pytest tests/unit/test_smart_router.py tests/unit/test_smart_router_integration.py tests/unit/test_metrics.py tests/unit/test_data_source_metrics_integration.py src/governance/tests/test_fetcher_bridge.py tests/integration/test_batch_processing.py tests/unit/adapters/test_runtime_data_source_regressions.py -q --no-cov`；`pytest tests/unit/data_source/test_data_source_client_contract.py -q --no-cov` | 新增 `tests/unit/data_source/test_data_source_client_contract.py` | local client 满足响应 metadata、typed error、timeout、cache_state、config write boundary；现有 V2 主链证据不回退 |
+| Phase 2 | `pytest tests/integration/data_source/test_remote_data_source_client_contract.py tests/api/file_tests/test_data_source_config_api.py tests/api/file_tests/test_data_source_registry_api.py -q --no-cov`；`bash scripts/run_data_source_runtime_smoke.sh` | 新增 remote contract parity、config facade parity、Docker smoke | local/remote 可切换；主后端 facade 兼容；数据源服务失败不拖垮主后端 |
+| Phase 3 | `pytest tests/integration/data_source/test_akshare_runtime_pilot.py -q --no-cov` | 新增 AkShare REST/pull pilot contract | route 可解释；provider timeout/fallback/circuit/cache/metrics 可观测；返回数据含 freshness/source/latency |
+| Phase 4 | `pytest tests/integration/data_source/test_market_stream_contract.py -q --no-cov` | 新增 WebSocket stream contract | subscribe/unsubscribe、snapshot、sequence、stale、reconnect、slow consumer、duplicate/out-of-order、market close/open 语义稳定 |
+| Phase 5 | `pytest tests/integration/data_source/test_mcp_access_modes.py -q --no-cov` | 新增 MCP access modes contract | stdio/standalone/mounted 边界清楚；mounted MCP 复用 `DataSourceRuntime`；MCP 不返回大批量行情或财务数据；SSE compatibility 满足部署约束 |
+| Phase 6 | `pytest tests/integration/data_source/test_data_source_public_api_parity.py -q --no-cov`；`openspec validate extract-data-source-runtime-service --strict` | 新增 public API parity 与旧路径退役检查 | 无平行 registry 真相源；旧 priority/config/manager 路径有退役证据；满足 archive 前验收 |
+
+## 5. 风险与处理
+
+| 风险 | 处理 |
+|---|---|
+| registry 真相源继续分裂 | Phase 0/1 先定 ownership，PostgreSQL 作为运行时真相源，YAML 降级为 seed/fallback |
+| 主后端 API 兼容破坏 | 保留 `/api/v1/data-sources*` facade，增加 public API parity tests |
+| provider 拖慢主后端 | 主后端只调用 `DataSourceClient`，设置 timeout，优先返回缓存快照，慢任务异步化 |
+| `DataSourceClient` 变成浅 wrapper | Phase 1 先写 interface contract tests，强制响应 metadata、typed error、timeout、cache_state、config write boundary |
+| runtime state 与业务数据仓库混淆 | 使用 ownership matrix：数据源运行时只管 provider 访问治理；TDengine/PostgreSQL 业务数据仓库不在第一阶段迁移 |
+| 与 `optimize-data-source-v2` 冲突或重复造轮子 | Phase 0.1 定义为依赖并接续；V2 active 尾项按 verification prerequisite 处理 |
+| Docker 服务变成浅 pass-through | 用 `DataSourceRuntime` 隐藏路由、缓存、熔断、限流、metrics，不把内部 handler 直接暴露给调用方 |
+| realtime 一开始过复杂 | 第一 pilot 选 AkShare REST/pull，WebSocket 放到 Phase 4 |
+| rate limit 被误认为已落地 | 明确写成目标能力，先用 mock provider 做限流测试 |
+| MCP 被滥用到热路径 | MCP 仅做 diagnostics/admin，行情和批量数据走 REST/WebSocket |
+| standalone MCP 变成第二套数据源运行时 | standalone MCP 只调用 `DataSourceClient` 或远程 REST，不维护完整 provider 连接池、缓存、熔断和限流 |
+| SSE compatibility 被代理层打散 session | 如启用 SSE transport，要求 `/sse` 和 `/messages` 同实例路由或外置 session state，并关闭代理 buffering |
+| 绕过 `STANDARDS.md` 直接开工 | Phase 0.2 写入 proposal-first、owner 唯一、兼容层薄封装、退役单独审批、阶段验收命令 |
+| 验收停留在概念层 | 第 4 节把每个 phase 绑定到命令和新增测试文件，OpenSpec proposal 需继承这些验收项 |
+
+## 6. 推荐审核结论
+
+建议批准进入 OpenSpec proposal 编写，但仍不建议直接实现。
+
+本版方案已在可行性层补齐以下审核项：
+
+1. `DataSourceClient` interface contract 与契约不变量。
+2. runtime state ownership 与 business storage ownership 的拆分矩阵。
+3. 与 active `optimize-data-source-v2` 的“依赖并接续”关系。
+4. ELTDX MCP access modes 的可借鉴边界：MCP 是诊断工具面，不是数据服务底座。
+5. `STANDARDS.md` 治理对齐：proposal-first、owner 唯一、兼容层薄封装、退役单独审批。
+6. 每个 migration phase 的可执行验收命令和新增测试目标。
+
+进入实现前，仍需要把这些内容正式落入 `extract-data-source-runtime-service` OpenSpec change，并由用户审核 affected specs、阶段范围、first pilot 和 rollback path。实现阶段应优先做 Phase 1 的进程内 `DataSourceClient`，确认本地契约稳定后再启动 Docker/remote 服务化。

--- a/docs/reports/architecture/data-source-runtime-service-migration-feasibility-plan-review-2026-06-09.md
+++ b/docs/reports/architecture/data-source-runtime-service-migration-feasibility-plan-review-2026-06-09.md
@@ -1,0 +1,133 @@
+# 数据源运行时服务化迁移可行性方案 — 审核报告
+
+日期：2026-06-09
+审核文档：`docs/reports/architecture/data-source-runtime-service-migration-feasibility-plan-2026-06-09.md`
+审核视角：Matt Pocock 架构词汇（Module / Interface / Seam / Adapter / Depth）+ 仓库 STANDARDS.md + OpenSpec 治理规则
+
+## 总评
+
+方案的核心判断是对的——"先定义 seam，再换 adapter，不要直接搬 Docker"。这比常见错误（拆服务=开容器）高出一个层次。文档在 MCP 边界、协议分工、弹性层设计上投入了大量篇幅，这部分质量很高。
+
+但文档与前序 review (`data-source-service-extraction-analysis-review-2026-06-09.md`) 之间的关系是**补充**而非**覆盖**。review 中标出的 HIGH 级问题，在这份可行性方案中有 4/7 已得到纠正，但仍有 3 个结构性缺陷。
+
+## 已修正的 review 发现（值得肯定）
+
+| 原 review 发现 | 可行性方案处理 | 判定 |
+|---|---|---|
+| Registry ownership 推迟到 Phase 4 太晚 | Phase 0 就明确 PostgreSQL=YAML 的真相源分工（第 96-105 行） | **已修正** |
+| Pilot 范围模糊（REALTIME_QUOTES vs AkShare REST） | 明确推荐 AkShare REST/pull 为首个试点（第 543-551 行） | **已修正** |
+| Rate limiting 被描述为已有能力 | 明确标注为目标能力（第 372 行注释），非当前默认主链 | **已修正** |
+| OpenSpec affected specs 模糊 | 新增 `data-source-runtime-service`，避免重载 `03-adapter-pattern`（第 449-456 行） | **已修正** |
+
+## 仍存在的阻塞性问题（3 个）
+
+### HIGH-1: `DataSourceClient` interface 只画了名字，没定义 contract invariant
+
+**位置**: 第 56-77 行
+
+**问题**: 方案画了 `DataSourceClient → Local / Remote` 的 adapter 结构，但没有定义 interface 本身的 invariants。Matt Pocock 的核心观点是：interface 的价值不在方法签名，在于调用方能依赖的不变量。
+
+**缺失内容**:
+
+- 调用 `fetch()` 失败时返回什么？typed error code？还是 exception？
+- 返回的 data 是否总带 `source` / `endpoint` / `freshness` / `staleness` metadata？
+- 超时行为：是 timeout budget 透传还是 caller 无感知？
+- cache hit 是否对调用方透明？还是调用方可以指定 `freshness_requirement`？
+- config write（create/update/delete/version/rollback）是否在 `DataSourceClient` interface 上？还是走独立的 `DataSourceConfigClient`？
+
+**影响**: 如果 Phase 1 只抽名字不定义 invariant，`RemoteDataSourceClient` 的行为会自然 drift 向"HTTP 语义"而非"DataSourceManagerV2 语义"，Phase 2 的 parity test 会变成补丁式修正。
+
+**建议**: 在 Phase 0 OpenSpec 中增加 `DataSourceClient` interface specification，至少包含：方法列表、每个方法的 error mode、返回 metadata schema、cache 语义、timeout 语义、config 操作归属。
+
+### HIGH-2: 运行时状态所有权（runtime state ownership）仍与业务存储混淆
+
+**位置**: 第 48-54 行模块分布表、第 86-91 行功能归属表
+
+**问题**: 方案说"数据源运行时"拥有 health、cache、circuit breaker、rate limit、metrics、call history。同时又引用 PostgreSQL、Redis、TDengine 作为外部服务。但没有回答：
+
+- circuit breaker state 放哪里？进程内？Redis？如果放进程内，数据源服务重启后所有 breaker 都 reset，这是否符合预期？
+- call history 放 PostgreSQL 还是数据源服务内部？如果是 PostgreSQL，数据源服务需要 DB 写权限，这扩大了它的存储边界。
+- endpoint health 的 true source 是数据源服务进程内状态，还是 PostgreSQL 里的 health 表？如果两者都有，又是一套平行真相源。
+- metrics 的 consumer 是谁？Prometheus 直接 scrape 数据源服务？还是后端 `/metrics` 聚合后再暴露？
+
+**影响**: 这不是"以后再定"的问题——Phase 2 创建 Docker 容器时，必须决定它连不连 PostgreSQL、需不需要独立的 Redis namespace。如果这里模糊，容器要么变成"无状态 pass-through"（与目标矛盾），要么变成"隐式有状态"（运维风险）。
+
+**建议**: 在 Phase 0 增加 Runtime State Ownership Matrix：
+
+```text
+| 状态               | 存储位置     | Owner                 | 重启后行为     |
+|--------------------|-------------|-----------------------|---------------|
+| circuit breaker    | 进程内       | data-source runtime   | reset to closed |
+| rate limit token   | 进程内       | data-source runtime   | reset to initial |
+| cache L1           | 进程内       | data-source runtime   | cold start    |
+| cache L2           | Redis       | shared                | preserved     |
+| call history       | PostgreSQL  | main backend          | preserved     |
+| endpoint health    | 进程内 + health API | data-source runtime | recalculated |
+| metrics            | Prometheus pull | data-source runtime | reset         |
+| registry           | PostgreSQL  | data-source runtime (write), main backend (facade) | preserved |
+```
+
+### HIGH-3: 与 `optimize-data-source-v2` 的依赖关系未定义
+
+**位置**: 第 465 行提及但未展开
+
+**问题**: `openspec/changes/optimize-data-source-v2/tasks.md` 显示该 change 仍在执行中，且 repo-truth 注记明确指出多个 V2 组件（SmartRouter、BatchProcessor、CircuitBreaker 主链包装、metrics 全局 REGISTRY 合并）**尚未完成**。
+
+方案引用 `DataSourceManagerV2` 作为 `LocalDataSourceClient` 的底层，但如果 V2 的 SmartRouter 没有接入、熔断没有包装到主链、BatchProcessor 没有切到主路径，那 `LocalDataSourceClient` 实际包装的是一个**半完成**的 V2 runtime。
+
+这意味着：
+
+- Phase 1 的"行为不变"承诺可能建立在未稳定的行为上
+- 如果 V2 change 继续推进并改变了 `DataSourceManagerV2` 的内部行为，Phase 1 的 seam 可能需要返工
+- 如果 V2 change 被放弃，Phase 1 的 seam 包装的就是一个不会再被优化的 runtime
+
+**建议**: 在 Phase 0 明确以下三种关系之一：
+
+1. **依赖完成**: `extract-data-source-runtime-service` 等待 V2 指定的 N 个关键 task 完成后再启动
+2. **接续**: V2 剩余 task 合并到新 change 的 Phase 1/Phase 2 中执行
+3. **替代**: V2 未完成部分作废，新 change 重新设计对应能力
+
+## 中等级别问题（2 个）
+
+### MED-1: ELTDX MCP 借鉴部分篇幅过大，主链路设计密度不足
+
+**位置**: 第 156-263 行（约 100 行）
+
+**观察**: 方案花了约 15% 的篇幅讨论 MCP 三种接入形态（stdio / standalone / mounted）和 SSE 兼容性部署约束。MCP 本身已被明确限定为"可选诊断工具入口"，不是核心 seam。但 MCP 的边界描述比 `DataSourceClient` interface 本身还要详细。
+
+**建议**: 压缩 MCP 部分为 Phase 5 的 implementation guidance，Phase 0 只需记录"MCP 仅限诊断/工具入口，不进热路径"这一原则性决策。
+
+### MED-2: 验收矩阵缺少可执行的验证命令
+
+**位置**: 第 657-666 行
+
+**观察**: 每个阶段的验收描述是"方向正确"的（例如 "remote contract parity"），但没有映射到具体的验证命令或测试套件。项目有 `pytest`、`stylelint`、`vue-tsc` 等已有验证路径（STANDARDS.md 第 4.2 节），验收矩阵应衔接这些。
+
+**建议**: 至少为 Phase 1 和 Phase 2 列出：
+
+- 现有哪些 test suites 必须继续 pass
+- 需要新增哪些 contract test files
+- Docker smoke 的具体命令（参考项目已有的 `scripts/run_e2e_pm2.sh`）
+
+## 低级别问题（1 个）
+
+### LOW-1: 缺少 STANDARDS.md 治理节奏对齐声明
+
+方案涉及拆分服务、迁移 registry 真相源、退役旧配置路径。这些都属于 STANDARDS.md 三、迁移收口规则的管辖范围。方案应在 Phase 0 显式声明将遵守哪些 STANDARDS.md 约束（单一真相源、迁移必须带收口条件、退出条件等）。
+
+## 最终判定
+
+| 维度 | 评分 |
+|---|---|
+| 方向正确性 | **强** — "先 seam 后容器"的思路正确 |
+| 技术深度 | **中** — 弹性层和协议分工深入，但 interface invariant 和 state ownership 欠缺 |
+| 仓库约束一致性 | **中** — 已遵守 OpenSpec 流程，但 STANDARDS.md 迁移规则和 V2 依赖未显式声明 |
+| 可执行性 | **弱** — Phase 0 的决策清单尚未闭合，缺 interface spec 和 state matrix |
+
+**建议**: 批准方向，**暂不批准进入 OpenSpec proposal**。在创建 OpenSpec change 前，补齐：
+
+1. `DataSourceClient` interface specification（invariants、error modes、metadata schema）
+2. Runtime State Ownership Matrix
+3. 与 `optimize-data-source-v2` 的依赖/接续/替代关系声明
+
+这三项补齐后，方案即可进入 Phase 0 OpenSpec 创建。

--- a/docs/reports/architecture/data-source-service-extraction-analysis-2026-06-09.md
+++ b/docs/reports/architecture/data-source-service-extraction-analysis-2026-06-09.md
@@ -1,0 +1,423 @@
+# Data Source Service Extraction Analysis
+
+Date: 2026-06-09
+Repository: `/opt/claude/mystocks_spec`
+Branch observed: `master`
+
+## Summary
+
+Separating data source management from the MyStocks functional core is feasible and directionally aligned with the existing V2 data source architecture. The current code already has the right concepts: a registry, route selection, endpoint health, cache, circuit breaker, handler abstraction, API management endpoints, and Docker runtime governance. The gap is that these concepts still run in-process inside the backend and are backed by mixed configuration truth sources.
+
+Recommended target:
+
+- Keep the main MyStocks backend as the functional core and API facade.
+- Add a containerized data-source runtime service as a separate process/service.
+- Keep `/api/v1/data-sources` and `/api/v1/data-sources/config` stable in the main backend initially, with the backend proxying or delegating to the data-source service.
+- Use REST/OpenAPI for control plane and request/response market data.
+- Use WebSocket for low-latency realtime quote/tick subscriptions.
+- Use SSE only for browser-facing one-way status/progress/dashboard streams, not as the main data ingestion protocol.
+- Use MCP only as an optional agent/tooling/admin surface, preferably MCP Streamable HTTP. Do not put latency-sensitive quote/tick traffic on MCP.
+
+## Current Repository Facts
+
+### Configuration
+
+- `config/data_sources.json` is the module-level runtime mode file. It defines `market`, `data`, `dashboard`, `technical_analysis`, `watchlist`, and `strategy` with mode, timeout, retry, fallback, cache and TTL settings.
+- `config/data_sources_registry.yaml` is still a large endpoint registry. Observed rough stats:
+  - 2268 lines.
+  - `source_name` counts: `akshare:52`, `system_mock:1`, `windows_nodes:1`.
+  - `source_type` counts: `api_library:53`, `mock:1`.
+  - data categories include `DERIVED_DATA`, `MARKET_DATA`, `REFERENCE_DATA`, `REALTIME_QUOTES`, `LEVERAGE_DATA`, `INSTITUTIONAL_DATA`, `FUTURES_DATA`, `DAILY_KLINE`.
+- `config/adapter_priority_config.yaml` defines priority lists:
+  - `realtime_quote`: `tdx`, `customer`, `akshare`
+  - `daily_kline`: `tdx`, `akshare`, `baostock`
+  - `financial_data`: `financial`, `tushare`
+  - `technical_indicators`: `tdx`, `akshare`
+  - `news_data`: `byapi`, `akshare`
+  - `default`: `tdx`, `akshare`, `baostock`, `tushare`, `financial`, `customer`, `byapi`
+- `config/data_sources_loader.py` documents the truth-source matrix:
+  - YAML registry: core endpoint registry and CRUD source of truth.
+  - JSON config: module runtime mode/source-mode selection.
+- `config/DATA_SOURCES_SPLIT_PLAN.md` is explicitly marked as historical. It planned splitting `data_sources_registry.yaml` into `config/data_sources/*.yaml`, but the current directory only contains `_template.yaml`. Treat the plan as useful background, not current fact.
+
+### Core Code
+
+- `src/interfaces/data_source.py` defines `IDataSource` with stock daily, index daily, stock basic, index components, realtime data, market calendar, financial data, and news data methods.
+- `src/adapters/data_source_manager.py` is the legacy facade. It registers in-process `IDataSource` instances, keeps local priority config, calls `DataSourceManagerV2` for some daily/index paths, and still falls back to legacy in-process routing.
+- `src/core/data_source/base.py` defines `DataSourceManagerV2`. It loads a registry, initializes endpoint-level circuit breakers, exposes `find_endpoints`, `get_best_endpoint`, `_call_endpoint`, daily/realtime helpers, endpoint listing, success/failure metrics, and health checks.
+- `src/core/data_source/registry.py` loads endpoint configs from database and YAML, merging database rows with YAML values.
+- `src/core/data_source/router.py` filters endpoints by category/source and sorts by `(priority, -data_quality_score)`.
+- `src/core/data_source/handler.py` handles cache keys, TTL resolution, circuit breaker execution, metrics, success/failure recording, and endpoint calls.
+- `src/core/data_source_handlers_v2.py` provides handlers for mock, AkShare, TuShare, BaoStock, TDX, and crawler-style HTTP sources. The handler factory currently maps `source_type` values such as `akshare`, `tushare`, `baostock`, `tdx`, `database`, `crawler`, `mock`, and `api_library`.
+- `src/database/service/adapter_queries.py` has a separate `get_data_with_failover()` path reading `config/adapter_priority_config.yaml`. This is another routing truth source that must be reconciled before or during extraction.
+
+### Backend API Surface
+
+- `web/backend/app/api/data_source_registry.py`
+  - Router prefix: `/api/v1/data-sources`
+  - Provides search/listing, category stats, detail, update, test, single health check, all health check.
+- `web/backend/app/api/_data_source_config_responses.py`
+  - Router prefix: `/api/v1/data-sources/config`
+  - Provides the config router and `get_config_manager()`.
+- `web/backend/app/api/data_source_config.py`
+  - Provides create, update, delete, detail, list, batch operations, version history, rollback, and reload.
+  - Uses `UnifiedResponse`, so any service extraction must preserve the OpenAPI/UnifiedResponse contract at the backend facade.
+- `web/backend/app/router_registry.py` directly includes both `data_source_registry.router` and `data_source_config.router`.
+
+### Frontend and Tests
+
+- `/api/v1/data-sources` appears in 11 files, including backend API tests, e2e tests, frontend version negotiation policy, and the data-source API modules.
+- `/api/v1/data-sources/config` appears in 10 files, including frontend API/config tests and backend API/auth tests.
+- `DataSourceManagerV2` appears in 20 files.
+- `data_source` appears widely across backend, frontend, tests, and docs. Treat static counts as broad impact evidence, not deletion/refactor proof.
+
+### Runtime and Docker
+
+- Existing compose files define backend, frontend, PostgreSQL, Redis, TDengine, Nginx, Prometheus/Grafana, and backup services.
+- No data-source service exists as a first-class Docker compose service today.
+- `docker/data-source-credentials.env.example` already contains data-source credential placeholders:
+  - `BYAPI_KEY`
+  - `BYAPI_BASE_URL`
+  - `TUSHARE_TOKEN`
+- `openspec/specs/containerized-runtime-deployment/spec.md` currently requires backend, frontend, PostgreSQL, and Redis services in the compose contract. Adding a data-source service would require an OpenSpec delta to this capability.
+
+### Realtime Channels
+
+- `web/backend/app/api/websocket.py`
+  - Router prefix: `/ws`
+  - Main endpoint: `/ws/events`
+  - Current channel model includes `events:market` and `events:market:{stock_code}`.
+- `web/backend/app/api/sse_endpoints.py`
+  - Router prefix: `/api/v1/sse`
+  - Current SSE streams are training, backtest, alerts, and dashboard.
+- `web/backend/app/core/sse_manager.py`
+  - Provides one-way event queues, broadcast, client cleanup, and 30-second keepalive behavior.
+- `docs/api/WEBSOCKET_OPTIMIZATION_GUIDE.md` documents existing WebSocket performance goals such as batching, connection pooling, >500 RPS throughput, and sub-50ms message latency.
+
+## GitNexus Impact Summary
+
+GitNexus index status was fresh at the time of inspection.
+
+| Target | File | Upstream impact | Risk |
+|---|---|---:|---|
+| `DataSourceManager` | `src/adapters/data_source_manager.py` | 9 impacted, all direct | MEDIUM |
+| `DataSourceManagerV2` | `src/core/data_source/base.py` | 24 impacted, 6 direct | MEDIUM |
+| `AdapterQueriesMixin.get_data_with_failover` | `src/database/service/adapter_queries.py` | 0 indexed upstream | LOW |
+| `DataAdapter` | `web/backend/app/services/data_adapter_new.py` | 0 indexed upstream | LOW |
+
+The LOW results should not be over-trusted for dynamic FastAPI/DI/API use. The safer reading is:
+
+- Core manager replacement is medium-risk.
+- Backend API facade compatibility is high-value because frontend/tests already depend on it.
+- Dynamic route and config-manager paths need contract tests even when static graph impact is low.
+
+## Protocol Recommendation
+
+### REST/OpenAPI
+
+Use REST as the default control plane and request/response data plane.
+
+Good fit:
+
+- Register/list/update/delete endpoints.
+- Version history and rollback.
+- Health checks and readiness.
+- Route-selection query: “best endpoint for category X”.
+- Historical daily/minute K-line batch fetch.
+- Financial/reference/fund-flow datasets.
+- Backend-to-data-source-service calls where Pydantic/OpenAPI contracts are valuable.
+
+Benefits:
+
+- Fits current FastAPI/Pydantic/OpenAPI standards.
+- Preserves current frontend/backend contract governance.
+- Easy to smoke test and gate in Docker runtime.
+- Easy to secure with service-to-service tokens.
+
+Risk:
+
+- Large pandas-style result sets serialized as JSON can become expensive. For large historical batches, add pagination/windowing first; later consider NDJSON, compressed JSON, Parquet, or Arrow only after baseline REST semantics are stable.
+
+### WebSocket
+
+Use WebSocket for low-latency realtime subscriptions.
+
+Good fit:
+
+- Realtime quotes.
+- Tick-like push streams.
+- Subscriptions by symbol, board, watchlist, or strategy universe.
+- Backend facade subscribing to data-source service and rebroadcasting to frontend `events:market` channels.
+
+Benefits:
+
+- Matches existing `/ws/events` channel model.
+- Better for bidirectional subscribe/unsubscribe and heartbeats than plain REST.
+- Existing WebSocket optimization docs already define batching and latency expectations.
+
+Risk:
+
+- Requires connection lifecycle, backpressure, replay/freshness semantics, and market-open/close behavior.
+- Needs explicit distinction between “latest snapshot” and “event stream”.
+
+### SSE
+
+Use SSE for browser-facing one-way updates, not as the primary data-source ingestion protocol.
+
+Good fit:
+
+- Dashboard status.
+- Long-running data-source sync/test progress.
+- Health/degradation notifications.
+- Backfill progress.
+
+Benefits:
+
+- Simple browser consumption.
+- Existing SSE manager already supports queues and keepalive.
+
+Risk:
+
+- One-way only.
+- Less suitable for dynamic symbol subscription and high-frequency quote/tick streams.
+
+### MCP
+
+Use MCP as an optional operator/agent/tool integration plane, not as the market data hot path.
+
+Good fit:
+
+- “List available data sources.”
+- “Test this endpoint with sample params.”
+- “Explain why endpoint X is unhealthy.”
+- “Trigger registry reload.”
+- “Inspect route decision for category Y.”
+- Agent-facing diagnostics and operational tooling.
+
+Not a good fit:
+
+- High-frequency quote/tick streaming.
+- Bulk K-line transfer.
+- Latency-sensitive strategy execution.
+
+Current official MCP transport facts:
+
+- The 2025-06-18 MCP spec defines `stdio` and `Streamable HTTP` as standard transports.
+- Streamable HTTP replaces the old HTTP+SSE transport from the 2024-11-05 spec.
+- Servers may keep old HTTP+SSE endpoints only for backwards compatibility.
+
+Recommendation: if MCP is added, implement MCP Streamable HTTP for tools/admin. Avoid naming the main design “MCP-over-SSE”; it is likely to age poorly and conflates deprecated HTTP+SSE compatibility with current Streamable HTTP behavior.
+
+Official source:
+
+- https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+- https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
+
+## Proposed Target Architecture
+
+### Services
+
+1. `mystocks-backend`
+   - Owns product API, auth, user-facing contracts, UnifiedResponse, frontend compatibility.
+   - Keeps existing `/api/v1/data-sources*` public API initially.
+   - Uses a `RemoteDataSourceClient` behind the current manager/facade.
+
+2. `mystocks-data-source`
+   - Owns data-source registry runtime, route selection, source credentials, source handlers, rate limits, cache, circuit breakers, data-source health, and outbound provider calls.
+   - Exposes:
+     - REST/OpenAPI for control and pull fetch.
+     - WebSocket for realtime subscriptions.
+     - Optional MCP Streamable HTTP for diagnostics/admin.
+
+3. Existing databases/cache
+   - PostgreSQL/TDengine/Redis remain first-class runtime services.
+   - Do not move storage ownership in the first extraction. First isolate provider access; storage writes can be revisited after the service boundary is stable.
+
+### Control Plane REST
+
+Candidate endpoints on the data-source service:
+
+- `GET /health/live`
+- `GET /health/ready`
+- `GET /sources`
+- `GET /sources/{endpoint_name}`
+- `POST /sources/{endpoint_name}/test`
+- `POST /registry/reload`
+- `GET /routing/best?category=REALTIME_QUOTES`
+- `GET /routing/endpoints?category=DAILY_KLINE&only_healthy=true`
+- `GET /metrics`
+
+The main backend can proxy these into existing `/api/v1/data-sources` and `/api/v1/data-sources/config` responses.
+
+### Pull Data REST
+
+Candidate endpoints:
+
+- `POST /data/fetch`
+  - Input: endpoint name or category, params, freshness requirement, timeout budget.
+  - Output: normalized records, metadata, source, timestamp, latency, route decision.
+- `POST /data/batch`
+  - Input: list of fetch jobs.
+  - Output: per-job success/error and normalized payload.
+
+Keep initial payload JSON-compatible because the current stack is already FastAPI/Pydantic/OpenAPI. Add binary/compressed bulk formats only after measuring actual payload pressure.
+
+### Streaming Data WebSocket
+
+Candidate endpoint:
+
+- `/ws/market`
+
+Message types:
+
+- `subscribe`
+- `unsubscribe`
+- `snapshot`
+- `quote.update`
+- `heartbeat`
+- `error`
+
+Include:
+
+- `symbol`
+- `source`
+- `endpoint_name`
+- `exchange_time`
+- `received_at`
+- `sequence`
+- `staleness_ms`
+- `quality_flags`
+
+The main backend can either proxy this to the frontend or consume it internally and rebroadcast to existing `/ws/events` market channels.
+
+### Optional MCP Tools
+
+Candidate MCP tools:
+
+- `list_data_sources`
+- `get_data_source_health`
+- `test_data_source_endpoint`
+- `explain_route_decision`
+- `reload_data_source_registry`
+- `get_data_source_metrics`
+
+These should call the same internal service layer as REST, not introduce a parallel truth source.
+
+## Migration Plan
+
+### Phase 0: Spec and Contract
+
+Create an OpenSpec change, for example `extract-data-source-runtime-service`.
+
+Likely affected specs:
+
+- `03-adapter-pattern`
+- `data-sources`
+- `market-data`
+- `containerized-runtime-deployment`
+- possibly a new `data-source-runtime-service` capability
+
+Decisions to capture:
+
+- Backend remains public API facade during migration.
+- REST/OpenAPI is the primary control and pull data contract.
+- WebSocket is the realtime market data stream contract.
+- MCP Streamable HTTP is optional admin/tooling, not hot path.
+- Registry truth source must be single and explicit.
+
+### Phase 1: Normalize In-Process Boundary
+
+Before adding containers, introduce a clean in-process port/interface:
+
+- `DataSourceClient` protocol/interface.
+- `LocalDataSourceClient` backed by `DataSourceManagerV2`.
+- Backend API calls use the client, not direct manager internals.
+- Existing tests continue to pass.
+
+This keeps behavior stable while making the later remote client a drop-in replacement.
+
+### Phase 2: Extract Service Without Changing Public Backend API
+
+Add `mystocks-data-source` service:
+
+- Reuse `DataSourceManagerV2` internals.
+- Add REST health, registry, route, and fetch endpoints.
+- Add Docker compose service and `.env.example` keys.
+- Add backend `RemoteDataSourceClient`.
+- Gate with contract tests and container smoke tests.
+
+Keep frontend and third-party callers on the existing backend paths.
+
+### Phase 3: Realtime Stream Split
+
+Add service WebSocket stream for `REALTIME_QUOTES`.
+
+Start with:
+
+- AkShare or TDX realtime quote pilot.
+- Explicit watchlist/symbol subscription.
+- Backend rebroadcast into existing `events:market` channels.
+
+Do not start with all 7 data sources. Start with one source/category pair and prove latency/freshness/health behavior.
+
+### Phase 4: Registry Ownership and Config Cleanup
+
+Converge truth sources:
+
+- Decide whether registry ownership lives in YAML, PostgreSQL, or service DB-backed config.
+- Reconcile `config/adapter_priority_config.yaml` with V2 registry routing.
+- Either complete or retire the historical `config/DATA_SOURCES_SPLIT_PLAN.md`.
+- Avoid long-term coexistence of legacy priority routing and V2 service routing.
+
+## Risk Register
+
+1. Parallel truth sources
+   - Current config already spans JSON module mode, YAML endpoint registry, adapter priority YAML, and DB-backed registry paths.
+   - Service extraction must reduce this, not add another registry.
+
+2. Serialization and latency overhead
+   - Moving in-process pandas calls behind HTTP adds serialization cost.
+   - Mitigation: keep hot realtime on WebSocket, batch historical calls, measure payload sizes before adopting binary formats.
+
+3. Provider-specific operational constraints
+   - TDX, TuShare, BYAPI, AkShare, BaoStock have different credentials, rate limits, connection behavior, and failure modes.
+   - Mitigation: source-specific sidecars or source-specific handler modules inside one service, plus per-source rate limiting and health.
+
+4. Handler coverage mismatch
+   - V2 handler map does not obviously cover every legacy priority source (`customer`, `byapi`, `financial`) as first-class handler types.
+   - Mitigation: pilot one supported path first, then add handler support under tests.
+
+5. Public API compatibility
+   - Frontend/tests depend on `/api/v1/data-sources*`.
+   - Mitigation: keep backend facade stable and proxy internally.
+
+6. Docker deployment contract expansion
+   - Containerized runtime spec currently names backend/frontend/postgresql/redis.
+   - Mitigation: OpenSpec delta for data-source service, env keys, health checks, and smoke artifacts.
+
+7. MCP misuse risk
+   - MCP is attractive for agent workflows but inefficient for market data hot paths.
+   - Mitigation: restrict MCP to admin/diagnostics and use current Streamable HTTP transport.
+
+## Recommendation
+
+Proceed, but as an OpenSpec-governed migration, not a direct refactor.
+
+Recommended first pilot:
+
+- Scope: `REALTIME_QUOTES` or one AkShare market-data category, not all data sources.
+- Service: one `mystocks-data-source` container.
+- Public API: keep existing backend `/api/v1/data-sources*`.
+- Internal protocol:
+  - REST for registry, health, route selection, and pull fetch.
+  - WebSocket for realtime market updates.
+  - MCP Streamable HTTP only for admin/agent diagnostics if needed.
+- Verification:
+  - Unit tests for `LocalDataSourceClient` and `RemoteDataSourceClient` contract parity.
+  - API contract tests for existing backend paths.
+  - Service integration tests with mock source and one real-source-gated test.
+  - Docker smoke test including data-source service readiness.
+  - Realtime WebSocket smoke with subscribe/update/unsubscribe.
+
+This path gives the main benefit you want: the data-source plane becomes independently deployable and observable, while the trading/product backend remains stable and does not absorb every provider-specific failure mode.
+

--- a/governance/mainline/task-cards/pr-475.yaml
+++ b/governance/mainline/task-cards/pr-475.yaml
@@ -1,0 +1,152 @@
+version: "v0.2"
+
+task:
+  id: "pr-475"
+  title: "add openstock runtime migration boundary"
+  owner: "codex"
+  created_at: "2026-06-10"
+
+mainline:
+  id: "L1-openstock-runtime-migration-boundary"
+  objective: "land the MyStocks-side openstock REST/WebSocket runtime migration boundary without changing frontend routes or API contracts"
+  milestone_id: "L2-data-source-runtime-extraction"
+  slice_id: "L3-openstock-runtime-boundary"
+
+classification:
+  task_type: "feature"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: "extract-data-source-runtime-service"
+  approval_status: "approved"
+
+function_tree:
+  domain_id: "domain-01"
+  node_id: "domain-01-node-03"
+  affected_entrypoints:
+    - "governance"
+    - "api"
+    - "core"
+    - "tests"
+    - "operations"
+  update_status: "not-needed"
+  secondary_domains:
+    - "domain-08"
+    - "domain-09"
+  exemption_reason: "The PR establishes a reviewed data-source runtime boundary under the existing multi-data-source integration node; config and core path coverage also touches system/data-management catalog domains, but frontend/API contracts and product entrypoints remain unchanged."
+
+scope:
+  allowed_paths:
+    - "config/data_sources_registry.yaml"
+    - "docs/reports/architecture/data-source-runtime-service-migration-feasibility-plan-2026-06-09.md"
+    - "docs/reports/architecture/data-source-runtime-service-migration-feasibility-plan-review-2026-06-09.md"
+    - "docs/reports/architecture/data-source-service-extraction-analysis-2026-06-09.md"
+    - "governance/mainline/task-cards/pr-475.yaml"
+    - "openspec/changes/extract-data-source-runtime-service/design.md"
+    - "openspec/changes/extract-data-source-runtime-service/proposal.md"
+    - "openspec/changes/extract-data-source-runtime-service/specs/architecture-governance/spec.md"
+    - "openspec/changes/extract-data-source-runtime-service/specs/containerized-runtime-deployment/spec.md"
+    - "openspec/changes/extract-data-source-runtime-service/specs/data-source-runtime-service/spec.md"
+    - "openspec/changes/extract-data-source-runtime-service/specs/data-sources/spec.md"
+    - "openspec/changes/extract-data-source-runtime-service/specs/market-data/spec.md"
+    - "openspec/changes/extract-data-source-runtime-service/tasks.md"
+    - "scripts/run_data_source_runtime_smoke.sh"
+    - "src/core/data_source/__init__.py"
+    - "src/core/data_source/client.py"
+    - "src/core/data_source/closure_policy.py"
+    - "src/core/data_source/market_stream_bridge.py"
+    - "src/core/data_source/mcp_diagnostics.py"
+    - "tests/integration/data_source/test_akshare_runtime_pilot.py"
+    - "tests/integration/data_source/test_data_source_public_api_parity.py"
+    - "tests/integration/data_source/test_market_stream_contract.py"
+    - "tests/integration/data_source/test_mcp_access_modes.py"
+    - "tests/integration/data_source/test_remote_data_source_client_contract.py"
+  forbidden_paths:
+    - "web/frontend/**"
+    - "web/backend/app/api/**"
+    - "web/backend/app/services/**"
+    - "docs/api/**"
+    - "src/adapters/**"
+    - "src/data_access/**"
+    - "src/factories/**"
+    - "docker/**"
+    - "docker-compose*.yml"
+
+non_goals:
+  - "No runtime MCP, MCP-over-SSE, or SSE gateway is introduced in this PR"
+  - "No frontend route, page, store, or generated API contract changes"
+  - "No provider batch migration beyond the AkShare REST/pull pilot contract coverage"
+  - "No retirement or deletion of legacy data-source paths"
+  - "No production deployment, auth, observability, or container orchestration hardening"
+  - "No PM2 commands or stateful runtime service changes"
+
+acceptance:
+  checks:
+    - id: "focused-data-source-regression"
+      command: >-
+        pytest tests/integration/data_source/test_remote_data_source_client_contract.py
+        tests/api/file_tests/test_data_source_config_api.py
+        tests/api/file_tests/test_data_source_registry_api.py
+        tests/integration/data_source/test_akshare_runtime_pilot.py
+        tests/integration/data_source/test_market_stream_contract.py
+        tests/integration/data_source/test_mcp_access_modes.py
+        tests/integration/data_source/test_data_source_public_api_parity.py
+        -q --no-cov -p no:cacheprovider
+      required: true
+    - id: "runtime-smoke-syntax"
+      command: "bash -n scripts/run_data_source_runtime_smoke.sh"
+      required: true
+    - id: "ruff-runtime-boundary"
+      command: >-
+        ruff check src/core/data_source/__init__.py src/core/data_source/client.py
+        src/core/data_source/market_stream_bridge.py src/core/data_source/mcp_diagnostics.py
+        src/core/data_source/closure_policy.py
+        tests/integration/data_source/test_remote_data_source_client_contract.py
+        tests/integration/data_source/test_akshare_runtime_pilot.py
+        tests/integration/data_source/test_market_stream_contract.py
+        tests/integration/data_source/test_mcp_access_modes.py
+        tests/integration/data_source/test_data_source_public_api_parity.py
+      required: true
+    - id: "openspec-strict"
+      command: "openspec validate extract-data-source-runtime-service --strict"
+      required: true
+    - id: "mainline-scope-gate"
+      command: >-
+        python governance/mainline/scripts/mainline_scope_gate.py
+        --task-card governance/mainline/task-cards/pr-475.yaml
+        --schema governance/mainline/schemas/ai-task-card.schema.json
+        --base-sha origin/wip/root-dirty-20260403
+        --head-sha HEAD
+        --report governance/mainline/reports/mainline-governance-report.json
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Reviewers may confuse diagnostics-only MCP access-mode coverage with an approved runtime MCP/SSE gateway"
+    - "The registry seed entry could be misread as transferring full runtime ownership before the approved openstock rollout phases"
+    - "The GitNexus index can be stale relative to this review commit, so graph impact must be treated as advisory"
+  rollback_plan: "Revert PR #475, including the openstock runtime boundary commit and this governance task card; openstock remains independently usable at its last pushed runtime/docs commits."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "add the MyStocks-side openstock REST/WebSocket runtime migration boundary"
+    modified_scope: "data-source client/bridge/diagnostics policy, registry seed, smoke script, OpenSpec deltas, architecture reports, integration tests, and this PR task card"
+    dependency_changes: "none in MyStocks; openstock runtime and documentation commits are delivered in the separate openstock repository"
+    legacy_logic_impact: "legacy data-source adapters and existing frontend/API contracts remain in place; registry entry is a remote pilot seed with fallback semantics"
+    rollback_ready: "yes"
+    risk_and_rollback_point: "revert PR #475 if runtime boundary, OpenSpec validation, or mainline scope governance regresses"
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "maintainer"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-10T09:22:28+08:00"
+    approval_note: "Human maintainer approved continuing the openstock runtime migration boundary after reviewing the feasibility plan, PR package, and no-runtime-MCP/SSE constraint."
+    secondary_approved: false

--- a/openspec/changes/extract-data-source-runtime-service/design.md
+++ b/openspec/changes/extract-data-source-runtime-service/design.md
@@ -1,0 +1,138 @@
+# Design: OpenStock data source runtime service extraction
+
+## Context
+
+The migration feasibility plan recommends separating MyStocks data-source management from the project feature foundation by deepening the seam between product/backend code and provider runtime code. The extracted solution is named `openstock`, with target local directory `/opt/claude/openstock` and target private remote `http://192.168.123.104:3001/john/openstock.git`. The goal is not to move source files into Docker directly. The goal is to make provider access a governed runtime capability behind a stable contract.
+
+`optimize-data-source-v2` already contains important local runtime work: SmartCache, CircuitBreaker, DataQualityValidator, SmartRouter, datasource metrics, BatchProcessor, and fetcher bridge evidence. This extraction should reuse those capabilities and turn them into a stable local/remote runtime boundary.
+
+## Goals
+
+- Keep the main backend responsible for product APIs, authentication, authorization, `UnifiedResponse`, frontend compatibility, strategy/risk/trade orchestration, and dashboards.
+- Move provider access governance into a data-source runtime owner: provider adapters, route decisions, registry reload/versioning, health, cache, rate limiting, circuit breaker state, metrics, and audit/cost state.
+- Keep external `/api/v1/data-sources*` compatibility during migration.
+- Support local and remote runtime modes through one `DataSourceClient` contract.
+- Make Docker/REST/WebSocket/MCP transport choices explicit by workload type.
+
+## Non-Goals
+
+- Do not move TDengine/PostgreSQL market-data storage.
+- Do not move strategy/risk/trade/portfolio/user domains.
+- Do not make MCP the data-service base.
+- Do not turn compatibility wrappers into long-term parallel implementations.
+
+## Target Boundary
+
+```text
+Business APIs / FastAPI routes
+        |
+        v
+DataSourceClient
+        |
+        +-- LocalDataSourceClient
+        |     -> existing DataSourceManagerV2 / optimize-data-source-v2 runtime
+        |
+        +-- RemoteDataSourceClient
+              -> REST / WebSocket / optional diagnostics against openstock
+
+openstock
+        |
+        +-- DataSourceRuntime
+              -> RegistryReader/Writer
+              -> RoutePolicy / SmartRouter
+              -> ProviderAdapter
+              -> Cache / RateLimiter / CircuitBreaker / Metrics
+```
+
+## DataSourceClient Contract
+
+Minimum capabilities:
+
+| Capability | Semantics |
+|---|---|
+| `resolve_route(request)` | Return selected provider/endpoint, fallback candidates, and route reason without slow provider calls. |
+| `fetch_snapshot(request)` | Fetch one pull-style snapshot with timeout, freshness, and typed error semantics. |
+| `fetch_batch(request)` | Fetch historical/financial/reference batches with async/pagination-friendly semantics. |
+| `test_endpoint(endpoint_name)` | Low-frequency diagnostics for provider endpoint health. |
+| `get_source_health(filter)` | Return provider/category/endpoint health and observation metrics. |
+| `reload_registry(version)` | Reload or switch registry version with audit and rollback semantics. |
+| `subscribe_quotes(request)` | Establish realtime quote subscription through WebSocket-only stream semantics. |
+
+Contract invariants:
+
+- Successful responses include `source`, `endpoint_name`, `route_decision_id`, `request_id`, `exchange_time`, `received_at`, `staleness_ms`, `cache_state`, `quality_flags`, and `latency_ms`.
+- Stale data is never returned silently; stale cache responses must carry `cache_state=stale`, `staleness_ms`, and downgrade reason.
+- Errors are typed at least as `ProviderUnavailable`, `ProviderTimeout`, `RateLimited`, `CircuitOpen`, `RegistryNotFound`, `InvalidRequest`, and `DataQualityFailed`.
+- Every call has an explicit timeout budget.
+- Cache state is explicit: `fresh`, `stale`, `miss`, or `bypass`.
+- Registry/config writes go through runtime-owner config APIs, not fetch APIs.
+- Local and remote clients run the same contract tests.
+
+## Runtime State Ownership
+
+| State/Data | Owner | Storage/Lifecycle |
+|---|---|---|
+| Provider registry | Data-source runtime | PostgreSQL source of truth; YAML seed/fallback |
+| Registry version history / rollback | Data-source runtime | PostgreSQL |
+| Route decision history | Data-source runtime | PostgreSQL or short-lived log plus metrics |
+| Provider health | Data-source runtime | Process state plus metrics; optional Redis for multi-instance |
+| Cache | Data-source runtime | L1 memory plus optional Redis L2 |
+| Rate limit state | Data-source runtime | Process state; Redis namespace for multi-instance |
+| Circuit breaker state | Data-source runtime | Process state; optional shared summary for clusters |
+| Metrics | Data-source runtime emits; main backend may aggregate/proxy | Prometheus `datasource_*` |
+| Provider call audit/cost | Data-source runtime | PostgreSQL and/or Prometheus |
+| Market-data warehouse | Existing data warehouse owners | TDengine/PostgreSQL unchanged |
+| Strategy/risk/trade/user data | Main backend/business domains | Existing storage unchanged |
+
+## Protocol Decisions
+
+| Protocol | Use | Not For |
+|---|---|---|
+| REST/OpenAPI | registry, health, route selection, endpoint test, pull fetch, batch fetch | realtime quote fan-out |
+| WebSocket | realtime quote/watchlist/strategy-universe subscriptions | bulk historical downloads |
+| SSE | one-way browser/admin status stream | bidirectional quote subscriptions |
+| MCP Streamable HTTP/SSE | agent/admin diagnostics | hot-path data service |
+
+MCP modes:
+
+- stdio MCP: local low-frequency diagnostics.
+- standalone MCP over Streamable HTTP/SSE: remote AI tool entrypoint that calls `DataSourceClient` or REST; it must not own provider pools/cache/circuit/rate state.
+- mounted MCP: optional diagnostics app inside `openstock`; it must reuse `DataSourceRuntime`.
+
+## Phase 2 Scope Lock
+
+Phase 2 must not start until this OpenSpec proposal, the completed Phase 0/1 evidence, and the Phase 2 implementation slice are approved.
+
+Phase 2 allowed scope:
+
+- Design and implement `openstock` REST/OpenAPI control-plane and pull-data runtime boundaries.
+- Design the WebSocket runtime contract and implement only the approved data-runtime stream slice.
+- Implement `RemoteDataSourceClient` against the approved REST/WebSocket boundary.
+- Prepare Docker/container readiness, health checks, and smoke evidence.
+
+Phase 2 excluded scope:
+
+- No MCP tool implementation.
+- No standalone MCP transport.
+- No mounted MCP diagnostics app.
+- No MCP-over-SSE compatibility work.
+- No provider-wide migration beyond the approved runtime boundary and first data-runtime slice.
+
+## Migration Plan
+
+1. Phase 0: Create and approve this OpenSpec change; reconcile `optimize-data-source-v2`; decide registry ownership, first pilot, and rollback gates.
+2. Phase 1: Add in-process `DataSourceClient` and local contract tests.
+3. Phase 2: After separate approval, add `openstock` REST/WebSocket runtime boundary, `RemoteDataSourceClient`, and Docker readiness; keep main backend facade stable; do not implement MCP.
+4. Phase 3: Migrate one AkShare REST/pull category as the pilot.
+5. Phase 4: Add WebSocket realtime quote pilot after REST/pull stabilizes.
+6. Phase 5: Add optional MCP diagnostics entrypoints.
+7. Phase 6: Retire old priority/config/manager paths only after parity, rollback, metrics, and smoke evidence pass.
+
+## Risks And Mitigations
+
+- Registry truth splits: PostgreSQL is runtime truth; YAML becomes seed/fallback.
+- Remote service becomes shallow pass-through: require `DataSourceRuntime` to own route/cache/circuit/rate/metrics.
+- Provider latency affects main backend: require timeout budgets, cache fallback, and async/batch semantics.
+- MCP becomes a hot path: spec forbids MCP for bulk market/financial data and realtime quote service.
+- V2 work is duplicated: this change depends on V2 and maps its implemented capabilities into the new runtime contract.
+- Old paths linger: compatibility wrappers must have closure criteria and cannot accumulate business logic.

--- a/openspec/changes/extract-data-source-runtime-service/proposal.md
+++ b/openspec/changes/extract-data-source-runtime-service/proposal.md
@@ -1,0 +1,61 @@
+# Change: Extract OpenStock data source runtime service
+
+> Source feasibility plan: `docs/reports/architecture/data-source-runtime-service-migration-feasibility-plan-2026-06-09.md`
+> Target extracted repository: `/opt/claude/openstock`
+> Target private remote: `http://192.168.123.104:3001/john/openstock.git`
+
+## Why
+
+MyStocks currently keeps data-source management, provider access, route selection, health checks, cache, circuit breaker state, metrics, and product/backend orchestration too close together. This makes provider changes leak into the main FastAPI backend and makes Docker, REST, WebSocket, SSE, and MCP access-mode decisions harder to reason about.
+
+The approved direction is to separate the data-source runtime from the project feature foundation without changing the public frontend/API contract first. The main backend should keep product APIs, auth, `UnifiedResponse`, strategy/risk/trade orchestration, and frontend compatibility paths. The extracted runtime will be named `openstock`; it should own provider access governance and expose it through a stable `DataSourceClient` seam.
+
+This change depends on and continues `optimize-data-source-v2`; it does not replace the SmartRouter, CircuitBreaker, metrics, cache, BatchProcessor, or runtime config work already captured there. `optimize-data-source-v2` remains active and must be treated as prerequisite evidence, especially for repo-local versus grey/production validation boundaries.
+
+## What Changes
+
+- Add a `DataSourceClient` contract that supports local and remote implementations with identical metadata, timeout, cache-state, typed-error, and config-boundary semantics.
+- Add an `openstock` runtime boundary that owns provider adapters, registry reload/versioning, route decisions, health, cache, rate limiting, circuit breakers, metrics, and provider call audit/cost state.
+- Keep `/api/v1/data-sources*` on the main backend as the external facade during migration.
+- Define PostgreSQL as the runtime registry/version-history source of truth; YAML registry files become seed/fallback material only.
+- Add optional containerized runtime deployment for the data-source runtime while preserving main backend local-mode rollback.
+- Use REST/OpenAPI for control-plane and pull data, WebSocket for realtime quote streams, SSE only for one-way status streams, and MCP only for agent/admin diagnostics.
+- Migrate incrementally: in-process `DataSourceClient`, remote container, AkShare REST/pull pilot, WebSocket pilot, optional MCP tools, then old path closure.
+- Treat Phase 2 as a separate approval gate after this proposal and Phase 0/1 evidence are reviewed.
+- Limit Phase 2 implementation to data-runtime REST/WebSocket boundaries, `RemoteDataSourceClient`, and Docker/container readiness; MCP tools are explicitly out of Phase 2 scope.
+
+## Non-Goals
+
+- Do not migrate TDengine/PostgreSQL business market-data warehouses in the first extraction.
+- Do not move strategy, risk, trade, portfolio, user, or dashboard business orchestration into the data-source runtime.
+- Do not migrate all providers or all AkShare endpoints in the first pilot.
+- Do not use MCP for high-volume quote, K-line, financial-data, or strategy execution hot paths.
+- Do not implement MCP tools, MCP transports, or MCP-mounted diagnostics in Phase 2.
+- Do not archive `optimize-data-source-v2` as part of this change unless its own archive criteria are independently satisfied.
+
+## Impact
+
+- Affected specs:
+  - `data-source-runtime-service` (new)
+  - `data-sources`
+  - `containerized-runtime-deployment`
+  - `market-data`
+  - `architecture-governance`
+- Candidate implementation areas:
+  - `src/core/data_source/*`
+  - `src/core/data_source_handlers_v2.py`
+  - `web/backend/app/api/data_source_registry.py`
+  - `web/backend/app/api/data_source_config.py`
+  - `web/backend/app/main.py`
+  - `config/monitoring-stack/*`
+  - container/runtime smoke scripts
+- External compatibility:
+  - Public `/api/v1/data-sources*` routes should remain stable.
+  - Frontend callers should not need to switch routes during Phase 1-3.
+  - Remote mode must be feature-flagged and reversible to local mode.
+- Deployment impact:
+  - Adds an optional `openstock` service and smoke evidence path.
+  - Does not require immediate all-project Docker migration.
+- Governance impact:
+  - Requires proposal approval before implementation.
+  - Requires explicit closure criteria before retiring old registry/priority/manager paths.

--- a/openspec/changes/extract-data-source-runtime-service/specs/architecture-governance/spec.md
+++ b/openspec/changes/extract-data-source-runtime-service/specs/architecture-governance/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Data Source Runtime Extraction Governance
+
+The architecture-governance capability SHALL treat data-source runtime extraction as a proposal-first, phased migration with explicit ownership, rollback, and closure gates.
+
+#### Scenario: Extraction proposal is approved before implementation
+
+- **WHEN** implementation work begins for data-source runtime extraction
+- **THEN** the `extract-data-source-runtime-service` proposal SHALL have passed strict OpenSpec validation
+- **AND** the user SHALL have approved implementation after reviewing affected specs, phase scope, first pilot, and rollback path
+
+#### Scenario: Phase 2 has an explicit approval gate
+
+- **WHEN** the team is ready to move from completed Phase 0/1 work into Phase 2
+- **THEN** Phase 2 SHALL require explicit approval of the REST/WebSocket runtime scope, `RemoteDataSourceClient`, Docker readiness work, and rollback path
+- **AND** Phase 2 approval SHALL explicitly exclude MCP tools, MCP transports, mounted MCP diagnostics, and MCP-over-SSE compatibility
+
+#### Scenario: Extraction depends on optimize-data-source-v2 evidence
+
+- **WHEN** the extraction proposal maps local runtime capabilities into the new `DataSourceClient` or `DataSourceRuntime`
+- **THEN** it SHALL reference `optimize-data-source-v2` as dependency evidence rather than re-implementing SmartRouter, CircuitBreaker, cache, metrics, BatchProcessor, or runtime config semantics
+- **AND** remaining grey/production validation items from `optimize-data-source-v2` SHALL be classified as blockers or parallel follow-up before remote extraction is treated as deliverable
+
+#### Scenario: Compatibility layers have closure criteria
+
+- **WHEN** local/remote clients, main-backend facades, old registry paths, old priority config, or old manager wrappers coexist during migration
+- **THEN** each compatibility layer SHALL be documented as thin forwarding or transition code
+- **AND** each compatibility layer SHALL have explicit exit criteria before old paths are retired
+- **AND** deletion or retirement SHALL follow `architecture/STANDARDS.md` approval and evidence requirements
+
+#### Scenario: Verification matrix is executable
+
+- **WHEN** a migration phase is marked complete
+- **THEN** its task entry SHALL include executable validation commands or named evidence artifacts
+- **AND** conceptual review alone SHALL NOT be sufficient to close implementation tasks

--- a/openspec/changes/extract-data-source-runtime-service/specs/containerized-runtime-deployment/spec.md
+++ b/openspec/changes/extract-data-source-runtime-service/specs/containerized-runtime-deployment/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: OpenStock Data Source Runtime Container
+
+The containerized runtime deployment capability SHALL support an optional `openstock` runtime service without forcing an immediate all-project Docker migration.
+
+#### Scenario: Compose topology includes optional data-source runtime
+
+- **WHEN** the data-source runtime extraction reaches remote mode
+- **THEN** the approved deployment topology SHALL include an `openstock` service definition or equivalent runtime entrypoint
+- **AND** that service SHALL expose readiness and liveness checks
+- **AND** the main backend SHALL be able to select local or remote data-source client mode through configuration
+
+#### Scenario: Data-source runtime smoke verifies readiness
+
+- **WHEN** `scripts/run_data_source_runtime_smoke.sh` executes successfully
+- **THEN** it SHALL verify data-source runtime readiness, main-backend facade compatibility, and local/remote rollback behavior
+- **AND** it SHALL avoid creating a parallel deployment truth source outside the approved runtime delivery artifacts
+
+#### Scenario: Data-source runtime failure does not take down main backend
+
+- **WHEN** the remote `openstock` service is unavailable or unhealthy
+- **THEN** the main backend SHALL remain available for non-data-source product APIs
+- **AND** operators SHALL be able to switch back to local data-source client mode if the local runtime prerequisites remain available

--- a/openspec/changes/extract-data-source-runtime-service/specs/data-source-runtime-service/spec.md
+++ b/openspec/changes/extract-data-source-runtime-service/specs/data-source-runtime-service/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: Data Source Client Contract
+
+The system SHALL expose a stable `DataSourceClient` contract that allows main-backend callers to use data-source capabilities without depending on concrete provider adapters, registry internals, handler internals, or local/remote transport details.
+
+#### Scenario: Local client returns contract metadata
+
+- **WHEN** the main backend calls the local `DataSourceClient` for a successful pull-style request
+- **THEN** the response SHALL include `source`, `endpoint_name`, `route_decision_id`, `request_id`, `exchange_time`, `received_at`, `staleness_ms`, `cache_state`, `quality_flags`, and `latency_ms`
+- **AND** the caller SHALL NOT need to inspect provider-specific adapter objects to understand the route or freshness result
+
+#### Scenario: Remote client preserves local contract parity
+
+- **WHEN** `DATA_SOURCE_CLIENT_MODE=remote` is enabled for the same contract test case that passes in local mode
+- **THEN** the remote client SHALL return the same contract fields and typed semantics as the local client
+- **AND** differences in HTTP, serialization, or container topology SHALL NOT leak into business callers
+
+#### Scenario: Client reports typed failures
+
+- **WHEN** a provider is unavailable, times out, hits rate limit, trips a circuit breaker, has missing registry config, receives an invalid request, or fails data quality validation
+- **THEN** the client SHALL return a typed failure category for the corresponding condition
+- **AND** the response SHALL include request identity and route context sufficient for diagnostics
+
+#### Scenario: Client enforces timeout and cache semantics
+
+- **WHEN** a caller provides a timeout or freshness requirement
+- **THEN** the data-source client SHALL enforce the timeout budget
+- **AND** cache state SHALL be explicit as `fresh`, `stale`, `miss`, or `bypass`
+- **AND** stale data SHALL NOT be returned without `staleness_ms` and downgrade reason metadata
+
+### Requirement: Data Source Runtime Ownership
+
+The system SHALL define a data-source runtime owner for provider access governance while preserving existing business-data storage ownership.
+
+#### Scenario: Registry ownership is singular
+
+- **WHEN** provider registry configuration is read, reloaded, versioned, or rolled back
+- **THEN** PostgreSQL SHALL be treated as the runtime source of truth
+- **AND** YAML registry material SHALL be limited to bootstrap seed or emergency fallback use
+- **AND** the main backend SHALL expose compatibility facades rather than becoming a second registry owner
+
+#### Scenario: Runtime state is not business storage
+
+- **WHEN** the data-source runtime owns provider health, route decisions, cache, rate limit state, circuit breaker state, metrics, or provider call audit/cost state
+- **THEN** those runtime states SHALL NOT imply moving TDengine/PostgreSQL market-data warehouse ownership
+- **AND** strategy, risk, trade, portfolio, user, and dashboard business data SHALL remain outside the data-source runtime
+
+### Requirement: Data Source Runtime Service API
+
+The system SHALL support a remote `openstock` runtime service after the in-process client contract is stable.
+
+#### Scenario: Phase 2 excludes MCP implementation
+
+- **WHEN** Phase 2 implementation begins
+- **THEN** implementation scope SHALL be limited to REST/OpenAPI, approved WebSocket data-runtime boundaries, `RemoteDataSourceClient`, and container readiness
+- **AND** Phase 2 SHALL NOT implement MCP tools, standalone MCP transport, mounted MCP diagnostics, or MCP-over-SSE compatibility
+- **AND** MCP diagnostics SHALL remain a later-phase capability
+
+#### Scenario: Runtime exposes control-plane and pull APIs
+
+- **WHEN** the remote data-source runtime is enabled
+- **THEN** it SHALL expose health, source listing, endpoint test, registry reload, route selection, fetch, and batch fetch capabilities through REST/OpenAPI
+- **AND** the main backend SHALL keep `/api/v1/data-sources*` as the public compatibility facade during migration
+
+#### Scenario: Runtime exposes realtime stream separately
+
+- **WHEN** realtime quote delivery is migrated
+- **THEN** the data-source runtime SHALL expose a WebSocket stream with subscribe, unsubscribe, snapshot, quote update, heartbeat, and error messages
+- **AND** bulk historical or financial-data downloads SHALL NOT use the realtime stream
+
+#### Scenario: Runtime exposes MCP diagnostics only
+
+- **WHEN** MCP access is enabled through stdio, standalone remote MCP, or mounted MCP
+- **THEN** MCP tools SHALL be limited to diagnostics or admin operations such as listing sources, checking health, testing endpoints, explaining route decisions, or reloading registry
+- **AND** MCP SHALL NOT return bulk quote, K-line, financial-data, or strategy execution hot-path results
+- **AND** mounted MCP SHALL reuse the same `DataSourceRuntime` instead of calling providers directly
+
+### Requirement: Data Source Runtime Resilience And Observability
+
+The system SHALL make provider access observable and resilient in both local and remote runtime modes.
+
+#### Scenario: Runtime reports provider health and metrics
+
+- **WHEN** a provider call succeeds, fails, falls back, hits cache, misses cache, times out, hits rate limit, or opens a circuit breaker
+- **THEN** the runtime SHALL emit `datasource_*` metrics that identify endpoint/category/status as appropriate
+- **AND** the health API SHALL expose enough summary state for operators and diagnostics tools
+
+#### Scenario: Runtime protects the main backend from slow providers
+
+- **WHEN** a provider is slow or unavailable
+- **THEN** the main backend SHALL not wait indefinitely
+- **AND** the data-source runtime SHALL apply timeout, cache fallback, rate limit, and circuit breaker policies before reporting the result to the caller

--- a/openspec/changes/extract-data-source-runtime-service/specs/data-sources/spec.md
+++ b/openspec/changes/extract-data-source-runtime-service/specs/data-sources/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Data Source Registry Runtime Ownership
+
+The data-source capability SHALL distinguish provider registry/runtime governance from business feature orchestration.
+
+#### Scenario: Registry writes are owned by data-source runtime
+
+- **WHEN** a caller creates, updates, deletes, reloads, versions, or rolls back provider registry configuration
+- **THEN** the data-source runtime SHALL own the write, audit, and rollback semantics
+- **AND** the main backend `/api/v1/data-sources*` routes SHALL preserve external compatibility as facades during migration
+
+#### Scenario: YAML registry is downgraded to seed or fallback
+
+- **WHEN** the remote data-source runtime is available
+- **THEN** YAML registry files SHALL NOT be treated as an equal runtime source of truth
+- **AND** YAML material SHALL be used only for bootstrap seed or emergency fallback paths
+
+### Requirement: Incremental Provider Migration Pilot
+
+The data-source capability SHALL migrate providers incrementally through a single REST/pull pilot before broader provider or realtime migration.
+
+#### Scenario: First pilot uses one AkShare REST pull category
+
+- **WHEN** the first provider/category migration begins
+- **THEN** the selected pilot SHALL be one AkShare REST/pull category
+- **AND** the migration SHALL NOT include all AkShare endpoints, all providers, TDX realtime, or WebSocket market streams in the first pilot
+
+#### Scenario: Pilot responses remain explainable
+
+- **WHEN** the pilot returns data through local or remote data-source runtime mode
+- **THEN** each response SHALL include source, endpoint, route decision, latency, cache/freshness metadata, and quality flags
+- **AND** provider timeout, fallback, cache, circuit breaker, and metrics behavior SHALL be observable through tests or runtime evidence

--- a/openspec/changes/extract-data-source-runtime-service/specs/market-data/spec.md
+++ b/openspec/changes/extract-data-source-runtime-service/specs/market-data/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Data Source Runtime Realtime Stream Pilot
+
+The market-data capability SHALL support a phased realtime stream pilot from the data-source runtime only after REST/pull migration is stable.
+
+#### Scenario: Runtime stream defines subscription lifecycle
+
+- **WHEN** the realtime pilot is enabled
+- **THEN** the data-source runtime SHALL expose a WebSocket stream with `subscribe`, `unsubscribe`, `snapshot`, `quote.update`, `heartbeat`, and `error` message types
+- **AND** the stream contract SHALL define reconnect, stale quote, duplicate message, out-of-order message, slow consumer, market open, and market close behavior
+
+#### Scenario: Main backend may proxy existing frontend channel
+
+- **WHEN** frontend compatibility is required during the realtime pilot
+- **THEN** the main backend MAY bridge or proxy the data-source runtime stream into the existing `/ws/events` consumer path
+- **AND** the proxy SHALL preserve message freshness and error semantics required by the stream contract
+
+#### Scenario: MCP is excluded from market-data hot paths
+
+- **WHEN** realtime quote or high-volume market-data delivery is required
+- **THEN** the system SHALL use WebSocket or REST according to workload type
+- **AND** MCP SHALL NOT be used as the hot-path transport for realtime quotes, bulk K-line data, or bulk financial data

--- a/openspec/changes/extract-data-source-runtime-service/tasks.md
+++ b/openspec/changes/extract-data-source-runtime-service/tasks.md
@@ -1,0 +1,130 @@
+## 0. Proposal And Governance
+
+- [x] 0.1 Confirm affected specs: `data-source-runtime-service`, `data-sources`, `containerized-runtime-deployment`, `market-data`, `architecture-governance`.
+  - Repo-truth（2026-06-09）：spec deltas 已创建于 `openspec/changes/extract-data-source-runtime-service/specs/`。
+- [x] 0.2 Reconcile `optimize-data-source-v2` active status and classify remaining grey/production validation items as blockers or parallel follow-up.
+  - Repo-truth（2026-06-09）：本 change 明确依赖并接续 `optimize-data-source-v2`，V2 剩余灰度/生产验收不由本地合成测试冒充完成。
+- [x] 0.3 Run `openspec validate extract-data-source-runtime-service --strict`.
+  - Repo-truth（2026-06-09）：strict validate 通过。
+- [x] 0.4 Obtain user approval before implementation.
+  - Repo-truth（2026-06-09）：用户已回复“同意，请继续”后才进入 Phase 1 代码变更。
+
+## 1. In-Process Client Contract
+
+- [x] 1.1 Add `DataSourceClient` interface and `LocalDataSourceClient` implementation backed by the current data-source runtime.
+  - Repo-truth（2026-06-09）：新增 `src/core/data_source/client.py`，当前实现只建立 local seam，不迁移 provider 源码。
+- [x] 1.2 Add `tests/unit/data_source/test_data_source_client_contract.py`.
+  - Repo-truth（2026-06-09）：新增 contract test 文件。
+- [x] 1.3 Verify successful responses include source, endpoint, route decision, request id, exchange/received time, staleness, cache state, quality flags, and latency metadata.
+  - Repo-truth（2026-06-09）：`test_local_client_fetch_snapshot_returns_contract_metadata` 覆盖该 metadata contract。
+- [x] 1.4 Verify typed errors for provider unavailable, timeout, rate limited, circuit open, registry missing, invalid request, and data quality failure.
+  - Repo-truth（2026-06-09）：`test_data_source_client_contract.py` 覆盖 provider unavailable、timeout、rate limited、circuit open、registry missing、invalid request 与 data quality failed。
+- [x] 1.5 Run V2 prerequisite matrix:
+  - `pytest tests/unit/test_smart_router.py tests/unit/test_smart_router_integration.py tests/unit/test_metrics.py tests/unit/test_data_source_metrics_integration.py src/governance/tests/test_fetcher_bridge.py tests/integration/test_batch_processing.py tests/unit/adapters/test_runtime_data_source_regressions.py -q --no-cov`
+  - Repo-truth（2026-06-09）：结果 `42 passed`。
+- [x] 1.6 Run local contract test:
+  - `pytest tests/unit/data_source/test_data_source_client_contract.py -q --no-cov`
+  - Repo-truth（2026-06-09）：结果 `8 passed`。
+
+## 2. OpenStock Remote Runtime Container
+
+- [x] 2.0 Obtain explicit Phase 2 approval after reviewing this proposal, completed Phase 0/1 evidence, REST/WebSocket runtime scope, and rollback path.
+  - Repo-truth（2026-06-09）：用户在 Phase 2 scope lock 后回复“请继续”，本轮仅执行 REST/WebSocket runtime 和 remote client，不执行 MCP。
+- [x] 2.1 Design the `openstock` REST/OpenAPI boundary for health, sources, registry reload, route selection, fetch, and batch endpoints.
+  - Repo-truth（2026-06-09）：`/opt/claude/openstock/openstock/app.py` 已提供 health、sources、registry reload、routing、fetch、batch 的最小 REST contract；已推送为 `openstock` 提交 `62e7cd7 feat: add openstock runtime tracer bullet`。
+- [x] 2.2 Design the `openstock` WebSocket data-runtime boundary for the approved stream slice; do not implement MCP transports or tools.
+  - Repo-truth（2026-06-09）：`/opt/claude/openstock/openstock/app.py` 已提供 `/ws/market` subscribe/snapshot 最小 contract；MCP 排除检查显示 runtime/tests 中无 MCP 实现痕迹。
+- [x] 2.3 Add `openstock` runtime service boundary with health, sources, registry reload, route selection, fetch, and batch endpoints.
+  - Repo-truth（2026-06-09）：`openstock` runtime tracer bullet 已覆盖 health、sources、registry reload、route selection、fetch、batch 与 `/ws/market` subscribe/snapshot。
+- [x] 2.4 Add `RemoteDataSourceClient` using REST/OpenAPI for pull/control-plane operations.
+  - Repo-truth（2026-06-09）：`src/core/data_source/client.py` 已新增 `RemoteDataSourceClient` 与 JSON transport。
+- [x] 2.5 Add `DATA_SOURCE_CLIENT_MODE=local|remote` rollback switch.
+  - Repo-truth（2026-06-09）：`create_data_source_client()` 支持 `DATA_SOURCE_CLIENT_MODE=local|remote`，remote base URL 默认 `OPENSTOCK_BASE_URL` 或 `http://localhost:8031`。
+- [x] 2.6 Add `tests/integration/data_source/test_remote_data_source_client_contract.py`.
+  - Repo-truth（2026-06-09）：remote client contract tests 已新增并通过。
+- [x] 2.7 Add or update config facade parity tests:
+  - `tests/api/file_tests/test_data_source_config_api.py`
+  - `tests/api/file_tests/test_data_source_registry_api.py`
+  - Repo-truth（2026-06-09）：现有 config/registry facade file-level contract tests 覆盖路由、响应模型、reload、registry 操作与配置更新；已与 remote client contract 一起验证通过。
+- [x] 2.8 Add `scripts/run_data_source_runtime_smoke.sh`.
+  - Repo-truth（2026-06-09）：smoke 脚本已新增；运行结果为 openstock runtime contract `4 passed`，MyStocks remote client contract `5 passed`。
+- [x] 2.9 Run:
+  - `pytest tests/integration/data_source/test_remote_data_source_client_contract.py tests/api/file_tests/test_data_source_config_api.py tests/api/file_tests/test_data_source_registry_api.py -q --no-cov`
+  - `bash scripts/run_data_source_runtime_smoke.sh`
+  - Repo-truth（2026-06-09）：combined remote/config facade command `30 passed, 14 warnings`；runtime smoke command openstock `4 passed`，MyStocks remote client `5 passed`。
+- [x] 2.10 Verify Phase 2 contains no MCP tool implementation, standalone MCP transport, mounted MCP app, or MCP-over-SSE compatibility work.
+  - Repo-truth（2026-06-09）：`openstock/openstock` 与 `openstock/tests` 中无 MCP 代码或测试实现；MCP 仍保留在 Phase 5。
+
+## 2A. OpenStock Repository Bootstrap
+
+- [x] 2A.1 Create or clone `/opt/claude/openstock`.
+  - Repo-truth（2026-06-09）：`/opt/claude/openstock` 已初始化为 Git 仓库，当前分支为 `main`。
+- [x] 2A.2 Connect the repository to `http://192.168.123.104:3001/john/openstock.git`.
+  - Repo-truth（2026-06-09）：`origin` 已绑定到本地私库并推送 `main`。
+- [x] 2A.3 Add an initial repository README that states `openstock` is the extracted MyStocks data-source runtime and that implementation requires approved OpenSpec scope.
+  - Repo-truth（2026-06-09）：初始提交 `446ddd3 docs: bootstrap openstock runtime repo` 仅包含 `README.md`。
+- [x] 2A.4 Do not copy source code from MyStocks into `openstock` until Phase 1 contract boundaries and approval are complete.
+  - Repo-truth（2026-06-09）：未向 `/opt/claude/openstock` 拷贝 MyStocks 源码；Phase 2 仅新增独立 REST/WebSocket runtime tracer bullet、contract tests、Dockerfile 与 `pyproject.toml`，提交为 `62e7cd7`。
+
+## 3. AkShare REST/Pull Pilot
+
+- [x] 3.1 Select one AkShare REST/pull category for the first provider/category migration.
+  - Repo-truth（2026-06-10）：首个 provider/category 选定为 AkShare A股实时行情/基础列表，MyStocks category 使用既有 `REALTIME_QUOTES`；openstock primary endpoint 为 `akshare.stock_zh_a_spot`。
+- [x] 3.2 Ensure route decisions are explainable and include fallback candidates.
+  - Repo-truth（2026-06-10）：`/routing/best` 返回 `reason=akshare_realtime_quotes_primary`，并暴露 `fallback_candidates=["akshare.stock_info_a_code_name", "legacy_mystocks_akshare", "local_cache"]`。
+- [x] 3.3 Ensure timeout, cache, fallback, circuit breaker, and metrics behavior are observable.
+  - Repo-truth（2026-06-10）：request payload 保留 `timeout_ms`；fetch response 暴露 `cache_state`、`quality_flags`、`circuit_state=closed`、`latency_ms`；真实 smoke 验证过 primary 成功路径，也验证过 primary 上游异常时可 fallback 到 `akshare.stock_info_a_code_name` 并通过 `quality_flags` 标注原因。
+- [x] 3.4 Add `tests/integration/data_source/test_akshare_runtime_pilot.py`.
+  - Repo-truth（2026-06-10）：MyStocks 侧新增 remote client AkShare runtime pilot tests；openstock 侧新增 `tests/test_akshare_runtime_pilot.py`。
+- [x] 3.5 Run:
+  - `pytest tests/integration/data_source/test_akshare_runtime_pilot.py -q --no-cov`
+  - Repo-truth（2026-06-10）：`pytest tests/integration/data_source/test_akshare_runtime_pilot.py -q --no-cov -p no:cacheprovider` 通过 `3 passed`；升级后的 `bash scripts/run_data_source_runtime_smoke.sh` 通过 openstock `9 passed`、真实 AkShare smoke、MyStocks remote client `5 passed`、MyStocks AkShare pilot `3 passed`。
+
+## 4. Realtime WebSocket Pilot
+
+- [x] 4.1 Add data-source runtime `/ws/market` stream for the selected realtime pilot.
+  - Repo-truth（2026-06-10）：`/opt/claude/openstock/openstock/app.py` 已将 `/ws/market` 升级为 AkShare realtime pilot stream，支持 subscribe ack、snapshot、quote.update、heartbeat、unsubscribe 与非法消息 error。
+- [x] 4.2 Preserve the main backend ability to proxy/bridge to existing `/ws/events` consumers during migration.
+  - Repo-truth（2026-06-10）：新增 `src/core/data_source/market_stream_bridge.py`，将 openstock stream message 映射为现有 `/ws/events` 语义通道：`events:market`、`events:market:{symbol}`、`events:system`；未改动既有 FastAPI WebSocket 路由。
+- [x] 4.3 Define message types: `subscribe`, `unsubscribe`, `snapshot`, `quote.update`, `heartbeat`, `error`.
+  - Repo-truth（2026-06-10）：openstock runtime contract 与 MyStocks bridge contract 均显式覆盖上述六类消息；control message 不广播到 `/ws/events` 消费者。
+- [x] 4.4 Add `tests/integration/data_source/test_market_stream_contract.py`.
+  - Repo-truth（2026-06-10）：MyStocks 新增 `tests/integration/data_source/test_market_stream_contract.py`；openstock 新增 `/opt/claude/openstock/tests/test_market_stream_contract.py` 并更新 runtime WebSocket contract。
+- [x] 4.5 Run:
+  - `pytest tests/integration/data_source/test_market_stream_contract.py -q --no-cov`
+  - Repo-truth（2026-06-10）：TDD 红灯已确认：openstock 初始失败为连接提前关闭/非法类型未识别；MyStocks 初始失败为缺少 bridge 模块。绿色验证：openstock websocket/runtime contract `6 passed`，MyStocks market stream bridge contract `5 passed`。
+  - Repo-truth（2026-06-10）：升级后的 `bash scripts/run_data_source_runtime_smoke.sh` 通过 openstock runtime/AkShare/market-stream `11 passed`、真实 AkShare smoke（`akshare.stock_zh_a_spot`）、MyStocks remote client `5 passed`、MyStocks AkShare pilot `3 passed`、MyStocks market stream bridge `5 passed`。
+  - Repo-truth（2026-06-10）：V2 前置回归矩阵保持 `42 passed`；`openspec validate extract-data-source-runtime-service --strict` 通过。
+
+## 5. MCP Diagnostics
+
+- [x] 5.1 Add stdio diagnostics MCP for local low-frequency admin tools if needed.
+  - Repo-truth（2026-06-10）：新增 `src/core/data_source/mcp_diagnostics.py`，`stdio` access mode 仅暴露 `get_data_source_health` 与 `explain_route_decision` 两个低频诊断工具，不暴露 fetch/batch/stream 热路径工具。
+- [x] 5.2 Add standalone remote MCP only as a diagnostics entrypoint that calls `DataSourceClient` or REST.
+  - Repo-truth（2026-06-10）：`standalone_remote` access mode 通过 `RemoteDataSourceClient`/REST `/routing/best` 解释 route decision；contract test 验证不会调用 `/data/fetch`、batch 或 stream。
+- [x] 5.3 Add mounted MCP only if it reuses the same `DataSourceRuntime`.
+  - Repo-truth（2026-06-10）：`mounted` access mode 要求传入既有 runtime client，并记录/返回同一 `runtime_identity`；未创建 provider 直连或第二套运行时。
+- [x] 5.4 Add `tests/integration/data_source/test_mcp_access_modes.py`.
+  - Repo-truth（2026-06-10）：新增 MCP access mode contract tests，覆盖 stdio、standalone remote、mounted 以及 `fetch_snapshot`、`fetch_batch`、`stream_market`、`subscribe_market` 热路径拒绝。
+- [x] 5.5 Run:
+  - `pytest tests/integration/data_source/test_mcp_access_modes.py -q --no-cov`
+  - Repo-truth（2026-06-10）：TDD 红灯为缺少 `src.core.data_source.mcp_diagnostics`；实现后 `pytest tests/integration/data_source/test_mcp_access_modes.py -q --no-cov -p no:cacheprovider` 通过 `8 passed`。
+  - Repo-truth（2026-06-10）：扩展后的 `bash scripts/run_data_source_runtime_smoke.sh` 通过 openstock runtime/AkShare/market-stream `11 passed`、真实 AkShare smoke（`akshare.stock_zh_a_spot`）、MyStocks remote client `5 passed`、AkShare pilot `3 passed`、market stream bridge `5 passed`、MCP access modes `8 passed`。
+  - Repo-truth（2026-06-10）：data-source Phase 1-5 组合验证 `30 passed`；V2 前置回归矩阵保持 `42 passed`；`openspec validate extract-data-source-runtime-service --strict` 通过。
+
+## 6. Old Path Closure
+
+- [x] 6.1 Migrate `adapter_priority_config.yaml` semantics into registry/routing policy after remote mode is stable.
+  - Repo-truth（2026-06-10）：新增 `src/core/data_source/closure_policy.py`，将 `config/adapter_priority_config.yaml` 解释为 runtime registry/routing 的 fallback seed policy；`REALTIME_QUOTES` 映射到 legacy `realtime_quote` 顺序 `tdx -> customer -> akshare`，未知 category 回退到 `default`。
+- [x] 6.2 Demote YAML registry to seed/fallback only.
+  - Repo-truth（2026-06-10）：closure policy 显式声明 `runtime_truth_source=openstock_runtime`、`yaml_registry_role=seed_or_fallback`，不再把 YAML registry 判定为运行时真相源。
+- [x] 6.3 Keep old manager/config paths as thin compatibility wrappers until closure evidence is complete.
+  - Repo-truth（2026-06-10）：Phase 6 未删除旧 manager/config 路径，policy 中 `retired_paths=()` 且 `compatibility_wrappers_retained=True`；旧路径保留为兼容/回滚边界。
+- [x] 6.4 Add `tests/integration/data_source/test_data_source_public_api_parity.py`.
+  - Repo-truth（2026-06-10）：新增 public API parity/closure tests，覆盖 legacy priority seed、openstock remote registry contract、YAML seed/fallback role 与旧路径未退役。
+- [x] 6.5 Run:
+  - `pytest tests/integration/data_source/test_data_source_public_api_parity.py -q --no-cov`
+  - `openspec validate extract-data-source-runtime-service --strict`
+  - Repo-truth（2026-06-10）：TDD 红灯为缺少 `src.core.data_source.closure_policy`；实现后 `pytest tests/integration/data_source/test_data_source_public_api_parity.py -q --no-cov -p no:cacheprovider` 通过 `3 passed`。
+  - Repo-truth（2026-06-10）：data-source Phase 1-6 组合验证 `33 passed`；扩展后的 `bash scripts/run_data_source_runtime_smoke.sh` 通过 openstock `11 passed`、真实 AkShare smoke、MyStocks remote `5 passed`、AkShare pilot `3 passed`、market stream `5 passed`、MCP access modes `8 passed`、public parity `3 passed`；V2 前置回归矩阵保持 `42 passed`。
+- [ ] 6.6 Archive the change only after implementation tasks, parity evidence, runtime smoke, and rollback evidence are complete.

--- a/scripts/run_data_source_runtime_smoke.sh
+++ b/scripts/run_data_source_runtime_smoke.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OPENSTOCK_DIR="${OPENSTOCK_DIR:-/opt/claude/openstock}"
+export MPLCONFIGDIR="${MPLCONFIGDIR:-/tmp/matplotlib-openstock-smoke}"
+
+if [[ ! -d "${OPENSTOCK_DIR}" ]]; then
+  echo "openstock directory not found: ${OPENSTOCK_DIR}" >&2
+  exit 1
+fi
+
+(
+  cd "${OPENSTOCK_DIR}"
+  pytest tests/test_runtime_contract.py tests/test_akshare_runtime_pilot.py tests/test_market_stream_contract.py -q -p no:timing -p no:tdd-guard -p no:cacheprovider
+
+  if [[ "${OPENSTOCK_SKIP_AKSHARE_REAL_SMOKE:-0}" != "1" ]]; then
+    python - <<'PY'
+import contextlib
+import io
+
+from fastapi.testclient import TestClient
+
+from openstock.app import create_app
+
+buffer = io.StringIO()
+with contextlib.redirect_stdout(buffer), contextlib.redirect_stderr(buffer):
+    response = TestClient(create_app()).post(
+        "/data/fetch",
+        json={
+            "data_category": "REALTIME_QUOTES",
+            "params": {"limit": 1},
+            "request_id": "smoke-akshare-real",
+            "timeout_ms": 15000,
+        },
+    )
+
+response.raise_for_status()
+payload = response.json()
+assert payload["source"] == "akshare", payload
+assert payload["endpoint_name"] in {"akshare.stock_zh_a_spot", "akshare.stock_info_a_code_name"}, payload
+assert payload["data"], payload
+assert payload["data"][0].get("symbol"), payload["data"][0]
+print(
+    "openstock akshare real smoke passed:",
+    payload["endpoint_name"],
+    payload["data"][0].get("symbol"),
+    payload["data"][0].get("name"),
+    payload["quality_flags"],
+)
+PY
+  fi
+)
+
+pytest tests/integration/data_source/test_remote_data_source_client_contract.py -q --no-cov -p no:cacheprovider
+pytest tests/integration/data_source/test_akshare_runtime_pilot.py -q --no-cov -p no:cacheprovider
+pytest tests/integration/data_source/test_market_stream_contract.py -q --no-cov -p no:cacheprovider
+pytest tests/integration/data_source/test_mcp_access_modes.py -q --no-cov -p no:cacheprovider
+pytest tests/integration/data_source/test_data_source_public_api_parity.py -q --no-cov -p no:cacheprovider

--- a/src/core/data_source/__init__.py
+++ b/src/core/data_source/__init__.py
@@ -16,13 +16,55 @@ Data Source Manager子模块
 
 from __future__ import annotations
 
+import importlib
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from src.core.data_source.base import DataSourceManagerV2
     from src.core.data_source.cache import LRUCache
+    from src.core.data_source.client import (
+        CircuitOpenError,
+        DataQualityFailedError,
+        DataSourceClient,
+        DataSourceClientError,
+        DataSourceRequest,
+        DataSourceResult,
+        DataSourceTransport,
+        InvalidRequestError,
+        LocalDataSourceClient,
+        ProviderTimeoutError,
+        ProviderUnavailableError,
+        RateLimitedError,
+        RegistryNotFoundError,
+        RemoteDataSourceClient,
+        RouteDecision,
+        UrlLibJsonTransport,
+        create_data_source_client,
+    )
 
-__all__ = ["DataSourceManagerV2", "LRUCache"]
+__all__ = [
+    "DataSourceManagerV2",
+    "LRUCache",
+    "CircuitOpenError",
+    "DataQualityFailedError",
+    "DataSourceClient",
+    "DataSourceClientError",
+    "DataSourceRequest",
+    "DataSourceResult",
+    "DataSourceTransport",
+    "InvalidRequestError",
+    "LocalDataSourceClient",
+    "ProviderTimeoutError",
+    "ProviderUnavailableError",
+    "RateLimitedError",
+    "RegistryNotFoundError",
+    "RemoteDataSourceClient",
+    "RouteDecision",
+    "UrlLibJsonTransport",
+    "create_data_source_client",
+]
+
+_CLIENT_EXPORTS = set(__all__[2:])
 
 
 def __getattr__(name: str) -> Any:
@@ -35,5 +77,9 @@ def __getattr__(name: str) -> Any:
         from src.core.data_source.cache import LRUCache
 
         return LRUCache
+
+    if name in _CLIENT_EXPORTS:
+        client_module = importlib.import_module("src.core.data_source.client")
+        return getattr(client_module, name)
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/core/data_source/client.py
+++ b/src/core/data_source/client.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Mapping, Protocol, Sequence
+
+CacheState = str
+
+
+@dataclass(frozen=True)
+class DataSourceRequest:
+    data_category: str
+    params: Mapping[str, Any] = field(default_factory=dict)
+    request_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    timeout_ms: int | None = None
+    freshness_ms: int | None = None
+
+
+@dataclass(frozen=True)
+class RouteDecision:
+    data_category: str
+    endpoint_name: str
+    source: str
+    endpoint_info: Mapping[str, Any]
+    route_decision_id: str
+    fallback_candidates: Sequence[str] = field(default_factory=tuple)
+    reason: str = "best_endpoint"
+
+
+@dataclass(frozen=True)
+class DataSourceResult:
+    data: Any
+    source: str
+    endpoint_name: str
+    route_decision_id: str
+    request_id: str
+    exchange_time: Any
+    received_at: str
+    staleness_ms: int
+    cache_state: CacheState
+    quality_flags: list[str]
+    latency_ms: float
+
+
+class DataSourceClientError(RuntimeError):
+    error_type = "DataSourceClientError"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        request_id: str,
+        endpoint_name: str | None = None,
+        route_decision_id: str | None = None,
+        cause: Exception | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.request_id = request_id
+        self.endpoint_name = endpoint_name
+        self.route_decision_id = route_decision_id
+        self.__cause__ = cause
+
+
+class ProviderUnavailableError(DataSourceClientError):
+    error_type = "ProviderUnavailable"
+
+
+class ProviderTimeoutError(DataSourceClientError):
+    error_type = "ProviderTimeout"
+
+
+class RateLimitedError(DataSourceClientError):
+    error_type = "RateLimited"
+
+
+class CircuitOpenError(DataSourceClientError):
+    error_type = "CircuitOpen"
+
+
+class RegistryNotFoundError(DataSourceClientError):
+    error_type = "RegistryNotFound"
+
+
+class InvalidRequestError(DataSourceClientError):
+    error_type = "InvalidRequest"
+
+
+class DataQualityFailedError(DataSourceClientError):
+    error_type = "DataQualityFailed"
+
+
+class DataSourceClient(Protocol):
+    def resolve_route(self, request: DataSourceRequest) -> RouteDecision: ...
+
+    def fetch_snapshot(self, request: DataSourceRequest) -> DataSourceResult: ...
+
+    def fetch_batch(self, requests: Sequence[DataSourceRequest]) -> list[DataSourceResult]: ...
+
+
+class DataSourceTransport(Protocol):
+    def post_json(self, path: str, payload: dict[str, Any], timeout_ms: int | None = None) -> Mapping[str, Any]: ...
+
+
+class UrlLibJsonTransport:
+    def __init__(self, base_url: str) -> None:
+        self._base_url = base_url.rstrip("/")
+
+    def post_json(self, path: str, payload: dict[str, Any], timeout_ms: int | None = None) -> Mapping[str, Any]:
+        body = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self._base_url}{path}",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        timeout = None if timeout_ms is None else timeout_ms / 1000
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                response_body = response.read().decode("utf-8")
+        except TimeoutError:
+            raise
+        except urllib.error.URLError as exc:
+            if isinstance(exc.reason, TimeoutError):
+                raise exc.reason
+            raise ProviderUnavailableError(
+                f"Remote data-source runtime request failed: {exc}",
+                request_id=str(payload.get("request_id") or ""),
+                cause=exc,
+            ) from exc
+        return json.loads(response_body)
+
+
+class LocalDataSourceClient:
+    def __init__(self, manager: Any | None = None) -> None:
+        if manager is None:
+            from src.core.data_source.base import DataSourceManagerV2
+
+            manager = DataSourceManagerV2()
+        self._manager = manager
+
+    def resolve_route(self, request: DataSourceRequest) -> RouteDecision:
+        if not request.data_category.strip():
+            raise InvalidRequestError(
+                "data_category is required",
+                request_id=request.request_id,
+            )
+
+        endpoint_info = self._manager.get_best_endpoint(request.data_category)
+        if not endpoint_info:
+            raise RegistryNotFoundError(
+                f"No data-source endpoint found for category {request.data_category}",
+                request_id=request.request_id,
+            )
+
+        endpoint_name = _endpoint_name(endpoint_info)
+        source = _source_name(endpoint_info)
+        return RouteDecision(
+            data_category=request.data_category,
+            endpoint_name=endpoint_name,
+            source=source,
+            endpoint_info=endpoint_info,
+            route_decision_id=f"route-{request.request_id}-{endpoint_name}",
+            fallback_candidates=tuple(_fallback_candidates(endpoint_info)),
+        )
+
+    def fetch_snapshot(self, request: DataSourceRequest) -> DataSourceResult:
+        started = time.perf_counter()
+        route = self.resolve_route(request)
+        try:
+            data = self._manager._call_endpoint(route.endpoint_info, **dict(request.params))
+        except TimeoutError as exc:
+            raise ProviderTimeoutError(
+                f"Provider timed out for endpoint {route.endpoint_name}",
+                request_id=request.request_id,
+                endpoint_name=route.endpoint_name,
+                route_decision_id=route.route_decision_id,
+                cause=exc,
+            ) from exc
+        except DataSourceClientError:
+            raise
+        except Exception as exc:
+            error_class = _typed_error_class(exc)
+            raise error_class(
+                f"{error_class.error_type} for endpoint {route.endpoint_name}: {exc}",
+                request_id=request.request_id,
+                endpoint_name=route.endpoint_name,
+                route_decision_id=route.route_decision_id,
+                cause=exc,
+            ) from exc
+
+        latency_ms = (time.perf_counter() - started) * 1000
+        return DataSourceResult(
+            data=data,
+            source=route.source,
+            endpoint_name=route.endpoint_name,
+            route_decision_id=route.route_decision_id,
+            request_id=request.request_id,
+            exchange_time=_exchange_time(data),
+            received_at=datetime.now(timezone.utc).isoformat(),
+            staleness_ms=_staleness_ms(route.endpoint_info),
+            cache_state=_cache_state(route.endpoint_info),
+            quality_flags=_quality_flags(route.endpoint_info),
+            latency_ms=latency_ms,
+        )
+
+    def fetch_batch(self, requests: Sequence[DataSourceRequest]) -> list[DataSourceResult]:
+        return [self.fetch_snapshot(request) for request in requests]
+
+
+class RemoteDataSourceClient:
+    def __init__(self, base_url: str, transport: DataSourceTransport | None = None) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._transport = transport or UrlLibJsonTransport(self._base_url)
+
+    def resolve_route(self, request: DataSourceRequest) -> RouteDecision:
+        if not request.data_category.strip():
+            raise InvalidRequestError(
+                "data_category is required",
+                request_id=request.request_id,
+            )
+        try:
+            payload = self._transport.post_json("/routing/best", _request_payload(request), request.timeout_ms)
+        except TimeoutError as exc:
+            raise ProviderTimeoutError(
+                "Remote data-source runtime route request timed out",
+                request_id=request.request_id,
+                cause=exc,
+            ) from exc
+        except DataSourceClientError:
+            raise
+        except Exception as exc:
+            raise ProviderUnavailableError(
+                f"Remote data-source runtime route request failed: {exc}",
+                request_id=request.request_id,
+                cause=exc,
+            ) from exc
+        return _route_decision_from_payload(request, payload)
+
+    def fetch_snapshot(self, request: DataSourceRequest) -> DataSourceResult:
+        if not request.data_category.strip():
+            raise InvalidRequestError(
+                "data_category is required",
+                request_id=request.request_id,
+            )
+        try:
+            payload = self._transport.post_json("/data/fetch", _request_payload(request), request.timeout_ms)
+        except TimeoutError as exc:
+            raise ProviderTimeoutError(
+                "Remote data-source runtime fetch request timed out",
+                request_id=request.request_id,
+                cause=exc,
+            ) from exc
+        except DataSourceClientError:
+            raise
+        except Exception as exc:
+            error_class = _typed_error_class(exc)
+            raise error_class(
+                f"{error_class.error_type} from remote data-source runtime: {exc}",
+                request_id=request.request_id,
+                cause=exc,
+            ) from exc
+        return _result_from_payload(request, payload)
+
+    def fetch_batch(self, requests: Sequence[DataSourceRequest]) -> list[DataSourceResult]:
+        request_list = list(requests)
+        timeout_ms = max(
+            (request.timeout_ms for request in request_list if request.timeout_ms is not None),
+            default=None,
+        )
+        try:
+            payload = self._transport.post_json(
+                "/data/batch",
+                {"requests": [_request_payload(request) for request in request_list]},
+                timeout_ms,
+            )
+        except TimeoutError as exc:
+            raise ProviderTimeoutError(
+                "Remote data-source runtime batch request timed out",
+                request_id="batch",
+                cause=exc,
+            ) from exc
+        except DataSourceClientError:
+            raise
+        except Exception as exc:
+            error_class = _typed_error_class(exc)
+            raise error_class(
+                f"{error_class.error_type} from remote data-source runtime batch: {exc}",
+                request_id="batch",
+                cause=exc,
+            ) from exc
+
+        result_payloads = payload.get("results") or []
+        return [
+            _result_from_payload(request, result_payload)
+            for request, result_payload in zip(request_list, result_payloads, strict=False)
+        ]
+
+
+def create_data_source_client(
+    *,
+    mode: str | None = None,
+    manager: Any | None = None,
+    base_url: str | None = None,
+    transport: DataSourceTransport | None = None,
+) -> DataSourceClient:
+    selected_mode = (mode or os.getenv("DATA_SOURCE_CLIENT_MODE") or "local").strip().lower()
+    if selected_mode == "local":
+        return LocalDataSourceClient(manager=manager)
+    if selected_mode == "remote":
+        resolved_base_url = base_url or os.getenv("OPENSTOCK_BASE_URL") or "http://localhost:8031"
+        return RemoteDataSourceClient(base_url=resolved_base_url, transport=transport)
+    raise InvalidRequestError(
+        f"Unsupported DATA_SOURCE_CLIENT_MODE: {selected_mode}",
+        request_id="create-data-source-client",
+    )
+
+
+def _request_payload(request: DataSourceRequest) -> dict[str, Any]:
+    return {
+        "data_category": request.data_category,
+        "params": dict(request.params),
+        "request_id": request.request_id,
+        "timeout_ms": request.timeout_ms,
+        "freshness_ms": request.freshness_ms,
+    }
+
+
+def _route_decision_from_payload(request: DataSourceRequest, payload: Mapping[str, Any]) -> RouteDecision:
+    endpoint_info = payload.get("endpoint_info") or {
+        "endpoint_name": payload.get("endpoint_name"),
+        "source": payload.get("source"),
+    }
+    return RouteDecision(
+        data_category=str(payload.get("data_category") or request.data_category),
+        endpoint_name=str(payload.get("endpoint_name") or _endpoint_name(endpoint_info)),
+        source=str(payload.get("source") or _source_name(endpoint_info)),
+        endpoint_info=endpoint_info,
+        route_decision_id=str(payload.get("route_decision_id") or f"route-{request.request_id}"),
+        fallback_candidates=tuple(str(candidate) for candidate in payload.get("fallback_candidates") or []),
+        reason=str(payload.get("reason") or "remote_runtime"),
+    )
+
+
+def _result_from_payload(request: DataSourceRequest, payload: Mapping[str, Any]) -> DataSourceResult:
+    return DataSourceResult(
+        data=payload.get("data"),
+        source=str(payload.get("source") or "unknown"),
+        endpoint_name=str(payload.get("endpoint_name") or "unknown"),
+        route_decision_id=str(payload.get("route_decision_id") or f"route-{request.request_id}"),
+        request_id=str(payload.get("request_id") or request.request_id),
+        exchange_time=payload.get("exchange_time"),
+        received_at=str(payload.get("received_at") or datetime.now(timezone.utc).isoformat()),
+        staleness_ms=_coerce_non_negative_int(payload.get("staleness_ms", 0)),
+        cache_state=_coerce_cache_state(payload.get("cache_state")),
+        quality_flags=[str(flag) for flag in payload.get("quality_flags") or []],
+        latency_ms=float(payload.get("latency_ms") or 0.0),
+    )
+
+
+def _endpoint_name(endpoint_info: Mapping[str, Any]) -> str:
+    value = (
+        endpoint_info.get("endpoint_name")
+        or endpoint_info.get("name")
+        or endpoint_info.get("api_name")
+        or endpoint_info.get("id")
+    )
+    return str(value or "unknown")
+
+
+def _source_name(endpoint_info: Mapping[str, Any]) -> str:
+    value = endpoint_info.get("source") or endpoint_info.get("provider") or endpoint_info.get("data_source")
+    return str(value or "unknown")
+
+
+def _fallback_candidates(endpoint_info: Mapping[str, Any]) -> list[str]:
+    candidates = endpoint_info.get("fallback_candidates") or endpoint_info.get("fallbacks") or []
+    return [str(candidate) for candidate in candidates]
+
+
+def _cache_state(endpoint_info: Mapping[str, Any]) -> CacheState:
+    return _coerce_cache_state(endpoint_info.get("cache_state"))
+
+
+def _coerce_cache_state(value: Any) -> CacheState:
+    state = str(value or "miss")
+    if state not in {"fresh", "stale", "miss", "bypass"}:
+        return "miss"
+    return state
+
+
+def _quality_flags(endpoint_info: Mapping[str, Any]) -> list[str]:
+    flags = endpoint_info.get("quality_flags") or []
+    return [str(flag) for flag in flags]
+
+
+def _staleness_ms(endpoint_info: Mapping[str, Any]) -> int:
+    return _coerce_non_negative_int(endpoint_info.get("staleness_ms", 0))
+
+
+def _coerce_non_negative_int(value: Any) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _exchange_time(data: Any) -> Any:
+    if isinstance(data, Mapping):
+        return data.get("exchange_time")
+    return None
+
+
+def _typed_error_class(exc: Exception) -> type[DataSourceClientError]:
+    marker = f"{exc.__class__.__name__} {exc}".lower()
+    if "rate" in marker and "limit" in marker:
+        return RateLimitedError
+    if "circuit" in marker:
+        return CircuitOpenError
+    if "quality" in marker or "validation" in marker:
+        return DataQualityFailedError
+    return ProviderUnavailableError

--- a/src/core/data_source/closure_policy.py
+++ b/src/core/data_source/closure_policy.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+LEGACY_DATA_CATEGORY_ALIASES = {
+    "REALTIME_QUOTES": "realtime_quote",
+    "DAILY_KLINE": "daily_kline",
+    "FINANCIAL_DATA": "financial_data",
+    "TECHNICAL_INDICATORS": "technical_indicators",
+    "NEWS_DATA": "news_data",
+}
+
+
+@dataclass(frozen=True)
+class RegistryClosurePolicy:
+    """Compatibility policy for moving legacy priority semantics to runtime routing."""
+
+    runtime_truth_source: str
+    yaml_registry_role: str
+    legacy_priority_role: str
+    source_order_by_category: Mapping[str, tuple[str, ...]]
+    remote_runtime_entries: tuple[str, ...]
+    retired_paths: tuple[str, ...] = ()
+    compatibility_wrappers_retained: bool = True
+
+    def fallback_sources_for_data_category(self, data_category: str) -> tuple[str, ...]:
+        category_key = LEGACY_DATA_CATEGORY_ALIASES.get(data_category.strip().upper(), data_category.strip().lower())
+        return self.source_order_by_category.get(
+            category_key,
+            self.source_order_by_category.get("default", ()),
+        )
+
+    def route_policy_for_entry(self, entry: Mapping[str, Any]) -> dict[str, Any]:
+        remote_runtime = entry.get("remote_runtime")
+        remote_runtime = remote_runtime if isinstance(remote_runtime, Mapping) else {}
+        data_category = _text(entry.get("data_category"))
+        return {
+            "primary_source": _text(entry.get("source_name")),
+            "data_category": data_category,
+            "runtime_transport": _text(remote_runtime.get("transport")),
+            "route_path": _text(remote_runtime.get("route_path")),
+            "fetch_path": _text(remote_runtime.get("fetch_path")),
+            "fallback_seed_sources": self.fallback_sources_for_data_category(data_category),
+        }
+
+
+def build_registry_closure_policy(
+    *,
+    registry: Mapping[str, Any],
+    adapter_priority_config: Mapping[str, Any],
+) -> RegistryClosurePolicy:
+    data_sources = registry.get("data_sources")
+    data_sources = data_sources if isinstance(data_sources, Mapping) else {}
+    return RegistryClosurePolicy(
+        runtime_truth_source="openstock_runtime",
+        yaml_registry_role="seed_or_fallback",
+        legacy_priority_role="fallback_seed",
+        source_order_by_category=_normalize_priority_config(adapter_priority_config),
+        remote_runtime_entries=tuple(
+            name
+            for name, entry in data_sources.items()
+            if isinstance(entry, Mapping) and _text(entry.get("source_type")) == "remote_runtime"
+        ),
+    )
+
+
+def _normalize_priority_config(
+    adapter_priority_config: Mapping[str, Any],
+) -> dict[str, tuple[str, ...]]:
+    normalized: dict[str, tuple[str, ...]] = {}
+    for category, sources in adapter_priority_config.items():
+        if isinstance(sources, list | tuple):
+            normalized[str(category)] = tuple(_text(source) for source in sources)
+    return normalized
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()

--- a/src/core/data_source/market_stream_bridge.py
+++ b/src/core/data_source/market_stream_bridge.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+OPENSTOCK_MARKET_STREAM_MESSAGE_TYPES = (
+    "subscribe",
+    "unsubscribe",
+    "snapshot",
+    "quote.update",
+    "heartbeat",
+    "error",
+)
+
+
+def bridge_openstock_market_message(
+    message: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    """Map openstock market stream messages to existing MyStocks ws-events events."""
+    message_type = str(message.get("type") or "")
+    if message_type in {"subscribe", "unsubscribe"}:
+        return []
+    if message_type == "snapshot":
+        return [_bridge_snapshot(message)]
+    if message_type == "quote.update":
+        return [_bridge_quote_update(message)]
+    if message_type == "heartbeat":
+        return [_bridge_heartbeat(message)]
+    if message_type == "error":
+        return [_bridge_error(message)]
+    return []
+
+
+def _bridge_snapshot(message: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "market.data.update",
+        "channels": ["events:market"],
+        "payload": {
+            "source": "openstock",
+            "request_id": _text(message.get("request_id")),
+            "quotes": list(message.get("quotes") or []),
+            "provider": _text(message.get("source")),
+            "endpoint_name": _text(message.get("endpoint_name")),
+            "quality_flags": list(message.get("quality_flags") or []),
+        },
+    }
+
+
+def _bridge_quote_update(message: Mapping[str, Any]) -> dict[str, Any]:
+    quote = dict(message.get("quote") or {})
+    symbol = _text(quote.get("symbol"))
+    channels = ["events:market"]
+    if symbol:
+        channels.append(f"events:market:{symbol}")
+
+    return {
+        "type": "market.price.update",
+        "channels": channels,
+        "payload": {
+            "source": "openstock",
+            "request_id": _text(message.get("request_id")),
+            "quote": quote,
+            "provider": _text(message.get("source")),
+            "endpoint_name": _text(message.get("endpoint_name")),
+            "quality_flags": list(message.get("quality_flags") or []),
+        },
+    }
+
+
+def _bridge_heartbeat(message: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "openstock.heartbeat",
+        "channels": ["events:system"],
+        "payload": {
+            "source": "openstock",
+            "request_id": _text(message.get("request_id")),
+            "stream": _text(message.get("stream")),
+            "ts": _text(message.get("ts")),
+        },
+    }
+
+
+def _bridge_error(message: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "openstock.error",
+        "channels": ["events:system"],
+        "payload": {
+            "source": "openstock",
+            "request_id": _text(message.get("request_id")),
+            "stream": _text(message.get("stream")),
+            "code": _text(message.get("code")),
+            "message": _text(message.get("message")),
+        },
+    }
+
+
+def _text(value: Any) -> str:
+    return str(value or "")

--- a/src/core/data_source/mcp_diagnostics.py
+++ b/src/core/data_source/mcp_diagnostics.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from src.core.data_source.client import (
+    DataSourceClient,
+    DataSourceRequest,
+    DataSourceTransport,
+    RemoteDataSourceClient,
+    RouteDecision,
+    create_data_source_client,
+)
+
+DATA_SOURCE_MCP_ACCESS_MODES = ("stdio", "standalone_remote", "mounted")
+DATA_SOURCE_MCP_TOOL_NAMES = (
+    "get_data_source_health",
+    "explain_route_decision",
+)
+DATA_SOURCE_MCP_HOT_PATH_TOOL_DENYLIST = (
+    "fetch_snapshot",
+    "fetch_batch",
+    "stream_market",
+    "subscribe_market",
+)
+
+
+class MCPDiagnosticsError(RuntimeError):
+    """Raised when a diagnostics MCP tool request violates the access contract."""
+
+
+@dataclass(frozen=True)
+class DataSourceMCPDiagnostics:
+    """Diagnostic/admin tool surface shared by future MCP transports."""
+
+    access_mode: str
+    transport: str
+    client: DataSourceClient
+    runtime_identity: int | str
+
+    def tools(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": "get_data_source_health",
+                "description": "Return diagnostics-plane health without fetching market data.",
+                "access_mode": self.access_mode,
+                "transport": self.transport,
+                "hot_path": False,
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"request_id": {"type": "string"}},
+                },
+            },
+            {
+                "name": "explain_route_decision",
+                "description": "Resolve and explain the route decision for a data category.",
+                "access_mode": self.access_mode,
+                "transport": self.transport,
+                "hot_path": False,
+                "input_schema": {
+                    "type": "object",
+                    "required": ["data_category"],
+                    "properties": {
+                        "data_category": {"type": "string"},
+                        "params": {"type": "object"},
+                        "request_id": {"type": "string"},
+                        "timeout_ms": {"type": "integer"},
+                    },
+                },
+            },
+        ]
+
+    def call_tool(self, tool_name: str, arguments: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        args = arguments or {}
+        if tool_name in DATA_SOURCE_MCP_HOT_PATH_TOOL_DENYLIST:
+            raise MCPDiagnosticsError(f"MCP diagnostics do not expose hot-path tool: {tool_name}")
+        if tool_name == "get_data_source_health":
+            return self._health_result(args)
+        if tool_name == "explain_route_decision":
+            return self._route_result(args)
+        raise MCPDiagnosticsError(f"Unsupported MCP diagnostics tool: {tool_name}")
+
+    def _health_result(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        return {
+            "tool": "get_data_source_health",
+            "access_mode": self.access_mode,
+            "transport": self.transport,
+            "diagnostic": {
+                "status": "ready",
+                "scope": "diagnostics",
+                "request_id": _text(arguments.get("request_id"), "mcp-health"),
+                "runtime_identity": self.runtime_identity,
+                "hot_path": False,
+            },
+        }
+
+    def _route_result(self, arguments: Mapping[str, Any]) -> dict[str, Any]:
+        request = _request_from_arguments(arguments)
+        decision = self.client.resolve_route(request)
+        return {
+            "tool": "explain_route_decision",
+            "access_mode": self.access_mode,
+            "transport": self.transport,
+            "diagnostic": _route_decision_payload(decision),
+        }
+
+
+def create_data_source_mcp_diagnostics(
+    *,
+    access_mode: str,
+    client: DataSourceClient | None = None,
+    base_url: str | None = None,
+    transport: DataSourceTransport | None = None,
+) -> DataSourceMCPDiagnostics:
+    mode = access_mode.strip().lower()
+    if mode == "stdio":
+        diagnostics_client = client or create_data_source_client(mode="local")
+        return DataSourceMCPDiagnostics(
+            access_mode=mode,
+            transport="stdio",
+            client=diagnostics_client,
+            runtime_identity=id(diagnostics_client),
+        )
+    if mode == "standalone_remote":
+        resolved_base_url = base_url or os.getenv("OPENSTOCK_BASE_URL") or "http://localhost:8031"
+        diagnostics_client = client or RemoteDataSourceClient(
+            base_url=resolved_base_url,
+            transport=transport,
+        )
+        return DataSourceMCPDiagnostics(
+            access_mode=mode,
+            transport="streamable_http",
+            client=diagnostics_client,
+            runtime_identity=resolved_base_url,
+        )
+    if mode == "mounted":
+        if client is None:
+            raise MCPDiagnosticsError("mounted MCP diagnostics require a runtime client")
+        return DataSourceMCPDiagnostics(
+            access_mode=mode,
+            transport="mounted",
+            client=client,
+            runtime_identity=id(client),
+        )
+    raise MCPDiagnosticsError(f"Unsupported MCP diagnostics access mode: {access_mode}")
+
+
+def _request_from_arguments(arguments: Mapping[str, Any]) -> DataSourceRequest:
+    params = arguments.get("params")
+    return DataSourceRequest(
+        data_category=_text(arguments.get("data_category")),
+        params=params if isinstance(params, Mapping) else {},
+        request_id=_text(arguments.get("request_id"), "mcp-route"),
+        timeout_ms=_optional_int(arguments.get("timeout_ms")),
+    )
+
+
+def _route_decision_payload(decision: RouteDecision) -> dict[str, Any]:
+    return {
+        "data_category": decision.data_category,
+        "source": decision.source,
+        "endpoint_name": decision.endpoint_name,
+        "route_decision_id": decision.route_decision_id,
+        "fallback_candidates": list(decision.fallback_candidates),
+        "reason": decision.reason,
+    }
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _text(value: Any, default: str = "") -> str:
+    text = str(value or "").strip()
+    return text or default

--- a/tests/integration/data_source/test_akshare_runtime_pilot.py
+++ b/tests/integration/data_source/test_akshare_runtime_pilot.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from src.core.data_source import DataSourceRequest, RemoteDataSourceClient
+
+
+class AkShareRuntimeTransport:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any], int | None]] = []
+
+    def post_json(self, endpoint: str, payload: dict[str, Any], timeout_ms: int | None = None) -> dict[str, Any]:
+        self.calls.append((endpoint, payload, timeout_ms))
+        if endpoint == "/routing/best":
+            return {
+                "data_category": "REALTIME_QUOTES",
+                "endpoint_name": "akshare.stock_zh_a_spot",
+                "source": "akshare",
+                "endpoint_info": {
+                    "endpoint_name": "akshare.stock_zh_a_spot",
+                    "source": "akshare",
+                    "data_category": "REALTIME_QUOTES",
+                    "transport": "rest_pull",
+                },
+                "route_decision_id": "route-akshare",
+                "fallback_candidates": [
+                    "akshare.stock_info_a_code_name",
+                    "legacy_mystocks_akshare",
+                    "local_cache",
+                ],
+                "reason": "akshare_realtime_quotes_primary",
+            }
+        if endpoint == "/data/fetch":
+            return {
+                "data": [{"symbol": "000001", "name": "平安银行", "price": 10.5}],
+                "source": "akshare",
+                "endpoint_name": "akshare.stock_zh_a_spot",
+                "route_decision_id": "route-akshare",
+                "request_id": payload["request_id"],
+                "exchange_time": None,
+                "received_at": "2026-06-10T00:00:00+00:00",
+                "staleness_ms": 0,
+                "cache_state": "miss",
+                "quality_flags": [],
+                "latency_ms": 12.5,
+            }
+        raise AssertionError(f"unexpected endpoint: {endpoint}")
+
+
+def test_remote_client_preserves_akshare_runtime_contract_metadata():
+    transport = AkShareRuntimeTransport()
+    client = RemoteDataSourceClient("http://openstock.local", transport=transport)
+
+    result = client.fetch_snapshot(
+        DataSourceRequest(
+            data_category="REALTIME_QUOTES",
+            params={"limit": 1},
+            request_id="req-akshare-runtime",
+            timeout_ms=5000,
+        )
+    )
+
+    assert result.source == "akshare"
+    assert result.endpoint_name == "akshare.stock_zh_a_spot"
+    assert result.request_id == "req-akshare-runtime"
+    assert result.data == [{"symbol": "000001", "name": "平安银行", "price": 10.5}]
+    assert result.cache_state == "miss"
+    assert result.quality_flags == []
+    assert transport.calls == [
+        (
+            "/data/fetch",
+            {
+                "data_category": "REALTIME_QUOTES",
+                "params": {"limit": 1},
+                "request_id": "req-akshare-runtime",
+                "timeout_ms": 5000,
+                "freshness_ms": None,
+            },
+            5000,
+        )
+    ]
+
+
+def test_remote_client_exposes_akshare_route_fallback_candidates():
+    transport = AkShareRuntimeTransport()
+    client = RemoteDataSourceClient("http://openstock.local", transport=transport)
+
+    decision = client.resolve_route(DataSourceRequest(data_category="REALTIME_QUOTES", request_id="req-route"))
+
+    assert decision.source == "akshare"
+    assert decision.endpoint_name == "akshare.stock_zh_a_spot"
+    assert decision.reason == "akshare_realtime_quotes_primary"
+    assert decision.fallback_candidates == (
+        "akshare.stock_info_a_code_name",
+        "legacy_mystocks_akshare",
+        "local_cache",
+    )
+
+
+def test_openstock_akshare_remote_config_entry_exists():
+    registry_path = Path("config/data_sources_registry.yaml")
+    registry = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+
+    entry = registry["data_sources"]["openstock_akshare_realtime_quotes"]
+
+    assert entry["source_name"] == "openstock"
+    assert entry["source_type"] == "remote_runtime"
+    assert entry["endpoint_name"] == "akshare.stock_zh_a_spot"
+    assert entry["data_category"] == "REALTIME_QUOTES"
+    assert entry["remote_runtime"]["base_url_env"] == "OPENSTOCK_BASE_URL"
+    assert entry["remote_runtime"]["fetch_path"] == "/data/fetch"

--- a/tests/integration/data_source/test_data_source_public_api_parity.py
+++ b/tests/integration/data_source/test_data_source_public_api_parity.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from src.core.data_source.closure_policy import build_registry_closure_policy
+
+
+def _load_yaml(path: str) -> dict:
+    return yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+
+
+def test_legacy_adapter_priority_is_translated_to_registry_seed_policy():
+    policy = build_registry_closure_policy(
+        registry=_load_yaml("config/data_sources_registry.yaml"),
+        adapter_priority_config=_load_yaml("config/adapter_priority_config.yaml"),
+    )
+
+    assert policy.runtime_truth_source == "openstock_runtime"
+    assert policy.yaml_registry_role == "seed_or_fallback"
+    assert policy.legacy_priority_role == "fallback_seed"
+    assert policy.fallback_sources_for_data_category("REALTIME_QUOTES") == (
+        "tdx",
+        "customer",
+        "akshare",
+    )
+    assert policy.fallback_sources_for_data_category("DAILY_KLINE") == (
+        "tdx",
+        "akshare",
+        "baostock",
+    )
+    assert policy.fallback_sources_for_data_category("UNKNOWN_CATEGORY") == (
+        "tdx",
+        "akshare",
+        "baostock",
+        "tushare",
+        "financial",
+        "customer",
+        "byapi",
+    )
+
+
+def test_openstock_registry_entry_keeps_remote_contract_and_legacy_fallback_seed():
+    registry = _load_yaml("config/data_sources_registry.yaml")
+    policy = build_registry_closure_policy(
+        registry=registry,
+        adapter_priority_config=_load_yaml("config/adapter_priority_config.yaml"),
+    )
+    entry = registry["data_sources"]["openstock_akshare_realtime_quotes"]
+
+    route_policy = policy.route_policy_for_entry(entry)
+
+    assert "openstock_akshare_realtime_quotes" in policy.remote_runtime_entries
+    assert route_policy == {
+        "primary_source": "openstock",
+        "data_category": "REALTIME_QUOTES",
+        "runtime_transport": "rest",
+        "route_path": "/routing/best",
+        "fetch_path": "/data/fetch",
+        "fallback_seed_sources": ("tdx", "customer", "akshare"),
+    }
+
+
+def test_yaml_registry_remains_seed_fallback_and_does_not_claim_runtime_ownership():
+    policy = build_registry_closure_policy(
+        registry=_load_yaml("config/data_sources_registry.yaml"),
+        adapter_priority_config=_load_yaml("config/adapter_priority_config.yaml"),
+    )
+
+    assert policy.runtime_truth_source != "yaml_registry"
+    assert policy.yaml_registry_role == "seed_or_fallback"
+    assert policy.retired_paths == ()
+    assert policy.compatibility_wrappers_retained is True

--- a/tests/integration/data_source/test_market_stream_contract.py
+++ b/tests/integration/data_source/test_market_stream_contract.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from src.core.data_source.market_stream_bridge import (
+    OPENSTOCK_MARKET_STREAM_MESSAGE_TYPES,
+    bridge_openstock_market_message,
+)
+
+
+def test_openstock_market_stream_message_types_are_declared():
+    assert OPENSTOCK_MARKET_STREAM_MESSAGE_TYPES == (
+        "subscribe",
+        "unsubscribe",
+        "snapshot",
+        "quote.update",
+        "heartbeat",
+        "error",
+    )
+
+
+def test_snapshot_message_bridges_to_existing_ws_events_market_channel():
+    events = bridge_openstock_market_message(
+        {
+            "type": "snapshot",
+            "stream": "market",
+            "request_id": "req-stream",
+            "quotes": [{"symbol": "000001", "name": "平安银行", "price": 10.5}],
+            "source": "akshare",
+            "endpoint_name": "akshare.stock_zh_a_spot",
+            "quality_flags": [],
+        }
+    )
+
+    assert events == [
+        {
+            "type": "market.data.update",
+            "channels": ["events:market"],
+            "payload": {
+                "source": "openstock",
+                "request_id": "req-stream",
+                "quotes": [{"symbol": "000001", "name": "平安银行", "price": 10.5}],
+                "provider": "akshare",
+                "endpoint_name": "akshare.stock_zh_a_spot",
+                "quality_flags": [],
+            },
+        }
+    ]
+
+
+def test_quote_update_message_bridges_to_market_and_symbol_channels():
+    events = bridge_openstock_market_message(
+        {
+            "type": "quote.update",
+            "stream": "market",
+            "request_id": "req-stream",
+            "quote": {"symbol": "000001", "name": "平安银行", "price": 10.5},
+            "source": "akshare",
+            "endpoint_name": "akshare.stock_zh_a_spot",
+            "quality_flags": [],
+        }
+    )
+
+    assert events == [
+        {
+            "type": "market.price.update",
+            "channels": ["events:market", "events:market:000001"],
+            "payload": {
+                "source": "openstock",
+                "request_id": "req-stream",
+                "quote": {"symbol": "000001", "name": "平安银行", "price": 10.5},
+                "provider": "akshare",
+                "endpoint_name": "akshare.stock_zh_a_spot",
+                "quality_flags": [],
+            },
+        }
+    ]
+
+
+def test_heartbeat_and_error_messages_bridge_to_system_channel():
+    assert bridge_openstock_market_message(
+        {"type": "heartbeat", "stream": "market", "request_id": "req-stream", "ts": "2026-06-10T00:00:00Z"}
+    ) == [
+        {
+            "type": "openstock.heartbeat",
+            "channels": ["events:system"],
+            "payload": {
+                "source": "openstock",
+                "request_id": "req-stream",
+                "stream": "market",
+                "ts": "2026-06-10T00:00:00Z",
+            },
+        }
+    ]
+
+    assert bridge_openstock_market_message(
+        {
+            "type": "error",
+            "stream": "market",
+            "request_id": "req-error",
+            "code": "unsupported_message_type",
+            "message": "Unsupported message type: invalid",
+        }
+    ) == [
+        {
+            "type": "openstock.error",
+            "channels": ["events:system"],
+            "payload": {
+                "source": "openstock",
+                "request_id": "req-error",
+                "stream": "market",
+                "code": "unsupported_message_type",
+                "message": "Unsupported message type: invalid",
+            },
+        }
+    ]
+
+
+def test_control_messages_do_not_broadcast_to_ws_events_consumers():
+    assert bridge_openstock_market_message({"type": "subscribe", "request_id": "req-stream"}) == []
+    assert bridge_openstock_market_message({"type": "unsubscribe", "request_id": "req-stream"}) == []

--- a/tests/integration/data_source/test_mcp_access_modes.py
+++ b/tests/integration/data_source/test_mcp_access_modes.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import pytest
+
+from src.core.data_source.client import DataSourceRequest, RouteDecision
+from src.core.data_source.mcp_diagnostics import (
+    DATA_SOURCE_MCP_HOT_PATH_TOOL_DENYLIST,
+    DATA_SOURCE_MCP_TOOL_NAMES,
+    MCPDiagnosticsError,
+    create_data_source_mcp_diagnostics,
+)
+
+
+class FakeDataSourceClient:
+    def __init__(self) -> None:
+        self.route_requests: list[DataSourceRequest] = []
+        self.fetch_calls = 0
+        self.batch_calls = 0
+
+    def resolve_route(self, request: DataSourceRequest) -> RouteDecision:
+        self.route_requests.append(request)
+        return RouteDecision(
+            data_category=request.data_category,
+            endpoint_name="akshare.stock_zh_a_spot",
+            source="akshare",
+            endpoint_info={"transport": "rest_pull"},
+            route_decision_id=f"route-{request.request_id}",
+            fallback_candidates=("akshare.stock_info_a_code_name", "local_cache"),
+            reason="akshare_realtime_quotes_primary",
+        )
+
+    def fetch_snapshot(self, request: DataSourceRequest):  # pragma: no cover - guard only
+        self.fetch_calls += 1
+        raise AssertionError("MCP diagnostics must not call hot-path fetch_snapshot")
+
+    def fetch_batch(self, requests):  # pragma: no cover - guard only
+        self.batch_calls += 1
+        raise AssertionError("MCP diagnostics must not call hot-path fetch_batch")
+
+
+class FakeRemoteTransport:
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, dict]] = []
+
+    def post_json(self, path: str, payload: dict, timeout_ms: int | None = None) -> dict:
+        self.requests.append((path, payload))
+        assert timeout_ms == 1500
+        assert path == "/routing/best"
+        return {
+            "data_category": payload["data_category"],
+            "endpoint_name": "akshare.stock_zh_a_spot",
+            "source": "akshare",
+            "endpoint_info": {"transport": "rest_pull"},
+            "route_decision_id": f"route-{payload['request_id']}",
+            "fallback_candidates": ["akshare.stock_info_a_code_name", "local_cache"],
+            "reason": "akshare_realtime_quotes_primary",
+        }
+
+
+def test_mcp_diagnostics_declares_admin_tools_and_blocks_hot_path_tools():
+    assert DATA_SOURCE_MCP_TOOL_NAMES == (
+        "get_data_source_health",
+        "explain_route_decision",
+    )
+    assert DATA_SOURCE_MCP_HOT_PATH_TOOL_DENYLIST == (
+        "fetch_snapshot",
+        "fetch_batch",
+        "stream_market",
+        "subscribe_market",
+    )
+
+    diagnostics = create_data_source_mcp_diagnostics(access_mode="stdio", client=FakeDataSourceClient())
+
+    assert [tool["name"] for tool in diagnostics.tools()] == list(DATA_SOURCE_MCP_TOOL_NAMES)
+    assert all(tool["hot_path"] is False for tool in diagnostics.tools())
+
+
+def test_stdio_mcp_explains_route_without_fetching_data():
+    client = FakeDataSourceClient()
+    diagnostics = create_data_source_mcp_diagnostics(access_mode="stdio", client=client)
+
+    result = diagnostics.call_tool(
+        "explain_route_decision",
+        {
+            "data_category": "REALTIME_QUOTES",
+            "params": {"symbol": "000001"},
+            "request_id": "mcp-stdio",
+            "timeout_ms": 1500,
+        },
+    )
+
+    assert diagnostics.access_mode == "stdio"
+    assert diagnostics.transport == "stdio"
+    assert client.fetch_calls == 0
+    assert client.batch_calls == 0
+    assert client.route_requests[0].data_category == "REALTIME_QUOTES"
+    assert result == {
+        "tool": "explain_route_decision",
+        "access_mode": "stdio",
+        "transport": "stdio",
+        "diagnostic": {
+            "data_category": "REALTIME_QUOTES",
+            "source": "akshare",
+            "endpoint_name": "akshare.stock_zh_a_spot",
+            "route_decision_id": "route-mcp-stdio",
+            "fallback_candidates": [
+                "akshare.stock_info_a_code_name",
+                "local_cache",
+            ],
+            "reason": "akshare_realtime_quotes_primary",
+        },
+    }
+
+
+def test_standalone_remote_mcp_calls_rest_route_only():
+    transport = FakeRemoteTransport()
+    diagnostics = create_data_source_mcp_diagnostics(
+        access_mode="standalone_remote",
+        base_url="http://openstock.test",
+        transport=transport,
+    )
+
+    result = diagnostics.call_tool(
+        "explain_route_decision",
+        {
+            "data_category": "REALTIME_QUOTES",
+            "params": {"symbol": "000001"},
+            "request_id": "mcp-remote",
+            "timeout_ms": 1500,
+        },
+    )
+
+    assert diagnostics.access_mode == "standalone_remote"
+    assert diagnostics.transport == "streamable_http"
+    assert [path for path, _payload in transport.requests] == ["/routing/best"]
+    assert result["diagnostic"]["route_decision_id"] == "route-mcp-remote"
+
+
+def test_mounted_mcp_reuses_supplied_runtime_client_identity():
+    client = FakeDataSourceClient()
+    diagnostics = create_data_source_mcp_diagnostics(access_mode="mounted", client=client)
+
+    health = diagnostics.call_tool("get_data_source_health", {"request_id": "mcp-health"})
+    route = diagnostics.call_tool(
+        "explain_route_decision",
+        {"data_category": "REALTIME_QUOTES", "request_id": "mcp-mounted"},
+    )
+
+    assert diagnostics.access_mode == "mounted"
+    assert diagnostics.transport == "mounted"
+    assert diagnostics.runtime_identity == id(client)
+    assert health["diagnostic"]["runtime_identity"] == id(client)
+    assert route["diagnostic"]["route_decision_id"] == "route-mcp-mounted"
+
+
+@pytest.mark.parametrize("tool_name", DATA_SOURCE_MCP_HOT_PATH_TOOL_DENYLIST)
+def test_mcp_diagnostics_rejects_hot_path_tools(tool_name: str):
+    diagnostics = create_data_source_mcp_diagnostics(access_mode="stdio", client=FakeDataSourceClient())
+
+    with pytest.raises(MCPDiagnosticsError, match=f"hot-path tool: {tool_name}"):
+        diagnostics.call_tool(tool_name, {})

--- a/tests/integration/data_source/test_remote_data_source_client_contract.py
+++ b/tests/integration/data_source/test_remote_data_source_client_contract.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.core.data_source.client import (
+    DataSourceRequest,
+    LocalDataSourceClient,
+    ProviderTimeoutError,
+    RemoteDataSourceClient,
+    create_data_source_client,
+)
+
+
+class FakeTransport:
+    def __init__(self):
+        self.requests: list[tuple[str, dict[str, Any], int | None]] = []
+
+    def post_json(self, path: str, payload: dict[str, Any], timeout_ms: int | None = None) -> dict[str, Any]:
+        self.requests.append((path, payload, timeout_ms))
+        if path == "/routing/best":
+            return {
+                "data_category": payload["data_category"],
+                "endpoint_name": "akshare.daily_kline",
+                "source": "akshare",
+                "route_decision_id": "route-remote-1",
+                "fallback_candidates": ["baostock.daily_kline"],
+                "reason": "best_endpoint",
+                "endpoint_info": {"endpoint_name": "akshare.daily_kline", "source": "akshare"},
+            }
+        if path == "/data/fetch":
+            return {
+                "data": [{"symbol": "000001", "close": 10.5}],
+                "source": "akshare",
+                "endpoint_name": "akshare.daily_kline",
+                "route_decision_id": "route-remote-1",
+                "request_id": payload["request_id"],
+                "exchange_time": None,
+                "received_at": "2026-06-09T00:00:00+00:00",
+                "staleness_ms": 0,
+                "cache_state": "miss",
+                "quality_flags": [],
+                "latency_ms": 12.5,
+            }
+        if path == "/data/batch":
+            return {
+                "results": [
+                    {
+                        "data": [{"symbol": request["params"]["symbol"], "close": 10.5}],
+                        "source": "akshare",
+                        "endpoint_name": "akshare.daily_kline",
+                        "route_decision_id": f"route-{request['request_id']}",
+                        "request_id": request["request_id"],
+                        "exchange_time": None,
+                        "received_at": "2026-06-09T00:00:00+00:00",
+                        "staleness_ms": 0,
+                        "cache_state": "miss",
+                        "quality_flags": [],
+                        "latency_ms": 12.5,
+                    }
+                    for request in payload["requests"]
+                ]
+            }
+        raise AssertionError(f"unexpected path {path}")
+
+
+class TimeoutTransport(FakeTransport):
+    def post_json(self, path: str, payload: dict[str, Any], timeout_ms: int | None = None) -> dict[str, Any]:
+        raise TimeoutError("remote runtime timeout")
+
+
+def test_remote_client_fetch_snapshot_preserves_contract_metadata():
+    transport = FakeTransport()
+    client = RemoteDataSourceClient(base_url="http://openstock.local", transport=transport)
+
+    result = client.fetch_snapshot(
+        DataSourceRequest(
+            data_category="DAILY_KLINE",
+            params={"symbol": "000001"},
+            request_id="req-remote-1",
+            timeout_ms=500,
+        )
+    )
+
+    assert result.data == [{"symbol": "000001", "close": 10.5}]
+    assert result.source == "akshare"
+    assert result.endpoint_name == "akshare.daily_kline"
+    assert result.route_decision_id == "route-remote-1"
+    assert result.request_id == "req-remote-1"
+    assert result.received_at == "2026-06-09T00:00:00+00:00"
+    assert result.cache_state == "miss"
+    assert result.quality_flags == []
+    assert result.latency_ms == 12.5
+    assert transport.requests == [
+        (
+            "/data/fetch",
+            {
+                "data_category": "DAILY_KLINE",
+                "params": {"symbol": "000001"},
+                "request_id": "req-remote-1",
+                "timeout_ms": 500,
+                "freshness_ms": None,
+            },
+            500,
+        )
+    ]
+
+
+def test_remote_client_resolve_route_uses_runtime_route_endpoint():
+    transport = FakeTransport()
+    client = RemoteDataSourceClient(base_url="http://openstock.local", transport=transport)
+
+    decision = client.resolve_route(DataSourceRequest(data_category="DAILY_KLINE", request_id="req-route"))
+
+    assert decision.endpoint_name == "akshare.daily_kline"
+    assert decision.source == "akshare"
+    assert decision.route_decision_id == "route-remote-1"
+    assert decision.fallback_candidates == ("baostock.daily_kline",)
+    assert transport.requests == [
+        (
+            "/routing/best",
+            {
+                "data_category": "DAILY_KLINE",
+                "params": {},
+                "request_id": "req-route",
+                "timeout_ms": None,
+                "freshness_ms": None,
+            },
+            None,
+        )
+    ]
+
+
+def test_remote_client_maps_transport_timeout_to_provider_timeout():
+    client = RemoteDataSourceClient(base_url="http://openstock.local", transport=TimeoutTransport())
+
+    with pytest.raises(ProviderTimeoutError) as exc_info:
+        client.fetch_snapshot(DataSourceRequest(data_category="DAILY_KLINE", request_id="req-timeout"))
+
+    assert exc_info.value.error_type == "ProviderTimeout"
+    assert exc_info.value.request_id == "req-timeout"
+
+
+def test_remote_client_fetch_batch_uses_runtime_batch_endpoint():
+    transport = FakeTransport()
+    client = RemoteDataSourceClient(base_url="http://openstock.local", transport=transport)
+
+    results = client.fetch_batch(
+        [
+            DataSourceRequest(
+                data_category="DAILY_KLINE",
+                params={"symbol": "000001"},
+                request_id="req-batch-1",
+            ),
+            DataSourceRequest(
+                data_category="DAILY_KLINE",
+                params={"symbol": "000002"},
+                request_id="req-batch-2",
+            ),
+        ]
+    )
+
+    assert [result.request_id for result in results] == ["req-batch-1", "req-batch-2"]
+    assert [result.data[0]["symbol"] for result in results] == ["000001", "000002"]
+    assert transport.requests == [
+        (
+            "/data/batch",
+            {
+                "requests": [
+                    {
+                        "data_category": "DAILY_KLINE",
+                        "params": {"symbol": "000001"},
+                        "request_id": "req-batch-1",
+                        "timeout_ms": None,
+                        "freshness_ms": None,
+                    },
+                    {
+                        "data_category": "DAILY_KLINE",
+                        "params": {"symbol": "000002"},
+                        "request_id": "req-batch-2",
+                        "timeout_ms": None,
+                        "freshness_ms": None,
+                    },
+                ]
+            },
+            None,
+        )
+    ]
+
+
+def test_create_data_source_client_selects_local_or_remote(monkeypatch):
+    monkeypatch.setenv("DATA_SOURCE_CLIENT_MODE", "local")
+    assert isinstance(create_data_source_client(manager=object()), LocalDataSourceClient)
+
+    monkeypatch.setenv("DATA_SOURCE_CLIENT_MODE", "remote")
+    client = create_data_source_client(base_url="http://openstock.local", transport=FakeTransport())
+    assert isinstance(client, RemoteDataSourceClient)


### PR DESCRIPTION
## Summary

This PR lands the OpenStock data-source runtime migration boundary as a clean, reviewable branch based on `origin/wip/root-dirty-20260403`.

It includes:

- OpenSpec change `extract-data-source-runtime-service`
- architecture and feasibility reports for the OpenStock extraction
- `DataSourceClient` local/remote contract boundary
- OpenStock AkShare remote registry entry
- market stream bridge for existing MyStocks `/ws/events` semantics
- low-frequency MCP diagnostics contract that rejects data hot-path operations
- closure policy for keeping legacy registry/config paths as seed/fallback compatibility
- smoke script coverage for OpenStock runtime, AkShare pilot, market stream, diagnostics, and parity

## Validation

Run from `.worktrees/dev-openstock-runtime-migration-review`:

- `pytest tests/integration/data_source/test_remote_data_source_client_contract.py tests/api/file_tests/test_data_source_config_api.py tests/api/file_tests/test_data_source_registry_api.py tests/integration/data_source/test_akshare_runtime_pilot.py tests/integration/data_source/test_market_stream_contract.py tests/integration/data_source/test_mcp_access_modes.py tests/integration/data_source/test_data_source_public_api_parity.py -q --no-cov -p no:cacheprovider`
  - `49 passed, 14 warnings`
- `bash scripts/run_data_source_runtime_smoke.sh`
  - OpenStock focused runtime tests: `11 passed`
  - real AkShare smoke passed
  - MyStocks remote client: `5 passed`
  - AkShare pilot: `3 passed`
  - market stream bridge: `5 passed`
  - MCP access modes: `8 passed`
  - public parity: `3 passed`
- `ruff check src/core/data_source/__init__.py src/core/data_source/client.py src/core/data_source/market_stream_bridge.py src/core/data_source/mcp_diagnostics.py src/core/data_source/closure_policy.py tests/integration/data_source/test_remote_data_source_client_contract.py tests/integration/data_source/test_akshare_runtime_pilot.py tests/integration/data_source/test_market_stream_contract.py tests/integration/data_source/test_mcp_access_modes.py tests/integration/data_source/test_data_source_public_api_parity.py`
  - `All checks passed`
- `openspec validate extract-data-source-runtime-service --strict`
  - `Change 'extract-data-source-runtime-service' is valid`

Notes:

- Existing warnings are Pydantic/FastAPI deprecations already present in the data-source API test surface.
- OpenSpec emits non-blocking PostHog telemetry flush noise in this restricted environment after reporting the change as valid.
- GitNexus compare against `origin/wip/root-dirty-20260403`: `LOW`, 23 changed files, 0 affected indexed processes.

## Related OpenStock Repo

OpenStock private repo has already been updated and pushed:

- `b93c494 feat: add market websocket pilot`
- `6f50c3a docs: add openstock documentation system`

