### PR TITLE
docs(governance): refresh service lifecycle DI residual pool after technical analysis merge

### DIFF
--- a/docs/reports/quality/backend-service-lifecycle-di-post-technical-analysis-residual-refresh-2026-06-13.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-post-technical-analysis-residual-refresh-2026-06-13.md
@@ -1,0 +1,117 @@
+# Backend Service Lifecycle DI Post-Technical-Analysis Residual Refresh
+
+Date: 2026-06-13
+Task: G2.335
+Mode: no-source governance refresh
+Base worktree: `g2-335-service-lifecycle-di-residual-refresh`
+Base commit: `74b548cf89bbb060ea17882cf6f750217e42c673`
+
+## Status
+
+G2.335 refreshes the service lifecycle DI residual pool after PR #480 landed the
+technical-analysis provider injection on `main`.
+
+This report is evidence only. It does not authorize source, test, API contract,
+frontend, runtime, script, configuration, OpenSpec implementation, deletion, or
+OpenStock internal changes.
+
+## Screening Method
+
+The scan used Python AST parsing over `web/backend/app/api/**/*.py` at
+`origin/main` commit `74b548cf8`.
+
+A route function was counted when it had a FastAPI route decorator such as
+`get`, `post`, `put`, `delete`, `patch`, `options`, `head`, or `api_route`.
+
+Strict residual candidates are route function bodies containing both:
+
+- a `DataSourceFactory()` constructor call
+- a body-level `get_data_source(...)` call
+
+Provider/helper functions outside route bodies are not counted as route-body
+residuals. Body-level `get_data_source(...)` calls without a
+`DataSourceFactory()` constructor remain observation items only.
+
+## Current Mainline Residual Pool
+
+After PR #480, `technical_analysis.py` has no strict route-body
+`DataSourceFactory` residuals.
+
+Current strict residual pool:
+
+| File | Residual route functions | Data source key | Functions |
+| --- | ---: | --- | --- |
+| `web/backend/app/api/watchlist.py` | 8 | `watchlist` | `get_my_watchlist`, `get_my_watchlist_symbols`, `add_to_watchlist`, `remove_from_watchlist`, `check_in_watchlist`, `update_watchlist_notes`, `get_watchlist_count`, `clear_watchlist` |
+| `web/backend/app/api/strategy.py` | 3 | `strategy` | `get_strategy_definitions`, `run_strategy_single`, `run_strategy_batch` |
+
+Total strict residual count: 11 route functions across 2 files.
+
+## Closed Candidate
+
+`web/backend/app/api/technical_analysis.py` is closed for this screening rule.
+
+The file still contains `DataSourceFactory` text because PR #480 centralized the
+factory construction in `get_technical_analysis_data_source()`, which is a
+provider function rather than a route body. No route handler in
+`technical_analysis.py` constructs `DataSourceFactory()` after PR #480.
+
+## Observation Item
+
+`web/backend/app/api/dashboard.py` still has a route-body `get_data_source(...)`
+usage without an in-body `DataSourceFactory()` constructor. This remains outside
+the strict residual definition and should not be used as source authorization
+evidence unless a future task broadens the lane from constructor residuals to
+general provider-boundary normalization.
+
+## Branch Split Notes
+
+The G2.330 branch split remains relevant:
+
+| Candidate family | Current `origin/main` status | Wip / PR anchor implication | G2.335 decision |
+| --- | --- | --- | --- |
+| Technical analysis | Closed by PR #480 | Previously cross-ref stable residual | Remove from residual pool; no follow-up source task needed for this rule |
+| Watchlist | 8 strict residual route handlers on current `main` | PR #474 accepted a watchlist provider anchor on the wip/root lane | Do not replay source work blindly; reconcile the accepted watchlist branch if selecting this family |
+| Strategy | 3 strict residual route handlers in `web/backend/app/api/strategy.py` | Wip/root uses `strategy_management/_strategy_execution_router.py` for the corresponding strategy family | Suitable narrow mainline candidate if the next task explicitly targets `origin/main` |
+| Dashboard summary | One body-level `get_data_source(...)` usage without constructor | Not selected by strict rule | Observation only |
+
+## Recommended Next Gate
+
+No source implementation is selected or authorized by G2.335.
+
+Recommended next source-authorization candidates:
+
+1. `strategy.py` mainline provider authorization: smallest current-main strict
+   residual family, 3 route handlers, no watchlist branch-anchor duplication.
+2. `watchlist.py` reconciliation authorization: larger current-main residual
+   family, 8 route handlers, but must reconcile the accepted PR #474 / wip-root
+   provider work before any mainline implementation decision.
+
+Any follow-up implementation must be a separate source-authorized task card with
+GitNexus impact analysis, route/API impact review, scoped source/test gates, and
+explicit base-branch selection.
+
+## OpenStock Boundary
+
+OpenStock internals remain out of scope. This MyStocks package records only the
+local residual evidence and branch-boundary implications. It does not modify
+OpenStock provider/runtime code, tests, configuration, packaging, or repository
+files.
+
+## Verification Scope
+
+This package is expected to modify only:
+
+| Path | Purpose |
+| --- | --- |
+| `docs/reports/quality/backend-service-lifecycle-di-post-technical-analysis-residual-refresh-2026-06-13.md` | G2.335 no-source residual refresh evidence |
+| `governance/mainline/task-cards/g2-335.yaml` | Mainline task card and no-source gate definition |
+
+Expected verification:
+
+| Check | Expected result |
+| --- | --- |
+| No-source path check | No changes under `src/**`, `web/backend/app/**`, `web/frontend/**`, `tests/**`, `scripts/**`, `config/**`, `openspec/changes/**`, or OpenStock internals |
+| Residual refresh assertion | Strict residual pool is `watchlist.py` 8, `strategy.py` 3, `technical_analysis.py` 0 |
+| Mainline scope gate | G2.335 task card validates the exact changed file set |
+| Git diff check | No whitespace errors |
+| GitNexus detect changes | Governance-only change; no indexed source symbols affected |

--- a/governance/mainline/task-cards/g2-335.yaml
+++ b/governance/mainline/task-cards/g2-335.yaml
@@ -1,0 +1,105 @@
+version: "v0.2"
+task:
+  id: "g2-335"
+  title: "Refresh service lifecycle DI residual pool after technical_analysis merge"
+  owner: "G/#79 service lifecycle DI + Route/OpenAPI governance"
+  created_at: "2026-06-13"
+
+mainline:
+  id: "L1-service-lifecycle-di-post-technical-analysis-residual-refresh"
+  objective: "Regenerate the current route-body DataSourceFactory residual pool after PR #480 landed technical_analysis provider injection."
+  milestone_id: "g2"
+  slice_id: "g2-335"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: ""
+  approval_status: "not_required"
+
+scope:
+  allowed_paths:
+    - "docs/reports/quality/backend-service-lifecycle-di-post-technical-analysis-residual-refresh-2026-06-13.md"
+    - "governance/mainline/task-cards/g2-335.yaml"
+  forbidden_paths:
+    - "src/**"
+    - "web/backend/app/**"
+    - "web/frontend/**"
+    - "tests/**"
+    - "scripts/**"
+    - "config/**"
+    - "requirements.txt"
+    - "web/backend/requirements.txt"
+    - "openspec/changes/**"
+    - "openstock/**"
+    - "OpenStock/**"
+
+non_goals:
+  - "Do not implement service lifecycle DI source changes."
+  - "Do not modify MyStocks API route source, tests, frontend, runtime state, scripts, configuration, dependency manifests, or OpenSpec implementation files."
+  - "Do not modify OpenStock internals, provider/runtime code, tests, configuration, packaging, or repository files."
+  - "Do not select watchlist or strategy source implementation scope without a separate source-authorized task card."
+  - "Do not authorize deletion, retirement, compatibility-layer removal, or full-file removal."
+
+acceptance:
+  checks:
+    - id: "no-source-path-check"
+      command: "git diff --name-only HEAD~1..HEAD excludes src/**, web/backend/app/**, web/frontend/**, tests/**, scripts/**, config/**, requirements.txt, web/backend/requirements.txt, openspec/changes/**, and OpenStock internals"
+      required: true
+    - id: "residual-refresh-report"
+      command: "docs/reports/quality/backend-service-lifecycle-di-post-technical-analysis-residual-refresh-2026-06-13.md records current origin/main strict residual pool after PR #480"
+      required: true
+    - id: "residual-refresh-assertion"
+      command: "AST scan confirms strict route-body residual pool: web/backend/app/api/watchlist.py=8, web/backend/app/api/strategy.py=3, web/backend/app/api/technical_analysis.py=0"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/g2-335.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha HEAD~1 --head-sha HEAD --report /tmp/g2-335-mainline-gate.json"
+      required: true
+    - id: "gitnexus-staged-detect-changes"
+      command: "gitnexus_detect_changes(scope=staged)"
+      required: true
+    - id: "diff-check"
+      command: "git diff HEAD~1..HEAD --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Current main still shows watchlist residuals even though PR #474 accepted a watchlist provider anchor on the wip/root lane; follow-up source work must not conflate those branches."
+    - "Strategy route paths differ across main and wip/root branch families; follow-up authorization must name the target base branch explicitly."
+    - "Dashboard body-level get_data_source usage is an observation item only and must not be treated as a strict DataSourceFactory constructor residual."
+  rollback_plan: "Revert this governance-only commit to remove the G2.335 report and task card."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Record the current service lifecycle DI residual pool after technical_analysis provider injection landed on main."
+    modified_scope: "Governance report and G2.335 task card only."
+    dependency_changes: "No dependency changes."
+    legacy_logic_impact: "No source, test, API, frontend, runtime, script, configuration, OpenSpec implementation, or OpenStock internal changes."
+    rollback_ready: "Revert this governance-only commit."
+    risk_and_rollback_point: "Any follow-up source work must use a separate source-authorized task card and explicit base-branch decision."
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "No business entrypoint changed; this is a no-source evidence and task-card package for mainline governance."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "G/#79 service lifecycle DI + Route/OpenAPI governance"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-13T09:28:43+08:00"
+    approval_note: "Human maintainer agreed to continue with the next MyStocks-side task after PR #480 merged; G2.335 is constrained to no-source residual refresh."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Refresh the current service lifecycle DI strict residual pool after PR #480 landed technical-analysis provider injection on main.
- Record that technical_analysis is now closed for the constructor-based strict residual rule and that the current mainline pool is watchlist + strategy.
- Keep this as a no-source governance package only.

## Boundary
- MyStocks governance/reporting only.
- No MyStocks application source, tests, API contracts, frontend, runtime, scripts, dependency manifests, OpenSpec implementation, or OpenStock internals changed.
- This task only refreshes the residual evidence and next-branch decision table.

## Validation
- AST residual assertion: watchlist=8, strategy=3, technical_analysis=0
- YAML parse for task card: pass
- report content checks: pass
- mainline scope gate for g2-335: pass
- git diff HEAD~1..HEAD --check: pass
- GitNexus detect_changes compare origin/main: LOW, 2 files, 0 symbols, 0 affected processes