### PR TITLE
fix(ci): align dependency safety manifests

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -16,9 +16,9 @@ tushare>=1.3.0
 efinance>=0.5.0
 
 # 工具
-python-dotenv>=1.0.0
+python-dotenv>=1.2.2
 schedule>=1.2.0
-requests>=2.32.4
+requests>=2.33.0
 certifi>=2025.11.12
 bcrypt>=5.0.0
 attrs>=25.4.0
@@ -35,7 +35,7 @@ aiohttp>=3.13.0
 sse-starlette>=3.0.3
 swagger-ui-py>=25.7.1
 email-validator>=2.3.0
-python-multipart>=0.0.22
+python-multipart>=0.0.27
 
 # GPU加速依赖 (可选安装，用于量化交易回测和AI策略)
 # RTX 2080 GPU加速支持
@@ -44,7 +44,7 @@ cudf-cu12>=25.10.0
 cuml-cu12>=25.10.0
 
 # 开发工具
-pytest>=7.4.0
+pytest>=9.0.3
 mypy>=1.5.0
 black>=25.11.0
 bleach>=6.3.0

--- a/docs/reports/quality/ci-dependency-safety-manifest-alignment-2026-06-13.md
+++ b/docs/reports/quality/ci-dependency-safety-manifest-alignment-2026-06-13.md
@@ -1,0 +1,61 @@
+# CI Dependency Safety Manifest Alignment
+
+Date: 2026-06-13
+Task: G2.333
+Mode: source-free dependency manifest fix
+Base worktree: `g2-333-ci-dependency-safety-manifest-alignment`
+Base commit: `dfeb6b2963aa2ca991dceb3cc3058e26461a80a0`
+
+## Status
+
+G2.333 isolates dependency manifest alignment required by the CI `Dependency
+Safety Check`. It updates only the requirement files scanned by that job:
+
+- `requirements.txt`
+- `config/requirements.txt`
+- `web/backend/requirements.txt`
+
+No MyStocks API source, frontend source, tests, scripts, runtime behavior,
+OpenSpec implementation files, or OpenStock internals are changed.
+
+## Dependency Changes
+
+| Package | Previous specifier(s) | Safety affected spec | Updated specifier(s) |
+| --- | --- | --- | --- |
+| `APScheduler` | Present only in `web/backend/requirements.txt` | N/A; needed for backend cache eviction imports in api-file-tests | `APScheduler>=3.10.4` added to root `requirements.txt` |
+| `python-dotenv` | `>=1.0.0` / `==1.0.1` | `<1.2.2` | `>=1.2.2` / `==1.2.2` |
+| `requests` | `>=2.32.4` / `==2.32.4` | `<2.33.0` | `>=2.33.0` / `==2.33.0` |
+| `python-multipart` | `>=0.0.22` / `==0.0.22` | `<0.0.27` | `>=0.0.27` / `==0.0.27` |
+| `pytest` | `>=7.4.0` / `==8.3.0` | `<9.0.3` | `>=9.0.3` / `==9.0.3` |
+| `pytest-asyncio` | `==0.24.0` | N/A; pip resolver compatibility with pytest 9 | `==1.4.0` |
+
+PyPI availability was checked for the required safety lower bounds:
+
+- `pytest`: latest/available includes `9.0.3`
+- `python-multipart`: available includes `0.0.27`
+- `requests`: available includes `2.33.0`
+- `python-dotenv`: latest/available includes `1.2.2`
+- `pytest-asyncio`: latest/available includes `1.4.0`; pip dry-run confirmed compatibility with `pytest==9.0.3`
+
+## Function-Tree Catalog Note
+
+The manifest fix maps to `domain-08-node-02` because it changes system
+dependency configuration used by CI/runtime setup. `config/**` was already
+covered by that node. G2.333 adds `requirements.txt` and
+`web/backend/requirements.txt` literal coverage so mainline gate attribution is
+explicit.
+
+## Verification
+
+| Check | Result |
+| --- | --- |
+| `python -c "assert CI-scanned dependency lower bounds are present"` | Required lower bounds and `pytest-asyncio==1.4.0` present in scanned manifests |
+| `safety check -r requirements.txt -r config/requirements.txt -r web/backend/requirements.txt` | 0 vulnerabilities reported; ignored unpinned warning ranges unchanged |
+| `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/g2-333.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha HEAD~1 --head-sha HEAD --report /tmp/g2-333-mainline-gate.json` | To be run after commit |
+| `gitnexus_detect_changes(scope=compare, base_ref=origin/main)` | To be run after commit |
+| `git diff HEAD~1..HEAD --check` | To be run after commit |
+
+## Rollback
+
+Revert the G2.333 commit to restore previous dependency specifiers and catalog
+metadata.

--- a/governance/function-tree/catalog.yaml
+++ b/governance/function-tree/catalog.yaml
@@ -539,6 +539,8 @@ domains:
         coverage_paths:
           - "web/backend/app/api/system.py"
           - "config/**"
+          - "requirements.txt"
+          - "web/backend/requirements.txt"
           - "web/frontend/src/views/TaskManagement.vue"
         entrypoints:
           governance:
@@ -557,6 +559,8 @@ domains:
           operations:
             - "docs/operations/deployment/README.md"
             - "docker/README.md"
+            - "requirements.txt"
+            - "web/backend/requirements.txt"
       - id: "domain-08-node-03"
         label: "8.3 备份恢复"
         coverage_paths:

--- a/governance/mainline/task-cards/g2-333.yaml
+++ b/governance/mainline/task-cards/g2-333.yaml
@@ -1,0 +1,103 @@
+version: "v0.2"
+task:
+  id: "g2-333"
+  title: "Align CI-scanned dependency safety manifests"
+  owner: "G/#79 service lifecycle DI + Route/OpenAPI governance"
+  created_at: "2026-06-13"
+
+mainline:
+  id: "L1-ci-dependency-safety-manifest-alignment"
+  objective: "Align dependency manifests scanned by CI safety checks so backend API file tests and dependency safety gates can run on current secure lower bounds."
+  milestone_id: "g2"
+  slice_id: "g2-333"
+
+classification:
+  task_type: "fix"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: ""
+  approval_status: "not_required"
+
+scope:
+  allowed_paths:
+    - "config/requirements.txt"
+    - "docs/reports/quality/ci-dependency-safety-manifest-alignment-2026-06-13.md"
+    - "governance/function-tree/catalog.yaml"
+    - "governance/mainline/task-cards/g2-333.yaml"
+    - "requirements.txt"
+    - "web/backend/requirements.txt"
+  forbidden_paths:
+    - "src/**"
+    - "web/backend/app/**"
+    - "web/backend/tests/**"
+    - "web/frontend/**"
+    - "tests/**"
+    - "scripts/**"
+    - "openspec/changes/**"
+    - "openstock/**"
+    - "OpenStock/**"
+
+non_goals:
+  - "Do not modify MyStocks API source, frontend source, tests, scripts, OpenSpec implementation files, or runtime behavior."
+  - "Do not modify OpenStock internals, provider/runtime code, tests, configuration, packaging, or repository files."
+  - "Do not broaden this task beyond the dependency manifests scanned by the CI Dependency Safety Check."
+  - "Do not resolve ignored unpinned dependency warnings in this task; only address vulnerabilities that CI reports as failing."
+
+acceptance:
+  checks:
+    - id: "ci-scanned-lower-bounds-present"
+      command: "python - <<'PY'\nfrom pathlib import Path\nexpected = {\n    'requirements.txt': ('APScheduler>=3.10.4', 'python-dotenv>=1.2.2', 'requests>=2.33.0', 'python-multipart>=0.0.27', 'pytest>=9.0.3'),\n    'config/requirements.txt': ('python-dotenv>=1.2.2', 'requests>=2.33.0', 'python-multipart>=0.0.27', 'pytest>=9.0.3'),\n    'web/backend/requirements.txt': ('python-dotenv==1.2.2', 'requests==2.33.0', 'python-multipart==0.0.27', 'pytest==9.0.3', 'pytest-asyncio==1.4.0'),\n}\nfor path, requirements in expected.items():\n    text = Path(path).read_text()\n    for requirement in requirements:\n        assert requirement in text, (path, requirement)\nPY"
+      required: true
+    - id: "dependency-safety-scan"
+      command: "safety check -r requirements.txt -r config/requirements.txt -r web/backend/requirements.txt"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/g2-333.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha HEAD~1 --head-sha HEAD --report /tmp/g2-333-mainline-gate.json"
+      required: true
+    - id: "gitnexus-detect-changes"
+      command: "gitnexus_detect_changes(scope=compare, base_ref=origin/main)"
+      required: true
+    - id: "diff-check"
+      command: "git diff HEAD~1..HEAD --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Raising pytest to 9.0.3 may expose plugin compatibility issues in CI; this is required by the active safety database and must be monitored in checks."
+    - "The update intentionally leaves ignored unpinned warning ranges untouched because they are not failing the current CI safety command."
+  rollback_plan: "Revert this commit to restore previous dependency specifiers if CI or runtime compatibility regresses."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Make CI-scanned dependency manifests pass the current Dependency Safety Check."
+    modified_scope: "Three dependency manifests, one function-tree catalog mapping, one governance report, and one task card."
+    dependency_changes: "Adds root APScheduler, raises safety-reported lower bounds for python-dotenv, requests, python-multipart, and pytest, and updates pytest-asyncio for pytest 9 compatibility."
+    legacy_logic_impact: "No source code, API contract, frontend, runtime, or OpenStock code is changed."
+    rollback_ready: "Revert this dependency-manifest commit."
+    risk_and_rollback_point: "Rollback restores previous dependency specifiers."
+
+function_tree:
+  domain_id: "domain-08"
+  node_id: "domain-08-node-02"
+  affected_entrypoints:
+    - "governance"
+    - "operations"
+  update_status: "required"
+  secondary_domains: []
+  exemption_reason: "This dependency safety fix updates only CI-scanned requirement manifests and function-tree governance metadata; no business entrypoint or source symbol changes."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "G/#79 service lifecycle DI + Route/OpenAPI governance"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-13T04:05:00+08:00"
+    approval_note: "Human maintainer asked to continue MyStocks-side work; this follow-up isolates CI dependency safety manifest alignment required before continuing G2.332."
+    secondary_approved: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,10 @@ tushare>=1.3.0
 efinance>=0.5.0
 
 # 工具
-python-dotenv>=1.0.0
+python-dotenv>=1.2.2
 schedule>=1.2.0
-requests>=2.32.4
+APScheduler>=3.10.4
+requests>=2.33.0
 certifi>=2025.11.12
 bcrypt>=5.0.0
 attrs>=25.4.0
@@ -35,7 +36,7 @@ aiohttp>=3.13.0
 sse-starlette>=3.0.3
 swagger-ui-py>=25.7.1
 email-validator>=2.3.0
-python-multipart>=0.0.22
+python-multipart>=0.0.27
 PyJWT>=2.10.1
 
 # GPU加速依赖 (可选安装，用于量化交易回测和AI策略)
@@ -45,7 +46,7 @@ cudf-cu12>=25.10.0
 cuml-cu12>=25.10.0
 
 # 开发工具
-pytest>=7.4.0
+pytest>=9.0.3
 mypy>=1.5.0
 black>=25.11.0
 bleach>=6.3.0

--- a/web/backend/requirements.txt
+++ b/web/backend/requirements.txt
@@ -1,7 +1,7 @@
 # Web Framework
 fastapi==0.115.0
 uvicorn[standard]==0.30.0
-python-multipart==0.0.22
+python-multipart==0.0.27
 python-socketio>=5.10.0
 aiofiles>=25.1.0
 
@@ -21,7 +21,7 @@ TA-Lib==0.4.28
 python-jose[cryptography]>=3.4.0
 PyJWT>=2.10.1
 passlib[bcrypt]==1.7.4
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 
 # Data Processing and Export
 openpyxl==3.1.5
@@ -39,7 +39,7 @@ email-validator>=2.3.0
 # Utils
 pydantic==2.9.0
 pydantic-settings==2.5.0
-requests==2.32.4
+requests==2.33.0
 celery==5.4.0
 psutil>=5.9.0
 
@@ -48,8 +48,8 @@ psutil>=5.9.0
 # We rely on it being available in the Python environment
 
 # Development
-pytest==8.3.0
-pytest-asyncio==0.24.0
+pytest==9.0.3
+pytest-asyncio==1.4.0
 httpx==0.27.0
 
 # E2E Testing (Playwright)


### PR DESCRIPTION
## Summary

- Aligns the dependency manifests scanned by CI `Dependency Safety Check`.
- Adds root `APScheduler>=3.10.4` so `api-file-tests` can import backend cache-eviction code already covered by `web/backend/requirements.txt`.
- Raises safety-reported lower bounds for `python-dotenv`, `requests`, `python-multipart`, and `pytest` across `requirements.txt`, `config/requirements.txt`, and `web/backend/requirements.txt`.
- Updates `pytest-asyncio` to `1.4.0` in `web/backend/requirements.txt` so the backend resolver can satisfy `pytest==9.0.3`.
- Adds function-tree coverage for root/backend requirement manifests under `domain-08-node-02`.
- Records G2.333 task card and quality report evidence.

## Verification

- `python -c "assert CI-scanned dependency lower bounds are present"` -> passed
- `python -m pip install --dry-run -r web/backend/requirements.txt` -> resolver passed; would install `pytest-asyncio-1.4.0`
- `safety check -r requirements.txt -r config/requirements.txt -r web/backend/requirements.txt` -> 0 vulnerabilities reported; ignored unpinned warning ranges unchanged
- `git diff HEAD~1..HEAD --check` -> passed
- `python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/g2-333.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha HEAD~1 --head-sha HEAD --report /tmp/g2-333-mainline-gate-final.json` -> pass=True
- `gitnexus_detect_changes(scope=compare, base_ref=origin/main)` -> LOW risk, 6 changed files, 0 changed symbols, 0 affected processes

## Boundary

- No MyStocks API source, frontend source, tests, scripts, runtime behavior, or OpenSpec implementation files were modified.
- No OpenStock internals were modified.
- Ignored unpinned dependency warnings are intentionally left for a separate dependency governance task; this PR only addresses vulnerabilities that fail the current CI safety command.
