### PR TITLE
docs: record g2-329 branch anchor reconciliation

### DIFF
--- a/.planning/codebase/generated/service-lifecycle-di-branch-anchor-reconciliation-2026-06-03.json
+++ b/.planning/codebase/generated/service-lifecycle-di-branch-anchor-reconciliation-2026-06-03.json
@@ -1,0 +1,136 @@
+{
+  "schema_version": "2026-06-03.g2-no-source-branch-anchor-reconciliation.v1",
+  "generated_at": "2026-06-03T22:23:56+08:00",
+  "repo": "chengjon/mystocks",
+  "base_branch": "wip/root-dirty-20260403",
+  "current_workspace_head": "06b0fc09548774ba997784c878349c25087d7c88",
+  "remote_anchor": {
+    "ref": "origin/wip/root-dirty-20260403",
+    "commit": "2ebff6d7ded33403c691a60fc43f87dabf90a975"
+  },
+  "accepted_pr_anchor": {
+    "pr": 474,
+    "state": "MERGED",
+    "merge_commit": "2ebff6d7ded33403c691a60fc43f87dabf90a975",
+    "title": "refactor(api): inject watchlist datasource provider"
+  },
+  "node": {
+    "id": "g2-329-service-lifecycle-di-branch-anchor-reconciliation-before-next-residual-selection",
+    "type": "no_source_branch_anchor_reconciliation",
+    "status": "accepted_reviewed_no_source",
+    "source_edit_authority": false,
+    "source_execution_started": false
+  },
+  "parent": {
+    "id": "g2-328-technical-analysis-datasourcefactory-provider-closeout-residual-refresh",
+    "status": "accepted_reviewed_no_source"
+  },
+  "allowed_scope": [
+    ".planning/codebase/generated/service-lifecycle-di-branch-anchor-reconciliation-2026-06-03.json",
+    ".planning/codebase/steward-tree/branch-register.md",
+    ".planning/codebase/steward-tree/current-next-gates.md",
+    ".planning/codebase/steward-tree/completed-ledger.md",
+    ".planning/codebase/steward-tree/evidence-index.md",
+    ".planning/codebase/steward-tree/tracks/service-lifecycle-di.md",
+    ".planning/codebase/steward-tree/steward-index.json",
+    "docs/reports/quality/backend-service-lifecycle-di-branch-anchor-reconciliation-2026-06-03.md",
+    "governance/mainline/task-cards/g2-329.yaml"
+  ],
+  "forbidden_scope": [
+    "web/**",
+    "src/**",
+    "tests/**",
+    "docs/api/**",
+    "web/frontend/**",
+    "config/**",
+    "scripts/**",
+    "openspec/**",
+    "PM2/runtime state"
+  ],
+  "branch_anchor_reconciliation": {
+    "commands": {
+      "git_rev_parse_head": "06b0fc09548774ba997784c878349c25087d7c88",
+      "git_rev_parse_origin_wip_root_dirty_20260403": "2ebff6d7ded33403c691a60fc43f87dabf90a975",
+      "git_merge_base_pr474_is_ancestor_of_head": 1,
+      "git_merge_base_head_is_ancestor_of_origin_wip": 1,
+      "git_merge_base_origin_wip_is_ancestor_of_head": 1
+    },
+    "classification": "local-head-and-remote-anchor-diverged",
+    "baseline_policy": "Use PR #474 / origin/wip/root-dirty-20260403 as the accepted watchlist provider anchor for service lifecycle residual statistics; do not use local HEAD watchlist counts as candidate truth."
+  },
+  "watchlist_calibration": {
+    "current_worktree": {
+      "datasourcefactory_calls": 8,
+      "get_data_source_calls": 8,
+      "depends_get_watchlist_data_source": 0
+    },
+    "current_head": {
+      "datasourcefactory_calls": 8,
+      "get_data_source_calls": 8,
+      "depends_get_watchlist_data_source": 0
+    },
+    "pr474_anchor": {
+      "datasourcefactory_calls": 1,
+      "get_data_source_calls": 1,
+      "depends_get_watchlist_data_source": 8
+    },
+    "reconciliation": "Watchlist 8/8 inline calls are branch-anchor drift in this local HEAD/worktree and must be excluded from the normalized residual candidate pool."
+  },
+  "candidate_pool_recalibration": {
+    "api_python_files_scanned": 218,
+    "raw_route_body_datasourcefactory_candidates": [
+      {
+        "file": "web/backend/app/api/watchlist.py",
+        "direct_handlers": 8,
+        "handlers": 15,
+        "datasourcefactory_calls": 8,
+        "get_data_source_calls": 8,
+        "classification": "excluded-by-pr474-anchor"
+      },
+      {
+        "file": "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+        "direct_handlers": 3,
+        "handlers": 6,
+        "datasourcefactory_calls": 3,
+        "get_data_source_calls": 3,
+        "classification": "normalized-active-candidate"
+      }
+    ],
+    "normalized_route_body_datasourcefactory_candidates": [
+      {
+        "file": "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+        "source": "worktree",
+        "direct_handlers": 3,
+        "handlers": 6,
+        "datasourcefactory_calls": 3,
+        "get_data_source_calls": 3
+      }
+    ],
+    "technical_analysis_adjustment": {
+      "source": "g2-327-reviewed-worktree",
+      "datasourcefactory_calls": 1,
+      "get_data_source_calls": 1,
+      "depends_get_technical_analysis_data_source": 8,
+      "handler_direct_datasourcefactory_calls": 0,
+      "handler_direct_get_data_source_calls": 0,
+      "classification": "closed-by-reviewed-local-g2-327"
+    }
+  },
+  "decision": {
+    "classification": "branch-anchor-reconciled-for-candidate-pool-statistics",
+    "g2_329_no_source_complete": true,
+    "next_gate": "g2-330-service-lifecycle-di-global-residual-candidate-screening",
+    "next_gate_state": "planned_no_source",
+    "next_gate_seed_candidate": "web/backend/app/api/strategy_management/_strategy_execution_router.py",
+    "next_gate_reason": "After excluding accepted watchlist drift and applying local reviewed technical_analysis closeout, the normalized route-body DataSourceFactory candidate pool has one remaining candidate."
+  },
+  "freshness": {
+    "checked_at": "2026-06-03T22:23:56+08:00",
+    "current_workspace_head": "06b0fc09548774ba997784c878349c25087d7c88",
+    "remote_anchor": "2ebff6d7ded33403c691a60fc43f87dabf90a975",
+    "stale_if_origin_wip_moves": true,
+    "stale_if_local_head_changes": true,
+    "stale_if_watchlist_worktree_changes": true,
+    "stale_if_candidate_pool_scan_changes": true
+  }
+}

--- a/.planning/codebase/steward-tree/branch-register.md
+++ b/.planning/codebase/steward-tree/branch-register.md
@@ -1,0 +1,43 @@
+# Steward Tree Branch Register
+
+> **历史文档说明**: 本文件是历史快照、历史方案或历史总结，不代表当前仓库的唯一事实状态。若需确认当前共享规则、执行口径、目录结构或实现状态，请优先以 `architecture/STANDARDS.md`、根目录 `AGENTS.md`、根目录 `CLAUDE.md`、当前代码与最近一次实际验证结果为准。
+
+## Status
+
+- Status: compact active branch / PR register
+- Prepared at: `2026-06-03T22:23:56+08:00`
+- Current workspace HEAD checked: `06b0fc09548774ba997784c878349c25087d7c88`
+- Accepted PR anchor: PR `#474` merge commit `2ebff6d7ded33403c691a60fc43f87dabf90a975`
+
+Boundary note: this register records relationship state only. It does not merge
+PRs, change issue labels, authorize source implementation, or replace GitHub
+PR state.
+
+## Active / Recent G Nodes And PRs
+
+| PR | Branch / node | Base | State | Relationship |
+|---|---|---|---|---|
+| `TBD` | `g2-330-service-lifecycle-di-global-residual-candidate-screening` | `wip/root-dirty-20260403` | `PLANNED_NO_SOURCE` | Screen normalized residual pool seeded by `strategy_management/_strategy_execution_router.py`; no source authorization |
+| `TBD` | `g2-329-service-lifecycle-di-branch-anchor-reconciliation-before-next-residual-selection` | `wip/root-dirty-20260403` | `ACCEPTED_REVIEWED_NO_SOURCE` | Reconciled branch-anchor drift and excluded watchlist false-positive statistics from candidate pool |
+| `TBD` | `g2-328-technical-analysis-datasourcefactory-provider-closeout-residual-refresh` | `wip/root-dirty-20260403` | `ACCEPTED_REVIEWED_NO_SOURCE` | Closed local technical_analysis provider lane for governance only; no PR/merge claimed |
+| `TBD` | `g2-327-technical-analysis-datasourcefactory-provider-implementation` | `wip/root-dirty-20260403` | `REVIEWED_BUT_NOT_MERGED` | Source implementation accepted locally by human maintainer; state remains source_implementation_review_required |
+| `TBD` | `g2-326-technical-analysis-datasourcefactory-provider-authorization-preflight` | `wip/root-dirty-20260403` | `ACCEPTED_MERGED` | Bounded future G2.327 source scope prepared; no source edits performed |
+| `TBD` | `g2-325-technical-analysis-datasourcefactory-ownership-decision` | `wip/root-dirty-20260403` | `ACCEPTED_MERGED` | Classified `technical_analysis.py` as active route-local DataSourceFactory provider seam candidate |
+| `TBD` | `g2-324-service-lifecycle-di-residual-candidate-selection` | `wip/root-dirty-20260403` | `ACCEPTED_MERGED` | Selected `technical_analysis.py` as next no-source ownership-decision candidate from accepted G2.322/G2.323 evidence |
+| `TBD` | `g2-323-watchlist-datasourcefactory-provider-steward-surface-compaction` | `wip/root-dirty-20260403` | `ACCEPTED_MERGED` | Compact-surface freeze accepted; current files keep only active gate, parent chain, and evidence refs |
+| `TBD` | `g2-322-watchlist-datasourcefactory-provider-closeout-residual-refresh` | `wip/root-dirty-20260403` | `ACCEPTED_MERGED` | Closed accepted G2.321 and refreshed DataSourceFactory residual observations |
+| `#474` | `g2-321-watchlist-datasourcefactory-provider-implementation` | `wip/root-dirty-20260403` | `MERGED` at `2ebff6d7ded33403c691a60fc43f87dabf90a975` | Source implementation accepted/merged after human review |
+
+## Current Boundary
+
+- G2.323 is accepted_merged as a no-source steward surface compaction / baseline freeze gate.
+- G2.324 is accepted_merged as a no-source residual candidate selection gate.
+- G2.325 is accepted_merged as a no-source ownership decision gate.
+- G2.326 is accepted_merged as a no-source authorization preflight gate.
+- G2.327 source implementation is reviewed-but-not-merged; it is not accepted_merged.
+- G2.328 is accepted reviewed no-source and does not claim PR creation or merge.
+- G2.329 is accepted reviewed no-source branch-anchor reconciliation.
+- G2.330 is planned no-source global residual candidate screening.
+- Current steward files should keep only the active gate, parent chain, and evidence references.
+- Long history stays in `archive/`, `completed-ledger.md`, historical reports, and generated evidence.
+- G2.328 and G2.329 authorize governance artifacts only; no source, tests, API contract, frontend, config, script, OpenSpec, PM2, runtime state, or shared DataSourceFactory implementation edits are authorized by these gates.

--- a/docs/reports/quality/backend-service-lifecycle-di-branch-anchor-reconciliation-2026-06-03.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-branch-anchor-reconciliation-2026-06-03.md
@@ -1,0 +1,126 @@
+# Backend Service Lifecycle DI Branch Anchor Reconciliation
+
+Date: 2026-06-03
+Freshness recheck: 2026-06-12
+Node: `g2-329-service-lifecycle-di-branch-anchor-reconciliation-before-next-residual-selection`
+Task card: `governance/mainline/task-cards/g2-329.yaml`
+Evidence: `.planning/codebase/generated/service-lifecycle-di-branch-anchor-reconciliation-2026-06-03.json`
+
+## Status
+
+G2.329 is a no-source branch-anchor reconciliation gate. It does not authorize
+source, test, API contract, frontend, config, script, OpenSpec, PM2, runtime
+state, or shared DataSourceFactory implementation edits.
+
+The node is accepted as reviewed no-source governance. Its purpose is to keep
+the service lifecycle DI residual candidate pool from being skewed by branch
+drift before G2.330 performs the next global residual screening.
+
+## Parent State
+
+| Surface | State |
+|---|---|
+| G2.321 watchlist DataSourceFactory provider | Merged through PR `#474` |
+| G2.327 technical_analysis DataSourceFactory provider | Reviewed locally but not merged; no PR/merge claimed |
+| G2.328 technical_analysis closeout / residual refresh | Accepted reviewed no-source |
+| G2.329 branch-anchor reconciliation | Accepted reviewed no-source |
+| G2.330 global residual screening | Planned no-source |
+
+## Original Anchor Evidence
+
+| Evidence | Value |
+|---|---|
+| Generated at | `2026-06-03T22:23:56+08:00` |
+| Recorded workspace HEAD | `06b0fc09548774ba997784c878349c25087d7c88` |
+| Recorded remote anchor | `origin/wip/root-dirty-20260403` at `2ebff6d7ded33403c691a60fc43f87dabf90a975` |
+| Accepted PR anchor | PR `#474`, merge commit `2ebff6d7ded33403c691a60fc43f87dabf90a975` |
+| Original classification | `local-head-and-remote-anchor-diverged` |
+| Baseline policy | Use PR `#474` as accepted watchlist provider anchor; do not use local `watchlist.py` counts as residual truth |
+
+## Watchlist Calibration
+
+The generated evidence showed that local `watchlist.py` still contained inline
+DataSourceFactory usage while the accepted PR `#474` anchor had moved the active
+route surface to the provider/Depends pattern.
+
+| Surface | DataSourceFactory calls | `get_data_source()` calls | Provider Depends calls | Disposition |
+|---|---:|---:|---:|---|
+| Local worktree in generated evidence | 8 | 8 | 0 | Exclude as branch-anchor drift |
+| Current HEAD in generated evidence | 8 | 8 | 0 | Exclude as branch-anchor drift |
+| PR `#474` anchor in generated evidence | 1 | 1 | 8 | Accepted watchlist provider anchor |
+
+Decision: watchlist inline-call counts are not residual candidate truth for this
+lane. G2.330 must not reselect watchlist from the local dirty branch counts.
+
+## Candidate Pool Recalibration
+
+The generated G2.329 pool used route-body DataSourceFactory scanning with two
+normalization overlays:
+
+| Candidate | Raw evidence | Normalized disposition |
+|---|---|---|
+| `web/backend/app/api/watchlist.py` | 8 direct handler calls in local branch evidence | Excluded by PR `#474` accepted watchlist anchor |
+| `web/backend/app/api/technical_analysis.py` | Local reviewed G2.327 provider lane showed provider/Depends shape | Treated as closed only as a reviewed local overlay; no merge claimed |
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 3 route-body DataSourceFactory / `get_data_source()` call expressions in generated evidence | Seed candidate for G2.330 no-source global residual screening |
+
+Decision: after excluding accepted watchlist drift and applying the reviewed
+technical_analysis overlay, the generated normalized route-body DataSourceFactory
+pool had one seed candidate: `strategy_management/_strategy_execution_router.py`.
+
+## Freshness Recheck
+
+A read-only freshness recheck was run on 2026-06-12 before this report was
+written. It found that the generated JSON is stale as current-branch evidence and
+must be treated as the historical G2.329 reconciliation record, not as current
+G2.330 screening truth.
+
+| Check | 2026-06-12 value |
+|---|---|
+| Current report worktree HEAD | `022afee048dfb6dd0f8a73ba971fc33d8db7d771` |
+| Current `origin/wip/root-dirty-20260403` | `e1dbb6d962affd2d04c7885879a9c9d19bcf0dfd` |
+| PR `#474` merge commit | `2ebff6d7ded33403c691a60fc43f87dabf90a975` |
+| PR `#474` state | `MERGED` |
+| Current origin equals PR `#474` anchor | No |
+| Generated JSON stale-if-local-head-changes | True |
+| Generated JSON stale-if-origin-wip-moves | True |
+
+Read-only spot counts from the freshness recheck:
+
+| Ref | File | DataSourceFactory calls | `get_data_source()` calls | Provider Depends calls |
+|---|---|---:|---:|---:|
+| Local HEAD | `web/backend/app/api/watchlist.py` | 9 | 8 | 0 |
+| PR `#474` | `web/backend/app/api/watchlist.py` | 2 | 1 | 8 |
+| Current origin/wip | `web/backend/app/api/watchlist.py` | 2 | 1 | 8 |
+| Local HEAD | `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 2 | 1 | 0 |
+| PR `#474` | `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 4 | 3 | 0 |
+| Current origin/wip | `web/backend/app/api/strategy_management/_strategy_execution_router.py` | 4 | 3 | 0 |
+| Local HEAD | `web/backend/app/api/technical_analysis.py` | 9 | 8 | 0 |
+| Current origin/wip | `web/backend/app/api/technical_analysis.py` | 9 | 8 | 0 |
+
+Freshness decision: G2.329 remains valid as a no-source branch-anchor
+reconciliation record, but G2.330 must regenerate the normalized candidate pool
+from the then-current accepted anchor before selecting or authorizing any source
+lane.
+
+## Verification
+
+| Check | Result |
+|---|---|
+| Source files changed | None |
+| Test files changed | None |
+| Runtime behavior changed | No |
+| OpenSpec implementation started | No |
+| Function-tree catalog metadata | Stale literal entrypoints synchronized to current paths so the mainline scope gate can validate this no-source package |
+| PR `#474` state checked | `MERGED` |
+| Branch anchor rechecked | Current origin/wip has moved since generated evidence |
+| Watchlist calibration rechecked | Watchlist local inline-call counts remain branch drift relative to PR `#474` / current origin provider shape |
+| Candidate pool status | Historical G2.329 seed candidate is `strategy_management/_strategy_execution_router.py`; G2.330 must refresh before use |
+
+## Next Gate
+
+G2.330 may proceed only as no-source global residual candidate screening. It may
+use this report to avoid reintroducing watchlist false positives, but it must
+rerun current route-body DataSourceFactory screening before preparing any source
+authorization packet.
+
+No source implementation is selected or authorized by this report.

--- a/governance/function-tree/catalog.yaml
+++ b/governance/function-tree/catalog.yaml
@@ -9,7 +9,6 @@ domains:
         label: "1.1 实时行情监控"
         coverage_paths:
           - "src/adapters/tdx/**"
-          - "web/backend/app/api/market.py"
           - "web/backend/app/api/market/**"
           - "web/frontend/src/api/mockApiClient.ts"
           - "web/frontend/src/composables/useWebSocketWithConfig.ts"
@@ -20,7 +19,6 @@ domains:
           governance:
             - "docs/FUNCTION_TREE.md"
           api:
-            - "web/backend/app/api/market.py"
             - "web/backend/app/api/market/**"
           frontend:
             - "web/frontend/src/api/mockApiClient.ts"
@@ -214,7 +212,7 @@ domains:
           governance:
             - "docs/FUNCTION_TREE.md"
           api:
-            - "web/backend/app/api/backtest_ws.py"
+            - "web/backend/app/api/v1/analysis/backtest.py"
           frontend:
             - "web/frontend/src/views/strategy/**"
           core:
@@ -256,13 +254,11 @@ domains:
         coverage_paths:
           - "src/governance/risk_management/**"
           - "web/backend/app/api/risk/**"
-          - "web/backend/app/api/risk_management.py"
         entrypoints:
           governance:
             - "docs/FUNCTION_TREE.md"
           api:
             - "web/backend/app/api/risk/**"
-            - "web/backend/app/api/risk_management.py"
           frontend:
             - "web/frontend/src/views/risk/**"
           core:
@@ -343,12 +339,10 @@ domains:
         coverage_paths:
           - "src/application/trading/**"
           - "src/trading/**"
-          - "web/backend/app/api/trading_monitor.py"
         entrypoints:
           governance:
             - "docs/FUNCTION_TREE.md"
           api:
-            - "web/backend/app/api/trading_monitor.py"
             - "web/backend/app/api/data/trading_api.py"
           frontend:
             - "web/frontend/src/views/trading/**"
@@ -399,7 +393,7 @@ domains:
             - "web/backend/app/api/signal_monitoring/**"
           frontend:
             - "web/frontend/src/views/monitoring/**"
-            - "web/frontend/src/views/monitor.vue"
+            - "web/frontend/src/views/system/PerformanceMonitor.vue"
             - "web/frontend/src/api/services/watchlistService.ts"
           core:
             - "src/monitoring/**"
@@ -566,13 +560,13 @@ domains:
       - id: "domain-08-node-03"
         label: "8.3 备份恢复"
         coverage_paths:
-          - "web/backend/app/api/backup_recovery.py"
+          - "web/backend/app/api/backup_recovery_secure.py"
           - "src/infrastructure/backup_recovery/**"
         entrypoints:
           governance:
             - "docs/FUNCTION_TREE.md"
           api:
-            - "web/backend/app/api/backup_recovery.py"
+            - "web/backend/app/api/backup_recovery_secure.py"
           frontend:
             - "web/frontend/src/views/system/**"
           core:
@@ -655,7 +649,6 @@ domains:
       - id: "domain-10-node-01"
         label: "10.1 公告管理"
         coverage_paths:
-          - "web/backend/app/api/announcement.py"
           - "web/backend/app/api/announcement/**"
           - "web/backend/app/services/announcement_service.py"
           - "web/backend/app/models/announcement.py"
@@ -663,7 +656,6 @@ domains:
           governance:
             - "docs/FUNCTION_TREE.md"
           api:
-            - "web/backend/app/api/announcement.py"
             - "web/backend/app/api/announcement/**"
           frontend:
             - "web/frontend/src/views/announcement/**"

--- a/governance/mainline/task-cards/g2-329.yaml
+++ b/governance/mainline/task-cards/g2-329.yaml
@@ -1,0 +1,100 @@
+version: "v0.2"
+task:
+  id: "g2-329"
+  title: "Reconcile service lifecycle DI branch anchor before next residual selection"
+  owner: "G/#79 service lifecycle DI + Route/OpenAPI governance"
+  created_at: "2026-06-03"
+
+mainline:
+  id: "L1-service-lifecycle-di-branch-anchor-reconciliation"
+  objective: "Anchor the baseline branch, calibrate watchlist drift, and fix candidate-pool statistics before the next global residual screen."
+  milestone_id: "g2"
+  slice_id: "g2-329"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: ""
+  approval_status: "not_required"
+
+scope:
+  allowed_paths:
+    - ".planning/codebase/generated/service-lifecycle-di-branch-anchor-reconciliation-2026-06-03.json"
+    - ".planning/codebase/steward-tree/branch-register.md"
+    - "docs/reports/quality/backend-service-lifecycle-di-branch-anchor-reconciliation-2026-06-03.md"
+    - "governance/function-tree/catalog.yaml"
+    - "governance/mainline/task-cards/g2-329.yaml"
+  forbidden_paths:
+    - "src/**"
+    - "web/backend/app/**"
+    - "web/frontend/**"
+    - "tests/**"
+    - "scripts/**"
+    - "config/**"
+    - "openspec/changes/**"
+
+non_goals:
+  - "Do not implement service lifecycle DI source changes."
+  - "Do not modify OpenStock internals or provider/runtime implementation."
+  - "Do not treat the 2026-06-03 candidate-pool evidence as current screening truth for G2.330."
+  - "Do not edit API, frontend, tests, runtime state, scripts, configuration, or OpenSpec implementation changes."
+
+acceptance:
+  checks:
+    - id: "no-source-path-check"
+      command: "git diff --name-only HEAD~1..HEAD excludes src/**, web/backend/app/**, web/frontend/**, tests/**, scripts/**, config/**, and openspec/changes/**"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/g2-329.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha HEAD~1 --head-sha HEAD --report /tmp/g2-329-mainline-gate.json"
+      required: true
+    - id: "function-tree-catalog-literal-check"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py validates governance/function-tree/catalog.yaml without stale literal entrypoints"
+      required: true
+    - id: "gitnexus-staged-detect-changes"
+      command: "gitnexus_detect_changes(scope=staged)"
+      required: true
+    - id: "diff-check"
+      command: "git diff HEAD~1..HEAD --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Local HEAD, origin/wip/root-dirty-20260403, and the PR #474 anchor have diverged; historical G2.329 evidence must not be reused as current source authorization."
+    - "The function-tree catalog had stale literal entrypoints; this task only aligns governance metadata so the no-source gate can validate."
+    - "G2.330 may use this report only to avoid known false positives, then must rerun current normalized residual screening."
+  rollback_plan: "Revert this governance-only commit to restore the pre-G2.329 task card, branch-anchor evidence, report, and function-tree catalog metadata."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Anchor service lifecycle DI baseline evidence before selecting the next residual candidate."
+    modified_scope: "Governance evidence, steward branch register, quality report, function-tree catalog metadata, and G2.329 task card."
+    dependency_changes: "No dependency changes."
+    legacy_logic_impact: "No source, test, API, frontend, runtime, script, configuration, or OpenSpec implementation changes."
+    rollback_ready: "Revert this governance-only commit."
+    risk_and_rollback_point: "G2.330 must rerun current route-body DataSourceFactory screening before any source authorization."
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "No business entrypoint changed; function-tree catalog literal entries were synchronized as governance metadata to keep mainline scope validation runnable."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "G/#79 service lifecycle DI + Route/OpenAPI governance"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-03T22:23:56+08:00"
+    approval_note: "Human maintainer authorized G2.329 as planned_no_source pure governance with no source modifications."
+    secondary_approved: false


### PR DESCRIPTION
## Summary

- Record G2.329 branch-anchor reconciliation evidence for service lifecycle DI residual screening.
- Convert `governance/mainline/task-cards/g2-329.yaml` to the current `v0.2` mainline task-card schema.
- Synchronize stale function-tree catalog literal entrypoints to current paths so the mainline scope gate can validate the no-source package.

## Scope

- MyStocks governance/docs metadata only.
- No OpenStock internal development or runtime/provider changes.
- No source, API, frontend, test, script, config, OpenSpec implementation, or runtime-state changes.

## Verification

- `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/g2-329.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha HEAD~1 --head-sha HEAD --report /tmp/g2-329-clean-pr-mainline-gate.json` -> pass
- `git diff HEAD~1..HEAD --check` -> pass
- Commit path gate: 5 changed files, unexpected=0, forbidden=0
- Function-tree catalog literal check: missing_literal_entrypoints=0
- GitNexus compare against `origin/main`: low risk, 0 changed symbols, 0 affected processes
