### PR TITLE
refactor(api): inject strategy data source provider

### DIFF
--- a/docs/reports/quality/backend-service-lifecycle-di-strategy-provider-2026-06-13.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-strategy-provider-2026-06-13.md
@@ -1,0 +1,114 @@
+# Backend Service Lifecycle DI Strategy Provider
+
+## Status
+
+- Date: 2026-06-13
+- Task: G2.337
+- Mode: source-authorized implementation
+- Branch: `g2-337-strategy-datasourcefactory-provider-injection`
+- Base: `origin/main`
+- Base commit: `356f9e2f969d6f5bc59c999b9e8ee5d095e52f7b`
+- OpenStock boundary: no OpenStock internals, tests, runtime, configuration, packaging, or repository files changed.
+
+## Authorization Boundary
+
+G2.336 selected `web/backend/app/api/strategy.py` as the next current-main service lifecycle DI candidate. G2.337 implements only that candidate.
+
+Allowed implementation scope:
+
+- `web/backend/app/api/strategy.py`
+- `web/backend/tests/test_strategy_provider_injection.py`
+- `governance/function-tree/catalog.yaml`
+- `governance/compliance/unified-response-contract-legacy-baseline.json`
+- `governance/mainline/task-cards/g2-337.yaml`
+- `docs/reports/quality/backend-service-lifecycle-di-strategy-provider-2026-06-13.md`
+
+Non-goals:
+
+- No strategy route path, response envelope, parameter validation, exception mapping, or adapter request payload changes.
+- No watchlist, technical_analysis, dashboard, frontend, runtime, dependency, configuration, OpenSpec implementation, or OpenStock internal changes.
+- No deletion, retirement, compatibility-layer removal, or response-contract migration.
+
+## Impact Evidence
+
+GitNexus pre-edit impact was attempted before source modification:
+
+- `api_impact(file=web/backend/app/api/strategy.py)`: returned no current routes for the file.
+- `impact(target=get_strategy_definitions, file_path=web/backend/app/api/strategy.py)`: `not_found`.
+- `impact(target=run_strategy_single, file_path=web/backend/app/api/strategy.py)`: `not_found`.
+- `impact(target=run_strategy_batch, file_path=web/backend/app/api/strategy.py)`: `not_found`.
+- `route_map(route=/api/v1/strategy)`: still maps strategy routes to `web/backend/app/api/strategy_management/_strategy_execution_router.py`, which is not the current-main source file.
+
+This is treated as an index coverage limitation, not as proof of no impact. The implementation is therefore constrained by AST verification and focused strategy tests.
+
+## Implementation Summary
+
+`strategy.py` now follows the same provider boundary pattern already used by `technical_analysis.py`:
+
+- Added `get_strategy_data_source()`.
+- Kept the single `DataSourceFactory()` construction inside that provider boundary.
+- Refreshed the function-tree catalog mapping so the current-main `strategy.py` route file and focused backend regression test map to `domain-03-node-01`.
+- Registered existing `strategy.py` UnifiedResponse contract debt in the explicit legacy baseline so this DI task does not change response models or return envelopes.
+- Injected `strategy_adapter: Any = Depends(get_strategy_data_source)` into:
+  - `get_strategy_definitions`
+  - `run_strategy_single`
+  - `run_strategy_batch`
+- Removed route-body `DataSourceFactory()` construction and route-body `get_data_source("strategy")` calls from those handlers.
+- Preserved existing `strategy_adapter.get_data(...)` operations and payload keys:
+  - `get_data("definitions")`
+  - `get_data("run_single", params)`
+  - `get_data("run_batch", params)`
+
+## TDD Evidence
+
+RED:
+
+- Command: `pytest --no-cov web/backend/tests/test_strategy_provider_injection.py`
+- Result before implementation: `2 failed`
+- Expected failure:
+  - three strategy routes still had inline `DataSourceFactory` calls
+  - `get_strategy_data_source` provider did not exist
+
+GREEN:
+
+- Command: `pytest --no-cov web/backend/tests/test_strategy_provider_injection.py`
+- Result after implementation: `2 passed in 8.73s`
+
+## AST Residual Check
+
+Post-implementation AST check:
+
+| Target | Route-body `DataSourceFactory` | Route-body `get_data_source` | Provider arg |
+| --- | ---: | ---: | --- |
+| `get_strategy_definitions` | 0 | 0 | `strategy_adapter` |
+| `run_strategy_single` | 0 | 0 | `strategy_adapter` |
+| `run_strategy_batch` | 0 | 0 | `strategy_adapter` |
+
+Provider boundary:
+
+| Provider | `DataSourceFactory` | `get_data_source` | Data source |
+| --- | ---: | ---: | --- |
+| `get_strategy_data_source` | 1 | 1 | `strategy` |
+
+## Validation
+
+Focused checks run after implementation:
+
+| Check | Result |
+| --- | --- |
+| `python -m py_compile web/backend/app/api/strategy.py` | pass |
+| `pytest --no-cov web/backend/tests/test_strategy_provider_injection.py` | `2 passed in 19.63s` |
+| `pytest --no-cov tests/api/file_tests/test_strategy_api.py` | `18 passed in 1.11s` |
+| `pytest --no-cov tests/unit/api/test_strategy_api.py` | `17 passed in 1.35s` |
+| `black --check web/backend/app/api/strategy.py web/backend/tests/test_strategy_provider_injection.py` | pass |
+| `pytest --no-cov tests/unit/scripts/test_unified_response_contract_guard.py` | `11 passed in 2.20s` |
+| `python scripts/compliance/unified_response_contract_guard.py --format json --root-dir $PWD --path web/backend/app/api/strategy.py` | pass; 0 errors; 6 legacy baseline exemptions |
+| `git diff HEAD~1..HEAD --check` | clean |
+| G2.337 mainline scope gate | `pass=True` |
+| GitNexus `detect_changes(scope=compare, base_ref=origin/main)` | LOW risk; 5 changed files; 0 changed symbols; 0 affected processes |
+
+PR CI remains the final merge gate.
+
+## Rollback
+
+Revert the G2.337 commit to restore route-body `DataSourceFactory()` construction and remove the focused provider-injection regression test, report, and task card.

--- a/governance/compliance/unified-response-contract-legacy-baseline.json
+++ b/governance/compliance/unified-response-contract-legacy-baseline.json
@@ -15,6 +15,18 @@
         "get_batch_indicators"
       ],
       "reason": "G2.332 is a service lifecycle DI cleanup. These existing routes require a separate UnifiedResponse contract migration because changing response_model/return envelopes would alter the API contract."
+    },
+    {
+      "path": "web/backend/app/api/strategy.py",
+      "endpoints": [
+        "get_strategy_definitions",
+        "run_strategy_single",
+        "run_strategy_batch",
+        "query_strategy_results",
+        "get_matched_stocks",
+        "get_strategy_summary"
+      ],
+      "reason": "G2.337 is a service lifecycle DI cleanup. These existing routes require a separate UnifiedResponse contract migration because changing response_model/return envelopes would alter the API contract."
     }
   ]
 }

--- a/governance/function-tree/catalog.yaml
+++ b/governance/function-tree/catalog.yaml
@@ -184,6 +184,7 @@ domains:
         coverage_paths:
           - "src/application/strategy/**"
           - "src/strategies/**"
+          - "web/backend/app/api/strategy.py"
           - "web/backend/app/api/strategy_management/**"
           - "web/backend/app/api/strategy_mgmt.py"
           - "web/frontend/src/views/strategy/**"
@@ -191,6 +192,7 @@ domains:
           governance:
             - "docs/FUNCTION_TREE.md"
           api:
+            - "web/backend/app/api/strategy.py"
             - "web/backend/app/api/strategy_management/**"
             - "web/backend/app/api/strategy_mgmt.py"
           frontend:
@@ -200,6 +202,9 @@ domains:
             - "src/application/strategy/**"
             - "src/strategies/**"
           tests:
+            - "tests/api/file_tests/test_strategy_api.py"
+            - "tests/unit/api/test_strategy_api.py"
+            - "web/backend/tests/test_strategy_provider_injection.py"
             - "tests/api/strategy.spec.ts"
             - "tests/e2e/strategy-management.spec.ts"
             - "web/frontend/tests/e2e/strategy-backtest.spec.ts"

--- a/governance/mainline/task-cards/g2-337.yaml
+++ b/governance/mainline/task-cards/g2-337.yaml
@@ -1,0 +1,124 @@
+version: "v0.2"
+task:
+  id: "g2-337"
+  title: "Inject strategy data source provider"
+  owner: "G/#79 service lifecycle DI + Route/OpenAPI governance"
+  created_at: "2026-06-13"
+
+mainline:
+  id: "L1-service-lifecycle-di-strategy-provider"
+  objective: "Move strategy route-body DataSourceFactory construction into a FastAPI provider dependency without changing route behavior."
+  milestone_id: "g2"
+  slice_id: "g2-337"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: ""
+  approval_status: "not_required"
+
+scope:
+  allowed_paths:
+    - "docs/reports/quality/backend-service-lifecycle-di-strategy-provider-2026-06-13.md"
+    - "governance/compliance/unified-response-contract-legacy-baseline.json"
+    - "governance/function-tree/catalog.yaml"
+    - "governance/mainline/task-cards/g2-337.yaml"
+    - "web/backend/app/api/strategy.py"
+    - "web/backend/tests/test_strategy_provider_injection.py"
+  forbidden_paths:
+    - "src/**"
+    - "web/frontend/**"
+    - "config/**"
+    - "requirements.txt"
+    - "web/backend/requirements.txt"
+    - "openspec/changes/**"
+    - "openstock/**"
+    - "OpenStock/**"
+
+non_goals:
+  - "Do not change strategy route paths, response envelopes, parameter validation, exception mapping, or adapter get_data(...) request payloads."
+  - "Do not modify OpenStock internals, provider/runtime code, tests, configuration, packaging, or repository files."
+  - "Do not modify watchlist, technical_analysis, dashboard, frontend, unrelated scripts, configuration, OpenSpec implementation files, unrelated dependency manifests, or unrelated tests."
+  - "Do not migrate strategy response models to UnifiedResponse in this DI task; record existing response-contract debt in the explicit legacy baseline instead."
+  - "Do not delete or retire files, compatibility layers, route handlers, imports with side effects, or response-contract debt."
+
+acceptance:
+  checks:
+    - id: "tdd-red-provider-injection-test"
+      command: "pytest --no-cov web/backend/tests/test_strategy_provider_injection.py fails before implementation because strategy route bodies still construct DataSourceFactory"
+      required: true
+    - id: "focused-provider-injection-test"
+      command: "pytest --no-cov web/backend/tests/test_strategy_provider_injection.py"
+      required: true
+    - id: "strategy-api-file-tests"
+      command: "pytest --no-cov tests/api/file_tests/test_strategy_api.py"
+      required: true
+    - id: "strategy-unit-api-tests"
+      command: "pytest --no-cov tests/unit/api/test_strategy_api.py"
+      required: true
+    - id: "strategy-py-compile"
+      command: "python -m py_compile web/backend/app/api/strategy.py"
+      required: true
+    - id: "unified-response-guard-baseline-test"
+      command: "pytest --no-cov tests/unit/scripts/test_unified_response_contract_guard.py"
+      required: true
+    - id: "unified-response-guard-strategy"
+      command: "python scripts/compliance/unified_response_contract_guard.py --format json --root-dir $PWD --path web/backend/app/api/strategy.py"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/g2-337.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha HEAD~1 --head-sha HEAD --report /tmp/g2-337-mainline-gate.json"
+      required: true
+    - id: "gitnexus-api-impact"
+      command: "gitnexus_api_impact(file=web/backend/app/api/strategy.py) attempted before editing; current index maps strategy routes to removed strategy_management router and the implementation report records this limitation"
+      required: true
+    - id: "gitnexus-detect-changes"
+      command: "gitnexus_detect_changes(scope=compare, base_ref=origin/main)"
+      required: true
+    - id: "diff-check"
+      command: "git diff HEAD~1..HEAD --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "GitNexus API and symbol impact do not currently resolve current-main web/backend/app/api/strategy.py; this task must preserve the limitation evidence and rely on AST plus focused route tests."
+    - "The route-body cleanup touches three API handlers in one file; behavior must remain unchanged except dependency construction location."
+    - "Static provider-boundary tests prove the lifecycle boundary but do not replace focused strategy API file and unit tests."
+    - "The UnifiedResponse guard baseline is explicit debt registration only; it must not be used to add new legacy endpoints."
+  rollback_plan: "Revert this source-authorized commit to restore route-body DataSourceFactory construction and remove the focused provider-injection test, report, and task card."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Move strategy DataSourceFactory construction from route bodies into a provider dependency."
+    modified_scope: "One API route file, one focused backend provider-injection test file, one function-tree catalog mapping, one UnifiedResponse legacy baseline entry, one governance report, and one task card."
+    dependency_changes: "No dependency changes."
+    legacy_logic_impact: "Strategy route paths, response envelopes, validation, exception mapping, and adapter get_data(...) calls are preserved."
+    rollback_ready: "Revert this source-authorized commit."
+    risk_and_rollback_point: "Rollback restores previous inline DataSourceFactory lifecycle behavior and removes the explicit strategy response-contract debt baseline entry."
+
+function_tree:
+  domain_id: "domain-03"
+  node_id: "domain-03-node-01"
+  affected_entrypoints:
+    - "governance"
+    - "api"
+    - "tests"
+  update_status: "required"
+  secondary_domains: []
+  exemption_reason: "Existing strategy API routes are unchanged; the source-authorized change moves strategy adapter construction from route bodies to a route module provider dependency, adds focused regression tests, and refreshes the function-tree catalog mapping for the current-main strategy.py route file."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "G/#79 service lifecycle DI + Route/OpenAPI governance"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-13T10:24:57+08:00"
+    approval_note: "Human maintainer agreed to continue after G2.336; G2.337 is constrained to MyStocks strategy.py provider injection with OpenStock boundary-only handling."
+    secondary_approved: false

--- a/web/backend/app/api/strategy.py
+++ b/web/backend/app/api/strategy.py
@@ -6,9 +6,9 @@
 import logging
 import re
 from datetime import date, datetime
-from typing import List, Optional
+from typing import Any, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field, field_validator
 
 from app.core.responses import ErrorCodes, ResponseMessages, create_error_response, create_success_response
@@ -18,6 +18,11 @@ from app.services.strategy_service import get_strategy_service
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+async def get_strategy_data_source() -> Any:
+    data_source_factory = DataSourceFactory()
+    return await data_source_factory.get_data_source("strategy")
 
 
 # ==================== 请求/响应模型 ====================
@@ -179,7 +184,10 @@ class MarketFilterParams(BaseModel):
 
 
 @router.get("/definitions", tags=["strategy"])
-async def get_strategy_definitions():
+async def get_strategy_definitions(
+    *,
+    strategy_adapter: Any = Depends(get_strategy_data_source),
+):
     """
     获取所有策略定义
 
@@ -187,10 +195,6 @@ async def get_strategy_definitions():
         所有可用策略的定义列表
     """
     try:
-        # 使用数据源工厂
-        data_source_factory = DataSourceFactory()
-        strategy_adapter = await data_source_factory.get_data_source("strategy")
-
         result = await strategy_adapter.get_data("definitions")
 
         if "error" in result:
@@ -221,6 +225,8 @@ async def run_strategy_single(
     symbol: str = Query(..., description="股票代码", min_length=1, max_length=20, pattern=r"^[A-Z0-9.]+$"),
     stock_name: Optional[str] = Query(None, description="股票名称", max_length=100),
     check_date: Optional[str] = Query(None, description="检查日期 YYYY-MM-DD", pattern=r"^\d{4}-\d{2}-\d{2}$"),
+    *,
+    strategy_adapter: Any = Depends(get_strategy_data_source),
 ):
     """
     对单只股票运行策略
@@ -235,10 +241,6 @@ async def run_strategy_single(
         策略执行结果
     """
     try:
-        # 使用数据源工厂
-        data_source_factory = DataSourceFactory()
-        strategy_adapter = await data_source_factory.get_data_source("strategy")
-
         params = {"strategy_code": strategy_code, "symbol": symbol, "stock_name": stock_name, "check_date": check_date}
 
         result = await strategy_adapter.get_data("run_single", params)
@@ -278,6 +280,8 @@ async def run_strategy_batch(
     market: Optional[str] = Query("A", description="市场类型 (A/SH/SZ/CYB/KCB)", pattern=r"^(A|SH|SZ|CYB|KCB)$"),
     limit: Optional[int] = Query(None, description="限制处理数量", ge=1, le=5000),
     check_date: Optional[str] = Query(None, description="检查日期 YYYY-MM-DD", pattern=r"^\d{4}-\d{2}-\d{2}$"),
+    *,
+    strategy_adapter: Any = Depends(get_strategy_data_source),
 ):
     """
     批量运行策略
@@ -293,10 +297,6 @@ async def run_strategy_batch(
         批量执行结果统计
     """
     try:
-        # 使用数据源工厂
-        data_source_factory = DataSourceFactory()
-        strategy_adapter = await data_source_factory.get_data_source("strategy")
-
         params = {
             "strategy_code": strategy_code,
             "symbols": symbols,

--- a/web/backend/tests/test_strategy_provider_injection.py
+++ b/web/backend/tests/test_strategy_provider_injection.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+STRATEGY_PATH = PROJECT_ROOT / "web/backend/app/api/strategy.py"
+PROVIDER_NAME = "get_strategy_data_source"
+ADAPTER_PARAM_NAME = "strategy_adapter"
+ROUTE_FUNCTIONS = {
+    "get_strategy_definitions",
+    "run_strategy_single",
+    "run_strategy_batch",
+}
+
+
+def _parse_module() -> ast.Module:
+    return ast.parse(STRATEGY_PATH.read_text(encoding="utf-8"))
+
+
+def _call_name(call: ast.Call) -> str:
+    func = call.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
+def _decorator_name(decorator: ast.expr) -> str:
+    if isinstance(decorator, ast.Call):
+        decorator = decorator.func
+    if isinstance(decorator, ast.Attribute):
+        return decorator.attr
+    if isinstance(decorator, ast.Name):
+        return decorator.id
+    return ""
+
+
+def _route_functions(tree: ast.Module) -> dict[str, ast.AsyncFunctionDef]:
+    route_names = {"get", "post", "put", "delete", "patch", "options", "head", "websocket", "api_route"}
+    routes: dict[str, ast.AsyncFunctionDef] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AsyncFunctionDef):
+            continue
+        if any(_decorator_name(decorator) in route_names for decorator in node.decorator_list):
+            routes[node.name] = node
+    return routes
+
+
+def _body_call_count(node: ast.AsyncFunctionDef, call_name: str) -> int:
+    count = 0
+    for statement in node.body:
+        for child in ast.walk(statement):
+            if isinstance(child, ast.Call) and _call_name(child) == call_name:
+                count += 1
+    return count
+
+
+def _depends_on_provider(arg: ast.arg, default: ast.expr | None) -> bool:
+    if arg.arg != ADAPTER_PARAM_NAME:
+        return False
+    if not isinstance(default, ast.Call) or _call_name(default) != "Depends" or not default.args:
+        return False
+    provider = default.args[0]
+    return isinstance(provider, ast.Name) and provider.id == PROVIDER_NAME
+
+
+def _kwonly_default_by_arg(node: ast.AsyncFunctionDef) -> dict[str, ast.expr | None]:
+    return dict(zip((arg.arg for arg in node.args.kwonlyargs), node.args.kw_defaults))
+
+
+def test_strategy_routes_inject_adapter_provider() -> None:
+    tree = _parse_module()
+    routes = _route_functions(tree)
+
+    missing = sorted(ROUTE_FUNCTIONS - set(routes))
+    assert not missing, f"missing expected strategy routes: {missing}"
+
+    inline_factory_routes = []
+    inline_getter_routes = []
+    missing_provider_routes = []
+    for route_name in sorted(ROUTE_FUNCTIONS):
+        route = routes[route_name]
+        if _body_call_count(route, "DataSourceFactory"):
+            inline_factory_routes.append(route_name)
+        if _body_call_count(route, "get_data_source"):
+            inline_getter_routes.append(route_name)
+
+        defaults = _kwonly_default_by_arg(route)
+        provider_arg = next((arg for arg in route.args.kwonlyargs if arg.arg == ADAPTER_PARAM_NAME), None)
+        if provider_arg is None or not _depends_on_provider(provider_arg, defaults.get(ADAPTER_PARAM_NAME)):
+            missing_provider_routes.append(route_name)
+
+    assert inline_factory_routes == []
+    assert inline_getter_routes == []
+    assert missing_provider_routes == []
+
+
+def test_strategy_provider_is_single_factory_boundary() -> None:
+    tree = _parse_module()
+    provider = next(
+        (node for node in ast.walk(tree) if isinstance(node, ast.AsyncFunctionDef) and node.name == PROVIDER_NAME),
+        None,
+    )
+
+    assert provider is not None
+    assert _body_call_count(provider, "DataSourceFactory") == 1
+    assert _body_call_count(provider, "get_data_source") == 1
+
+    data_source_names = [
+        call.args[0].value
+        for call in ast.walk(provider)
+        if isinstance(call, ast.Call)
+        and _call_name(call) == "get_data_source"
+        and call.args
+        and isinstance(call.args[0], ast.Constant)
+    ]
+    assert data_source_names == ["strategy"]


### PR DESCRIPTION
## Summary
- Move strategy route-body DataSourceFactory construction into get_strategy_data_source() and inject it with FastAPI Depends.
- Add focused AST regression coverage for the strategy provider boundary.
- Refresh function-tree catalog mapping so current-main strategy.py and the new provider test map to domain-03-node-01.

## Boundary
- MyStocks-side only; no OpenStock internals changed.
- Preserves strategy route paths, response envelopes, validation, exception mapping, and adapter get_data(...) payloads.
- No frontend, config, dependency, OpenSpec implementation, deletion, or retirement changes.

## Validation
- RED: pytest --no-cov web/backend/tests/test_strategy_provider_injection.py failed before implementation with 2 expected failures.
- GREEN: pytest --no-cov web/backend/tests/test_strategy_provider_injection.py = 2 passed in 19.63s.
- python -m py_compile web/backend/app/api/strategy.py: pass.
- pytest --no-cov tests/api/file_tests/test_strategy_api.py = 18 passed in 1.11s.
- pytest --no-cov tests/unit/api/test_strategy_api.py = 17 passed in 1.35s.
- black --check web/backend/app/api/strategy.py web/backend/tests/test_strategy_provider_injection.py: pass.
- mainline scope gate for G2.337: pass=True.
- git diff HEAD~1..HEAD --check: clean.
- GitNexus detect_changes compare origin/main: LOW risk, 5 changed files, 0 changed symbols, 0 affected processes.

## Notes
- GitNexus api_impact and symbol impact do not currently resolve current-main web/backend/app/api/strategy.py; report records this as an index coverage limitation, not proof of no impact.