### PR TITLE
docs(governance): authorize strategy service DI candidate

### DIFF
--- a/docs/reports/quality/backend-service-lifecycle-di-strategy-authorization-2026-06-13.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-strategy-authorization-2026-06-13.md
@@ -1,0 +1,157 @@
+# Backend Service Lifecycle DI Strategy Authorization
+
+Date: 2026-06-13
+Task: G2.336
+Mode: no-source authorization preflight
+Base worktree: `g2-336-strategy-datasourcefactory-provider-authorization`
+Base commit: `1cca050be6e2704af84890812a759765c9445557`
+
+## Status
+
+G2.336 is a no-source authorization preflight for the backend service lifecycle
+DI lane. It selects the next MyStocks-side candidate family after G2.335
+refreshed the residual pool, and records the implementation boundary for a
+later source-authorized task.
+
+This package does not modify or authorize in-place changes to source, tests,
+API contracts, frontend code, runtime state, scripts, configuration, dependency
+manifests, OpenSpec implementation files, deletion paths, or OpenStock internals.
+
+## Parent Evidence
+
+G2.335 refreshed the current `origin/main` residual pool after PR #480 landed
+the technical-analysis provider injection:
+
+| Candidate family | Current `origin/main` status | G2.336 disposition |
+| --- | --- | --- |
+| Technical analysis routes | `technical_analysis.py` has 0 strict route-body `DataSourceFactory()` residuals | Closed for this strict residual rule |
+| Strategy routes | `strategy.py` has 3 strict route-body `DataSourceFactory()` residuals | Select as the next narrow mainline candidate |
+| Watchlist routes | `watchlist.py` has 8 strict route-body `DataSourceFactory()` residuals | Defer; must reconcile PR #474 / wip-root accepted provider anchor before mainline source work |
+| Dashboard summary | One body-level `get_data_source(...)` call without `DataSourceFactory()` | Observation only |
+
+The selected candidate is `web/backend/app/api/strategy.py` because it is the
+smallest current-main strict residual family and avoids the watchlist branch
+anchor conflict.
+
+## Current Strategy Residuals
+
+The current `origin/main` route-body scan finds 3 strict residual route
+functions in `web/backend/app/api/strategy.py`.
+
+| Function | Line | Route | Data source key | `DataSourceFactory()` calls | Body `get_data_source()` calls |
+| --- | ---: | --- | --- | ---: | ---: |
+| `get_strategy_definitions` | 182 | `GET /definitions` | `strategy` | 1 | 1 |
+| `run_strategy_single` | 219 | `POST /run/single` | `strategy` | 1 | 1 |
+| `run_strategy_batch` | 273 | `POST /run/batch` | `strategy` | 1 | 1 |
+
+Total residuals: 3 route functions, 3 `DataSourceFactory()` calls, and 3
+body-level `get_data_source("strategy")` calls.
+
+Other route functions in `strategy.py` do not match this strict constructor
+residual rule.
+
+## GitNexus And Route Index Snapshot
+
+GitNexus `api_impact(file="web/backend/app/api/strategy.py")` did not resolve
+current `strategy.py` routes. `route_map("/strategy")` returned indexed routes
+for `web/backend/app/api/strategy_management/_strategy_execution_router.py`,
+but that file is absent from current `origin/main`.
+
+Local Git and AST evidence at `1cca050be` confirms:
+
+| Path | Current main status |
+| --- | --- |
+| `web/backend/app/api/strategy.py` | Exists and owns the current mainline strategy routes |
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | Absent |
+
+GitNexus symbol impact for the three selected current-main functions also
+returned `not_found`. This is treated as an index coverage limitation, not as a
+proof of no impact.
+
+Any future source-authorized implementation must rerun impact/API-impact from
+its own branch. If GitNexus still cannot resolve the current route file, the
+implementation task must explicitly record the limitation and rely on local AST
+route evidence plus focused route tests as the hard gate.
+
+## Baseline Test Snapshot
+
+The following focused baseline checks passed before this authorization package
+was written:
+
+| Check | Result |
+| --- | --- |
+| `python -m py_compile web/backend/app/api/strategy.py` | Pass |
+| `pytest --no-cov tests/api/file_tests/test_strategy_api.py` | 18 passed |
+| `pytest --no-cov tests/unit/api/test_strategy_api.py` | 17 passed |
+
+These checks are baseline evidence only. The future implementation task must
+rerun focused tests after source edits.
+
+## Proposed Implementation Boundary
+
+The later source-authorized task should keep the change narrow:
+
+| Scope | Proposed path |
+| --- | --- |
+| Primary source file | `web/backend/app/api/strategy.py` |
+| Route/API regression tests | `tests/api/file_tests/test_strategy_api.py` and `tests/unit/api/test_strategy_api.py` |
+| Provider-injection regression test | A focused test may be added under `web/backend/tests/` or another existing backend route-test location if needed |
+
+The expected implementation pattern should follow the already-landed
+technical-analysis provider shape:
+
+1. Move `DataSourceFactory()` construction out of the three selected route
+   bodies into a small provider helper such as `get_strategy_data_source()`.
+2. Inject the strategy adapter into the three route handlers with `Depends(...)`.
+3. Preserve route paths, response models, response envelopes, parameter
+   validation, exception mapping, and adapter method calls.
+4. Add or adjust focused tests only for the provider-injection behavior and the
+   affected strategy route contract.
+
+## Non-Goals
+
+The follow-up implementation must not:
+
+| Non-goal | Reason |
+| --- | --- |
+| Modify OpenStock internals | OpenStock work is owned separately and remains out of scope |
+| Rewrite strategy execution algorithms or adapter behavior | G2.336 only targets route-body `DataSourceFactory()` lifecycle residuals |
+| Change response schemas, return envelopes, or OpenAPI contracts | The task is DI lifecycle cleanup, not API redesign |
+| Touch watchlist residuals | Watchlist has branch-anchor reconciliation risk and needs separate authorization |
+| Broaden to dashboard `get_data_source()` observation | It does not match the strict `DataSourceFactory()` residual rule |
+| Delete or retire files | Deletion/retirement requires separate authorization under repository standards |
+
+## Authorization Decision
+
+G2.336 authorizes only the next planning direction:
+
+| Decision | Result |
+| --- | --- |
+| Next candidate family | `strategy.py` service lifecycle DI residuals |
+| Target base | `origin/main` |
+| Source implementation status | Not implemented by this task |
+| Required next node | Separate source-authorized task card before any code/test edits |
+| OpenStock status | Boundary-only; no OpenStock development or modification |
+
+## Required Next Gate
+
+Before editing source in the next node, the implementation branch must:
+
+1. Create a source-authorized task card with explicit allowed source and test
+   paths.
+2. Rerun GitNexus impact/API-impact for `web/backend/app/api/strategy.py` and
+   report either the resolved risk level or the current route-index limitation.
+3. Inspect existing strategy tests and choose focused regression coverage before
+   writing implementation code.
+4. Run `python -m py_compile`, focused strategy API tests, mainline scope gate,
+   path whitelist, `git diff --check`, GitNexus detect changes, and GitHub CI.
+5. Keep OpenStock internals out of scope.
+
+## Verification Scope
+
+This package is expected to modify only:
+
+| Path | Purpose |
+| --- | --- |
+| `docs/reports/quality/backend-service-lifecycle-di-strategy-authorization-2026-06-13.md` | G2.336 no-source authorization preflight evidence |
+| `governance/mainline/task-cards/g2-336.yaml` | G2.336 mainline task card and no-source gate definition |

--- a/governance/mainline/task-cards/g2-336.yaml
+++ b/governance/mainline/task-cards/g2-336.yaml
@@ -1,0 +1,108 @@
+version: "v0.2"
+task:
+  id: "g2-336"
+  title: "Authorize strategy service lifecycle DI candidate"
+  owner: "G/#79 service lifecycle DI + Route/OpenAPI governance"
+  created_at: "2026-06-13"
+
+mainline:
+  id: "L1-service-lifecycle-di-strategy-authorization"
+  objective: "Select strategy.py as the next current-main service lifecycle DI candidate and record the source-authorization boundary for a later implementation task."
+  milestone_id: "g2"
+  slice_id: "g2-336"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: ""
+  approval_status: "not_required"
+
+scope:
+  allowed_paths:
+    - "docs/reports/quality/backend-service-lifecycle-di-strategy-authorization-2026-06-13.md"
+    - "governance/mainline/task-cards/g2-336.yaml"
+  forbidden_paths:
+    - "src/**"
+    - "web/backend/app/**"
+    - "web/frontend/**"
+    - "tests/**"
+    - "scripts/**"
+    - "config/**"
+    - "requirements.txt"
+    - "web/backend/requirements.txt"
+    - "openspec/changes/**"
+    - "openstock/**"
+    - "OpenStock/**"
+
+non_goals:
+  - "Do not implement service lifecycle DI source changes in this task."
+  - "Do not modify strategy.py, route tests, frontend code, runtime state, scripts, configuration, dependency manifests, or OpenSpec implementation files."
+  - "Do not modify OpenStock internals, provider/runtime code, tests, configuration, packaging, or repository files."
+  - "Do not touch watchlist, dashboard, technical_analysis, or other service lifecycle DI residual families."
+  - "Do not authorize deletion, retirement, compatibility-layer removal, or full-file removal."
+
+acceptance:
+  checks:
+    - id: "no-source-path-check"
+      command: "git diff --name-only HEAD~1..HEAD excludes src/**, web/backend/app/**, web/frontend/**, tests/**, scripts/**, config/**, requirements.txt, web/backend/requirements.txt, openspec/changes/**, and OpenStock internals"
+      required: true
+    - id: "authorization-preflight-report"
+      command: "docs/reports/quality/backend-service-lifecycle-di-strategy-authorization-2026-06-13.md records the strategy residual table, GitNexus route-index limitation, baseline test snapshot, and next source-authorized gate"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/g2-336.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha HEAD~1 --head-sha HEAD --report /tmp/g2-336-mainline-gate.json"
+      required: true
+    - id: "gitnexus-staged-detect-changes"
+      command: "gitnexus_detect_changes(scope=staged)"
+      required: true
+    - id: "strategy-baseline-tests"
+      command: "Baseline evidence recorded: py_compile strategy.py pass; pytest --no-cov tests/api/file_tests/test_strategy_api.py = 18 passed; pytest --no-cov tests/unit/api/test_strategy_api.py = 17 passed"
+      required: true
+    - id: "gitnexus-api-impact-preflight"
+      command: "GitNexus api_impact(file=web/backend/app/api/strategy.py) returned no current routes; report records route-index limitation and requires rerun in source implementation task"
+      required: true
+    - id: "diff-check"
+      command: "git diff HEAD~1..HEAD --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "GitNexus route/API impact does not currently resolve web/backend/app/api/strategy.py and instead maps strategy routes to a removed strategy_management execution router; source implementation must record fresh impact evidence or the index limitation."
+    - "Route-body DI cleanup must preserve response schemas, return envelopes, parameter validation, exception mapping, and adapter method calls."
+    - "Watchlist remains a separate residual family with branch-anchor reconciliation risk and must not be mixed into strategy implementation."
+  rollback_plan: "Revert this governance-only commit to remove the G2.336 authorization preflight report and task card."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Select strategy.py as the next current-main service lifecycle DI residual candidate."
+    modified_scope: "Governance report and G2.336 task card only."
+    dependency_changes: "No dependency changes."
+    legacy_logic_impact: "No source, test, API, frontend, runtime, script, configuration, OpenSpec implementation, or OpenStock internal changes."
+    rollback_ready: "Revert this governance-only commit."
+    risk_and_rollback_point: "Future source work requires a separate source-authorized task card, fresh impact/API-impact attempt, and focused strategy tests."
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "No business entrypoint changed; this is a no-source authorization preflight package for mainline governance."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "G/#79 service lifecycle DI + Route/OpenAPI governance"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-13T09:57:51+08:00"
+    approval_note: "Human maintainer agreed to continue after G2.335; G2.336 is constrained to no-source strategy authorization preflight and OpenStock boundary-only handling."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Add G2.336 no-source authorization preflight for the current-main strategy service lifecycle DI candidate.
- Select web/backend/app/api/strategy.py as the next source-authorized implementation candidate after G2.335 residual refresh.
- Record GitNexus/route-index limitations and preserve OpenStock/MyStocks boundary: no OpenStock work and no source/test/runtime/config changes in this PR.

## Validation
- python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/g2-336.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha HEAD~1 --head-sha HEAD --report /tmp/g2-336-mainline-gate.json: pass=True
- git diff HEAD~1..HEAD --check: clean
- no-source path whitelist: docs report + governance task card only, forbidden paths=[]
- YAML task card parse: pass
- report section check: pass
- GitNexus detect_changes compare origin/main: LOW risk, 2 changed files, 0 changed symbols, 0 affected processes

## Notes
- This PR does not authorize or implement source edits.
- Future source implementation must use a separate source-authorized task card and rerun route/API impact checks for strategy.py.