### PR TITLE
docs(governance): refresh service DI residual pool

### DIFF
--- a/docs/reports/quality/backend-service-lifecycle-di-residual-refresh-2026-06-13.md
+++ b/docs/reports/quality/backend-service-lifecycle-di-residual-refresh-2026-06-13.md
@@ -1,0 +1,117 @@
+# Backend Service Lifecycle DI Residual Refresh
+
+## Status
+
+- Date: 2026-06-13
+- Task: G2.338
+- Mode: no-source residual refresh
+- Branch: `g2-338-service-di-residual-refresh`
+- Base: `origin/main`
+- Base commit: `6a858519c8a2d5c8948776ecc0986ef2b4a5f769`
+- Parent PR: `https://github.com/chengjon/mystocks/pull/485`
+- OpenStock boundary: no OpenStock internals, tests, runtime, configuration, packaging, or repository files changed.
+
+## Scope
+
+G2.338 refreshes the service lifecycle DI residual pool after G2.337 merged the strategy provider-injection implementation.
+
+Allowed output:
+
+- This report.
+- G2.338 mainline task card.
+
+Forbidden in this task:
+
+- Source, tests, frontend, config, dependency, runtime, OpenSpec implementation, OpenStock, deletion, or retirement changes.
+
+## Scan Method
+
+The scan parsed Python AST from backend API route files and counted route-body calls to:
+
+- `DataSourceFactory`
+- `get_data_source`
+
+Classification:
+
+- **Strict constructor residual**: route body still calls `DataSourceFactory()` and `get_data_source(...)`.
+- **Weak direct-source residual**: route body calls a module-level `get_data_source()` directly but does not construct `DataSourceFactory()`.
+- **Provider boundary**: `DataSourceFactory()` and `get_data_source(...)` are contained in a non-route provider function, and route bodies receive the adapter/source through dependency injection or an equivalent provider boundary.
+
+## Current Mainline Result
+
+Current mainline ref:
+
+| Ref | Commit | API files scanned | Residual files | Residual routes |
+| --- | --- | ---: | ---: | ---: |
+| `origin/main` | `6a858519c8a2d5c8948776ecc0986ef2b4a5f769` | 204 | 2 | 9 |
+
+Current mainline strict constructor residuals:
+
+| File | Route functions | Count | Decision |
+| --- | --- | ---: | --- |
+| `web/backend/app/api/watchlist.py` | `get_my_watchlist`, `get_my_watchlist_symbols`, `add_to_watchlist`, `remove_from_watchlist`, `check_in_watchlist`, `update_watchlist_notes`, `get_watchlist_count`, `clear_watchlist` | 8 | Next current-main strict constructor candidate. Requires separate source-authorized task. |
+
+Current mainline weak direct-source residuals:
+
+| File | Route function | Route | Evidence | Decision |
+| --- | --- | --- | --- | --- |
+| `web/backend/app/api/dashboard.py` | `get_dashboard_summary` | `GET /summary` | calls module-level `get_data_source()` in the route body, without constructing `DataSourceFactory()` | Track as a separate weak residual candidate after watchlist. Do not mix with watchlist implementation authorization. |
+
+Current mainline resolved focus files:
+
+| File | Status |
+| --- | --- |
+| `web/backend/app/api/strategy.py` | Resolved. No route-body residuals; provider boundary `get_strategy_data_source` remains as intended. |
+| `web/backend/app/api/technical_analysis.py` | Resolved. No route-body residuals; provider boundary `get_technical_analysis_data_source` remains as intended. |
+| `web/backend/app/api/strategy_management/_strategy_execution_router.py` | Absent on current main. Do not use this historical seed as current-main source truth. |
+
+## Multi-Ref Branch-Anchor Comparison
+
+| Ref | Commit | Watchlist | Strategy | Technical Analysis | Dashboard weak residual |
+| --- | --- | --- | --- | --- | --- |
+| `origin/main` | `6a858519c8a2d5c8948776ecc0986ef2b4a5f769` | 8 strict constructor residuals in `watchlist.py` | resolved in `strategy.py` | resolved in `technical_analysis.py` | 1 weak direct-source residual in `dashboard.py` |
+| `origin/wip/root-dirty-20260403` | `e1dbb6d962affd2d04c7885879a9c9d19bcf0dfd` | resolved through `get_watchlist_data_source` provider boundary | `strategy.py` absent; historical `_strategy_execution_router.py` has 3 strict constructor residuals | 8 strict constructor residuals | not selected in this scan |
+| PR #474 merge | `2ebff6d7ded33403c691a60fc43f87dabf90a975` | resolved through `get_watchlist_data_source` provider boundary | `strategy.py` absent; historical `_strategy_execution_router.py` has 3 strict constructor residuals | 8 strict constructor residuals | not selected in this scan |
+
+Interpretation:
+
+- The G2.337 current-main strategy implementation is effective: `strategy.py` now has zero route-body residuals.
+- The earlier G2.332 current-main technical-analysis implementation is effective: `technical_analysis.py` now has zero route-body residuals.
+- Watchlist remains unresolved on current main, even though PR #474 and `origin/wip/root-dirty-20260403` show an accepted provider-boundary shape for the wip branch.
+- The watchlist wip/PR #474 anchor is useful evidence but is not the same as current-main authorization. A future source task must work against current `origin/main` and may use the PR #474 pattern as evidence, not as a blind merge source.
+- Dashboard `/summary` is a weaker direct-source residual, not a route-body `DataSourceFactory()` constructor residual. It should be handled separately after the strict constructor pool is closed.
+
+## Decision
+
+G2.338 does not authorize source implementation.
+
+Recommended next gate:
+
+1. Prepare a source-authorized watchlist provider-injection task against current `origin/main`.
+2. Bound the allowed source/test files to `web/backend/app/api/watchlist.py` and focused watchlist provider/API tests.
+3. Re-run GitNexus/API impact for `watchlist.py` before editing.
+4. Preserve watchlist route paths, response envelopes, parameter validation, exception mapping, and data-source method payloads.
+5. Record PR #474 as branch-anchor evidence only.
+6. Leave dashboard weak residual for a later, separate no-source or source-authorized task.
+
+## Verification
+
+Commands/evidence:
+
+- AST scan across `origin/main`, `origin/wip/root-dirty-20260403`, and PR #474 merge commit.
+- Current-main focus scan confirmed:
+  - `strategy.py`: zero route-body residuals.
+  - `technical_analysis.py`: zero route-body residuals.
+  - `watchlist.py`: eight strict constructor residuals.
+  - `dashboard.py`: one weak direct-source residual.
+
+Remaining required closeout checks:
+
+- `git diff HEAD~1..HEAD --check`
+- G2.338 mainline scope gate
+- GitNexus `detect_changes(scope=compare, base_ref=origin/main)`
+- PR CI before merge
+
+## Rollback
+
+Revert the G2.338 governance commit to remove this residual-refresh report and task card. No source behavior changes are involved.

--- a/governance/mainline/task-cards/g2-338.yaml
+++ b/governance/mainline/task-cards/g2-338.yaml
@@ -1,0 +1,102 @@
+version: "v0.2"
+task:
+  id: "g2-338"
+  title: "Refresh service lifecycle DI residual pool"
+  owner: "G/#79 service lifecycle DI + Route/OpenAPI governance"
+  created_at: "2026-06-13"
+
+mainline:
+  id: "L1-service-lifecycle-di-residual-refresh"
+  objective: "Refresh the current-main service lifecycle DI residual pool after G2.337 and select the next authorization boundary without modifying source code."
+  milestone_id: "g2"
+  slice_id: "g2-338"
+
+classification:
+  task_type: "cleanup"
+  secondary_type: "none"
+  secondary_change_budget_percent: 0
+  secondary_allowed_paths: []
+
+openspec:
+  change_id: ""
+  approval_status: "not_required"
+
+scope:
+  allowed_paths:
+    - "docs/reports/quality/backend-service-lifecycle-di-residual-refresh-2026-06-13.md"
+    - "governance/mainline/task-cards/g2-338.yaml"
+  forbidden_paths:
+    - "src/**"
+    - "web/backend/app/**"
+    - "web/frontend/**"
+    - "tests/**"
+    - "scripts/**"
+    - "config/**"
+    - "requirements.txt"
+    - "web/backend/requirements.txt"
+    - "openspec/changes/**"
+    - "openstock/**"
+    - "OpenStock/**"
+
+non_goals:
+  - "Do not implement service lifecycle DI source changes in this task."
+  - "Do not modify backend source, route tests, frontend code, runtime state, scripts, configuration, dependency manifests, or OpenSpec implementation files."
+  - "Do not modify OpenStock internals, provider/runtime code, tests, configuration, packaging, or repository files."
+  - "Do not modify watchlist, dashboard, strategy, technical_analysis, or any other API source file."
+  - "Do not authorize deletion, retirement, compatibility-layer removal, response-contract migration, or full-file removal."
+
+acceptance:
+  checks:
+    - id: "residual-refresh-report"
+      command: "docs/reports/quality/backend-service-lifecycle-di-residual-refresh-2026-06-13.md records current-main residual pool, weak dashboard residual, branch-anchor comparison, and next source gate"
+      required: true
+    - id: "no-source-path-check"
+      command: "git diff --name-only HEAD~1..HEAD excludes source, tests, frontend, scripts, config, OpenSpec implementation, dependency manifests, and OpenStock internals"
+      required: true
+    - id: "mainline-scope-gate"
+      command: "python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/g2-338.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha HEAD~1 --head-sha HEAD --report /tmp/g2-338-mainline-gate.json"
+      required: true
+    - id: "gitnexus-detect-changes"
+      command: "gitnexus_detect_changes(scope=compare, base_ref=origin/main)"
+      required: true
+    - id: "diff-check"
+      command: "git diff HEAD~1..HEAD --check"
+      required: true
+
+risk_and_rollback:
+  risks:
+    - "Watchlist is resolved in the wip/PR #474 branch-anchor but remains unresolved on current main; future source work must not conflate the branch-anchor with current-main implementation truth."
+    - "Dashboard has a weaker direct-source residual that should not be mixed into the strict constructor residual watchlist implementation task."
+    - "This task records recommendations only and does not authorize source edits."
+  rollback_plan: "Revert this governance-only commit to remove the G2.338 residual-refresh report and task card."
+
+delivery:
+  six_line_summary_required: true
+  six_line_summary:
+    change_purpose: "Refresh the service lifecycle DI residual pool after G2.337."
+    modified_scope: "Governance report and G2.338 task card only."
+    dependency_changes: "No dependency changes."
+    legacy_logic_impact: "No source, test, API behavior, frontend, runtime, script, configuration, OpenSpec implementation, or OpenStock internal changes."
+    rollback_ready: "Revert this governance-only commit."
+    risk_and_rollback_point: "Future watchlist source work requires a separate source-authorized task card and fresh impact/API-impact attempt."
+
+function_tree:
+  domain_id: "meta-governance"
+  node_id: "meta-governance-mainline"
+  affected_entrypoints:
+    - "governance"
+  update_status: "not-needed"
+  secondary_domains: []
+  exemption_reason: "No business entrypoint changed; this is a no-source residual-refresh package for mainline governance."
+
+governance:
+  phase: "phase_b_dual_hard_gate"
+  mainline_drift_threshold_percent: 0
+  stop_rule_owner: "G/#79 service lifecycle DI + Route/OpenAPI governance"
+  stop_rule_sla_hours: 24
+  approval:
+    required: true
+    approved_by: "human-maintainer"
+    approved_at: "2026-06-13T11:19:23+08:00"
+    approval_note: "Human maintainer agreed to continue after G2.337; G2.338 is constrained to no-source residual refresh and OpenStock boundary-only handling."
+    secondary_approved: false


### PR DESCRIPTION
## Summary
- Add G2.338 no-source residual refresh after G2.337 strategy provider injection.
- Confirm current-main strict constructor residual pool: watchlist.py has 8 route-body DataSourceFactory residuals; strategy.py and technical_analysis.py are resolved.
- Record dashboard.py /summary as a separate weak direct-source residual and preserve the PR #474/watchlist branch-anchor distinction.

## Boundary
- No source, test, frontend, config, dependency, runtime, OpenSpec implementation, or OpenStock internal changes.
- This PR does not authorize watchlist implementation; it only selects the next source-authorized gate.

## Validation
- AST scan across origin/main, origin/wip/root-dirty-20260403, and PR #474 merge commit.
- python governance/mainline/scripts/mainline_scope_gate.py --task-card governance/mainline/task-cards/g2-338.yaml --schema governance/mainline/schemas/ai-task-card.schema.json --base-sha HEAD~1 --head-sha HEAD --report /tmp/g2-338-mainline-gate.json: pass=True
- git diff HEAD~1..HEAD --check: clean
- no-source path whitelist: report + task card only
- GitNexus detect_changes compare origin/main: LOW risk, 2 changed files, 0 changed symbols, 0 affected processes

## Next Gate
- Prepare a separate source-authorized watchlist provider-injection task against current origin/main.
- Treat PR #474 as branch-anchor evidence only, not as a blind merge source.
- Leave dashboard weak residual for a later separate task.