### PR TITLE
docs: authorize g2-331 technical analysis di candidate

### DIFF
--- a/docs/reports/quality/backend-service-lifecycle-di-technical-analysis-authorization-2026-06-13.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-technical-analysis-authorization-2026-06-13.md
@@ -1,0 +1,144 @@
+# Backend Service Lifecycle DI Technical Analysis Authorization
+
+Date: 2026-06-13
+Task: G2.331
+Mode: no-source authorization preflight
+Base worktree: `g2-331-technical-analysis-datasourcefactory-authorization`
+Base commit: `02eb277bb1fd9c9e75a82e8029d3b5e384a096fe`
+
+## Status
+
+G2.331 is a no-source authorization preflight for the backend service
+lifecycle DI lane. It selects the next MyStocks-side candidate family and
+records the implementation boundary for a later source-authorized task.
+
+This package does not modify or authorize in-place changes to source, tests,
+API contracts, frontend code, runtime state, scripts, configuration, OpenSpec
+implementation files, or OpenStock internals.
+
+## Parent Evidence
+
+G2.330 recorded the current branch split after PR `#478`:
+
+| Candidate family | `origin/main` status | `origin/wip/root-dirty-20260403` / PR `#474` status | G2.331 disposition |
+| --- | --- | --- | --- |
+| Strategy routes | `web/backend/app/api/strategy.py` has 3 strict route-body `DataSourceFactory()` residuals | `strategy.py` is absent; `strategy_management/_strategy_execution_router.py` has the corresponding 3 residuals | Defer until the target base branch is explicitly selected |
+| Technical analysis routes | `web/backend/app/api/technical_analysis.py` has 8 strict route-body residuals | Same file has the same 8 strict residuals | Select as the next candidate family |
+| Watchlist routes | `web/backend/app/api/watchlist.py` has 8 strict route-body residuals | PR `#474` / wip anchor already moved watchlist to provider dependency shape | Defer mainline reconciliation; do not treat as a wip residual |
+| Dashboard summary | One body-level `get_data_source()` call without a `DataSourceFactory()` constructor | Not selected by the strict rule | Observation only |
+
+The selected candidate is `web/backend/app/api/technical_analysis.py` because it
+is stable across `origin/main`, `origin/wip/root-dirty-20260403`, and the PR
+`#474` anchor. This avoids the strategy filename split and the watchlist
+branch-anchor conflict.
+
+## Current Technical Analysis Residuals
+
+The current `origin/main` route-body scan finds 8 strict residual route
+functions in `web/backend/app/api/technical_analysis.py`.
+
+| Function | Line | Route | `DataSourceFactory()` calls | Body `get_data_source()` calls |
+| --- | ---: | --- | ---: | ---: |
+| `get_all_indicators` | 235 | `GET /{symbol}/indicators` | 1 | 1 |
+| `get_trend_indicators` | 340 | `GET /{symbol}/trend` | 1 | 1 |
+| `get_momentum_indicators` | 411 | `GET /{symbol}/momentum` | 1 | 1 |
+| `get_volatility_indicators` | 462 | `GET /{symbol}/volatility` | 1 | 1 |
+| `get_volume_indicators` | 512 | `GET /{symbol}/volume` | 1 | 1 |
+| `get_trading_signals` | 562 | `GET /{symbol}/signals` | 1 | 1 |
+| `get_stock_history` | 616 | `GET /{symbol}/history` | 1 | 1 |
+| `get_batch_indicators` | 663 | `POST /batch/indicators` | 1 | 1 |
+
+Total residuals: 8 route functions, 8 `DataSourceFactory()` calls, and 8
+body-level `get_data_source()` calls.
+
+## API Impact Snapshot
+
+GitNexus `api_impact` was run against
+`web/backend/app/api/technical_analysis.py`.
+
+| Route | Direct consumers | Affected flows | Risk |
+| --- | ---: | ---: | --- |
+| `/{symbol}/indicators` | 0 | 0 | LOW |
+| `/{symbol}/trend` | 0 | 0 | LOW |
+| `/{symbol}/momentum` | 0 | 0 | LOW |
+| `/{symbol}/volatility` | 0 | 0 | LOW |
+| `/{symbol}/volume` | 0 | 0 | LOW |
+| `/{symbol}/signals` | 0 | 0 | LOW |
+| `/{symbol}/history` | 0 | 0 | LOW |
+| `/batch/indicators` | 0 | 0 | LOW |
+
+Index note: GitNexus reported a stale-index warning because the indexed commit
+differs from the current commit, but the API impact result still provides a
+useful preflight snapshot. Any future source-authorized implementation must
+rerun GitNexus impact/API-impact from its own branch before editing route
+handlers.
+
+## Proposed Implementation Boundary
+
+The later source-authorized task should keep the change narrow:
+
+| Scope | Proposed path |
+| --- | --- |
+| Primary source file | `web/backend/app/api/technical_analysis.py` |
+| Route/API regression tests | Existing technical-analysis API or route tests only, selected after inspection in the implementation branch |
+| Contract/E2E smoke, if required by the implementation branch | Existing `/api/technical/*` coverage only |
+
+The expected implementation pattern is the accepted PR `#474` watchlist provider
+shape:
+
+1. Move `DataSourceFactory()` construction out of individual route bodies into
+   a small provider helper such as `get_technical_analysis_data_source()`.
+2. Inject the adapter into the 8 route handlers with `Depends(...)`.
+3. Preserve the current route paths, response models, validation behavior,
+   circuit-breaker behavior, exception mapping, and adapter `get_data(...)`
+   calls.
+4. Add or adjust focused tests only for the provider-injection behavior and the
+   affected technical-analysis route contract.
+
+## Non-Goals
+
+The follow-up implementation must not:
+
+| Non-goal | Reason |
+| --- | --- |
+| Modify OpenStock internals | OpenStock work is owned separately and was reported complete by its own handoff |
+| Rewrite the technical-analysis adapter or calculation logic | G2.331 only targets route-body `DataSourceFactory()` lifecycle residuals |
+| Change response schemas or OpenAPI contracts | The task is DI lifecycle cleanup, not API redesign |
+| Touch watchlist or strategy residuals | Those families have branch-split decisions and need separate authorization |
+| Broaden to dashboard `get_data_source()` observation | It does not match the strict `DataSourceFactory()` residual rule |
+| Delete or retire files | Deletion/retirement requires separate authorization under repository standards |
+
+## Authorization Decision
+
+G2.331 authorizes only the next planning direction:
+
+| Decision | Result |
+| --- | --- |
+| Next candidate family | `technical_analysis.py` service lifecycle DI residuals |
+| Target base | `origin/main` |
+| Source implementation status | Not implemented by this task |
+| Required next node | Separate source-authorized task card before any code/test edits |
+| OpenStock status | Boundary-only; no OpenStock development or modification |
+
+## Required Next Gate
+
+Before editing source in the next node, the implementation branch must:
+
+1. Create a source-authorized task card with explicit allowed source and test
+   paths.
+2. Rerun GitNexus impact/API-impact for
+   `web/backend/app/api/technical_analysis.py` and report the risk level.
+3. Inspect existing technical-analysis tests and choose focused regression
+   coverage before writing implementation code.
+4. Run the mainline scope gate, path whitelist, `git diff --check`, GitNexus
+   detect changes, and project-native focused tests.
+5. Keep OpenStock internals out of scope.
+
+## Verification Scope
+
+This package is expected to modify only:
+
+| Path | Purpose |
+| --- | --- |
+| `docs/reports/quality/backend-service-lifecycle-di-technical-analysis-authorization-2026-06-13.md` | G2.331 no-source authorization preflight evidence |
+| `governance/mainline/task-cards/g2-331.yaml` | G2.331 mainline task card and no-source gate definition |

--- a/governance/mainline/task-cards/g2-331.yaml
+++ b/governance/mainline/task-cards/g2-331.yaml
@@ -1,0 +1,103 @@
+version: "v0.2"
+task:
+  id: "g2-331"
+  title: "Authorize technical_analysis service lifecycle DI candidate"
+  owner: "G/#79 service lifecycle DI + Route/OpenAPI governance"
+  created_at: "2026-06-13"
+
+mainline:
+  id: "L1-service-lifecycle-di-technical-analysis-authorization"
+  objective: "Select technical_analysis.py as the next stable cross-ref service lifecycle DI candidate and record the source-authorization boundary for a later implementation task."
+  milestone_id: "g2"
+  slice_id: "g2-331"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: ""
+  approval_status: "not_required"
+
+scope:
+  allowed_paths:
+    - "docs/reports/quality/backend-service-lifecycle-di-technical-analysis-authorization-2026-06-13.md"
+    - "governance/mainline/task-cards/g2-331.yaml"
+  forbidden_paths:
+    - "src/**"
+    - "web/backend/app/**"
+    - "web/frontend/**"
+    - "tests/**"
+    - "scripts/**"
+    - "config/**"
+    - "openspec/changes/**"
+    - "openstock/**"
+    - "OpenStock/**"
+
+non_goals:
+  - "Do not implement service lifecycle DI source changes in this task."
+  - "Do not modify technical_analysis.py, route tests, frontend code, runtime state, scripts, configuration, or OpenSpec implementation files."
+  - "Do not modify OpenStock internals, provider/runtime code, tests, configuration, packaging, or repository files."
+  - "Do not touch watchlist, strategy, dashboard, or other service lifecycle DI residual families."
+  - "Do not authorize deletion, retirement, compatibility-layer removal, or full-file removal."
+
+acceptance:
+  checks:
+    - id: "no-source-path-check"
+      command: "git diff --name-only HEAD~1..HEAD excludes src/**, web/backend/app/**, web/frontend/**, tests/**, scripts/**, config/**, openspec/changes/**, and OpenStock internals"
+      required: true
+    - id: "authorization-preflight-report"
+      command: "docs/reports/quality/backend-service-lifecycle-di-technical-analysis-authorization-2026-06-13.md records the technical_analysis residual table, API impact snapshot, branch-split disposition, and next source-authorized gate"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/g2-331.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha HEAD~1 --head-sha HEAD --report /tmp/g2-331-mainline-gate.json"
+      required: true
+    - id: "gitnexus-staged-detect-changes"
+      command: "gitnexus_detect_changes(scope=staged)"
+      required: true
+    - id: "gitnexus-api-impact-preflight"
+      command: "gitnexus_api_impact(file=web/backend/app/api/technical_analysis.py) recorded LOW risk across 8 routes as preflight evidence; source implementation must rerun it"
+      required: true
+    - id: "diff-check"
+      command: "git diff HEAD~1..HEAD --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "technical_analysis.py is a stable residual family across screened refs, but source implementation still needs a separate source-authorized branch and fresh impact analysis."
+    - "Route-body DI cleanup must preserve response schemas, validation behavior, circuit-breaker behavior, exception mapping, and adapter get_data(...) calls."
+    - "GitNexus API impact reported LOW risk but with a stale-index warning; future source work must rerun from the implementation branch."
+  rollback_plan: "Revert this governance-only commit to remove the G2.331 authorization preflight report and task card."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Select technical_analysis.py as the next stable service lifecycle DI residual candidate."
+    modified_scope: "Governance report and G2.331 task card only."
+    dependency_changes: "No dependency changes."
+    legacy_logic_impact: "No source, test, API, frontend, runtime, script, configuration, OpenSpec implementation, or OpenStock internal changes."
+    rollback_ready: "Revert this governance-only commit."
+    risk_and_rollback_point: "Future source work requires a separate source-authorized task card, fresh GitNexus impact/API-impact, and focused tests."
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "No business entrypoint changed; this is a no-source authorization preflight package for mainline governance."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "G/#79 service lifecycle DI + Route/OpenAPI governance"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-13T02:42:05+08:00"
+    approval_note: "Human maintainer asked to continue MyStocks-side work; G2.331 is constrained to no-source authorization preflight and OpenStock boundary-only handling."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Add the G2.331 no-source authorization preflight report for the service lifecycle DI lane.
- Add the G2.331 mainline task card with exact allowed paths and source/OpenStock forbidden paths.
- Select `web/backend/app/api/technical_analysis.py` as the next stable cross-ref residual candidate while requiring a separate source-authorized task before implementation.

## Evidence
- G2.330 selected technical_analysis as the stable candidate family across origin/main, origin/wip/root-dirty-20260403, and the PR #474 anchor.
- Current origin/main residuals in technical_analysis.py: 8 route functions, 8 `DataSourceFactory()` calls, 8 body-level `get_data_source()` calls.
- GitNexus api_impact preflight: 8 technical-analysis routes, 0 direct consumers, 0 affected flows, LOW risk.

## Scope
- No source, API route implementation, frontend, test, script, config, OpenSpec implementation, runtime, or OpenStock internal changes.
- This only records the next candidate and the required next source-authorized gate.

## Verification
- git diff --cached --check
- committed path whitelist: 2 files, 0 outside allowed paths, 0 forbidden hits
- python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/g2-331.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha HEAD~1 --head-sha HEAD --report /tmp/g2-331-mainline-gate.json
- GitNexus detect_changes(scope=staged): low risk, 0 changed symbols, 0 affected processes
- GitNexus detect_changes(scope=compare, base_ref=origin/main): low risk, 0 changed symbols, 0 affected processes
